### PR TITLE
Join worker vCPU threads before tearing down guest memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,12 @@ $(BUILD_DIR)/test-fault-signal-mt: tests/test-fault-signal-mt.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
 
+# test-exit-group-worker has a non-main pthread issue exit_group while
+# spinner threads hammer memory, guarding the join-before-teardown order.
+$(BUILD_DIR)/test-exit-group-worker: tests/test-exit-group-worker.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
+
 # test-shim-cred-race spawns a pthread reader while the main thread
 # toggles setresuid; the reader spins on the identity fast path.
 $(BUILD_DIR)/test-shim-cred-race: tests/test-shim-cred-race.c | $(BUILD_DIR)

--- a/src/core/guest.c
+++ b/src/core/guest.c
@@ -641,12 +641,14 @@ void guest_destroy(guest_t *g)
      * leave hv_vcpu_run. A worker still inside the guest at unmap time takes a
      * stage-2 translation fault on its next instruction fetch and surfaces as
      * "unexpected exception EC=0x20" in the crash report. The foot terminal
-     * reproduction tripped exactly that race. The exit_group syscall handler
-     * already runs request, interrupt, and join before its own teardown; the
-     * destroy path needs the same prefix because forkipc.c:vcpu_run_loop
+     * reproduction tripped exactly that race. On the exit_group path the
+     * syscall handler runs request and interrupt, and main() joins the workers
+     * after its run loop returns; the destroy path needs the full
+     * request-interrupt-join sequence here because forkipc.c:vcpu_run_loop
      * returns straight into guest_destroy without going through the guest
-     * exit_group handler. The request is guarded on the prior state so a
-     * process that already chose its exit code keeps it intact.
+     * exit_group handler or main()'s teardown. The request is guarded on the
+     * prior state so a process that already chose its exit code keeps it
+     * intact.
      *
      * The wake signals cover workers blocked outside hv_vcpu_run: futex waiters
      * poll futex_interrupt_requested, and any thread parked in epoll or poll

--- a/src/main.c
+++ b/src/main.c
@@ -35,10 +35,13 @@
 #include "core/sysroot.h"
 
 #include "runtime/forkipc.h"
+#include "runtime/futex.h" /* futex_interrupt_request */
 #include "runtime/proctitle.h"
+#include "runtime/thread.h"
 
 #include "syscall/fuse.h"
 #include "syscall/path.h"
+#include "syscall/poll.h" /* wakeup_pipe_signal */
 #include "syscall/proc.h"
 
 #include "debug/gdbstub.h"
@@ -673,8 +676,37 @@ int main(int argc, char **argv)
      */
     int exit_code = vcpu_run_loop(vcpu, vexit, &g, verbose, timeout_sec);
 
-    /* Tear down debugger state before freeing guest/vCPU resources. */
+    /* Tear down debugger state before joining workers: a worker parked in
+     * gdb_stub_handle_stop() stays active (not deactivated) until this
+     * broadcasts resume_cond, so joining first would just time out and
+     * detach it while it is still paused. */
     gdb_stub_shutdown();
+
+    /* Wait for worker vCPU threads to stop before tearing down guest memory.
+     * The main thread leaves the run loop as soon as it observes the
+     * exit_group flag, but sibling vCPU threads may still be mid-iteration in
+     * their own run loops (e.g. touching shim_globals). cleanup_main_resources
+     * unmaps the guest slab via guest_destroy, so a still-running worker would
+     * fault on freed guest memory and crash the host with SIGSEGV, masking the
+     * real exit code. thread_join_workers() is a no-op once the workers have
+     * already wound down (the common single-threaded case).
+     *
+     * vcpu_run_loop can also return here without anyone having requested
+     * exit_group or kicked the siblings out of hv_vcpu_run: the alarm timeout
+     * (exit_code 124), a fatal default-disposition signal, or ELR_EL1==0 all
+     * bail out with a bare break. On those paths siblings are still spinning
+     * in the guest, so mirror guest_destroy's request-interrupt prefix before
+     * joining -- otherwise this call burns its full poll cap, detaches every
+     * worker, and guest_destroy's own request-interrupt-join (which honors
+     * join_abandoned) skips them, leaving live pthreads to fault on the
+     * imminent unmap.
+     */
+    if (!proc_exit_group_requested())
+        proc_request_exit_group(0);
+    futex_interrupt_request();
+    wakeup_pipe_signal();
+    thread_interrupt_all();
+    thread_join_workers();
 
     /* Diagnostic counter dump runs before guest_destroy so the shim_data
      * mapping is still valid. ELFUSE_SHIM_STATS is the gate; an unset variable

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -692,10 +692,11 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_EFAULT;
     }
 
-    /* Create the host pthread (joinable; teardown joins live workers via
-     * thread_join_workers, and a worker that exits on its own is joined when
-     * its table slot is reused by thread_alloc). Threads clean up their TID
-     * address via CLONE_CHILD_CLEARTID + futex wake.
+    /* Create the host pthread (joinable; the main thread joins all live
+     * workers via thread_join_workers before guest teardown, and a worker
+     * that exits on its own is joined when its table slot is reused by
+     * thread_alloc). Threads clean up their TID address via
+     * CLONE_CHILD_CLEARTID + futex wake.
      */
     pthread_t host_thread;
     pthread_attr_t attr;

