### PR TITLE
Emit GNU symbol versioning in the synthetic vDSO

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -12,7 +12,7 @@
         test-case-collision test-case-collision-fallback test-sysroot-create-paths \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-timeout-disable test-fuse-alpine \
-        test-sysroot-nofollow test-sysroot-chdir perf
+        test-sysroot-nofollow test-sysroot-chdir test-go perf
 
 ## Build and run the assembly hello world test
 test-hello: $(ELFUSE_BIN) $(TEST_HELLO_DEP)
@@ -51,6 +51,13 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage
 	@$(MAKE) --no-print-directory test-timeout-disable
 	@printf "\n$(BLUE)━━━ rosetta CLI gating ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-rosetta-cli
+	@printf "\n$(BLUE)━━━ Go static binary vDSO regression ━━━$(RESET)\n"
+	@$(MAKE) --no-print-directory test-go
+
+## Build a Go static linux/arm64 binary and run it under elfuse, guarding the
+## vDSO symbol-versioning regression. Skips when the Go toolchain is absent.
+test-go: $(ELFUSE_BIN)
+	$(call RUN_OPTIONAL_SKIP77,bash tests/test-go.sh $(ELFUSE_BIN),test-go)
 
 test-sysroot-rename: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-rename
 	@set -e; \

--- a/src/core/vdso.c
+++ b/src/core/vdso.c
@@ -14,6 +14,16 @@
  * HVF's CNTVOFF_EL2 virtualization, so the seqlock interpolation produced bogus
  * times (year 26382). The fast path is gone; SVC is correct and the trap cost
  * is negligible compared to the work clock_gettime callers tend to do anyway.
+ *
+ * GNU symbol versioning: every real Linux vDSO carries a .gnu.version_d
+ * (DT_VERDEF) defining "LINUX_2.6.39" plus a .gnu.version (DT_VERSYM) array
+ * binding each symbol to it. glibc and musl tolerate its absence, but the Go
+ * runtime does not: runtime.vdsoInitFromSysinfoEhdr marks any vDSO with a hash
+ * + symtab + strtab as valid, then runtime.vdsoFindVersion dereferences
+ * info.verdef (guarded only by info.valid). With no DT_VERDEF that pointer is
+ * NULL and Go reads vd_flags at struct offset 2 -> guest address 0x2 -> SIGSEGV
+ * before the first syscall. Emitting the version tables fixes Go and keeps the
+ * vDSO fast path live for glibc/musl, which look up the same "LINUX_2.6.39".
  */
 
 #include <stdint.h>
@@ -44,6 +54,15 @@ typedef struct {
     uint64_t st_value, st_size;
 } elf64_sym_t;
 
+typedef struct {
+    uint16_t vd_version, vd_flags, vd_ndx, vd_cnt;
+    uint32_t vd_hash, vd_aux, vd_next;
+} elf64_verdef_t;
+
+typedef struct {
+    uint32_t vda_name, vda_next;
+} elf64_verdaux_t;
+
 /* ELF constants */
 #define SHT_STRTAB 3
 #define SHT_HASH 5
