### PR TITLE
Add hvc 6 yield runtime hook

### DIFF
--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -932,6 +932,13 @@ int64_t sys_waitid(guest_t *g,
 
 /* vCPU run loop. */
 
+static _Thread_local bool hvc6_yield_requested;
+
+void proc_request_hvc6_yield(void)
+{
+    hvc6_yield_requested = true;
+}
+
 /* Global vCPU handle for the SIGALRM handler (unavoidable global state --
  * signal handlers cannot receive context parameters).
  */
@@ -1787,9 +1794,14 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                         uint64_t args[8] = {0};
                         for (int i = 0; i < 8; i++)
                             hv_vcpu_get_reg(vcpu, HV_REG_X0 + i, &args[i]);
+                        hvc6_yield_requested = false;
                         uint64_t result =
                             g->hvc6_handler(x8, args, g->hvc6_userdata);
                         hv_vcpu_set_reg(vcpu, HV_REG_X0, result);
+                        if (hvc6_yield_requested) {
+                            hvc6_yield_requested = false;
+                            running = false;
+                        }
                     }
                     /* PC already advanced by HVC instruction */
                     break;

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -347,6 +347,12 @@ int proc_exit_group_requested(void);
 
 /* vCPU run loop. */
 
+/* Request that the current host thread's HVC #6 run loop returns after the
+ * active handler completes. Safe for concurrent HVC #6 handlers because the
+ * request is thread-local and consumed only by the current vcpu_run_loop().
+ */
+void proc_request_hvc6_yield(void);
+
 /* Run the vCPU execution loop. Returns the exit code.
  *
  * When timeout_sec > 0 (main thread): uses alarm() for per-iteration


### PR DESCRIPTION
Cooperative yield request from the HVC 6 handler. When set, the current guest run loop exits after the handler returns and control is yielded back to the host.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a cooperative yield path for HVC 6 so the handler can request the vCPU run loop to exit and return control to the host right after it returns. Introduces a thread-local runtime hook via `proc_request_hvc6_yield()` that `vcpu_run_loop` clears before the HVC 6 handler and checks after; when set, the loop stops immediately after the handler returns.

<sup>Written for commit 42d897a3e0385ba9aba55bcc350e649dd7467f8b. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/elfuse/pull/42?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

