### PR TITLE
Emit named IN_CREATE/IN_DELETE for inotify directory watches

### DIFF
--- a/src/syscall/inotify.c
+++ b/src/syscall/inotify.c
@@ -28,6 +28,8 @@
 #include <errno.h>
 #include <limits.h>
 #include <pthread.h>
+#include <dirent.h>
+#include <stdlib.h>
 #include <sys/event.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
@@ -82,6 +84,11 @@ typedef struct {
     bool is_dir;   /* true if watching a directory */
     dev_t dev;     /* Device ID (for re-add lookup by inode) */
     ino_t ino;     /* Inode number (for re-add lookup by inode) */
+    /* Dir watches only: path + entry-name snapshot, diffed on change to
+     * recover the child name kqueue omits. NULL/0 for file watches. */
+    char *path;
+    char **entries;
+    int n_entries;
 } inotify_watch_t;
 
 typedef struct {
@@ -295,12 +302,136 @@ static void pipe_drain(inotify_instance_t *inst)
         ;
 }
 
+/* Snapshot the entry names of a directory (excluding "." and ".."). On return
+ * *out is a malloc'd array of malloc'd strings with *n_out entries (free with
+ * free_dir_snapshot). On any failure the snapshot is left empty.
+ */
+static void dir_snapshot(const char *path, char ***out, int *n_out)
+{
+    *out = NULL;
+    *n_out = 0;
+
+    DIR *d = opendir(path);
+    if (!d)
+        return;
+
+    char **names = NULL;
+    int n = 0, cap = 0;
+    struct dirent *de;
+    while ((de = readdir(d)) != NULL) {
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
+            continue;
+        if (n == cap) {
+            int ncap = cap ? cap * 2 : 16;
+            char **tmp = realloc(names, (size_t) ncap * sizeof(char *));
+            if (!tmp)
+                break;
+            names = tmp;
+            cap = ncap;
+        }
+        names[n] = strdup(de->d_name);
+        if (!names[n])
+            break;
+        n++;
+    }
+    closedir(d);
+
+    *out = names;
+    *n_out = n;
+}
+
+static void free_dir_snapshot(char **entries, int n)
+{
+    if (!entries)
+        return;
+    for (int i = 0; i < n; i++)
+        free(entries[i]);
+    free(entries);
+}
+
+static bool snapshot_contains(char *const *entries, int n, const char *name)
+{
+    for (int i = 0; i < n; i++)
+        if (!strcmp(entries[i], name))
+            return true;
+    return false;
+}
+
 /* Collect events from kqueue. */
 
