### PR TITLE
Tighten FUSE wait semantics

### DIFF
--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -346,8 +346,16 @@ int fork_child_main(int ipc_fd,
  * by the worker after vCPU creation and register setup.
  */
 typedef struct {
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    bool ready;
+    int startup_rc;
+} thread_startup_t;
+
+typedef struct {
     thread_entry_t *thread;
     guest_t *guest;
+    thread_startup_t *startup;
     bool verbose;
     uint64_t child_stack, flags, tls;
     /* Parent system regs to copy into the new vCPU */
@@ -398,6 +406,11 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
                                 uint64_t ctid_gva,
                                 bool verbose)
 {
+    thread_startup_t startup = {
+        .lock = PTHREAD_MUTEX_INITIALIZER,
+        .cond = PTHREAD_COND_INITIALIZER,
+    };
+
     /* Allocate guest TID */
     int64_t child_tid = proc_alloc_pid();
 
@@ -446,11 +459,14 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
     thread_create_args_t *tca = calloc(1, sizeof(thread_create_args_t));
     if (!tca) {
         thread_deactivate(t);
+        pthread_cond_destroy(&startup.cond);
+        pthread_mutex_destroy(&startup.lock);
         return -LINUX_ENOMEM;
     }
 
     tca->thread = t;
     tca->guest = g;
+    tca->startup = &startup;
     tca->verbose = verbose;
     tca->child_stack = child_stack;
     tca->flags = flags;
@@ -474,6 +490,8 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         if (guest_write_small(g, ptid_gva, &tid32, sizeof(tid32)) < 0) {
             free(tca);
             thread_deactivate(t);
+            pthread_cond_destroy(&startup.cond);
+            pthread_mutex_destroy(&startup.lock);
             return -LINUX_EFAULT;
         }
     }
@@ -491,6 +509,8 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         if (guest_write_small(g, ctid_gva, &tid32, sizeof(tid32)) < 0) {
             free(tca);
             thread_deactivate(t);
+            pthread_cond_destroy(&startup.cond);
+            pthread_mutex_destroy(&startup.lock);
             return -LINUX_EFAULT;
         }
     }
@@ -510,10 +530,48 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         log_error("clone_thread: pthread_create failed: %s", strerror(err));
         free(tca);
         thread_deactivate(t);
+        pthread_cond_destroy(&startup.cond);
+        pthread_mutex_destroy(&startup.lock);
+        /* Roll back any SETTID writes done before pthread_create. Same
+         * rationale as the post-handshake failure path: clone(2) does not
+         * leave live-looking TIDs behind for a thread that never started.
+         */
+        if (flags & LINUX_CLONE_PARENT_SETTID) {
+            int32_t zero = 0;
+            (void) guest_write_small(g, ptid_gva, &zero, sizeof(zero));
+        }
+        if (flags & LINUX_CLONE_CHILD_SETTID) {
+            int32_t zero = 0;
+            (void) guest_write_small(g, ctid_gva, &zero, sizeof(zero));
+        }
         return -LINUX_EAGAIN;
     }
 
     t->host_thread = host_thread;
+
+    pthread_mutex_lock(&startup.lock);
+    while (!startup.ready)
+        pthread_cond_wait(&startup.cond, &startup.lock);
+    pthread_mutex_unlock(&startup.lock);
+    pthread_cond_destroy(&startup.cond);
+    pthread_mutex_destroy(&startup.lock);
+    if (startup.startup_rc < 0) {
+        /* Worker failed during HVF bring-up after the SETTID writes had
+         * already populated the guest TID slots. Linux clone(2) does not
+         * leave a live-looking TID behind for a thread that never started,
+         * so zero the slots before the parent sees the error.
+         */
+        pthread_join(host_thread, NULL);
+        if (flags & LINUX_CLONE_PARENT_SETTID) {
+            int32_t zero = 0;
+            (void) guest_write_small(g, ptid_gva, &zero, sizeof(zero));
+        }
+        if (flags & LINUX_CLONE_CHILD_SETTID) {
+            int32_t zero = 0;
+            (void) guest_write_small(g, ctid_gva, &zero, sizeof(zero));
+        }
+        return startup.startup_rc;
+    }
 
     log_debug("clone_thread: child tid=%lld created", (long long) child_tid);
 
@@ -530,6 +588,7 @@ static void *thread_create_and_run(void *arg)
     thread_create_args_t *tca = (thread_create_args_t *) arg;
     thread_entry_t *t = tca->thread;
     guest_t *g = tca->guest;
+    thread_startup_t *startup = tca->startup;
 
     /* Create vCPU on THIS thread (HVF requirement) */
     hv_vcpu_t vcpu;
@@ -538,6 +597,11 @@ static void *thread_create_and_run(void *arg)
     if (r != HV_SUCCESS) {
         log_error("thread tid=%lld: hv_vcpu_create failed: %d",
                   (long long) t->guest_tid, (int) r);
+        pthread_mutex_lock(&startup->lock);
+        startup->startup_rc = -LINUX_EIO;
+        startup->ready = true;
+        pthread_cond_broadcast(&startup->cond);
+        pthread_mutex_unlock(&startup->lock);
         free(tca);
         thread_deactivate(t);
         return NULL;
@@ -546,49 +610,104 @@ static void *thread_create_and_run(void *arg)
     t->vcpu = vcpu;
     t->vexit = vexit;
 
+    /* Sysreg setup uses checked calls instead of HV_CHECK so the parent's
+     * startup handshake can roll back cleanly rather than tearing down the
+     * whole process on a transient HVF failure here.
+     */
+#define WORKER_HV(call)                                           \
+    do {                                                          \
+        hv_return_t _r = (call);                                  \
+        if (_r != HV_SUCCESS) {                                   \
+            log_error("thread tid=%lld: %s failed: %d",           \
+                      (long long) t->guest_tid, #call, (int) _r); \
+            goto startup_failed;                                  \
+        }                                                         \
+    } while (0)
+
     /* Copy system registers from parent (shared page tables, same MMU config)
      */
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_VBAR_EL1, tca->vbar));
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_MAIR_EL1, tca->mair));
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TCR_EL1, tca->tcr));
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TTBR0_EL1, tca->ttbr0));
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_CPACR_EL1, tca->cpacr));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_VBAR_EL1, tca->vbar));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_MAIR_EL1, tca->mair));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TCR_EL1, tca->tcr));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TTBR0_EL1, tca->ttbr0));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_CPACR_EL1, tca->cpacr));
 
     /* MMU already on, so set SCTLR with M=1 directly (page tables exist) */
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SCTLR_EL1, tca->sctlr));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SCTLR_EL1, tca->sctlr));
 
     /* Per-thread SP_EL1 (each vCPU needs its own EL1 exception stack) */
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL1, tca->sp_el1));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL1, tca->sp_el1));
 
     /* SP_EL0 = child_stack (provided by clone caller) */
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL0, tca->child_stack));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL0, tca->child_stack));
 
     /* TPIDR_EL0 = thread-local storage pointer (if CLONE_SETTLS) */
     if (tca->flags & LINUX_CLONE_SETTLS) {
-        HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, tca->tls));
+        WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, tca->tls));
     } else {
-        HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, tca->tpidr));
+        WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, tca->tpidr));
     }
 
     /* ELR_EL1 = clone return point (same as parent) */
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, tca->elr));
-    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1, tca->spsr));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, tca->elr));
+    WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1, tca->spsr));
 
