### PR TITLE
Translate fcntl flock l_type between Linux and macOS

### DIFF
--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -655,11 +655,33 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         memcpy(&l_start, lflock + 8, 8); /* offset 8 due to padding */
         memcpy(&l_len, lflock + 16, 8);
 
+        /* l_type constants differ between Linux and macOS/BSD:
+         *   Linux: F_RDLCK=0, F_WRLCK=1, F_UNLCK=2
+         *   macOS: F_RDLCK=1, F_UNLCK=2, F_WRLCK=3
+         * Passing the Linux value straight through makes a Linux F_RDLCK (0)
+         * an invalid type on macOS, which fcntl() rejects with EINVAL. This is
+         * the lock POSIX databases (e.g. SQLite) take first, so it must map. */
+        short mac_type;
+        switch (l_type) {
+        case 0: /* LINUX_F_RDLCK */
+            mac_type = F_RDLCK;
+            break;
+        case 1: /* LINUX_F_WRLCK */
+            mac_type = F_WRLCK;
+            break;
+        case 2: /* LINUX_F_UNLCK */
+            mac_type = F_UNLCK;
+            break;
+        default:
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EINVAL;
+        }
+
         struct flock mac_fl = {
             .l_start = l_start,
             .l_len = l_len,
             .l_pid = 0,
-            .l_type = l_type, /* F_RDLCK=0, F_WRLCK=1, F_UNLCK=2 same on both */
+            .l_type = mac_type,
             .l_whence = l_whence, /* SEEK_SET=0, SEEK_CUR=1, SEEK_END=2 same */
         };
 