-/* Poll the kqueue for pending vnode events and translate them into inotify
- * events in the instance buffer.
- *
- * Returns the number of events collected.
+/* Translate one EVFILT_VNODE notification into queued inotify events for the
+ * watch on host_fd. Returns the number queued, or -1 on buffer overflow (an
+ * IN_Q_OVERFLOW marker is queued). Caller holds inotify_lock.
+ */
+static int process_vnode_event(inotify_instance_t *inst,
+                               int host_fd,
+                               uint32_t fflags)
+{
+    int widx = watch_find_by_hostfd(inst, host_fd);
+    if (widx < 0)
+        return 0;
+
+    inotify_watch_t *w = &inst->watches[widx];
+    int queued = 0;
+    bool overflow = false;
+
+    if (w->is_dir && (fflags & NOTE_WRITE) && w->path) {
+        char **now = NULL;
+        int now_n = 0;
+        dir_snapshot(w->path, &now, &now_n);
+
+        for (int j = 0; j < now_n && !overflow; j++) {
+            if ((w->mask & IN_CREATE) &&
+                !snapshot_contains(w->entries, w->n_entries, now[j])) {
+                if (queue_event(inst, w->wd, IN_CREATE, 0, now[j]) < 0)
+                    overflow = true;
+                else
+                    queued++;
+            }
+        }
+        for (int j = 0; j < w->n_entries && !overflow; j++) {
+            if ((w->mask & IN_DELETE) &&
+                !snapshot_contains(now, now_n, w->entries[j])) {
+                if (queue_event(inst, w->wd, IN_DELETE, 0, w->entries[j]) < 0)
+                    overflow = true;
+                else
+                    queued++;
+            }
+        }
+
+        /* Advance the snapshot regardless: the directory state has moved on,
+         * and any names dropped under overflow are covered by IN_Q_OVERFLOW.
+         */
+        free_dir_snapshot(w->entries, w->n_entries);
+        w->entries = now;
+        w->n_entries = now_n;
+    }
+
+    if (!overflow) {
+        uint32_t in_mask = notes_to_in_mask(fflags, w->mask, w->is_dir);
+        /* The per-child create/delete is emitted by the diff above; only emit
+         * the bare-mask event for file watches or non-create/delete changes.
+         */
+        if (in_mask != 0 &&
+            !(w->is_dir && (in_mask & (IN_CREATE | IN_DELETE)))) {
+            if (queue_event(inst, w->wd, in_mask, 0, NULL) < 0)
+                overflow = true;
+            else
+                queued++;
+        }
+    }
+
+    if (overflow) {
+        /* IN_Q_OVERFLOW (0x4000) uses wd=-1 per Linux semantics. */
+        queue_event(inst, -1, 0x4000, 0, NULL);
+        return -1;
+    }
+    return queued;
+}
+
+/* Poll the kqueue for pending vnode events and translate them into
+ * inotify events in the instance buffer. Returns the number of
+ * events collected.
  */
 static int collect_events(inotify_instance_t *inst)
 {
@@ -312,35 +443,19 @@ static int collect_events(inotify_instance_t *inst)
         return 0;
 
     int collected = 0;
+    bool overflow = false;
     for (int i = 0; i < nev; i++) {
-        int host_fd = (int) kevs[i].ident;
-        int widx = watch_find_by_hostfd(inst, host_fd);
-        if (widx < 0)
-            continue;
-
-        inotify_watch_t *w = &inst->watches[widx];
-        uint32_t in_mask =
-            notes_to_in_mask((uint32_t) kevs[i].fflags, w->mask, w->is_dir);
-        if (in_mask == 0)
-            continue;
-
-        /* Queue event without a filename for file watches. For directory
-         * watches, inotify emulation also omits the filename since kqueue
-         * EVFILT_VNODE does not report which child changed.
-         */
-        if (queue_event(inst, w->wd, in_mask, 0, NULL) == 0) {
-            collected++;
-        } else {
-            /* Fixed inotify queue is full; queue IN_Q_OVERFLOW and stop.
-             * IN_Q_OVERFLOW (0x4000) uses wd=-1 per Linux semantics.
-             */
-            queue_event(inst, -1, 0x4000, 0, NULL);
+        int r = process_vnode_event(inst, (int) kevs[i].ident,
+                                    (uint32_t) kevs[i].fflags);
+        if (r < 0) {
+            overflow = true;
             break;
         }
+        collected += r;
     }
 
     /* Signal the self-pipe so poll/epoll sees readability */
-    if (collected > 0)
+    if (collected > 0 || overflow)
         pipe_signal(inst);
 
     return collected;
@@ -438,12 +553,27 @@ int64_t sys_inotify_add_watch(guest_t *g,
     /* Strip IN_MASK_ADD control flag before storing */
     uint32_t event_mask = mask & ~(uint32_t) IN_MASK_ADD;
 
+    /* For directory watches, snapshot the path + current entries up-front
+     * (outside the lock) so collect_events can diff on each change to emit
+     * named IN_CREATE/IN_DELETE. Ownership moves to the watch slot on success;
+     * every early-exit path below frees these.
+     */
+    char *wpath = NULL;
+    char **wentries = NULL;
+    int wn = 0;
+    if (is_dir) {
+        wpath = strdup(path);
+        dir_snapshot(path, &wentries, &wn);
+    }
+
     pthread_mutex_lock(&inotify_lock);
 
     int slot = inotify_find(inotify_fd);
     if (slot < 0) {
         pthread_mutex_unlock(&inotify_lock);
         close(host_fd);
+        free_dir_snapshot(wentries, wn);
+        free(wpath);
         return -LINUX_EBADF;
     }
 
@@ -467,8 +597,12 @@ int64_t sys_inotify_add_watch(guest_t *g,
         uint32_t snapshot_mask = w->mask; /* Snapshot before unlock */
         pthread_mutex_unlock(&inotify_lock);
 
-        /* Close the duplicate fd; inotify emulation keeps the original */
+        /* Close the duplicate fd; inotify emulation keeps the original.
+         * The existing watch keeps its snapshot; drop this call's copy.
+         */
         close(host_fd);
+        free_dir_snapshot(wentries, wn);
+        free(wpath);
 
         /* Update kevent filter with the new mask (use snapshot -- w->mask may
          * be modified by another thread after unlock)
@@ -487,6 +621,8 @@ int64_t sys_inotify_add_watch(guest_t *g,
     if (widx < 0) {
         pthread_mutex_unlock(&inotify_lock);
         close(host_fd);
+        free_dir_snapshot(wentries, wn);
+        free(wpath);
         return -LINUX_ENOSPC;
     }
 
@@ -502,6 +638,9 @@ int64_t sys_inotify_add_watch(guest_t *g,
     w->is_dir = is_dir;
     w->dev = st.st_dev;
     w->ino = st.st_ino;
+    w->path = wpath;
+    w->entries = wentries;
+    w->n_entries = wn;
 
     /* Capture kq_fd while under lock */
     int kq_fd = inst->kq_fd;
@@ -522,6 +661,11 @@ int64_t sys_inotify_add_watch(guest_t *g,
         pthread_mutex_lock(&inotify_lock);
         w->wd = 0;
         w->host_fd = 0;
+        free_dir_snapshot(w->entries, w->n_entries);
+        w->entries = NULL;
+        w->n_entries = 0;
+        free(w->path);
+        w->path = NULL;
         pthread_mutex_unlock(&inotify_lock);
         close(host_fd);
         errno = saved;
@@ -556,6 +700,11 @@ int64_t sys_inotify_rm_watch(int inotify_fd, int wd)
     w->host_fd = 0;
     w->mask = 0;
     w->is_dir = 0;
+    free_dir_snapshot(w->entries, w->n_entries);
+    w->entries = NULL;
+    w->n_entries = 0;
+    free(w->path);
+    w->path = NULL;
     pthread_mutex_unlock(&inotify_lock);
 
     /* Remove from kqueue and close outside lock */
@@ -619,18 +768,12 @@ int64_t inotify_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
             }
             inst = &inotify_state[slot];
 
-            /* Process the received event */
+            /* Process the received event (same named-directory diff as the
+             * non-blocking collect path).
+             */
             int host_fd = (int) kev.ident;
-            int widx = watch_find_by_hostfd(inst, host_fd);
-            if (widx >= 0) {
-                inotify_watch_t *w = &inst->watches[widx];
-                uint32_t in_mask =
-                    notes_to_in_mask((uint32_t) kev.fflags, w->mask, w->is_dir);
-                if (in_mask != 0) {
-                    queue_event(inst, w->wd, in_mask, 0, NULL);
-                    pipe_signal(inst);
-                }
-            }
+            if (process_vnode_event(inst, host_fd, (uint32_t) kev.fflags) != 0)
+                pipe_signal(inst);
         }
     }
 
@@ -711,6 +854,11 @@ static void inotify_close(int guest_fd)
             watch_fds[nfds++] = inst->watches[i].host_fd;
             inst->watches[i].wd = 0;
         }
+        free_dir_snapshot(inst->watches[i].entries, inst->watches[i].n_entries);
+        inst->watches[i].entries = NULL;
+        inst->watches[i].n_entries = 0;
+        free(inst->watches[i].path);
+        inst->watches[i].path = NULL;
     }
 
     inst->guest_fd = -1;

