### PR TITLE
Accept FIOASYNC ioctl and F_SETOWN/F_GETOWN fcntl

### DIFF
--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -358,6 +358,7 @@ typedef struct {
 #define LINUX_FIONBIO 0x5421    /* set/clear O_NONBLOCK (arg: int *) */
 #define LINUX_FIONCLEX 0x5450   /* clear close-on-exec on fd */
 #define LINUX_FIOCLEX 0x5451    /* set close-on-exec on fd */
+#define LINUX_FIOASYNC 0x5452   /* set/clear O_ASYNC (arg: int *) */
 #define LINUX_TIOCNOTTY 0x5422  /* -> macOS TIOCNOTTY (same semantics) */
 #define LINUX_TIOCGSID 0x5429   /* -> macOS TIOCGSID (same semantics) */
 /* termios2 variant (adds c_ispeed/c_ospeed) */

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -1116,6 +1116,40 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         host_fd_ref_close(&host_ref);
         return 0;
     }
+    case 8: /* F_SETOWN */
+        /* SIGIO/SIGURG delivery owner. nginx's ngx_spawn_process pairs
+         * ioctl(FIOASYNC) with fcntl(F_SETOWN) on the channel socket before
+         * fork() and aborts the worker (NGX_INVALID_PID) if either fails.
+         * elfuse does not deliver host SIGIO into the guest (see LINUX_FIOASYNC
+         * in sys_ioctl), so no owner is tracked: accept the request as a no-op.
+         * F_SETOWN's arg is the owner pid passed by value, so there is no user
+         * pointer to validate. */
+        return 0;
+    case 15: { /* F_SETOWN_EX */
+        /* Same no-op owner semantics as F_SETOWN, but the arg is a
+         * struct f_owner_ex { int type; int pid; } pointer that Linux reads
+         * before applying. Read it through so a bad guest pointer faults with
+         * EFAULT rather than silently succeeding; the value is then discarded.
+         */
+        int32_t owner_ex[2];
+        if (guest_read_small(g, arg, owner_ex, sizeof(owner_ex)) < 0)
+            return -LINUX_EFAULT;
+        return 0;
+    }
+    case 9: /* F_GETOWN */
+        /* No owner tracked; report none. */
+        return 0;
+    case 16: { /* F_GETOWN_EX */
+        /* glibc implements fcntl(F_GETOWN) on top of F_GETOWN_EX, so this must
+         * answer coherently with the F_SETOWN no-op above rather than EINVAL
+         * (which would make F_GETOWN fail under glibc). Report "owned by no
+         * specific process": struct f_owner_ex { int type; int pid; } with
+         * type=F_OWNER_PID(1), pid=0. */
+        int32_t owner_ex[2] = {1 /* F_OWNER_PID */, 0 /* pid */};
+        if (guest_write_small(g, arg, owner_ex, sizeof(owner_ex)) < 0)
+            return -LINUX_EFAULT;
+        return 0;
+    }
     case 1024: /* F_GETPIPE_SZ */
         /* macOS does not support pipe size queries; return default 64KiB */
         return 65536;

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -1768,6 +1768,26 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         host_fd_ref_close(&host_ref);
         return 0;
     }