@@ -59,6 +78,13 @@ typedef struct {
 #define DT_SYMENT 11
 #define STB_GLOBAL 1
 #define STT_FUNC 2
+#define SHT_GNU_VERSYM 0x6fffffffU
+#define SHT_GNU_VERDEF 0x6ffffffdU
+#define DT_VERSYM 0x6ffffff0
+#define DT_VERDEF 0x6ffffffc
+#define DT_VERDEFNUM 0x6ffffffd
+#define VER_DEF_CURRENT 1
+#define VER_FLG_BASE 0x1
 #define ELF_ST_INFO(bind, type) (((bind) << 4) | ((type) & 0xf))
 
 /* Layout.
@@ -82,24 +108,36 @@ typedef struct {
 #define TEXT_OFF_GETTOD 0x0D4
 #define TEXT_END 0x0E0
 
-/* dynstr, dynsym, hash, dynamic, shdr follow */
+/* .dynstr appends the version name "LINUX_2.6.39" and the soname
+ * "linux-vdso.so.1" after the four __kernel_* names.
+ */
 #define VDSO_OFF_DYNSTR 0x0E0
-#define DYNSTR_SIZE 90
+#define VER_NAME_OFF 90 /* .dynstr offset of "LINUX_2.6.39" */
+#define SONAME_OFF 103  /* .dynstr offset of "linux-vdso.so.1" */
+#define DYNSTR_SIZE 119
 
-/* Padded to 4-byte align: 0x0E0 + 90 = 0x13A, pad to 0x13C */
-#define VDSO_OFF_DYNSYM 0x13C
+/* 8-byte align: 0x0E0 + 119 = 0x157, pad to 0x158 */
+#define VDSO_OFF_DYNSYM 0x158
 
-/* 5 * 24 = 120, 0x13C + 120 = 0x1B4 */
-#define VDSO_OFF_HASH 0x1B4
+/* 5 * 24 = 120, 0x158 + 120 = 0x1D0 */
+#define VDSO_OFF_HASH 0x1D0
 
-/* 2+1+5 = 8 words * 4 = 32, 0x1B4 + 32 = 0x1D4, pad to 0x1D8 */
-#define VDSO_OFF_DYNAMIC 0x1D8
+/* (2+1+5) words * 4 = 32, 0x1D0 + 32 = 0x1F0 */
+#define VDSO_OFF_VERSYM 0x1F0
 
-/* 6 * 16 = 96, 0x1D8 + 96 = 0x238 */
-#define VDSO_OFF_SHDR 0x238
+/* 5 * 2 = 10, 0x1F0 + 10 = 0x1FA, 8-byte align to 0x200 */
+#define VDSO_OFF_VERDEF 0x200
 
-/* 6 * 64 = 384, 0x238 + 384 = 0x3B8 (fits in 4KiB) */
+/* 2 verdef (20) + 2 verdaux (8) = 56, 0x200 + 56 = 0x238 */
+#define VDSO_OFF_DYNAMIC 0x238
+
+/* 9 * 16 = 144, 0x238 + 144 = 0x2C8 */
+#define VDSO_OFF_SHDR 0x2C8
+
+/* 8 * 64 = 512, 0x2C8 + 512 = 0x4C8 (fits in 4KiB) */
 #define VDSO_NUM_SYMS 4
+#define VDSO_NUM_VERDEF 2
+#define VER_NDX_LINUX 2 /* version index bound to the four symbols */
 #define HASH_NCHAIN (VDSO_NUM_SYMS + 1)
 #define HASH_NBUCKET 1
 #define HASH_SIZE ((2 + HASH_NBUCKET + HASH_NCHAIN) * sizeof(uint32_t))
@@ -109,7 +147,9 @@ static const char dynstr_data[] =
     "\0__kernel_rt_sigreturn"
     "\0__kernel_clock_getres"
     "\0__kernel_clock_gettime"
-    "\0__kernel_gettimeofday";
+    "\0__kernel_gettimeofday"
+    "\0LINUX_2.6.39"
+    "\0linux-vdso.so.1";
 
 /* Symbol name offsets */
 static const uint32_t sym_name_offsets[VDSO_NUM_SYMS] = {1, 23, 45, 68};
@@ -119,6 +159,19 @@ static const uint32_t sym_text_off[VDSO_NUM_SYMS] = {
     TEXT_OFF_SIGRET, TEXT_OFF_GETRES, TEXT_OFF_GETTIME, TEXT_OFF_GETTOD};
 static const uint32_t sym_text_size[VDSO_NUM_SYMS] = {
     12, 12, TEXT_OFF_GETTOD - TEXT_OFF_GETTIME, 12};
+
+/* SysV ELF hash, used by .gnu.version_d::vd_hash. */
+static uint32_t elf_hash(const char *name)
+{
+    uint32_t h = 0, g;
+    for (const unsigned char *p = (const unsigned char *) name; *p; p++) {
+        h = (h << 4) + *p;
+        if ((g = h & 0xf0000000U))
+            h ^= g >> 24;
+        h &= ~g;
+    }
+    return h;
+}
 
 /* Emit a 12-byte SVC trampoline: mov x8, #syscall_nr; svc #0; ret. */
 static void emit_svc_trampoline(uint32_t *code, unsigned syscall_nr)
@@ -160,7 +213,7 @@ uint64_t vdso_build(guest_t *g)
     ehdr->e_phentsize = sizeof(elf64_phdr_t);
     ehdr->e_phnum = 2;
     ehdr->e_shentsize = sizeof(elf64_shdr_t);
-    ehdr->e_shnum = 6;
+    ehdr->e_shnum = 8;
     ehdr->e_shstrndx = 2;
 
     /* Program header 0: PT_LOAD. */
@@ -181,8 +234,8 @@ uint64_t vdso_build(guest_t *g)
     phdr1->p_offset = VDSO_OFF_DYNAMIC;
     phdr1->p_vaddr = VDSO_OFF_DYNAMIC;
     phdr1->p_paddr = VDSO_OFF_DYNAMIC;
-    phdr1->p_filesz = 6 * sizeof(elf64_dyn_t);
-    phdr1->p_memsz = 6 * sizeof(elf64_dyn_t);
+    phdr1->p_filesz = 9 * sizeof(elf64_dyn_t);
+    phdr1->p_memsz = 9 * sizeof(elf64_dyn_t);
     phdr1->p_align = 8;
 
     /* Text trampolines.  Each entry is the same 12-byte mov/svc/ret pattern
@@ -221,6 +274,44 @@ uint64_t vdso_build(guest_t *g)
     }
     hash[2] = first_sym;
 
+    /* .gnu.version: one version index per .dynsym entry. Index 0 is the local
+     * null symbol; the four exported symbols bind to "LINUX_2.6.39".
+     */
+    uint16_t *versym = (uint16_t *) (page + VDSO_OFF_VERSYM);
+    versym[0] = 0;
+    for (int i = 1; i <= VDSO_NUM_SYMS; i++)
+        versym[i] = VER_NDX_LINUX;
+
+    /* .gnu.version_d: a base entry (the soname) followed by "LINUX_2.6.39".
+     * verdef and verdaux do not share a stride, so step by byte offset.
+     */
+    uint8_t *verdef = page + VDSO_OFF_VERDEF;
+    elf64_verdef_t *vd = (elf64_verdef_t *) verdef;
+    vd->vd_version = VER_DEF_CURRENT;
+    vd->vd_flags = VER_FLG_BASE;
+    vd->vd_ndx = 1;
+    vd->vd_cnt = 1;
+    vd->vd_hash = elf_hash("linux-vdso.so.1");
+    vd->vd_aux = sizeof(elf64_verdef_t);
+    vd->vd_next = sizeof(elf64_verdef_t) + sizeof(elf64_verdaux_t);
+    elf64_verdaux_t *vda =
+        (elf64_verdaux_t *) (verdef + sizeof(elf64_verdef_t));
+    vda->vda_name = SONAME_OFF;
+    vda->vda_next = 0;
+
+    verdef += vd->vd_next;
+    vd = (elf64_verdef_t *) verdef;
+    vd->vd_version = VER_DEF_CURRENT;
+    vd->vd_flags = 0;
+    vd->vd_ndx = VER_NDX_LINUX;
+    vd->vd_cnt = 1;
+    vd->vd_hash = elf_hash("LINUX_2.6.39");
+    vd->vd_aux = sizeof(elf64_verdef_t);
+    vd->vd_next = 0;
+    vda = (elf64_verdaux_t *) (verdef + sizeof(elf64_verdef_t));
+    vda->vda_name = VER_NAME_OFF;
+    vda->vda_next = 0;
+
     /* Dynamic table. */
     elf64_dyn_t *dyn = (elf64_dyn_t *) (page + VDSO_OFF_DYNAMIC);
     dyn[0] = (elf64_dyn_t) {DT_HASH, VDSO_OFF_HASH};
@@ -228,7 +319,10 @@ uint64_t vdso_build(guest_t *g)
     dyn[2] = (elf64_dyn_t) {DT_STRTAB, VDSO_OFF_DYNSTR};
     dyn[3] = (elf64_dyn_t) {DT_STRSZ, DYNSTR_SIZE};
     dyn[4] = (elf64_dyn_t) {DT_SYMENT, sizeof(elf64_sym_t)};
-    dyn[5] = (elf64_dyn_t) {DT_NULL, 0};
+    dyn[5] = (elf64_dyn_t) {DT_VERSYM, VDSO_OFF_VERSYM};
+    dyn[6] = (elf64_dyn_t) {DT_VERDEF, VDSO_OFF_VERDEF};
+    dyn[7] = (elf64_dyn_t) {DT_VERDEFNUM, VDSO_NUM_VERDEF};
+    dyn[8] = (elf64_dyn_t) {DT_NULL, 0};
 
     /* Section headers. */
     elf64_shdr_t *shdr = (elf64_shdr_t *) (page + VDSO_OFF_SHDR);
@@ -272,14 +366,35 @@ uint64_t vdso_build(guest_t *g)
     shdr[4].sh_entsize = 4;
 
     shdr[5].sh_name = 0;
-    shdr[5].sh_type = SHT_DYNAMIC;
+    shdr[5].sh_type = SHT_GNU_VERSYM;
     shdr[5].sh_flags = SHF_ALLOC;
-    shdr[5].sh_addr = VDSO_OFF_DYNAMIC;
-    shdr[5].sh_offset = VDSO_OFF_DYNAMIC;
-    shdr[5].sh_size = 6 * sizeof(elf64_dyn_t);
-    shdr[5].sh_link = 2;
-    shdr[5].sh_addralign = 8;
-    shdr[5].sh_entsize = sizeof(elf64_dyn_t);
+    shdr[5].sh_addr = VDSO_OFF_VERSYM;
+    shdr[5].sh_offset = VDSO_OFF_VERSYM;
+    shdr[5].sh_size = (VDSO_NUM_SYMS + 1) * sizeof(uint16_t);
+    shdr[5].sh_link = 3;
+    shdr[5].sh_addralign = 2;
+    shdr[5].sh_entsize = 2;
+
+    shdr[6].sh_name = 0;
+    shdr[6].sh_type = SHT_GNU_VERDEF;
+    shdr[6].sh_flags = SHF_ALLOC;
+    shdr[6].sh_addr = VDSO_OFF_VERDEF;
+    shdr[6].sh_offset = VDSO_OFF_VERDEF;
+    shdr[6].sh_size =
+        VDSO_NUM_VERDEF * (sizeof(elf64_verdef_t) + sizeof(elf64_verdaux_t));
+    shdr[6].sh_link = 2;
+    shdr[6].sh_info = VDSO_NUM_VERDEF;
+    shdr[6].sh_addralign = 8;
+
+    shdr[7].sh_name = 0;
+    shdr[7].sh_type = SHT_DYNAMIC;
+    shdr[7].sh_flags = SHF_ALLOC;
+    shdr[7].sh_addr = VDSO_OFF_DYNAMIC;
+    shdr[7].sh_offset = VDSO_OFF_DYNAMIC;
+    shdr[7].sh_size = 9 * sizeof(elf64_dyn_t);
+    shdr[7].sh_link = 2;
+    shdr[7].sh_addralign = 8;
+    shdr[7].sh_entsize = sizeof(elf64_dyn_t);
 
     return VDSO_BASE;
 }