--- a/src/syscall/inotify.c
+++ b/src/syscall/inotify.c
@@ -302,44 +302,6 @@ static void pipe_drain(inotify_instance_t *inst)
         ;
 }
 
-/* Snapshot the entry names of a directory (excluding "." and ".."). On return
- * *out is a malloc'd array of malloc'd strings with *n_out entries (free with
- * free_dir_snapshot). On any failure the snapshot is left empty.
- */
-static void dir_snapshot(const char *path, char ***out, int *n_out)
-{
-    *out = NULL;
-    *n_out = 0;
-
-    DIR *d = opendir(path);
-    if (!d)
-        return;
-
-    char **names = NULL;
-    int n = 0, cap = 0;
-    struct dirent *de;
-    while ((de = readdir(d)) != NULL) {
-        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
-            continue;
-        if (n == cap) {
-            int ncap = cap ? cap * 2 : 16;
-            char **tmp = realloc(names, (size_t) ncap * sizeof(char *));
-            if (!tmp)
-                break;
-            names = tmp;
-            cap = ncap;
-        }
-        names[n] = strdup(de->d_name);
-        if (!names[n])
-            break;
-        n++;
-    }
-    closedir(d);
-
-    *out = names;
-    *n_out = n;
-}
-
 static void free_dir_snapshot(char **entries, int n)
 {
     if (!entries)
@@ -347,6 +309,67 @@ static void free_dir_snapshot(char **entries, int n)
     for (int i = 0; i < n; i++)
         free(entries[i]);
     free(entries);
+}
+
+/* List a directory's child names, excluding "." and "..", into the out array
+ * (free with free_dir_snapshot). Returns false on any failure, leaving the
+ * result empty -- which the caller must treat as distinct from a true return
+ * with zero entries, since a failure mistaken for "empty" would diff every
+ * known child as deleted.
+ */
+static bool dir_snapshot(const char *path, char ***out, int *n_out)
+{
+    *out = NULL;
+    *n_out = 0;
+
+    DIR *d = opendir(path);
+    if (!d)
+        return false;
+
+    char **names = NULL;
+    int n = 0, cap = 0;
+    bool ok = true;
+    for (;;) {
+        /* readdir returns NULL both at end-of-stream and on error; reset
+         * errno immediately before each call so a non-zero errno afterwards
+         * unambiguously signals a read error rather than EOF.
+         */
+        errno = 0;
+        struct dirent *de = readdir(d);
+        if (!de) {
+            if (errno != 0)
+                ok = false;
+            break;
+        }
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
+            continue;
+        if (n == cap) {
+            int ncap = cap ? cap * 2 : 16;
+            char **tmp = realloc(names, (size_t) ncap * sizeof(char *));
+            if (!tmp) {
+                ok = false;
+                break;
+            }
+            names = tmp;
+            cap = ncap;
+        }
+        names[n] = strdup(de->d_name);
+        if (!names[n]) {
+            ok = false;
+            break;
+        }
+        n++;
+    }
+    closedir(d);
+
+    if (!ok) {
+        free_dir_snapshot(names, n);
+        return false;
+    }
+
+    *out = names;
+    *n_out = n;
+    return true;
 }
 
 static bool snapshot_contains(char *const *entries, int n, const char *name)