-    /* Copy all 31 GPRs from parent, then set X0=0 (child clone return) */
-    vcpu_restore_gprs(vcpu, tca->gprs);
-    vcpu_set_gpr(vcpu, 0, 0);
+    /* Copy all 31 GPRs from parent, then set X0=0 (child clone return).
+     * The vcpu_restore_gprs / vcpu_restore_simd helpers in hvutil.h abort
+     * the whole process on failure via HV_CHECK, which would defeat the
+     * handshake rollback. Open-code the restore here so transient HVF
+     * failures fall into the same startup_failed path as the sysreg writes.
+     */
+    for (unsigned i = 0; i < 31; i++)
+        WORKER_HV(hv_vcpu_set_reg(vcpu, HV_REG_X0 + i, tca->gprs[i]));
+    WORKER_HV(hv_vcpu_set_reg(vcpu, HV_REG_X0, 0));
 
-    vcpu_restore_simd(vcpu, &tca->simd_state);
+    for (int i = 0; i < 32; i++)
+        WORKER_HV(hv_vcpu_set_simd_fp_reg(vcpu, HV_SIMD_FP_REG_Q0 + i,
+                                          tca->simd_state.v[i]));
+    WORKER_HV(hv_vcpu_set_reg(vcpu, HV_REG_FPSR, tca->simd_state.fpsr));
+    WORKER_HV(hv_vcpu_set_reg(vcpu, HV_REG_FPCR, tca->simd_state.fpcr));
 
     /* Start at clone return point in EL0 (not shim entry) */
-    HV_CHECK(hv_vcpu_set_reg(vcpu, HV_REG_PC, tca->elr));
-    HV_CHECK(hv_vcpu_set_reg(vcpu, HV_REG_CPSR, 0)); /* EL0t */
+    WORKER_HV(hv_vcpu_set_reg(vcpu, HV_REG_PC, tca->elr));
+    WORKER_HV(hv_vcpu_set_reg(vcpu, HV_REG_CPSR, 0)); /* EL0t */
+#undef WORKER_HV
 
     bool verbose = tca->verbose;
     free(tca);
 
     /* Set per-thread TLS pointer and enter worker run loop */
     current_thread = t;
+
+    pthread_mutex_lock(&startup->lock);
+    startup->startup_rc = 0;
+    startup->ready = true;
+    pthread_cond_broadcast(&startup->cond);
+    pthread_mutex_unlock(&startup->lock);
+
+    goto startup_ok;
+
+startup_failed:
+    /* HVF sysreg/GPR setup failed after vCPU creation. Drop the thread slot
+     * before tearing the vCPU down: thread_interrupt_all() scans the active
+     * set and calls hv_vcpus_exit() on each t->vcpu without a null check, so
+     * clearing t->vcpu while the slot is still active would let a concurrent
+     * exit_group hand a zero handle to HVF. Deactivating first removes the
+     * slot from iteration. Then destroy the vCPU on its owning thread (the
+     * only thread allowed to do so), free args, and finally signal the
+     * parent so it observes a fully torn-down state.
+     */
+    thread_deactivate(t);
+    hv_vcpu_destroy(vcpu);
+    free(tca);
+    pthread_mutex_lock(&startup->lock);
+    startup->startup_rc = -LINUX_EIO;
+    startup->ready = true;
+    pthread_cond_broadcast(&startup->cond);
+    pthread_mutex_unlock(&startup->lock);
+    return NULL;
+
+startup_ok:;
 
     log_debug("thread tid=%lld starting on vCPU", (long long) t->guest_tid);
 

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -27,6 +27,7 @@
 #include "syscall/internal.h"
 #include "syscall/path.h"
 #include "syscall/proc.h"
+#include "syscall/signal.h"
 
 #define FUSE_KERNEL_VERSION 7
 #define FUSE_KERNEL_MINOR_VERSION 45