@@ -671,7 +693,20 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
 
         /* For F_GETLK, write back the result */
         if (cmd == 5) {
-            int16_t rt = mac_fl.l_type, rw = mac_fl.l_whence;
+            /* Map macOS l_type back to Linux constants (see above). */
+            int16_t rt;
+            switch (mac_fl.l_type) {
+            case F_RDLCK:
+                rt = 0; /* LINUX_F_RDLCK */
+                break;
+            case F_WRLCK:
+                rt = 1; /* LINUX_F_WRLCK */
+                break;
+            default:
+                rt = 2; /* LINUX_F_UNLCK */
+                break;
+            }
+            int16_t rw = mac_fl.l_whence;
             int64_t rs = mac_fl.l_start, rl = mac_fl.l_len;
             int32_t rp = mac_fl.l_pid;
             memset(lflock, 0, sizeof(lflock));

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -42,6 +42,7 @@ test-socket
 
 [section] Syscall coverage tests
 test-file-ops
+test-flock
 test-sysinfo
 test-io-opt
 test-syscall-smoke

--- a/tests/test-flock.c
+++ b/tests/test-flock.c
@@ -1,0 +1,99 @@
+/* Test POSIX advisory record locking via fcntl(F_SETLK/F_GETLK/F_SETLKW)
+ *
+ * Copyright 2026 elfuse contributors
+ * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression coverage for the Linux<->macOS struct flock translation. The
+ * l_type constants differ between the two ABIs (Linux F_RDLCK=0/F_WRLCK=1,
+ * macOS F_RDLCK=1/F_WRLCK=3), so passing the guest value straight through to
+ * the host made the very first lock SQLite takes (a shared F_RDLCK) fail with
+ * EINVAL and surface as "disk I/O error". The byte offsets below mirror the
+ * ones SQLite locks around its 1GiB "pending byte".
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+#define PENDING_BYTE 0x40000000L
+#define RESERVED_BYTE (PENDING_BYTE + 1)
+#define SHARED_FIRST (PENDING_BYTE + 2)
+#define SHARED_SIZE 510
+
+static int set_lock(int fd, short type, off_t start, off_t len)
+{
+    struct flock fl = {
+        .l_type = type,
+        .l_whence = SEEK_SET,
+        .l_start = start,
+        .l_len = len,
+    };
+    return fcntl(fd, F_SETLK, &fl);
+}
+
+int main(void)
+{
+    int passes = 0, fails = 0;
+    const char *path = "/tmp/elfuse-test-flock.db";
+
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+
+    /* Shared read lock -- this is the call that regressed to EINVAL. */
+    TEST("F_SETLK F_RDLCK (shared)");
+    EXPECT_EQ(set_lock(fd, F_RDLCK, SHARED_FIRST, SHARED_SIZE), 0,
+              "shared read lock rejected");
+
+    /* Promote the pending byte to a write lock, then drop it. */
+    TEST("F_SETLK F_WRLCK (pending)");
+    EXPECT_EQ(set_lock(fd, F_WRLCK, PENDING_BYTE, 1), 0,
+              "pending write lock rejected");
+
+    TEST("F_SETLK F_WRLCK (reserved)");
+    EXPECT_EQ(set_lock(fd, F_WRLCK, RESERVED_BYTE, 1), 0,
+              "reserved write lock rejected");
+
+    TEST("F_SETLK F_UNLCK (release shared)");
+    EXPECT_EQ(set_lock(fd, F_UNLCK, SHARED_FIRST, SHARED_SIZE), 0,
+              "unlock rejected");
+
+    /* Blocking variant must take the same translation path. */
+    TEST("F_SETLKW F_WRLCK");
+    struct flock wfl = {
+        .l_type = F_WRLCK,
+        .l_whence = SEEK_SET,
+        .l_start = 0,
+        .l_len = 16,
+    };
+    EXPECT_EQ(fcntl(fd, F_SETLKW, &wfl), 0, "F_SETLKW rejected");
+
+    /* F_GETLK on a region this process already write-locks must report back a
+     * Linux l_type. Linux reports F_UNLCK for locks held by the *same* owner,
+     * so the only thing we can assert portably is that the type round-trips to
+     * a valid Linux constant and the call succeeds. */
+    TEST("F_GETLK round-trips l_type");
+    struct flock gfl = {
+        .l_type = F_WRLCK,
+        .l_whence = SEEK_SET,
+        .l_start = 0,
+        .l_len = 16,
+    };
+    int gr = fcntl(fd, F_GETLK, &gfl);
+    EXPECT_TRUE(gr == 0 && (gfl.l_type == F_UNLCK || gfl.l_type == F_RDLCK ||
+                            gfl.l_type == F_WRLCK),
+                "F_GETLK returned an invalid l_type");
+
+    close(fd);
+    unlink(path);
+
+    SUMMARY("test-flock");
+    return fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

The `F_GETLK`/`F_SETLK`/`F_SETLKW` handler in `src/syscall/fs.c` copied the
guest's `l_type` field straight into the host `struct flock`, on the
assumption (stated in a comment) that the lock-type constants match. They do
not:

| constant | Linux aarch64 | macOS / BSD |
|----------|:---:|:---:|
| `F_RDLCK` | 0 | 1 |
| `F_WRLCK` | 1 | 3 |
| `F_UNLCK` | 2 | 2 |

A Linux `F_RDLCK` (0) is not a valid lock type on macOS, so the host
`fcntl()` rejects it with `EINVAL`. POSIX-locking databases take a shared
read lock first, so this breaks them. Concretely, **SQLite fails to open any
on-disk database** with `disk I/O error (10)`: its initial `F_RDLCK` on the
1 GiB "pending byte" never succeeds. In-memory databases are unaffected,
which is what made this easy to miss.

Trace from a failing `sqlite3 file.db "CREATE TABLE ..."` under `--verbose`:

```
syscall 25@... (0x3, 0x6, 0x7ffc490, ...)   # fcntl(fd=3, F_SETLK=6, &flock)
  -> -22 (EINVAL)
```

## Fix

Map `l_type` Linux→macOS on input for all three commands, and map it back
macOS→Linux when writing the `F_GETLK` result. Unknown types are rejected
with `EINVAL` rather than passed through.

## Test

Adds `tests/test-flock.c` (registered in `manifest.txt` under "Syscall
coverage tests"), which exercises `F_SETLK`/`F_SETLKW`/`F_GETLK` around the
same 1 GiB pending-byte offsets SQLite uses. It **fails with `errno 22`
before this change and passes after** — verified by reverting the fix.

## Validation

- `make check`: all 97 tests pass (including the new `test-flock`).
- Local CI replication: `check-newline`, `check-format` (clang-format 22),
  `check-security`, `cppcheck`, syscall-dispatch consistency, and
  `make lint` all clean; `make elfuse` builds and codesigns.
- End-to-end with a statically cross-compiled aarch64 SQLite 3.47.2: on-disk
  CRUD, transactions, JSON1 function indexes, FTS5, WAL + `wal_checkpoint`,
  a 50k-row transaction, and `.dump`/`.read` round-trips all succeed; the
  resulting file is readable by the host `sqlite3`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `fcntl` lock-type translation between Linux guests and macOS hosts to prevent EINVAL on valid read locks. Restores on-disk SQLite and other POSIX-locking apps by correctly mapping `l_type` for `F_GETLK`, `F_SETLK`, and `F_SETLKW`.

- **Bug Fixes**
  - Map `l_type` Linux→macOS on input and macOS→Linux on `F_GETLK` output; reject unknown types with `EINVAL`.
  - Add `tests/test-flock.c` (registered in `tests/manifest.txt`) to cover SQLite’s pending-byte lock pattern; failed before, passes now.

<sup>Written for commit 63e7a9331263a0ebdb422bea784164c29ff5511f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