+
+    case LINUX_FIOASYNC: {
+        /* Set/clear O_ASYNC (SIGIO-driven I/O). nginx's ngx_spawn_process arms
+         * this on the master's channel socket right before fork() and treats a
+         * failure as fatal (ngx_close_channel + return NGX_INVALID_PID), so
+         * answering ENOTTY here aborts worker spawning entirely -- the master
+         * is left with no workers and accepted connections are never serviced.
+         * elfuse does not forward host SIGIO into the guest, and nginx workers
+         * receive both client I/O and channel commands via epoll rather than
+         * SIGIO, so accept the request as a no-op: read the int arg for EFAULT
+         * parity and report success without arming host async delivery. */
+        int32_t on = 0;
+        if (guest_read_small(g, arg, &on, sizeof(on)) < 0) {
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EFAULT;
+        }
+        host_fd_ref_close(&host_ref);
+        return 0;
+    }
+
     case LINUX_TIOCSPTLCK: {
         /* Lock/unlock the slave side of a pty. glibc unlockpt() always passes 0
          * (unlock); util-linux's setlock(1) passes 1 to lock. macOS exposes

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -69,6 +69,7 @@ test-timerfd
 test-large-io-boundary
 test-ioctl-cloexec
 test-pty
+test-ioctl-fioasync
 
 [section] /proc and /dev emulation tests
 test-proc

--- a/tests/test-ioctl-fioasync.c
+++ b/tests/test-ioctl-fioasync.c
@@ -1,0 +1,120 @@
+/* FIOASYNC ioctl + F_SETOWN/F_GETOWN fcntl regression test
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * nginx's ngx_spawn_process arms the master->worker channel socket with
+ * ioctl(FIOASYNC) immediately followed by fcntl(F_SETOWN), right before fork(),
+ * and treats a failure of EITHER as fatal: it logs an alert, ngx_close_channel,
+ * and returns NGX_INVALID_PID -- so it never forks the worker. elfuse used to
+ * answer FIOASYNC with ENOTTY and F_SETOWN with EINVAL, which silently left the
+ * master with zero workers: the listen socket still accepted connections at the
+ * host kernel, but nothing in the guest ever accept()ed them, so every request
+ * hung. This test pins the fix by replaying that pre-fork channel arming.
+ *
+ * elfuse does not forward host SIGIO into the guest, and nginx workers receive
+ * client I/O and channel commands via epoll rather than SIGIO, so both calls
+ * are accepted as no-ops that report success (F_GETOWN reports "no owner", 0).
+ *
+ * Syscalls exercised: socketpair(199), socket(198), ioctl(29) FIOASYNC,
+ * fcntl(25) F_SETOWN/F_GETOWN, getpid(172), close(57)
+ */
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+#ifndef FIOASYNC
+#define FIOASYNC 0x5452
+#endif
+#ifndef F_SETOWN_EX
+#define F_SETOWN_EX 15
+#endif
+#ifndef F_OWNER_PID
+#define F_OWNER_PID 1
+#endif
+
+/* struct f_owner_ex is _GNU_SOURCE-gated; declare a layout-compatible struct
+ * locally so the test does not depend on glibc feature macros. */
+struct elfuse_f_owner_ex {
+    int type;
+    int pid;
+};
+
+int passes = 0, fails = 0;
+
+/* Replay nginx's ngx_spawn_process async/owner arming on a single fd. */
+static void check_async_owner(int fd, const char *what)
+{
+    char label[80];
+    int on = 1;
+
+    snprintf(label, sizeof(label), "%s: ioctl(FIOASYNC) enable -> 0", what);
+    TEST(label);
+    EXPECT_EQ(ioctl(fd, FIOASYNC, &on), 0, "FIOASYNC enable rejected");
+
+    snprintf(label, sizeof(label), "%s: fcntl(F_SETOWN) -> 0", what);
+    TEST(label);
+    EXPECT_EQ(fcntl(fd, F_SETOWN, getpid()), 0, "F_SETOWN rejected");
+
+    /* F_SETOWN_EX takes a struct f_owner_ex* and is the variant glibc uses
+     * when targeting a thread/pgrp; a valid pointer is accepted as a no-op. */
+    struct elfuse_f_owner_ex owner = {F_OWNER_PID, getpid()};
+    snprintf(label, sizeof(label), "%s: fcntl(F_SETOWN_EX) valid -> 0", what);
+    TEST(label);
+    EXPECT_EQ(fcntl(fd, F_SETOWN_EX, &owner), 0, "F_SETOWN_EX rejected");
+
+    /* F_GETOWN reports the owner; elfuse tracks none, so 0 (no error). glibc
+     * may probe F_GETOWN_EX first and fall back to plain F_GETOWN on EINVAL --
+     * either way the visible result must not be a failure. */
+    snprintf(label, sizeof(label), "%s: fcntl(F_GETOWN) -> not an error", what);
+    TEST(label);
+    EXPECT_TRUE(fcntl(fd, F_GETOWN) >= 0, "F_GETOWN returned an error");
+
+    on = 0;
+    snprintf(label, sizeof(label), "%s: ioctl(FIOASYNC) disable -> 0", what);
+    TEST(label);
+    EXPECT_EQ(ioctl(fd, FIOASYNC, &on), 0, "FIOASYNC disable rejected");
+}
+
+int main(void)
+{
+    printf("test-ioctl-fioasync: FIOASYNC ioctl + F_SETOWN/F_GETOWN fcntl\n");
+
+    /* nginx's channel is an AF_UNIX SOCK_STREAM socketpair; FIOASYNC/F_SETOWN
+     * are applied to channel[0] (nginx also marks it non-blocking via FIONBIO
+     * first, which this test omits to stay focused on the calls added here). */
+    int sp[2];
+    TEST("socketpair(AF_UNIX, SOCK_STREAM)");
+    EXPECT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sp), 0, "socketpair failed");
+
+    check_async_owner(sp[0], "unix socketpair");
+
+    close(sp[0]);
+    close(sp[1]);
+
+    /* A plain TCP socket too -- the same family as nginx's listen sockets. */
+    int s = socket(AF_INET, SOCK_STREAM, 0);
+    TEST("socket(AF_INET, SOCK_STREAM)");
+    EXPECT_TRUE(s >= 0, "socket failed");
+    if (s >= 0) {
+        check_async_owner(s, "tcp socket");
+
+        /* F_SETOWN_EX reads the struct before applying, so a bad guest pointer
+         * must fault with EFAULT rather than silently succeeding (the no-op
+         * owner path used to skip the read entirely). Page 0 is never mapped.
+         */
+        TEST("fcntl(F_SETOWN_EX) bad pointer -> EFAULT");
+        EXPECT_ERRNO(fcntl(s, F_SETOWN_EX, (struct elfuse_f_owner_ex *) 16),
+                     EFAULT,
+                     "F_SETOWN_EX with bad pointer did not fail with EFAULT");
+
+        close(s);
+    }
+
+    SUMMARY("test-ioctl-fioasync");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Problem