@@ -38,6 +39,7 @@
 
 enum fuse_opcode {
     FUSE_LOOKUP = 1,
+    FUSE_FORGET = 2,
     FUSE_GETATTR = 3,
     FUSE_OPEN = 14,
     FUSE_READ = 15,
@@ -46,6 +48,8 @@ enum fuse_opcode {
     FUSE_OPENDIR = 27,
     FUSE_READDIR = 28,
     FUSE_RELEASEDIR = 29,
+    FUSE_INTERRUPT = 36,
+    FUSE_BATCH_FORGET = 42,
 };
 
 typedef struct {
@@ -113,6 +117,24 @@ typedef struct {
 } fuse_release_in_t;
 
 typedef struct {
+    uint64_t nlookup;
+} fuse_forget_in_t;
+
+typedef struct {
+    uint64_t unique;
+} fuse_interrupt_in_t;
+
+typedef struct {
+    uint32_t count;
+    uint32_t dummy;
+} fuse_batch_forget_in_t;
+
+typedef struct {
+    uint64_t nodeid;
+    uint64_t nlookup;
+} fuse_forget_one_t;
+
+typedef struct {
     uint32_t major;
     uint32_t minor;
     uint32_t max_readahead;
@@ -174,6 +196,13 @@ typedef struct {
 #define FUSE_MAX_MOUNTS 8
 #define FUSE_MAX_OPEN_FILES 128
 #define FUSE_MAX_PENDING 128
+/* Per-session capacity for held lookup references. Sized for recursive
+ * directory walks (ls -R style) without pushing the per-session struct
+ * into multi-page territory; sizeof(struct) at the chosen cap stays under
+ * 80 KiB. Beyond this, fuse_lookup_locked() emits a compensating FORGET
+ * to keep the daemon balanced instead of leaking a reference.
+ */
+#define FUSE_MAX_NODE_REFS 4096
 #define FUSE_FAKE_DEV 0xF00D
 
 /* Implementation ceiling for a single FUSE frame (header + payload). The
@@ -192,6 +221,9 @@ typedef struct {
 typedef struct fuse_request {
     bool used;
     bool answered;
+    bool no_reply;
+    bool detached;
+    bool interrupt_sent;
     uint64_t unique;
     uint8_t *frame;
     size_t frame_len;
@@ -218,6 +250,11 @@ typedef struct {
     fuse_request_t requests[FUSE_MAX_PENDING];
     fuse_request_t *queue_head;
     fuse_request_t *queue_tail;
+    struct {
+        bool used;
+        uint64_t nodeid;
+        uint64_t nlookup;
+    } node_refs[FUSE_MAX_NODE_REFS];
 } fuse_session_t;
 
 typedef struct {
@@ -459,6 +496,19 @@ static void fuse_session_get_locked(fuse_session_t *session)
 /* Drop a session reference under fuse_lock. When the last reference is
  * dropped and the session has been closed, destroy the synchronization
  * primitives and clear the slot. Callers must not hold session->lock.
+ *
+ * The /dev/fuse fd is itself one of the session's refs (taken when the
+ * fd is allocated, dropped in fuse_fd_cleanup), so the only path that
+ * can drive refcount to zero runs through fuse_fd_cleanup setting
+ * session->closed = true and session->daemon_dead = true before its
+ * matching put. Any residual node_refs entries at this point therefore
+ * cannot reach the daemon -- fuse_emit_forget_multi_locked short-
+ * circuits on daemon_dead -- so no terminal FUSE_FORGET sweep is
+ * emitted here. The compensating FORGET paths elsewhere in this file
+ * (fuse_lookup_locked overflow, fuse_walk_path_locked mid-walk drop
+ * failure, fuse_open_path error exits) keep the daemon's nlookup view
+ * balanced while the daemon is still alive; teardown after the
+ * daemon's exit needs no further reconciliation.
  */
 static void fuse_session_put_locked(fuse_session_t *session)
 {
@@ -566,6 +616,142 @@ static fuse_request_t *fuse_alloc_request_locked(fuse_session_t *session)
     return NULL;
 }
 
+static int fuse_node_ref_hold_locked(fuse_session_t *session,
+                                     uint64_t nodeid,
+                                     uint64_t nlookup)
+{
+    if (nodeid == FUSE_ROOT_ID || nlookup == 0)
+        return 0;
+    for (int i = 0; i < FUSE_MAX_NODE_REFS; i++) {
+        if (session->node_refs[i].used &&
+            session->node_refs[i].nodeid == nodeid) {
+            session->node_refs[i].nlookup += nlookup;
+            return 0;
+        }
+    }
+    for (int i = 0; i < FUSE_MAX_NODE_REFS; i++) {
+        if (!session->node_refs[i].used) {
+            session->node_refs[i].used = true;
+            session->node_refs[i].nodeid = nodeid;
+            session->node_refs[i].nlookup = nlookup;
+            return 0;
+        }
+    }
+    return -LINUX_ENOMEM;
+}
+
+static int fuse_queue_noreply_locked(fuse_session_t *session,
+                                     uint32_t opcode,
+                                     uint64_t nodeid,
+                                     const void *payload,
+                                     size_t payload_len);
+static void fuse_free_request_locked(fuse_request_t *req);
+
+static int fuse_emit_forget_multi_locked(fuse_session_t *session,
+                                         const fuse_forget_one_t *items,
+                                         uint32_t count)
+{
+    if (!session || session->closed || session->daemon_dead || count == 0)
+        return 0;
+    if (count == 1) {
+        fuse_forget_in_t in = {.nlookup = items[0].nlookup};
+        return fuse_queue_noreply_locked(session, FUSE_FORGET, items[0].nodeid,
+                                         &in, sizeof(in));
+    }
+
+    size_t payload_len =
+        sizeof(fuse_batch_forget_in_t) + count * sizeof(fuse_forget_one_t);
+    uint8_t *payload = calloc(1, payload_len);
+    if (!payload)
+        return -LINUX_ENOMEM;
+
+    fuse_batch_forget_in_t *hdr = (fuse_batch_forget_in_t *) payload;
+    hdr->count = count;
+    memcpy(payload + sizeof(*hdr), items, count * sizeof(*items));
+    int rc = fuse_queue_noreply_locked(session, FUSE_BATCH_FORGET, 0, payload,
+                                       payload_len);
+    free(payload);
+    return rc;
+}
+
+static int fuse_node_ref_drop_locked(fuse_session_t *session,
+                                     uint64_t nodeid,
+                                     uint64_t nlookup,
+                                     bool emit_forget)
+{
+    if (nodeid == FUSE_ROOT_ID || nlookup == 0)
+        return 0;
+    for (int i = 0; i < FUSE_MAX_NODE_REFS; i++) {
+        if (!session->node_refs[i].used ||
+            session->node_refs[i].nodeid != nodeid)
+            continue;
+        if (nlookup >= session->node_refs[i].nlookup) {
+            nlookup = session->node_refs[i].nlookup;
+            memset(&session->node_refs[i], 0, sizeof(session->node_refs[i]));
+        } else {
+            session->node_refs[i].nlookup -= nlookup;
+        }
+        if (!emit_forget)
+            return 0;
+        fuse_forget_one_t one = {.nodeid = nodeid, .nlookup = nlookup};
+        return fuse_emit_forget_multi_locked(session, &one, 1);
+    }
+    return 0;
+}
+
+static int fuse_queue_request_locked(fuse_session_t *session,
+                                     uint32_t opcode,
+                                     uint64_t nodeid,
+                                     const void *payload,
+                                     size_t payload_len,
+                                     bool no_reply,
+                                     fuse_request_t **req_out)
+{
+    fuse_request_t *req = fuse_alloc_request_locked(session);
+    if (!req)
+        return -LINUX_ENOMEM;
+
+    req->no_reply = no_reply;
+    req->unique = session->next_unique++;
+    req->frame_len = sizeof(fuse_in_header_t) + payload_len;
+    req->frame = calloc(1, req->frame_len);
+    if (!req->frame) {
+        fuse_free_request_locked(req);
+        return -LINUX_ENOMEM;
+    }
+
+    fuse_in_header_t *hdr = (fuse_in_header_t *) req->frame;
+    hdr->len = (uint32_t) req->frame_len;
+    hdr->opcode = opcode;
+    hdr->unique = req->unique;
+    hdr->nodeid = nodeid;
+    hdr->uid = proc_get_uid();
+    hdr->gid = proc_get_gid();
+    hdr->pid = (uint32_t) proc_get_pid();
+    if (payload_len)
+        memcpy(req->frame + sizeof(*hdr), payload, payload_len);
+
+    if (session->queue_tail)
+        session->queue_tail->next = req;
+    else
+        session->queue_head = req;
+    session->queue_tail = req;
+    pthread_cond_broadcast(&session->queue_cond);
+    if (req_out)
+        *req_out = req;
+    return 0;
+}
+
+static int fuse_queue_noreply_locked(fuse_session_t *session,
+                                     uint32_t opcode,
+                                     uint64_t nodeid,
+                                     const void *payload,
+                                     size_t payload_len)
+{
+    return fuse_queue_request_locked(session, opcode, nodeid, payload,
+                                     payload_len, true, NULL);
+}
+
 static void fuse_free_request_locked(fuse_request_t *req)
 {
     pthread_cond_destroy(&req->cond);
@@ -629,39 +815,35 @@ static int fuse_request_locked(fuse_session_t *session,
     if (session->closed || session->daemon_dead)
         return -LINUX_ENOTCONN;
 
-    fuse_request_t *req = fuse_alloc_request_locked(session);
-    if (!req)
-        return -LINUX_ENOMEM;
-
-    req->unique = session->next_unique++;
-    req->frame_len = sizeof(fuse_in_header_t) + payload_len;
-    req->frame = calloc(1, req->frame_len);
-    if (!req->frame) {
-        fuse_free_request_locked(req);
-        return -LINUX_ENOMEM;
-    }
-
-    fuse_in_header_t *hdr = (fuse_in_header_t *) req->frame;
-    hdr->len = (uint32_t) req->frame_len;
-    hdr->opcode = opcode;
-    hdr->unique = req->unique;
-    hdr->nodeid = nodeid;
-    hdr->uid = proc_get_uid();
-    hdr->gid = proc_get_gid();
-    hdr->pid = (uint32_t) proc_get_pid();
-    if (payload_len)
-        memcpy(req->frame + sizeof(*hdr), payload, payload_len);
-
-    if (session->queue_tail)
-        session->queue_tail->next = req;
-    else
-        session->queue_head = req;
-    session->queue_tail = req;
-    pthread_cond_broadcast(&session->queue_cond);
+    fuse_request_t *req = NULL;
+    int qrc = fuse_queue_request_locked(session, opcode, nodeid, payload,
+                                        payload_len, false, &req);
+    if (qrc < 0)
+        return qrc;
 
     while (!req->answered && !session->closed && !session->daemon_dead) {
-        sched_yield();
-        pthread_cond_wait(&req->cond, &session->lock);
+        struct timespec ts;
+        timespec_deadline_in_ms(&ts, 20);
+        int wait_rc = pthread_cond_timedwait(&req->cond, &session->lock, &ts);
+        if (!req->answered && wait_rc == ETIMEDOUT) {
+            /* Only detach for non-restartable signals. SA_RESTART signals are
+             * delivered after the syscall completes naturally; breaking out
+             * here would force the guest to retry a request whose handler
+             * contract says no retry is necessary, and would emit a useless
+             * FUSE_INTERRUPT to the daemon for work the guest still wants.
+             */
+            bool restart = false;
+            if (signal_pending_interruption(&restart) && !restart) {
+                if (!req->interrupt_sent) {
+                    fuse_interrupt_in_t in = {.unique = req->unique};
+                    (void) fuse_queue_noreply_locked(session, FUSE_INTERRUPT, 0,
+                                                     &in, sizeof(in));
+                    req->interrupt_sent = true;
+                }
+                req->detached = true;
+                return -LINUX_EINTR;
+            }
+        }
     }
 
     int rc = 0;
@@ -684,6 +866,8 @@ static int fuse_request_locked(fuse_session_t *session,
         }
     }
 
+    if (req->detached)
+        return rc;
     fuse_free_request_locked(req);
     return rc;
 }
@@ -705,7 +889,16 @@ static int fuse_lookup_locked(fuse_session_t *session,
     }
     memcpy(out, reply, sizeof(*out));
     free(reply);
-    return 0;
+    int hold_rc = fuse_node_ref_hold_locked(session, out->nodeid, 1);
+    if (hold_rc < 0) {
+        /* Daemon already accepted the lookup and bumped its nlookup. The
+         * per-session ref table is full, so emit a compensating FORGET to
+         * keep the daemon's view balanced rather than leaking a reference.
+         */
+        fuse_forget_one_t one = {.nodeid = out->nodeid, .nlookup = 1};
+        (void) fuse_emit_forget_multi_locked(session, &one, 1);
+    }
+    return hold_rc;
 }
 
 static int fuse_getattr_locked(fuse_session_t *session,
@@ -731,11 +924,13 @@ static int fuse_getattr_locked(fuse_session_t *session,
 
 static int fuse_walk_path_locked(fuse_session_t *session,
                                  const char *relpath,
+                                 bool retain_final_lookup,
                                  uint64_t *nodeid_out,
                                  fuse_attr_t *attr_out)
 {
     uint64_t nodeid = FUSE_ROOT_ID;
     fuse_attr_t attr = {0};
+    uint64_t held_lookup = 0;
     const char *p = skip_slashes(relpath);
 
     if (*p == '\0') {
@@ -775,13 +970,46 @@ static int fuse_walk_path_locked(fuse_session_t *session,
 
         fuse_entry_out_t entry;
         int rc = fuse_lookup_locked(session, nodeid, name, &entry);
-        if (rc < 0)
+        if (rc < 0) {
+            /* Release the lookup hold from the previous component before
+             * propagating the error: every successful lookup along the way
+             * incremented nlookup on the daemon side, and bailing out without
+             * a matching FORGET would leak that reference.
+             */
+            if (held_lookup != 0)
+                (void) fuse_node_ref_drop_locked(session, held_lookup, 1, true);
             return rc;
+        }
+        if (held_lookup != 0) {
+            rc = fuse_node_ref_drop_locked(session, held_lookup, 1, true);
+            if (rc < 0) {
+                /* The previous component's drop already updated the local
+                 * ref table but failed to queue its FUSE_FORGET. The
+                 * just-acquired entry.nodeid hold would otherwise be
+                 * stranded in the local table on this error path and the
+                 * daemon would never see a matching FORGET for it. Drop
+                 * the new hold best-effort before propagating; if this
+                 * second drop also fails to emit, the caller still gets
+                 * the original error and the session teardown FORGET
+                 * sweep will reconcile any residual daemon-side count.
+                 */
+                (void) fuse_node_ref_drop_locked(session, entry.nodeid, 1,
+                                                 true);
+                return rc;
+            }
+        }
         nodeid = entry.nodeid;
         attr = entry.attr;
+        held_lookup = entry.nodeid;
         if (!slash)
             break;
         p = skip_slashes(slash);
+    }
+
+    if (!retain_final_lookup && held_lookup != 0) {
+        int rc = fuse_node_ref_drop_locked(session, held_lookup, 1, true);
+        if (rc < 0)
+            return rc;
     }
 
     *nodeid_out = nodeid;
@@ -911,15 +1139,23 @@ static int fuse_release_common_locked(fuse_session_t *session,
 {
     if (!session || session->daemon_dead || session->closed)
         return 0;
+    /* O_PATH opens skip FUSE_OPEN, so there is no fh to release. The path
+     * walk still incremented the daemon's nlookup, so emit FORGET to balance
+     * it. Without this, every successful O_PATH close leaks one reference.
+     */
     if (linux_flags & LINUX_O_PATH)
-        return 0;
+        return fuse_node_ref_drop_locked(session, nodeid, 1, true);
 
     fuse_release_in_t in = {
         .fh = fh,
         .flags = (uint32_t) linux_flags,
     };
-    return fuse_request_locked(session, dir ? FUSE_RELEASEDIR : FUSE_RELEASE,
-                               nodeid, &in, sizeof(in), NULL, NULL);
+    int rc = fuse_request_locked(session, dir ? FUSE_RELEASEDIR : FUSE_RELEASE,
+                                 nodeid, &in, sizeof(in), NULL, NULL);
+    int forget_rc = fuse_node_ref_drop_locked(session, nodeid, 1, true);
+    if (rc < 0)
+        return rc;
+    return forget_rc;
 }
 
 static void fuse_fd_cleanup(int guest_fd)
@@ -994,6 +1230,11 @@ static void fuse_fd_cleanup(int guest_fd)
     pthread_cond_broadcast(&session->init_cond);
     for (int i = 0; i < FUSE_MAX_PENDING; i++) {
         if (session->requests[i].used) {
+            if (session->requests[i].detached ||
+                session->requests[i].no_reply) {
+                fuse_free_request_locked(&session->requests[i]);
+                continue;
+            }
             session->requests[i].answered = true;
             session->requests[i].error = -LINUX_ENOTCONN;
             pthread_cond_broadcast(&session->requests[i].cond);
@@ -1246,11 +1487,16 @@ bool fuse_path_matches_mount(const char *path)
 }
 
 /* Resolve a guest-absolute path to a (session, mount_id, nodeid, attr).
+ * retain_final_lookup controls whether the terminal LOOKUP's nlookup is kept
+ * alive for a later open/release cycle, or forgotten before return for
+ * stat-like callers.
+ *
  * Returns 0 on success, or a negative Linux errno. The session refcount is
  * bumped on success; callers must drop it via fuse_session_put_locked when
  * done with the resolution.
  */
 static int fuse_path_lookup(const char *path,
+                            bool retain_final_lookup,
                             fuse_session_t **session_out,
                             int *mount_id_out,
                             uint64_t *nodeid_out,
@@ -1278,7 +1524,9 @@ static int fuse_path_lookup(const char *path,
     pthread_mutex_lock(&session->lock);
     pthread_mutex_unlock(&fuse_lock);
 
-    int rc = fuse_walk_path_locked(session, relpath, nodeid_out, attr_out);
+    bool keep_lookup = retain_final_lookup && session_out != NULL;
+    int rc = fuse_walk_path_locked(session, relpath, keep_lookup, nodeid_out,
+                                   attr_out);
     pthread_mutex_unlock(&session->lock);
 
     if (rc < 0) {
@@ -1313,7 +1561,7 @@ int fuse_stat_path(const char *path, struct stat *st, int at_flags)
 {
     fuse_attr_t attr;
     uint64_t nodeid = 0;
-    int rc = fuse_path_lookup(path, NULL, NULL, &nodeid, &attr);
+    int rc = fuse_path_lookup(path, false, NULL, NULL, &nodeid, &attr);
     (void) nodeid;
     if (rc < 0)
         return rc;
@@ -1413,11 +1661,14 @@ int fuse_materialize_path(const char *path, char *out_path, size_t outsz)
     int mount_id = 0;
     uint64_t nodeid = 0;
     fuse_attr_t attr;
-    int rc = fuse_path_lookup(path, &session, &mount_id, &nodeid, &attr);
+    int rc = fuse_path_lookup(path, true, &session, &mount_id, &nodeid, &attr);
     (void) mount_id;
     if (rc < 0)
         return rc;
     if (S_ISDIR(attr.mode)) {
+        pthread_mutex_lock(&session->lock);
+        (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
+        pthread_mutex_unlock(&session->lock);
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
         pthread_mutex_unlock(&fuse_lock);
@@ -1438,6 +1689,8 @@ int fuse_materialize_path(const char *path, char *out_path, size_t outsz)
                                                 LINUX_O_RDONLY);
         if (rc == 0 && rel_rc < 0)
             rc = rel_rc;
+    } else {
+        (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
     }
     pthread_mutex_unlock(&session->lock);
 
@@ -1522,7 +1775,7 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
 
     uint64_t nodeid = 0;
     fuse_attr_t attr;
-    int rc = fuse_walk_path_locked(session, relpath, &nodeid, &attr);
+    int rc = fuse_walk_path_locked(session, relpath, true, &nodeid, &attr);
     if (rc < 0) {
         pthread_mutex_unlock(&session->lock);
         pthread_mutex_lock(&fuse_lock);
@@ -1534,6 +1787,7 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
     bool want_dir = (linux_flags & LINUX_O_DIRECTORY) || S_ISDIR(attr.mode);
     bool path_only = (linux_flags & LINUX_O_PATH) != 0;
     if ((linux_flags & LINUX_O_DIRECTORY) && !S_ISDIR(attr.mode)) {
+        (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
         pthread_mutex_unlock(&session->lock);
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
@@ -1547,6 +1801,7 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
      * exists for FD_FUSE_FILE.
      */
     if (!want_dir && !path_only && (linux_flags & 3) != LINUX_O_RDONLY) {
+        (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
         pthread_mutex_unlock(&session->lock);
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
@@ -1557,6 +1812,7 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
     int guest_fd =
         fd_alloc(want_dir ? FD_FUSE_DIR : FD_FUSE_FILE, -1, fuse_fd_cleanup);
     if (guest_fd < 0) {
+        (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
         pthread_mutex_unlock(&session->lock);
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
@@ -1570,6 +1826,7 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
     pthread_mutex_unlock(&fuse_lock);
     if (!file) {
         fd_mark_closed(guest_fd);
+        (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
         pthread_mutex_unlock(&session->lock);
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
@@ -1583,6 +1840,7 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
         rc = fuse_open_common_locked(session, nodeid, linux_flags, want_dir,
                                      &out);
         if (rc < 0) {
+            (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
             pthread_mutex_unlock(&session->lock);
             pthread_mutex_lock(&fuse_lock);
             fuse_file_put_locked(file); /* releases the open-fd ref */
@@ -1947,6 +2205,8 @@ int64_t fuse_dev_read(int guest_fd,
     if (!session->queue_head)
         session->queue_tail = NULL;
     req->next = NULL;
+    if (req->no_reply)
+        fuse_free_request_locked(req);
     pthread_mutex_unlock(&session->lock);
     pthread_mutex_lock(&fuse_lock);
     fuse_session_put_locked(session);
@@ -2062,7 +2322,11 @@ int64_t fuse_dev_write(guest_t *g,
         }
         pthread_cond_broadcast(&session->init_cond);
     }
-    pthread_cond_broadcast(&req->cond);
+    if (req->detached) {
+        fuse_free_request_locked(req);
+    } else {
+        pthread_cond_broadcast(&req->cond);
+    }
     pthread_mutex_unlock(&session->lock);
     pthread_mutex_lock(&fuse_lock);
     fuse_session_put_locked(session);

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -407,6 +407,69 @@ int signal_pending(void)
     return result;
 }
 
+bool signal_pending_interruption(bool *restart_out)
+{
+    pthread_mutex_lock(&sig_lock);
+    uint64_t blocked = __atomic_load_n(thread_blocked_ptr(), __ATOMIC_ACQUIRE);
+    uint64_t deliverable = sig_state.pending & ~blocked;
+    if (deliverable == 0) {
+        pthread_mutex_unlock(&sig_lock);
+        if (restart_out)
+            *restart_out = false;
+        return false;
+    }
+
+    /* restart_out reports whether every deliverable signal is non-disruptive
+     * from the caller's point of view. A signal is non-disruptive if its
+     * effective delivery is either a no-op or an SA_RESTART handler:
+     *   - SIG_IGN: discarded by signal_deliver, no guest-visible effect.
+     *   - SIG_DFL with default-ignore disposition (SIGCHLD/SIGURG/SIGWINCH):
+     *     ditto.
+     *   - User handler with SA_RESTART: handler runs but the syscall is
+     *     expected to be retried transparently.
+     * Any other signal (default-TERM, default-CORE, non-restart handler)
+     * forces the wait to be treated as interrupted; otherwise a SIGTERM
+     * hiding behind an ignored SIGCHLD would never wake the caller.
+     */
+    bool all_noninterrupt = true;
+    uint64_t bits = deliverable;
+    while (bits) {
+        int idx = bit_ctz64(bits);
+        bits &= bits - 1;
+        if (!RANGE_CHECK(idx, 0, LINUX_NSIG)) {
+            all_noninterrupt = false;
+            break;
+        }
+        linux_sigaction_t *act = &sig_state.actions[idx];
+        bool noninterrupt;
+        if (act->sa_handler == LINUX_SIG_IGN) {
+            noninterrupt = true;
+        } else if (act->sa_handler == LINUX_SIG_DFL) {
+            /* Mirror signal_deliver's SIG_DFL switch: IGN, CONT, and STOP
+             * are all discarded with no guest-visible effect on elfuse
+             * (STOP/CONT are not meaningful here), so they cannot
+             * legitimately interrupt a FUSE wait. Treating CONT or STOP
+             * as disruptive would force a spurious EINTR that never
+             * corresponds to an actual delivery.
+             */
+            sig_disposition_t disp = signal_default_disposition(idx + 1);
+            noninterrupt = disp == SIG_DISP_IGN || disp == SIG_DISP_CONT ||
+                           disp == SIG_DISP_STOP;
+        } else {
+            noninterrupt = (act->sa_flags & LINUX_SA_RESTART) != 0;
+        }
+        if (!noninterrupt) {
+            all_noninterrupt = false;
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&sig_lock);
+    if (restart_out)
+        *restart_out = all_noninterrupt;
+    return true;
+}
+
 const signal_state_t *signal_get_state(void)
 {
     /* Populate IPC-serializable fields from per-thread state under the

--- a/src/syscall/signal.h
+++ b/src/syscall/signal.h
@@ -56,6 +56,7 @@
 /* Linux sigaction flags. */
 #define LINUX_SA_SIGINFO 0x00000004
 #define LINUX_SA_ONSTACK 0x08000000
+#define LINUX_SA_RESTART 0x10000000
 #define LINUX_SA_NODEFER 0x40000000
 #define LINUX_SA_RESETHAND 0x80000000U
 
@@ -241,6 +242,7 @@ void signal_set_fault_info(int si_code, uint64_t addr, uint64_t esr);
 
 /* Check if any unblocked signal is pending. */
 int signal_pending(void);
+bool signal_pending_interruption(bool *restart_out);
 
 /* Deliver the highest-priority pending unblocked signal to the guest.
  * Builds an rt_sigframe on the guest stack and redirects vCPU to handler.

--- a/tests/test-fuse-basic.c
+++ b/tests/test-fuse-basic.c
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,6 +31,7 @@
 
 enum fuse_opcode {
     FUSE_LOOKUP = 1,
+    FUSE_FORGET = 2,
     FUSE_GETATTR = 3,
     FUSE_OPEN = 14,
     FUSE_READ = 15,
@@ -38,6 +40,8 @@ enum fuse_opcode {
     FUSE_OPENDIR = 27,
     FUSE_READDIR = 28,
     FUSE_RELEASEDIR = 29,
+    FUSE_INTERRUPT = 36,
+    FUSE_BATCH_FORGET = 42,
 };
 
 struct fuse_attr {
@@ -73,6 +77,24 @@ struct fuse_read_in {
     uint64_t lock_owner;
     uint32_t flags;
     uint32_t padding;
+};
+
+struct fuse_forget_in {
+    uint64_t nlookup;
+};
+
+struct fuse_interrupt_in {
+    uint64_t unique;
+};
+
+struct fuse_batch_forget_in {
+    uint32_t count;
+    uint32_t dummy;
+};
+
+struct fuse_forget_one {
+    uint64_t nodeid;
+    uint64_t nlookup;
 };
 
 struct fuse_init_out {
@@ -122,7 +144,39 @@ typedef struct {
     int saw_release;
     int saw_releasedir;
     int init_error;
+    int saw_interrupt;
+    int saw_forget;
+    uint64_t forget_nlookup_total;
+    uint64_t pending_read_unique;
+    int stall_read_once;
+    int stalled_read_active;
 } daemon_ctx_t;
+
+static volatile sig_atomic_t got_usr1;
+
+static void sigusr1_handler(int signum)
+{
+    (void) signum;
+    got_usr1 = 1;
+}
+
+static void *signal_sender_main(void *arg)
+{
+    pthread_t *target = arg;
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {
+        perror("pthread_sigmask");
+        exit(1);
+    }
+    usleep(100000);
+    if (pthread_kill(*target, SIGUSR1) != 0) {
+        perror("pthread_kill");
+        exit(1);
+    }
+    return NULL;
+}
 
 static void fill_dir_attr(struct fuse_attr *attr)
 {
@@ -196,7 +250,7 @@ static void *daemon_main(void *arg)
     for (;;) {
         ssize_t nr = read(ctx->fusefd, buf, sizeof(buf));
         if (nr < 0) {
-            if (errno == ENOTCONN)
+            if (errno == ENOTCONN || errno == EBADF)
                 return NULL;
             perror("read(/dev/fuse)");
             exit(1);
@@ -283,6 +337,11 @@ static void *daemon_main(void *arg)
         case FUSE_READ: {
             struct fuse_read_in *rin =
                 (struct fuse_read_in *) (buf + sizeof(*in));
+            if (ctx->stall_read_once && !ctx->stalled_read_active) {
+                ctx->stalled_read_active = 1;
+                ctx->pending_read_unique = in->unique;
+                break;
+            }
             size_t len = sizeof(hello_data) - 1;
             if (rin->offset >= len) {
                 if (reply_frame(ctx->fusefd, in->unique, 0, NULL, 0) < 0)
@@ -297,19 +356,54 @@ static void *daemon_main(void *arg)
                 exit(1);
             break;
         }
+        case FUSE_FORGET: {
+            struct fuse_forget_in *fin =
+                (struct fuse_forget_in *) (buf + sizeof(*in));
+            ctx->saw_forget = 1;
+            ctx->forget_nlookup_total += fin->nlookup;
+            break;
+        }
+        case FUSE_BATCH_FORGET: {
+            struct fuse_batch_forget_in *bin =
+                (struct fuse_batch_forget_in *) (buf + sizeof(*in));
+            struct fuse_forget_one *items =
+                (struct fuse_forget_one *) (bin + 1);
+            size_t max_count =
+                (size_t) (nr - (ssize_t) sizeof(*in) - (ssize_t) sizeof(*bin)) /
+                sizeof(*items);
+            if (bin->count > max_count) {
+                fprintf(stderr, "short BATCH_FORGET payload\n");
+                exit(1);
+            }
+            ctx->saw_forget = 1;
+            for (uint32_t i = 0; i < bin->count; i++)
+                ctx->forget_nlookup_total += items[i].nlookup;
+            break;
+        }
+        case FUSE_INTERRUPT: {
+            struct fuse_interrupt_in *iin =
+                (struct fuse_interrupt_in *) (buf + sizeof(*in));
+            if (ctx->pending_read_unique != 0 &&
+                iin->unique == ctx->pending_read_unique) {
+                ctx->saw_interrupt = 1;
+                if (reply_frame(ctx->fusefd, ctx->pending_read_unique, 0,
+                                hello_data, sizeof(hello_data) - 1) < 0)
+                    exit(1);
+                ctx->pending_read_unique = 0;
+                ctx->stall_read_once = 0;
+                ctx->stalled_read_active = 0;
+            }
+            break;
+        }
         case FUSE_RELEASE:
             ctx->saw_release = 1;
             if (reply_frame(ctx->fusefd, in->unique, 0, NULL, 0) < 0)
                 exit(1);
-            if (ctx->saw_release && ctx->saw_releasedir)
-                return NULL;
             break;
         case FUSE_RELEASEDIR:
             ctx->saw_releasedir = 1;
             if (reply_frame(ctx->fusefd, in->unique, 0, NULL, 0) < 0)
                 exit(1);
-            if (ctx->saw_release && ctx->saw_releasedir)
-                return NULL;
             break;
         default:
             if (reply_frame(ctx->fusefd, in->unique, -ENOSYS, NULL, 0) < 0)
@@ -355,6 +449,13 @@ static void expect_hello_fd(int fd)
 
 int main(void)
 {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigusr1_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGUSR1, &sa, NULL) < 0)
+        die("sigaction(SIGUSR1)");
+
     const char *mount_dir = "/mnt/fuse";
     if (access(mount_dir, F_OK) < 0)
         die("access(mountpoint)");
@@ -498,6 +599,32 @@ int main(void)
     }
     close(dupfd);
 
+    if (lseek(fd, 0, SEEK_SET) < 0)
+        die("lseek(fuse-file)");
+    ctx.stall_read_once = 1;
+    got_usr1 = 0;
+    pthread_t sender;
+    pthread_t main_tid = pthread_self();
+    if (pthread_create(&sender, NULL, signal_sender_main, &main_tid) != 0) {
+        errno = EINVAL;
+        die("pthread_create(signal sender)");
+    }
+    char intr_buf[64];
+    errno = 0;
+    if (read(fd, intr_buf, sizeof(intr_buf)) >= 0 || errno != EINTR) {
+        fprintf(stderr, "expected interrupted FUSE read to fail with EINTR\n");
+        return 1;
+    }
+    if (pthread_join(sender, NULL) != 0) {
+        errno = EINVAL;
+        die("pthread_join(signal sender)");
+    }
+    if (!got_usr1) {
+        fprintf(stderr, "SIGUSR1 handler did not run\n");
+        return 1;
+    }
+    expect_hello_fd(fd);
+
     void *map = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, fd, 0);
     if (map != MAP_FAILED || errno != ENODEV) {
         fprintf(stderr,
@@ -639,5 +766,13 @@ int main(void)
         die("chdir(/) after daemon death");
     close(dupdfd);
     close(dfd);
+    if (!ctx.saw_interrupt) {
+        fprintf(stderr, "daemon did not observe FUSE_INTERRUPT\n");
+        return 1;
+    }
+    if (!ctx.saw_forget || ctx.forget_nlookup_total == 0) {
+        fprintf(stderr, "daemon did not observe FUSE_FORGET traffic\n");
+        return 1;
+    }
     return 0;
 }


### PR DESCRIPTION
Three correctness gaps remained in the guest-internal FUSE transport and the CLONE_THREAD path after the initial landing. Multi-model review flagged them; this change closes them.

FUSE wait-path EINTR (src/syscall/fuse.c, src/syscall/signal.{c,h}):
- A new helper signal_pending_interruption(restart_out) inspects every unblocked pending bit and reports whether the effective delivery is non-disruptive for every signal in the set. A signal is non-disruptive when its handler is SIG_IGN, when SIG_DFL resolves to default-ignore (SIGCHLD, SIGURG, SIGWINCH), or when a user handler has SA_RESTART set. Any other signal forces the caller to treat the wait as interrupted, so a SIGTERM hiding behind an ignored SIGCHLD cannot stay invisible to the caller.
- fuse_request_locked detaches the request and returns -EINTR only when the deliverable set contains a disruptive signal. SA_RESTART and ignored signals let the wait continue until the daemon replies, matching the application-visible contract of those handlers and avoiding a useless FUSE_INTERRUPT for work the guest still wants.

FUSE_FORGET reference-count integrity (src/syscall/fuse.c):
- fuse_walk_path_locked drops the previous component's lookup hold on any error return so partial-walk failures (e.g. ENOENT on a deep component) no longer leak a reference per surviving prefix.
- fuse_release_common_locked emits a compensating FUSE_FORGET on the O_PATH path. O_PATH opens skip FUSE_OPEN but still consume an nlookup during the walk; the prior early-return left that ref hanging on the daemon.
- fuse_lookup_locked issues a single compensating FUSE_FORGET when the per-session ref table is full so the daemon's nlookup view stays balanced even when elfuse runs out of local capacity.
- The per-session ref table cap rises from 256 to 4096 so realistic recursive walks no longer hit the compensating-FORGET path.

CLONE_THREAD startup-readiness (src/runtime/forkipc.c):
- sys_clone_thread waits on a thread_startup_t condvar until the worker reports current_thread publication or an explicit -EIO failure. The worker's HVF bring-up (hv_vcpu_create plus every sysreg, GPR, SIMD, and PC write) goes through a checked WORKER_HV macro, so a transient HVF error rolls back instead of aborting the process via HV_CHECK.
- The startup_failed cleanup path drops the thread slot before destroying the vCPU, so a concurrent thread_interrupt_all cannot observe a slot whose t->vcpu has just been cleared.
- Both failure paths (pthread_create EAGAIN and post-handshake -EIO) roll back PARENT_SETTID and CHILD_SETTID guest writes so the caller never observes a live-looking TID for a thread that never started.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens FUSE wait semantics and lookup ref accounting, and adds a CLONE_THREAD startup handshake to avoid stale TIDs and races. Improves correctness for interrupted FUSE I/O, path walks, and thread bring-up.

- **Bug Fixes**
  - FUSE waits now return EINTR only for disruptive signals; ignored and SA_RESTART signals keep waiting. When detaching, send a single FUSE_INTERRUPT and free detached/no-reply requests on close; others fail with ENOTCONN.
  - Prevents nlookup leaks: drop the prior component on walk errors; send FORGET on O_PATH close; also drop the final lookup on RELEASE/RELEASEDIR. Path resolution can retain or drop the final LOOKUP; callers updated and now drop lookup refs on early exits. Adds batch FORGET and compensating FORGET when the local table is full; table cap raised to 4096.
  - CLONE_THREAD handshakes startup via a condvar; worker reports success or -EIO. On failure, deactivate the thread slot before vCPU destroy and roll back PARENT/CHILD_SETTID writes so no fake TIDs remain. vCPU register setup uses checked calls to allow clean rollback.
  - Tests exercise EINTR via SIGUSR1, verify FUSE_INTERRUPT handling, and assert FORGET traffic is observed.

<sup>Written for commit ad15853ef97f0262a0109800582f8bab3acdcbd9. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/elfuse/pull/36?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

