### PR TITLE
Fail run_check and run_pipe on non-zero exit

### DIFF
--- a/tests/lib/test-runner.sh
+++ b/tests/lib/test-runner.sh
@@ -123,7 +123,11 @@ run_check()
         rc=$?
     fi
 
-    if printf "%s\n" "$output" | grep -qE "$pattern"; then
+    if [ "$rc" -ne 0 ]; then
+        test_report fail "$tool" " (exit rc=$rc)"
+        test_excerpt "$output"
+        fail=$((fail + 1))
+    elif printf "%s\n" "$output" | grep -qE "$pattern"; then
         test_report ok "$tool"
         pass=$((pass + 1))
     else
@@ -172,7 +176,11 @@ run_pipe()
         rc=$?
     fi
 
-    if printf "%s\n" "$output" | grep -qE "$pattern"; then
+    if [ "$rc" -ne 0 ]; then
+        test_report fail "$tool" " (exit rc=$rc)"
+        test_excerpt "$output"
+        fail=$((fail + 1))
+    elif printf "%s\n" "$output" | grep -qE "$pattern"; then
         test_report ok "$tool"
         pass=$((pass + 1))
     else


### PR DESCRIPTION
The shared test helpers captured the subprocess exit code into rc but never consulted it. A guest that printed the expected substring and then died on SIGBUS or SIGSEGV (rc 138 or 139) would still match the pattern via grep and report OK, hiding the crash.

Check rc first in both helpers: any non-zero exit is reported as FAIL with the exit code in the detail, before the pattern match runs. The remaining branches keep the original semantics for the clean-exit cases.

All current callers in test-busybox.sh and test-coreutils-smoke.sh expect rc 0 from the applet under test; non-zero-rc cases use the explicit run helper, which is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `run_check` and `run_pipe` fail on any non-zero exit before pattern matching, so crashes don’t get reported as passing.

- **Bug Fixes**
  - Check `rc` first; non-zero exits now report FAIL with `rc` and output excerpt.
  - Keep original behavior for clean exits; the explicit `run` helper is unchanged.

<sup>Written for commit aded850ee22362c9d1d1537b2f15004f55dd219e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