--- a/tests/test-go.sh
+++ b/tests/test-go.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# test-go.sh - Go static aarch64 binary vDSO symbol-versioning regression
+#
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# A Go runtime built for linux/arm64 parses the kernel vDSO at startup and walks
+# its GNU version-definition table. A vDSO missing .gnu.version_d (DT_VERDEF)
+# made runtime.vdsoFindVersion dereference a NULL pointer and SIGSEGV (data
+# abort at FAR=0x2) before main(). This generates a tiny Go program, builds it
+# for linux/arm64, and runs it under elfuse to guard that path.
+#
+# Exits 77 (skip) when the Go cross-toolchain is unavailable.
+
+set -euo pipefail
+
+ELFUSE_INPUT="${1:-build/elfuse}"
+case "$ELFUSE_INPUT" in
+    /*) ELFUSE="$ELFUSE_INPUT" ;;
+    *) ELFUSE="$(pwd)/$ELFUSE_INPUT" ;;
+esac
+
+if ! command -v go > /dev/null 2>&1; then
+    printf 'go toolchain not found; skipping Go vDSO regression\n' >&2
+    exit 77
+fi
+if [ ! -x "$ELFUSE" ]; then
+    printf 'elfuse binary not found: %s\n' "$ELFUSE" >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Reaching the print proves the runtime cleared vDSO startup; time.Now() also
+# exercises the resolved clock_gettime trampoline. Kept inline rather than as a
+# tracked .go file so the C-only tests/ tree stays a non-Go package.
+cat > "$WORKDIR/hello.go" <<'EOF'
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	if time.Now().UnixNano() <= 0 {
+		panic("vDSO clock returned a non-positive time")
+	}
+	fmt.Println("hello from go vdso")
+}
+EOF
+
+if ! GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$WORKDIR/hello-go" \
+    "$WORKDIR/hello.go" > "$WORKDIR/build.log" 2>&1; then
+    cat "$WORKDIR/build.log" >&2
+    printf 'go build for linux/arm64 failed; skipping Go vDSO regression\n' >&2
+    exit 77
+fi
+
+set +e
+out="$("$ELFUSE" "$WORKDIR/hello-go" 2>&1)"
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -q 'hello from go vdso'; then
+    printf 'PASS test-go (Go runtime cleared vDSO startup)\n'
+    exit 0
+fi
+
+printf 'FAIL test-go: rc=%d\n' "$rc" >&2
+printf '%s\n' "$out" >&2
+exit 1


### PR DESCRIPTION
## Problem

Static Go aarch64 binaries (`GOOS=linux GOARCH=arm64 CGO_ENABLED=0`) SIGSEGV under elfuse during runtime startup, before the first syscall: a data abort at `FAR=0x2`, PC in `runtime.vdsoFindVersion`.

The Go runtime parses the kernel vDSO (`vdsoInitFromSysinfoEhdr`) and treats any image with a hash table, symtab and strtab as valid, then calls `vdsoFindVersion` guarded only by that flag. `vdsoFindVersion` dereferences `info.verdef` unconditionally. The synthetic vDSO advertised `DT_HASH`/`DT_SYMTAB`/`DT_STRTAB` but no `DT_VERDEF`, so `verdef` was NULL and Go read `vd_flags` at struct offset 2 -> address `0x2`. Real Linux vDSOs always ship `.gnu.version_d` (`LINUX_2.6.39`); glibc and musl tolerate the omission, which is why only Go was affected.

## Fix

Emit `.gnu.version` (`DT_VERSYM`) and `.gnu.version_d` (`DT_VERDEF`): a base version node plus `LINUX_2.6.39`, with each exported symbol bound to it. The page layout shifts to make room (dynsym and hash move; versym and verdef are inserted before the dynamic table). This matches the real arm64 vDSO and keeps the vDSO fast path live for glibc/musl, which look up the same version.

## Test

`tests/test-go.sh` (wired into `make check`) builds a tiny linux/arm64 Go binary and runs it under elfuse, asserting it reaches `main` and that `time.Now()` (the resolved vDSO `clock_gettime`) returns a sane value. It skips (exit 77) when the Go toolchain is unavailable, mirroring the other optional checks.

## Verification

- Before: the Go binary exits 139 (SIGSEGV, `FAR=0x2`). After: it prints and exits 0; `make test-go` passes, and skips cleanly with no `go` on `PATH`.
- Ran `tests/driver.sh` against a prebuilt guest-binary corpus before and after the change: identical pass/fail set, no regression. (The local toolchain could not cross-build the in-tree guest tests, so the full `make check` plus `test-go` will exercise on the CI Apple Silicon runner.)
- `clang-format-22`, `cppcheck` (`.ci/check-cppcheck.sh`), `shellcheck`, `gofmt`: clean.

Closes #49


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GNU symbol versioning to the synthetic vDSO to fix startup SIGSEGVs in static linux/arm64 Go binaries. The vDSO now matches Linux (with LINUX_2.6.39) and keeps the glibc/musl fast path.

- **Bug Fixes**
  - Emit `.gnu.version` (`DT_VERSYM`) and `.gnu.version_d` (`DT_VERDEF`) with a base node and `LINUX_2.6.39`; bind all exported symbols; add `DT_VERDEFNUM`.
  - Adjust vDSO layout and section counts to include the new tables; behavior matches the real arm64 vDSO for glibc/musl.
  - Add regression test `tests/test-go.sh` wired to `make check` (target `test-go`): builds a tiny static linux/arm64 Go binary, runs it under elfuse, and skips when the Go toolchain is absent.

<sup>Written for commit 729d7d805380dbca3f1604d78a28290a6ea70fc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/50?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

