### PR TITLE
Add make check prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ toolchain. The default paths in `mk/toolchain.mk` target the toolchain layout
 used by the repository test harness, but `CROSS_COMPILE` and
 `BAREMETAL_CROSS` are overridable.
 
+To run `make check`, install the Homebrew AArch64 embedded toolchain first:
+
+```sh
+brew install --cask gcc-aarch64-embedded
+```
+
 ## Quick Start
 
 ```sh


### PR DESCRIPTION
`make check` need aarch64-none-elf-as. 
brew install --cask gcc-aarch64-embedded will install aarch64-none-elf-as

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates README to document the `make check` prerequisite: `aarch64-none-elf-as`. Adds a Homebrew install step for the AArch64 embedded toolchain: `brew install --cask gcc-aarch64-embedded`.

<sup>Written for commit 2d2876bb222978b0b7e945df161c466b80215607. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