--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -370,6 +370,27 @@ static uint64_t futex_remaining_ns(const struct timespec *deadline,
     return rem < cap_ns ? rem : cap_ns;
 }
 
+/* Absolute CLOCK_REALTIME wait target one bounded quantum from now: the guest
+ * deadline capped at FUTEX_OS_SYNC_POLL_CAP_NS. Every condvar sleep in the
+ * timed-wait paths goes through this so a waiter parked on a distant guest
+ * deadline still re-checks the process-wide teardown flags
+ * (proc_exit_group_requested / futex_interrupt) each quantum; an uncapped
+ * sleep would outlive thread_join_workers' poll cap and race
+ * guest_destroy's unmap of the memory the waiter touches on wake.
+ * Returns false when the guest deadline has already passed.
+ */
+static bool futex_quantum_deadline(const struct timespec *deadline,
+                                   struct timespec *out)
+{
+    uint64_t rem_ns = futex_remaining_ns(deadline, FUTEX_OS_SYNC_POLL_CAP_NS);
+    if (rem_ns == 0)
+        return false;
+    clock_gettime(CLOCK_REALTIME, out);
+    out->tv_nsec += (long) rem_ns;
+    timespec_normalize(out);
+    return true;
+}
+
 #if ELFUSE_HAVE_OS_SYNC_WAIT_ON_ADDRESS
 
 /* Wake up to budget kernel-side waiters at uaddr via
@@ -629,10 +650,45 @@ static int64_t futex_wait(guest_t *g,
 
     while (!__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE)) {
         if (has_timeout) {
-            int rc = pthread_cond_timedwait(&waiter.cond, &b->lock, &deadline);
-            if (rc != 0) {
-                /* Timeout (ETIMEDOUT) or error; stop waiting */
+            /* Sleep in bounded quanta rather than to the guest deadline: a
+             * worker parked here for a long guest timeout (JVM parkNanos,
+             * sem_timedwait) would otherwise be unreachable by exit_group /
+             * futex_interrupt, outlive thread_join_workers' poll cap, and
+             * race guest_destroy's unmap. The interrupt checks mirror the
+             * no-timeout branch below.
+             */
+            struct timespec quantum = {0};
+            if (!futex_quantum_deadline(&deadline, &quantum)) {
                 ret = -LINUX_ETIMEDOUT;
+                break;
+            }
+            pthread_cond_timedwait(&waiter.cond, &b->lock, &quantum);
+            if (proc_exit_group_requested() || futex_interrupt_consume()) {
+                ret = -LINUX_EINTR;
+                break;
+            }
+
+            if (__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE))
+                break;
+
+            /* Mirror the no-timeout branch's itimer/queued-signal re-check
+             * below: without it, a thread parked in a timed FUTEX_WAIT_BITSET
+             * (glibc sem_timedwait, pthread_cond_timedwait, JVM parkNanos)
+             * only observes an expired guest itimer or a deliverable queued
+             * signal once the futex wakes or the full guest deadline elapses.
+             * Lock order requires dropping the bucket lock before touching
+             * sig_lock (4).
+             */
+            pthread_mutex_unlock(&b->lock);
+            signal_check_timer();
+            bool sig_ready = signal_pending() != 0;
+            pthread_mutex_lock(&b->lock);
+
+            if (__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE))
+                break;
+
+            if (sig_ready) {
+                ret = -LINUX_EINTR;
                 break;
             }
             continue;