@@ -378,33 +401,38 @@ static int process_vnode_event(inotify_instance_t *inst,
     if (w->is_dir && (fflags & NOTE_WRITE) && w->path) {
         char **now = NULL;
         int now_n = 0;
-        dir_snapshot(w->path, &now, &now_n);
-
-        for (int j = 0; j < now_n && !overflow; j++) {
-            if ((w->mask & IN_CREATE) &&
-                !snapshot_contains(w->entries, w->n_entries, now[j])) {
-                if (queue_event(inst, w->wd, IN_CREATE, 0, now[j]) < 0)
-                    overflow = true;
-                else
-                    queued++;
-            }
-        }
-        for (int j = 0; j < w->n_entries && !overflow; j++) {
-            if ((w->mask & IN_DELETE) &&
-                !snapshot_contains(now, now_n, w->entries[j])) {
-                if (queue_event(inst, w->wd, IN_DELETE, 0, w->entries[j]) < 0)
-                    overflow = true;
-                else
-                    queued++;
-            }
-        }
-
-        /* Advance the snapshot regardless: the directory state has moved on,
-         * and any names dropped under overflow are covered by IN_Q_OVERFLOW.
+        /* Only diff against -- and advance to -- a snapshot that succeeded.
+         * On failure keep the previous baseline; the next successful snapshot
+         * reconciles whatever changed in between.
          */
-        free_dir_snapshot(w->entries, w->n_entries);
-        w->entries = now;
-        w->n_entries = now_n;
+        if (dir_snapshot(w->path, &now, &now_n)) {
+            for (int j = 0; j < now_n && !overflow; j++) {
+                if ((w->mask & IN_CREATE) &&
+                    !snapshot_contains(w->entries, w->n_entries, now[j])) {
+                    if (queue_event(inst, w->wd, IN_CREATE, 0, now[j]) < 0)
+                        overflow = true;
+                    else
+                        queued++;
+                }
+            }
+            for (int j = 0; j < w->n_entries && !overflow; j++) {
+                if ((w->mask & IN_DELETE) &&
+                    !snapshot_contains(now, now_n, w->entries[j])) {
+                    if (queue_event(inst, w->wd, IN_DELETE, 0, w->entries[j]) <
+                        0)
+                        overflow = true;
+                    else
+                        queued++;
+                }
+            }
+
+            /* Advance the snapshot: the directory state has moved on, and any
+             * names dropped under overflow are covered by IN_Q_OVERFLOW.
+             */
+            free_dir_snapshot(w->entries, w->n_entries);
+            w->entries = now;
+            w->n_entries = now_n;
+        }
     }
 
     if (!overflow) {
@@ -563,7 +591,10 @@ int64_t sys_inotify_add_watch(guest_t *g,
     int wn = 0;
     if (is_dir) {
         wpath = strdup(path);
-        dir_snapshot(path, &wentries, &wn);
+        /* Best-effort: a failed listing starts the watch with an empty
+         * baseline, which is the only state worth recording at add time.
+         */
+        (void) dir_snapshot(path, &wentries, &wn);
     }
 
     pthread_mutex_lock(&inotify_lock);

--- a/src/syscall/inotify.c
+++ b/src/syscall/inotify.c
@@ -384,9 +384,17 @@ static bool snapshot_contains(char *const *entries, int n, const char *name)
 
 /* Translate one EVFILT_VNODE notification into queued inotify events for the
  * watch on host_fd. Returns the number queued, or -1 on buffer overflow (an
- * IN_Q_OVERFLOW marker is queued). Caller holds inotify_lock.
+ * IN_Q_OVERFLOW marker is queued).
+ *
+ * Caller holds inotify_lock; it is held again on return. For a directory write
+ * the lock is released around the opendir/readdir snapshot so filesystem I/O
+ * does not stall inotify operations on other instances. guest_fd identifies
+ * this instance: because the table can change while unlocked, the instance and
+ * the watch are re-validated (by host_fd and dev/ino) before the snapshot is
+ * applied, and a teardown or host_fd reuse during the window discards it.
  */
 static int process_vnode_event(inotify_instance_t *inst,
+                               int guest_fd,
                                int host_fd,
                                uint32_t fflags)
 {
@@ -398,41 +406,77 @@ static int process_vnode_event(inotify_instance_t *inst,
     int queued = 0;
     bool overflow = false;
 
+    char **now = NULL;
+    int now_n = 0;
+    bool snap_ok = false;
+
     if (w->is_dir && (fflags & NOTE_WRITE) && w->path) {
-        char **now = NULL;
-        int now_n = 0;
+        /* Copy the path + identity, then release the lock for the opendir/
+         * readdir snapshot so filesystem I/O does not block other instances.
+         */
+        char *path = strdup(w->path);
+        if (path) {
+            dev_t dev = w->dev;
+            ino_t ino = w->ino;
+            int slot = (int) (inst - inotify_state);
+
+            pthread_mutex_unlock(&inotify_lock);
+            snap_ok = dir_snapshot(path, &now, &now_n);
+            free(path);
+            pthread_mutex_lock(&inotify_lock);
+
+            /* Re-validate across the unlocked window: the instance may have
+             * been closed, or the watch removed and its host_fd reused for a
+             * different file. Any of these discards the stale snapshot.
+             */
+            widx = watch_find_by_hostfd(inst, host_fd);
+            if (inotify_state[slot].guest_fd != guest_fd || widx < 0) {
+                free_dir_snapshot(now, now_n);
+                return 0;
+            }
+            w = &inst->watches[widx];
+            if (!w->is_dir || w->dev != dev || w->ino != ino) {
+                free_dir_snapshot(now, now_n);
+                return 0;
+            }
+        }
+    }
+
+    if (snap_ok) {
         /* Only diff against -- and advance to -- a snapshot that succeeded.
          * On failure keep the previous baseline; the next successful snapshot
          * reconciles whatever changed in between.
          */
-        if (dir_snapshot(w->path, &now, &now_n)) {
-            for (int j = 0; j < now_n && !overflow; j++) {
-                if ((w->mask & IN_CREATE) &&
-                    !snapshot_contains(w->entries, w->n_entries, now[j])) {
-                    if (queue_event(inst, w->wd, IN_CREATE, 0, now[j]) < 0)
-                        overflow = true;
-                    else
-                        queued++;
-                }
+        for (int j = 0; j < now_n && !overflow; j++) {
+            if ((w->mask & IN_CREATE) &&
+                !snapshot_contains(w->entries, w->n_entries, now[j])) {
+                if (queue_event(inst, w->wd, IN_CREATE, 0, now[j]) < 0)
+                    overflow = true;
+                else
+                    queued++;
             }
-            for (int j = 0; j < w->n_entries && !overflow; j++) {
-                if ((w->mask & IN_DELETE) &&
-                    !snapshot_contains(now, now_n, w->entries[j])) {
-                    if (queue_event(inst, w->wd, IN_DELETE, 0, w->entries[j]) <
-                        0)
-                        overflow = true;
-                    else
-                        queued++;
-                }
-            }
-
-            /* Advance the snapshot: the directory state has moved on, and any
-             * names dropped under overflow are covered by IN_Q_OVERFLOW.
-             */
-            free_dir_snapshot(w->entries, w->n_entries);
-            w->entries = now;
-            w->n_entries = now_n;
         }
+        for (int j = 0; j < w->n_entries && !overflow; j++) {
+            if ((w->mask & IN_DELETE) &&
+                !snapshot_contains(now, now_n, w->entries[j])) {
+                if (queue_event(inst, w->wd, IN_DELETE, 0, w->entries[j]) < 0)
+                    overflow = true;
+                else
+                    queued++;
+            }
+        }
+
+        /* Advance the snapshot: the directory state has moved on, and any
+         * names dropped under overflow are covered by IN_Q_OVERFLOW.
+         */
+        free_dir_snapshot(w->entries, w->n_entries);
+        w->entries = now;
+        w->n_entries = now_n;
+    } else {
+        /* File watch or failed snapshot: nothing to apply. free_dir_snapshot
+         * tolerates the NULL result dir_snapshot leaves on failure.
+         */
+        free_dir_snapshot(now, now_n);
     }
 
     if (!overflow) {
@@ -470,20 +514,28 @@ static int collect_events(inotify_instance_t *inst)
     if (nev <= 0)
         return 0;
 
+    /* process_vnode_event may release inotify_lock around directory I/O;
+     * capture the instance identity to detect teardown across that window.
+     */
+    int slot = (int) (inst - inotify_state);
+    int guest_fd = inst->guest_fd;
+
     int collected = 0;
     bool overflow = false;
     for (int i = 0; i < nev; i++) {
-        int r = process_vnode_event(inst, (int) kevs[i].ident,
+        int r = process_vnode_event(inst, guest_fd, (int) kevs[i].ident,
                                     (uint32_t) kevs[i].fflags);
         if (r < 0) {
             overflow = true;
             break;
         }
         collected += r;
+        if (inotify_state[slot].guest_fd != guest_fd)
+            return collected; /* instance closed during snapshot I/O */
     }
 
     /* Signal the self-pipe so poll/epoll sees readability */
-    if (collected > 0 || overflow)
+    if ((collected > 0 || overflow) && inotify_state[slot].guest_fd == guest_fd)
         pipe_signal(inst);
 
     return collected;
@@ -762,6 +814,14 @@ int64_t inotify_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
     if (inst->event_used == 0) {
         int n = collect_events(inst);
 
+        /* collect_events may release the lock for directory I/O; bail if the
+         * instance was closed in that window.
+         */
+        if (inotify_state[slot].guest_fd != guest_fd) {
+            pthread_mutex_unlock(&inotify_lock);
+            return -LINUX_EBADF;
+        }
+
         if (n == 0) {
             if (inst->nonblock) {
                 pthread_mutex_unlock(&inotify_lock);
@@ -803,7 +863,16 @@ int64_t inotify_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
              * non-blocking collect path).
              */
             int host_fd = (int) kev.ident;
-            if (process_vnode_event(inst, host_fd, (uint32_t) kev.fflags) != 0)
+            int r = process_vnode_event(inst, guest_fd, host_fd,
+                                        (uint32_t) kev.fflags);
+            /* process_vnode_event may release the lock for the snapshot; bail
+             * if the instance was closed in that window.
+             */
+            if (inotify_state[slot].guest_fd != guest_fd) {
+                pthread_mutex_unlock(&inotify_lock);
+                return -LINUX_EBADF;
+            }
+            if (r != 0)
                 pipe_signal(inst);
         }
     }

--- a/tests/test-inotify.c
+++ b/tests/test-inotify.c
@@ -15,7 +15,10 @@
 
 #include <fcntl.h>
 #include <poll.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/inotify.h>
 #include <unistd.h>
@@ -188,6 +191,72 @@ static void test_dir_create(void)
     close(fd);
 }
 
+/* Test 6: a directory watch must deliver a NAMED IN_CREATE for the new child,
+ * not just a nameless event.
+ */
+static void test_dir_create_named(void)
+{
+    TEST("watch dir delivers named IN_CREATE");
+
+    char dir[] = "/tmp/elfuse-inotify-dir-XXXXXX";
+    if (!mkdtemp(dir)) {
+        FAIL("mkdtemp");
+        return;
+    }
+
+    int fd = inotify_init1(IN_NONBLOCK);
+    if (fd < 0) {
+        FAIL("inotify_init1");
+        rmdir(dir);
+        return;
+    }
+
+    int wd = inotify_add_watch(fd, dir, IN_CREATE);
+    if (wd < 0) {
+        FAIL("inotify_add_watch");
+        close(fd);
+        rmdir(dir);
+        return;
+    }
+
+    const char *child = "manifest.yaml";
+    char path[300];
+    snprintf(path, sizeof(path), "%s/%s", dir, child);
+    int tfd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0644);
+    if (tfd < 0) {
+        FAIL("create child in watched dir");
+        inotify_rm_watch(fd, wd);
+        close(fd);
+        rmdir(dir);
+        return;
+    }
+    close(tfd);
+
+    /* read() drives the diff; retry until the vnode notification is queued. */
+    bool found = false;
+    for (int attempt = 0; attempt < 50 && !found; attempt++) {
+        char buf[1024];
+        ssize_t n = read(fd, buf, sizeof(buf));
+        for (ssize_t off = 0;
+             off + (ssize_t) sizeof(struct inotify_event) <= n;) {
+            struct inotify_event *ev = (struct inotify_event *) (buf + off);
+            if ((ev->mask & IN_CREATE) && ev->len > 0 &&
+                strcmp(ev->name, child) == 0)
+                found = true;
+            off += (ssize_t) sizeof(struct inotify_event) + ev->len;
+        }
+        if (!found)
+            usleep(20000); /* 20ms */
+    }
+
+    EXPECT_TRUE(found, "named IN_CREATE for new child not delivered");
+
+    unlink(path);
+    inotify_rm_watch(fd, wd);
+    close(fd);
+    rmdir(dir);
+}
+
 /* Main */
 
 int main(void)
@@ -199,6 +268,7 @@ int main(void)
     test_modify_event();
     test_nonblock();
     test_dir_create();
+    test_dir_create_named();
 
     SUMMARY("test-inotify");
     return fails > 0 ? 1 : 0;


### PR DESCRIPTION
Fixes #55.

Synthesizes named `IN_CREATE`/`IN_DELETE` for directory watches by snapshotting the directory's entry names and diffing on each `NOTE_WRITE` (kqueue `EVFILT_VNODE` reports only that the directory changed, not which child). Full rationale in the commit message.

Adds a regression test (`test-inotify` Test 6) that watches a fresh directory, creates a child, and asserts a named `IN_CREATE` is delivered.

Validation on Apple Silicon: `make elfuse` and `make check` pass; the new test fails before this change (event arrives with an empty name) and passes after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit named IN_CREATE/IN_DELETE for directory watches by diffing per‑watch snapshots, and keep the previous baseline on snapshot failure. Snapshots now run without holding `inotify_lock` to avoid blocking other watches. Fixes nameless directory events so fsnotify tools can match child names (fixes #55).

- **Bug Fixes**
  - Maintain a per-watch directory snapshot; on NOTE_WRITE, diff to emit named IN_CREATE/IN_DELETE; suppress redundant bare directory events.
  - Advance the baseline only on a successful snapshot; keep the old baseline on failure; the initial add-watch snapshot is best-effort.
  - Take snapshots with the lock released and re-validate the instance/watch on return (return EBADF if torn down); use one event translator for blocking and non-blocking paths; on overflow, queue IN_Q_OVERFLOW; add a regression test asserting a named IN_CREATE is delivered.

<sup>Written for commit 9c28c569f01b5b0ed94c96f7db9fa92132166f86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