Running nginx (aarch64 Linux, e.g. `nginx:alpine`) under elfuse in its **default master/worker mode** never serves requests: the listen socket binds, the host kernel completes TCP handshakes, but every request hangs and times out. With `master_process off;` (single process, no fork) nginx serves correctly, which masks the real issue.

## Root cause

nginx's `ngx_spawn_process` arms the master→worker channel socket **right before `fork()`** with:

```c
ioctl(channel[0], FIOASYNC, &on);     /* enable SIGIO-driven I/O   */
fcntl(channel[0], F_SETOWN, ngx_pid); /* who receives that SIGIO   */
```

and treats failure of **either** as fatal — it logs an alert, `ngx_close_channel()`, and `return NGX_INVALID_PID` *without ever calling `fork()`*. elfuse answered `FIOASYNC` with `ENOTTY` and `F_SETOWN` with `EINVAL`, so the master silently ended up with **zero workers**. A verbose trace shows no `clone(220)`, no `accept4(242)`, no `epoll_pwait(22)` after the FIOASYNC failure — the master just spins in `rt_sigsuspend`, and the accepted connections are never serviced.

## Fix

elfuse does not forward host `SIGIO` into the guest, and nginx workers receive both client I/O and channel commands via `epoll` rather than `SIGIO`, so both calls are safe to accept as no-ops:

- **`sys_ioctl`**: `FIOASYNC` reads the `int` arg (for `EFAULT` parity) and returns success without arming host `O_ASYNC`.
- **`sys_fcntl`**: `F_SETOWN` / `F_SETOWN_EX` accept and track no owner; `F_GETOWN` / `F_GETOWN_EX` report "no owner". glibc implements `fcntl(F_GETOWN)` on top of `F_GETOWN_EX`, so the EX form writes a `struct f_owner_ex{type=F_OWNER_PID, pid=0}` to stay coherent.

With this, `nginx -g "daemon off;"` forks its worker and serves HTTP on the stock config: GET/HEAD/404, keep-alive, and 100-way concurrency all return 200 with byte-identical bodies.

## Testing

- New `tests/test-ioctl-fioasync.c` (registered in `tests/manifest.txt`) replays nginx's pre-fork channel arming on a socketpair and a TCP socket, asserting `FIOASYNC`, `F_SETOWN`, and `F_GETOWN` all succeed.
- `make check`: the full guest driver suite passes (the only failure observed was the pre-existing, unrelated flaky `test-fork` — "unexpected exit reason 0x3" — which is racy on `main` and untouched by this change, which only adds switch cases in `sys_ioctl`/`sys_fcntl`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `FIOASYNC` ioctl and `F_SETOWN`/`F_GETOWN` (and EX variants) fcntl as safe no-ops so nginx master/worker mode forks workers and serves requests under elfuse. Fixes the hang where requests timed out because no workers were spawned.

- **Bug Fixes**
  - `sys_ioctl`: handle `LINUX_FIOASYNC` as a no-op; read `int` arg and return `EFAULT` on bad pointer; add constant in `abi.h`.
  - `sys_fcntl`: accept `F_SETOWN`/`F_SETOWN_EX`; `F_GETOWN` returns 0; `F_GETOWN_EX` writes `{type=F_OWNER_PID, pid=0}`; read/write user memory for correct `EFAULT`.
  - Tests: add `tests/test-ioctl-fioasync.c` and manifest entry; cover socketpair and TCP sockets; verify `F_SETOWN_EX` with a bad pointer returns `EFAULT`.

<sup>Written for commit a04311855c1d686679bd5f50b257403be8cdf472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