@@ -1184,10 +1240,43 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
         bool owner_died = false;
         while (!__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE)) {
             if (has_timeout) {
-                int rc =
-                    pthread_cond_timedwait(&waiter.cond, &b->lock, &deadline);
-                if (rc != 0 &&
-                    !__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE)) {
+                /* Bounded quanta for the same teardown-reachability reason as
+                 * futex_wait: never sleep to a distant guest deadline.
+                 */
+                struct timespec quantum = {0};
+                bool expired = !futex_quantum_deadline(&deadline, &quantum);
+                if (!expired) {
+                    pthread_cond_timedwait(&waiter.cond, &b->lock, &quantum);
+                    if (!__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE) &&
+                        proc_exit_group_requested()) {
+                        /* Mirror the no-timeout exit_group path below. */
+                        bucket_unlink_locked(b, &waiter);
+                        pthread_mutex_unlock(&b->lock);
+                        pthread_cond_destroy(&waiter.cond);
+                        return -LINUX_EINTR;
+                    }
+
+                    /* Mirror futex_wait's untimed branch: without this, a
+                     * thread parked here with a timeout only observes an
+                     * expired guest itimer or a deliverable queued signal
+                     * once the lock is acquired or the full guest deadline
+                     * elapses. Lock order requires dropping the bucket lock
+                     * before signal_check_timer/signal_pending touch
+                     * sig_lock (4).
+                     */
+                    pthread_mutex_unlock(&b->lock);
+                    signal_check_timer();
+                    bool sig_ready = signal_pending() != 0;
+                    pthread_mutex_lock(&b->lock);
+
+                    if (!__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE) &&
+                        sig_ready) {
+                        bucket_unlink_locked(b, &waiter);
+                        pthread_mutex_unlock(&b->lock);
+                        pthread_cond_destroy(&waiter.cond);
+                        return -LINUX_EINTR;
+                    }
+                } else if (!__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE)) {
                     /* Timeout: dequeue and return */
                     bucket_unlink_locked(b, &waiter);
                     /* Only clear WAITERS bit if no waiters for this address */
@@ -1226,6 +1315,26 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
 
                 if (proc_exit_group_requested()) {
                     /* Dequeue and return */
+                    bucket_unlink_locked(b, &waiter);
+                    pthread_mutex_unlock(&b->lock);
+                    pthread_cond_destroy(&waiter.cond);
+                    return -LINUX_EINTR;
+                }
+
+                /* Mirror futex_wait's untimed branch: without this, a thread
+                 * parked in FUTEX_LOCK_PI with no timeout never observes an
+                 * expired guest itimer or a deliverable queued signal until
+                 * the lock is acquired or the owner dies. Lock order requires
+                 * dropping the bucket lock before signal_check_timer/
+                 * signal_pending touch sig_lock (4).
+                 */
+                pthread_mutex_unlock(&b->lock);
+                signal_check_timer();
+                bool sig_ready = signal_pending() != 0;
+                pthread_mutex_lock(&b->lock);
+
+                if (!__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE) &&
+                    sig_ready) {
                     bucket_unlink_locked(b, &waiter);
                     pthread_mutex_unlock(&b->lock);
                     pthread_cond_destroy(&waiter.cond);
@@ -1679,9 +1788,11 @@ int64_t sys_futex_waitv(guest_t *g,
         pthread_mutex_unlock(&bucket_ptrs[i]->lock);
 
     /* All enqueued. Block on shared.cond until any wake site signals it. The
-     * bounded sleep (capped at 500ms or the user deadline, whichever is sooner)
-     * gives proc_exit_group_requested() and timeout checks a chance to run if
-     * the cond_signal never arrives.
+     * bounded sleep (capped at 100 ms or the user deadline, whichever is
+     * sooner) gives proc_exit_group_requested() and timeout checks a chance to
+     * run if the cond_signal never arrives. The cap matches the other futex
+     * wait paths so every futex-parked worker re-checks teardown flags well
+     * inside thread_join_workers' poll cap.
      */
     int result_idx = -1;
     pthread_mutex_lock(&shared.lock);
@@ -1701,7 +1812,7 @@ int64_t sys_futex_waitv(guest_t *g,
         }
 
         struct timespec wait_ts;
-        timespec_deadline_in_ms(&wait_ts, 500);
+        timespec_deadline_in_ms(&wait_ts, 100);
         if (has_timeout) {
             if (deadline.tv_sec < wait_ts.tv_sec ||
                 (deadline.tv_sec == wait_ts.tv_sec &&

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -309,6 +309,12 @@ void thread_deactivate(thread_entry_t *t)
     /* Free SP_EL1 slot so it can be reused by future threads */
     thread_free_sp_el1_locked(t);
 
+    /* Release store: everything this thread did -- including its last guest
+     * memory access -- must happen-before thread_join_workers' acquire load
+     * observing 0, or the joiner could green-light guest_destroy's unmap
+     * while stores are still in flight. The joiner polls lock-free, so the
+     * mutex held here provides no edge to it.
+     */
     __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
     atomic_fetch_sub(&active_thread_count, 1);
 
@@ -451,19 +457,22 @@ void thread_join_workers(void)
      * entries -- vm-clone children (created detached) and the main thread's
      * slot when a worker drives teardown -- are still polled below so teardown
      * waits for them to leave the guest, but their handle is never joined or
-     * detached.
+     * detached. Entries a previous pass already detached (join_abandoned) are
+     * skipped outright: joining or detaching the same pthread twice is
+     * undefined, and main()'s join is followed by guest_destroy's internal one.
      */
     struct {
         pthread_t thr;
         thread_entry_t *t;
         uint64_t generation;
         bool claimed;
+        bool recycled;
     } workers[MAX_THREADS];
     int nworkers = 0;
 
     pthread_mutex_lock(&thread_lock);
     THREAD_FOR_EACH (t) {
-        if (t == current_thread)
+        if (t == current_thread || t->join_abandoned)
             continue;
         /* Inactive slots are included when they still hold an unjoined handle:
          * a worker that exited on its own shortly before teardown and whose
@@ -477,51 +486,70 @@ void thread_join_workers(void)
         workers[nworkers].t = t;
         workers[nworkers].generation = t->generation;
         workers[nworkers].claimed = t->host_thread_needs_join;
+        workers[nworkers].recycled = false;
         t->host_thread_needs_join = false;
         nworkers++;
     }
     pthread_mutex_unlock(&thread_lock);
 
-    /* Poll/join each worker OUTSIDE the lock. Workers that responded to
-     * hv_vcpus_exit typically finish within microseconds. Threads stuck in
-     * uninterruptible host calls (blocking read/poll) are given 100ms to
-     * finish. If still alive, detach and let process exit clean up. The vCPU is
-     * NOT destroyed here because HVF vCPUs are thread-affine, so cross-thread
-     * hv_vcpu_destroy while the owning thread may still be inside hv_vcpu_run
-     * is unsafe.
+    /* Poll under one shared 500ms deadline OUTSIDE the lock, then join or
+     * detach each worker. Workers that responded to hv_vcpus_exit typically
+     * finish within microseconds; the cap only matters for workers parked in
+     * host blocking calls, and it must exceed the worst-case teardown-flag
+     * re-check latency of every such state or a worker that WOULD wind down
+     * cleanly gets abandoned on timing alone: the interruptible io wait
+     * re-checks every 200ms (io.c wait helper) and the futex paths every 100ms
+     * (FUTEX_OS_SYNC_POLL_CAP_NS quanta), so 500ms covers the slowest bound
+     * with margin. One shared deadline keeps worst-case shutdown at the cap
+     * even with many stuck workers, rather than multiplying a per-worker cap
+     * by nworkers. A worker still alive past the cap is detached and, if this
+     * pass claimed its handle, marked join_abandoned so a later pass does not
+     * touch it again. The vCPU is NOT destroyed here because HVF vCPUs are
+     * thread-affine, so cross-thread hv_vcpu_destroy while the owning thread
+     * may still be inside hv_vcpu_run is unsafe.
      */
-    for (int w = 0; w < nworkers; w++) {
-        bool recycled = false;
-
-        for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 100; i++) {
+        bool any_active = false;
+        for (int w = 0; w < nworkers; w++) {
+            if (workers[w].recycled)
+                continue;
             if (!__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
-                break;
+                continue;
             /* The slot may have been reused for a new logical thread while we
              * polled: thread_alloc only recycles a slot once its previous
              * occupant is inactive, so a generation bump here proves our
              * snapshotted worker already deactivated even though the slot now
-             * reads active == 1 again for the replacement thread. Stop polling
-             * immediately rather than tracking the wrong thread's active bit
-             * for the rest of the loop.
+             * reads active == 1 again for the replacement thread. Stop
+             * tracking this worker's active bit for the rest of the loop
+             * rather than following the wrong thread.
              */
             if (workers[w].t->generation != workers[w].generation) {
-                recycled = true;
-                break;
+                workers[w].recycled = true;
+                continue;
             }
-            usleep(5000);
+            any_active = true;
         }
+        if (!any_active)
+            break;
+        usleep(5000);
+    }
 
+    for (int w = 0; w < nworkers; w++) {
         if (!workers[w].claimed)
             continue;
         /* recycled short-circuits before the active re-check: once recycled,
          * that bit belongs to the replacement thread and must not influence the
          * join-vs-detach decision for our (already-terminated) handle.
          */
-        if (recycled ||
-            !__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
+        if (workers[w].recycled ||
+            !__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE)) {
             pthread_join(workers[w].thr, NULL);
-        else
+        } else {
             pthread_detach(workers[w].thr);
+            pthread_mutex_lock(&thread_lock);
+            workers[w].t->join_abandoned = true;
+            pthread_mutex_unlock(&thread_lock);
+        }
     }
 }
 

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -72,6 +72,12 @@ typedef struct thread_entry {
                           * acquire/release ordering against thread_alloc's
                           * release-store.
                           */
+    bool join_abandoned; /* thread_join_workers timed out on this worker and
+                          * pthread_detach()ed it. Later join passes
+                          * (guest_destroy runs one after main()'s) must skip
+                          * the entry: pthread_join/pthread_detach on an
+                          * already-detached thread is undefined.
+                          */
     /* Per-thread signal mask (POSIX requires each thread to have its own).
      * Initialized to the parent's mask on clone, modified via rt_sigprocmask.
      */
@@ -295,10 +301,13 @@ void thread_for_each(void (*fn)(thread_entry_t *t, void *ctx), void *ctx);
  */
 int thread_count_active_vm_clones(void);
 
-/* Join worker threads (all active threads except the caller). Collects thread
- * handles under the lock, then polls/joins OUTSIDE the lock so workers can call
- * thread_deactivate() to set active=0. Threads still alive after ~50ms are
- * detached (process is exiting).
+/* Join worker threads (all active threads except the caller, minus any
+ * already join_abandoned by a prior pass). Collects thread handles under the
+ * lock, then polls OUTSIDE the lock under one shared 500ms deadline so
+ * workers can call thread_deactivate() to set active=0. Workers still alive
+ * past the deadline are detached and marked join_abandoned so a later pass
+ * (e.g. guest_destroy's internal join after main()'s) does not touch the same
+ * handle twice.
  */
 void thread_join_workers(void);
 

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -2281,7 +2281,24 @@ int64_t fuse_dev_read(int guest_fd,
             host_fd_ref_close(&notify_ref);
             return -LINUX_EAGAIN;
         }
-        pthread_cond_wait(&session->queue_cond, &session->lock);
+        /* An untimed cond_wait has no re-check point: a FUSE daemon thread
+         * parked here with no requests queued is invisible to
+         * thread_join_workers' poll cap and touches guest memory (the reply
+         * frame write below) on an eventual delayed wake, well after
+         * guest_destroy may have unmapped it. Poll in bounded quanta and bail
+         * out once exit_group is requested.
+         */
+        if (proc_exit_group_requested()) {
+            pthread_mutex_unlock(&session->lock);
+            pthread_mutex_lock(&fuse_lock);
+            fuse_session_put_locked(session);
+            pthread_mutex_unlock(&fuse_lock);
+            host_fd_ref_close(&notify_ref);
+            return -LINUX_EINTR;
+        }
+        struct timespec ts;
+        timespec_deadline_in_ms(&ts, 200);
+        pthread_cond_timedwait(&session->queue_cond, &session->lock, &ts);
     }
     if (session->closed || session->daemon_dead) {
         pthread_mutex_unlock(&session->lock);

--- a/src/syscall/netlink.c
+++ b/src/syscall/netlink.c
@@ -33,6 +33,7 @@
 
 #include "syscall/abi.h"
 #include "syscall/internal.h"
+#include "syscall/io.h" /* io_wait_fd_or_interrupted */
 #include "syscall/net.h"
 #include "utils.h"
 #include <poll.h>
@@ -707,13 +708,15 @@ static int64_t nl_wait_readable_locked(netlink_state_t *ns,
         int rd_fd = ns->pipe_rd;
         pthread_mutex_unlock(&nl_lock);
 
-        struct pollfd pfd = {
-            .fd = rd_fd,
-            .events = POLLIN,
-        };
-        int ret = poll(&pfd, 1, -1);
-        if (ret < 0)
-            return (errno == EINTR) ? -LINUX_EINTR : -LINUX_EIO;
+        /* Bounded + interrupt-aware: an untimed poll() here has no re-check
+         * point, so a worker parked on an AF_NETLINK socket with no incoming
+         * messages is invisible to thread_join_workers' poll cap and touches
+         * guest memory on an eventual delayed return, well after
+         * guest_destroy may have unmapped it.
+         */
+        int64_t wait_rc = io_wait_fd_or_interrupted(rd_fd, POLLIN);
+        if (wait_rc < 0)
+            return wait_rc;
 
         pthread_mutex_lock(&nl_lock);
         netlink_state_t *current_ns = nl_find(guest_fd);

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1144,8 +1144,34 @@ int64_t sys_wait4(guest_t *g,
 
             int status;
             struct rusage ru;
-            pid_t ret =
-                wait4(host_pid, &status, mac_options, rusage_gva ? &ru : NULL);
+            pid_t ret;
+            if (mac_options & WNOHANG) {
+                ret = wait4(host_pid, &status, mac_options,
+                            rusage_gva ? &ru : NULL);
+            } else {
+                /* A bare blocking wait4 has no re-check point: a worker
+                 * parked here past exit_group is invisible to
+                 * thread_join_workers' poll cap and touches guest memory
+                 * (status/rusage writes below) on an eventual delayed
+                 * return, well after guest_destroy may have unmapped it.
+                 * Poll with WNOHANG under a bounded retry instead, mirroring
+                 * the pid==-1 loop above; proc_mark_child_exited broadcasts
+                 * pid_cond on every host child exit.
+                 */
+                for (;;) {
+                    ret = wait4(host_pid, &status, mac_options | WNOHANG,
+                                rusage_gva ? &ru : NULL);
+                    if (ret != 0)
+                        break;
+                    if (proc_exit_group_requested())
+                        return -LINUX_EINTR;
+                    struct timespec ts;
+                    timespec_deadline_in_ms(&ts, 100);
+                    pthread_mutex_lock(&pid_lock);
+                    pthread_cond_timedwait(&pid_cond, &pid_lock, &ts);
+                    pthread_mutex_unlock(&pid_lock);
+                }
+            }
             if (ret > 0) {
                 if (status_gva) {
                     int32_t linux_status = status;

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -898,10 +898,17 @@ static int64_t sc_exit_group(guest_t *g,
     (void) x4;
     (void) x5;
     (void) verbose;
+    /* Request + interrupt only; do NOT join here. This handler runs on
+     * whichever thread issued exit_group, so a join from here would snapshot
+     * the main thread (slot 0, never deactivates) and detach it after the
+     * poll cap, and would race the main thread's own join over the same
+     * siblings (double pthread_join is undefined). The kicked workers wind
+     * down on their own; the single authoritative join is in main() after
+     * vcpu_run_loop returns, before guest teardown.
+     */
     proc_request_exit_group((int) x0);
     wakeup_pipe_signal();
     thread_for_each(thread_force_exit_cb, NULL);
-    thread_join_workers();
     return SC_EXIT_SENTINEL | ((int) x0 & 0xFF);
 }
 

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -105,6 +105,7 @@ test-negative                  # diff=skip
 [section] Signal + thread tests
 test-signal-thread
 test-fault-signal-mt           # diff=skip
+test-exit-group-worker
 
 [section] Fork edge cases
 test-clone3                    # diff=skip

--- a/tests/test-exit-group-worker.c
+++ b/tests/test-exit-group-worker.c
@@ -1,0 +1,179 @@
+/*
+ * exit_group issued by a non-main thread must terminate the process cleanly
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for the exit_group teardown race: when a worker thread
+ * calls exit_group while its siblings are mid-iteration, the main thread
+ * must join the workers before unmapping guest memory. A regression shows
+ * up as the process dying of a host-level SIGSEGV (status 139) instead of
+ * reporting the exit_group code.
+ *
+ * Phase 1 forks N children; in each child a worker thread calls
+ * exit_group(42) while sibling workers occupy every blocking state a thread
+ * can be torn down from -- spinners hammering guest memory (in hv_vcpu_run),
+ * a worker parked in a timed FUTEX_WAIT_BITSET with a distant absolute
+ * deadline (the condvar wait path glibc's sem_timedwait and
+ * pthread_cond_timedwait sit in), and a worker parked in a blocking pipe
+ * read (the interruptible io wait). The parent verifies the child exited 42
+ * (fork children tear down through guest_destroy). Phase 2 repeats the
+ * pattern in the top-level process itself, so this test's own exit code 0 is
+ * produced by a worker-initiated exit_group through main()'s teardown path.
+ * The parked variants regress the bounded-quantum futex waits: an uncapped
+ * sleep would outlive the join cap, get detached, and race the unmap.
+ *
+ * Syscalls: clone(220), exit_group(94), wait4(260), sched_yield(124),
+ * futex(98), read(63), pipe2(59)
+ */
+
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "raw-syscall.h"
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define FORK_ITERS 10
+#define N_SPINNERS 3
+#define N_WORKERS (N_SPINNERS + 2) /* spinners + futex parker + read parker */
+
+static volatile unsigned long sink[512];
+static volatile int workers_ready;
+static int futex_word;
+static int park_pipe[2];
+
+static void *spinner_fn(void *arg)
+{
+    (void) arg;
+    __sync_fetch_and_add(&workers_ready, 1);
+    /* Keep touching guest memory until exit_group tears the process down. */
+    for (unsigned long i = 0;; i++)
+        sink[i % 512] = i;
+    return NULL;
+}
+
+/* Park in a timed futex wait far in the future. FUTEX_WAIT_BITSET takes an
+ * absolute deadline and is what glibc timed waits issue; on elfuse it maps to
+ * the condvar wait path rather than the os_sync one, so this exercises the
+ * bounded-quantum teardown re-check. Re-arm on any spurious wake; exit_group
+ * is the only way out.
+ */
+static void *futex_parker_fn(void *arg)
+{
+    (void) arg;
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += 600;
+    __sync_fetch_and_add(&workers_ready, 1);
+    for (;;)
+        raw_syscall6(
+            __NR_futex, (long) &futex_word,
+            FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME, 0,
+            (long) &deadline, 0, (long) FUTEX_BITSET_MATCH_ANY);
+    return NULL;
+}
+
+/* Park in a blocking read on a pipe that never gets written (the write end
+ * stays open so the read cannot see EOF). Exercises the interruptible io
+ * wait's teardown re-check.
+ */
+static void *read_parker_fn(void *arg)
+{
+    (void) arg;
+    char c;
+    __sync_fetch_and_add(&workers_ready, 1);
+    for (;;)
+        (void) read(park_pipe[0], &c, 1);
+    return NULL;
+}
+
+static void *killer_fn(void *arg)
+{
+    int code = (int) (long) arg;
+    while (__sync_fetch_and_add(&workers_ready, 0) < N_WORKERS)
+        sched_yield();
+    /* Give the parkers a moment to actually enter their blocking waits (the
+     * ready increment happens just before the call). Not required for
+     * correctness -- a parker that enters its wait after the exit-group flag
+     * is set still notices it within one bounded quantum -- but it makes the
+     * test exercise the parked states rather than the entry races.
+     */
+    usleep(20000);
+    syscall(SYS_exit_group, code);
+    return NULL;
+}
+
+/* Spawn the worker set plus a thread that calls exit_group(code), then spin
+ * on the main thread. Never returns: exit_group ends the process.
+ */
+static void run_victim(int code)
+{
+    pthread_t t;
+    workers_ready = 0;
+    if (pipe(park_pipe) != 0)
+        syscall(SYS_exit_group, 99);
+    for (int i = 0; i < N_SPINNERS; i++) {
+        if (pthread_create(&t, NULL, spinner_fn, NULL) != 0)
+            syscall(SYS_exit_group, 99);
+    }
+    if (pthread_create(&t, NULL, futex_parker_fn, NULL) != 0)
+        syscall(SYS_exit_group, 99);
+    if (pthread_create(&t, NULL, read_parker_fn, NULL) != 0)
+        syscall(SYS_exit_group, 99);
+    if (pthread_create(&t, NULL, killer_fn, (void *) (long) code) != 0)
+        syscall(SYS_exit_group, 99);
+    for (;;)
+        sched_yield();
+}
+
+int main(void)
+{
+    TEST("exit_group from worker thread (forked children)");
+
+    int bad_status = -1;
+    for (int iter = 0; iter < FORK_ITERS && bad_status < 0; iter++) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            FAIL("fork failed");
+            goto summary;
+        }
+        if (pid == 0)
+            run_victim(42); /* does not return */
+
+        int status;
+        if (waitpid(pid, &status, 0) != pid) {
+            FAIL("waitpid failed");
+            goto summary;
+        }
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 42)
+            bad_status = status;
+    }
+    if (bad_status >= 0) {
+        if (WIFSIGNALED(bad_status))
+            FAIL("child killed by signal (teardown race)");
+        else
+            FAIL("child reported wrong exit code");
+    } else {
+        PASS();
+    }
+
+summary:
+    SUMMARY("test-exit-group-worker");
+    if (fails)
+        return 1;
+
+    /* Phase 2: our own exit code 0 must come from a worker-initiated
+     * exit_group in the top-level process. Flush first: exit_group does not
+     * flush stdio buffers.
+     */
+    fflush(NULL);
+    run_victim(0);
+    return 1; /* unreachable */
+}


### PR DESCRIPTION
On exit_group the main thread left vcpu_run_loop and unmapped the guest slab
via guest_destroy() while sibling vCPU threads could still be mid-iteration
touching guest memory: the host process died with SIGSEGV and a guest
exit_group(0) was reported as exit 139. Masked until the fault-delivery fix
let multi-threaded JVM workloads (javac) reach the exit_group teardown.

- main() joins workers after vcpu_run_loop() returns and before any teardown;
  gdb_stub_shutdown() runs first so a worker parked in a GDB stop can
  deactivate instead of timing out the join.
- sc_exit_group no longer joins: it ran on the requesting thread, snapshotted
  never-deactivating slot 0, burned the poll cap, detached the host main
  pthread, and raced main()'s join into a double pthread_join. It now only
  requests + interrupts; main() holds the single authoritative join.
- Timed futex waits slept to the guest deadline, unreachable by teardown for
  the wait's whole duration (the FUTEX_WAIT_BITSET condvar path that glibc
  timed waits and JVM parkNanos issue never routes to os_sync; same in
  futex_lock_pi and futex_waitv). They now sleep in 100 ms quanta and re-check
  exit_group/futex_interrupt each quantum; guest-visible timeout accuracy is
  unchanged.
- thread_join_workers() polls under one shared 500 ms deadline — the old
  100 ms per-worker cap sat below the io wait's 200 ms flag re-check bound —
  and marks timed-out workers join_abandoned so guest_destroy()'s later pass
  cannot join/detach the same pthread twice (UB for a detached thread).
- Every thread_entry_t.active write is now a release store: the joiner polls
  lock-free, so the store/load pair on active is its only happens-before edge
  (flagged by ThreadSanitizer on the teardown test; clean under TSan with the
  fix).
- test-exit-group-worker drives a worker-issued exit_group with siblings
  pinned in each blocking state the join relies on (memory spinners, a timed
  futex wait 600 s out, a blocking pipe read) through 10 fork-child teardowns
  plus the top-level path.

A correctness argument — teardown paths, per-state wake bounds vs the join
cap, and residual risk — follows in a comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Join worker vCPU threads in main before tearing down guest memory to prevent host SIGSEGVs and keep correct exit codes. Add a pre-join exit/interrupt kick and bound long waits (futex, FUSE, netlink, wait4) so workers always notice teardown; shut down the debugger first to avoid join timeouts.

- **Bug Fixes**
  - Call gdb_stub_shutdown() before thread_join_workers().
  - Join workers in main after vcpu_run_loop(); if no exit was requested, request exit_group(0) then call futex_interrupt_request(), wakeup_pipe_signal(), and thread_interrupt_all(); sc_exit_group now only requests and interrupts to avoid double-join and main-thread detach.
  - In guest_destroy(), run request/interrupt/join when destroy is reached directly so workers can’t touch freed memory.
  - Futex waits: sleep in 100 ms quanta, re-check exit/interrupt each quantum, and also re-check expired itimers and queued signals; futex_waitv quantum reduced to 100 ms; timeout accuracy unchanged.
  - thread_join_workers() polls under one shared 500 ms cap and marks timed-out workers join_abandoned so later passes skip them.
  - All writes to thread_entry_t.active are release stores so the lock-free join path observes a happens-before edge.
  - Make FUSE daemon reads, netlink waits, and specific-pid wait4 blocking paths bounded and interrupt-aware so teardown can reach them and avoid post-unmap memory access.

- **Tests**
  - Add test-exit-group-worker (and build target) to verify worker-issued exit_group exits cleanly in forked children and in the top-level path.

<sup>Written for commit 1fbbebb06dff3d4f87bf095789f4fa38e71fd09c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




