### PR TITLE
Build on pre-Sequoia SDKs

### DIFF
--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -63,6 +63,22 @@
 /* Generated from src/syscall/dispatch.tbl into $(BUILD_DIR). */
 #include "dispatch.h"
 
+/* HV_SYS_REG_ACTLR_EL1 was added in the macOS 15 (Sequoia) SDK. Older SDKs
+ * (e.g., the Nix-pinned apple-sdk-14.4) lack the enumerator. The encoding is
+ * stable: op0=3, op1=0, CRn=1, CRm=0, op2=1 -> 0xc081. Hypervisor.framework
+ * exposes ACTLR_EL1 only on hardware/OS combinations where the bit is
+ * meaningful (Apple Silicon TSO toggle); older platforms simply leave actlr
+ * at 0, which falls through to PR_SET_MEM_MODEL_DEFAULT.
+ *
+ * The guard checks the SDK version rather than the macro presence: on
+ * macOS 15+ the symbol is an enumerator (not a #define), so a plain
+ * #ifndef would always fire and shadow the SDK name with a macro of the
+ * same spelling.
+ */
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 150000
+#define HV_SYS_REG_ACTLR_EL1 ((hv_sys_reg_t) 0xc081)
+#endif
+
 
 void syscall_init(void)
 {


### PR DESCRIPTION
Apple added HV_SYS_REG_ACTLR_EL1 to the Hypervisor.framework header in macOS 15 (Sequoia) SDK. Older SDKs, including the Nix-pinned apple-sdk-14.4 used by the issue 11 reporter, lack the enumerator and fail to compile. The encoding is stable across versions:
op0=3, op1=0, CRn=1, CRm=0, op2=1 -> 0xc081.

Define the value as a macro fallback when the SDK target predates Sequoia. The guard checks __MAC_OS_X_VERSION_MAX_ALLOWED rather than testing macro presence, because on macOS 15+ the symbol is an enum member, not a #define, so a plain #ifndef would always fire and shadow the SDK name with a same-spelling macro.

The semantic of PR_GET_MEM_MODEL is unchanged: when the host kernel or hardware does not expose ACTLR_EL1, hv_vcpu_get_sys_reg returns a non-success status, actlr stays at 0, and the call falls through to PR_SET_MEM_MODEL_DEFAULT.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix build failures on pre-Sequoia macOS SDKs by adding a fallback for HV_SYS_REG_ACTLR_EL1. Uses an SDK-version guard to avoid enum/macro conflicts; PR_GET_MEM_MODEL behavior is unchanged.

- **Bug Fixes**
  - Define HV_SYS_REG_ACTLR_EL1 when __MAC_OS_X_VERSION_MAX_ALLOWED < 150000 (e.g., SDK 14.4) using the stable encoding 0xc081.
  - If ACTLR_EL1 isn’t exposed, hv_vcpu_get_sys_reg fails and we fall back to PR_SET_MEM_MODEL_DEFAULT.

<sup>Written for commit ff3f4a9bf8b4d541de3365a8bd3df53de9c1ebfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

