### PR TITLE
Treat chown EPERM as no-op success for emulated-root guests

### DIFF
--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -1693,6 +1693,14 @@ int64_t sys_fchmodat(guest_t *g,
     return 0;
 }
 
+/* Fake success on EPERM: emulated-root guests expect chown to succeed. */
+static int64_t chown_result(int rc)
+{
+    if (rc < 0)
+        return (errno == EPERM) ? 0 : linux_errno();
+    return 0;
+}
+
 int64_t sys_fchownat(guest_t *g,
                      int dirfd,
                      uint64_t path_gva,
@@ -1719,13 +1727,10 @@ int64_t sys_fchownat(guest_t *g,
         return -LINUX_EBADF;
 
     int mac_flags = translate_at_flags(flags);
-    if (fchownat(dir_ref.fd, tx.host_path, owner, group, mac_flags) < 0) {
-        host_fd_ref_close(&dir_ref);
-        return linux_errno();
-    }
-
+    int64_t out = chown_result(
+        fchownat(dir_ref.fd, tx.host_path, owner, group, mac_flags));
     host_fd_ref_close(&dir_ref);
-    return 0;
+    return out;
 }
 
 int64_t sys_fchown(int fd, uint32_t owner, uint32_t group)
@@ -1737,12 +1742,9 @@ int64_t sys_fchown(int fd, uint32_t owner, uint32_t group)
     host_fd_ref_t host_ref;
     if (host_fd_ref_open(fd, &host_ref) < 0)
         return -LINUX_EBADF;
-    if (fchown(host_ref.fd, owner, group) < 0) {
-        host_fd_ref_close(&host_ref);
-        return linux_errno();
-    }
+    int64_t out = chown_result(fchown(host_ref.fd, owner, group));
     host_fd_ref_close(&host_ref);
-    return 0;
+    return out;
 }
 
 int64_t sys_utimensat(guest_t *g,


### PR DESCRIPTION
Fixes #54.

Maps host `EPERM` from `chown`/`fchown`/`fchownat` to a no-op success: an emulated-root guest expects ownership changes to succeed, but macOS only permits chown-to-arbitrary-uid for the superuser. All other errors propagate. Full rationale in the commit message.

Validation on Apple Silicon: `make elfuse` and `make check` pass; the invalid-`*at`-flags negative path still returns EINVAL (rejected before the chown call).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat host EPERM from chown/fchown/fchownat as a no-op success for emulated-root guests on macOS to prevent false failures when changing ownership. All other errors propagate normally; invalid *at flags still return EINVAL.

<sup>Written for commit 8a1eec42a345ed64d6da8e7b4c7a94ba3cf9d4cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/57?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

