### PR TITLE
Add HVC 6 embedder extension hook

### DIFF
--- a/src/core/guest.h
+++ b/src/core/guest.h
@@ -275,6 +275,21 @@ typedef struct {
      * 64-bit to avoid wrap-around stale hits over long-running sessions.
      */
     _Atomic uint64_t pt_gen;
+
+    /*
+     * Optional HVC #6 embedder extension hook.
+     *
+     * The handler may be invoked concurrently from multiple host threads once
+     * the guest becomes multi-threaded, so implementations must be thread-safe.
+     *
+     * The hook is process-local and does not survive fork(). elfuse implements
+     * fork via posix_spawn() of a fresh process, so the child must register its
+     * own handler during bootstrap.
+     */
+    uint64_t (*hvc6_handler)(uint64_t call_nr,
+                             const uint64_t args[8],
+                             void *userdata);
+    void *hvc6_userdata;
 } guest_t;
 
 /* Bump the page table generation counter (call after any PT modification).

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1742,6 +1742,26 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                     break;
                 }
 
+                case 6: {
+                    /* HVC #6: embedder extension hook.
+                     * X8 = call number, X0-X7 = arguments.
+                     * If a dispatch function is registered via
+                     * elfuse_set_hvc6_handler(), it is called here.
+                     * Otherwise falls through as a no-op. */
+                    if (g->hvc6_handler) {
+                        uint64_t x8 = 0;
+                        hv_vcpu_get_reg(vcpu, HV_REG_X8, &x8);
+                        uint64_t args[8] = {0};
+                        for (int i = 0; i < 8; i++)
+                            hv_vcpu_get_reg(vcpu, HV_REG_X0 + i, &args[i]);
+                        uint64_t result =
+                            g->hvc6_handler(x8, args, g->hvc6_userdata);
+                        hv_vcpu_set_reg(vcpu, HV_REG_X0, result);
+                    }
+                    /* PC already advanced by HVC instruction */
+                    break;
+                }
+
                 default: {
                     log_error("%s: unexpected HVC #%u", prefix, imm);
                     char detail[64];


### PR DESCRIPTION
Allows embedders to register a custom dispatch handler for HVC immediate 6, keeping it separate from the Linux syscall path (HVC 5).

The hook is registered via two fields on guest_t:
  hvc6_handler   - callback fn(call_nr, args[8], userdata) -> result
  hvc6_userdata  - opaque pointer passed to the callback

The hook is zero-cost when unset (NULL check). Intended for use cases such as JNI bridges, device emulation, or other guest↔host ABI extensions that need their own HVC immediate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an HVC 6 hook for custom host calls, separate from the Linux syscall path (HVC 5). Defaults to a no-op when no handler is registered.

- **New Features**
  - Adds `hvc6_handler(call_nr, args[8], userdata)` and `hvc6_userdata` to `guest_t`.
  - On HVC 6, reads X8 (call) and X0–X7 (args), calls the handler if set, and writes the result to X0.
  - Handler must be thread-safe; the hook is process‑local and must be re‑registered after fork/posix_spawn.

<sup>Written for commit cdbc3b26795110b154c85555692c7cca0c37f5e1. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/elfuse/pull/40?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

