### PR TITLE
Deliver synchronous fault signals to the faulting thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,12 @@ $(BUILD_DIR)/test-scm-creds: tests/test-scm-creds.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
 
+# test-fault-signal-mt spawns pthreads that each take recoverable SIGSEGVs to
+# stress synchronous-fault delivery routing in a multi-threaded guest.
+$(BUILD_DIR)/test-fault-signal-mt: tests/test-fault-signal-mt.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
+
 # test-shim-cred-race spawns a pthread reader while the main thread
 # toggles setresuid; the reader spins on the identity fast path.
 $(BUILD_DIR)/test-shim-cred-race: tests/test-shim-cred-race.c | $(BUILD_DIR)

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1465,8 +1465,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                             uint64_t esr;
                             hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ESR_EL1, &esr);
                             signal_set_fault_info(LINUX_SEGV_ACCERR, far, esr);
-                            signal_queue(LINUX_SIGSEGV);
-                            int sig_ret = signal_deliver(vcpu, g, &exit_code);
+                            int sig_ret = signal_deliver_fault(
+                                vcpu, g, LINUX_SIGSEGV, &exit_code);
                             if (sig_ret < 0)
                                 running = false;
                             break;
@@ -1549,7 +1549,6 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                         hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ESR_EL1, &brk_esr);
                         signal_set_fault_info(LINUX_TRAP_BRKPT, brk_pc,
                                               brk_esr);
-                        signal_queue(LINUX_SIGTRAP);
                         if (verbose) {
                             uint64_t thread_blocked =
                                 current_thread ? current_thread->blocked
@@ -1561,7 +1560,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                                 (unsigned long long) signal_get_state()
                                     ->pending);
                         }
-                        int sig_ret = signal_deliver(vcpu, g, &exit_code);
+                        int sig_ret = signal_deliver_fault(
+                            vcpu, g, LINUX_SIGTRAP, &exit_code);
                         if (verbose)
                             log_debug("%s: signal_deliver returned %d", prefix,
                                       sig_ret);
@@ -1621,8 +1621,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                                 prefix, (unsigned long long) elr_addr,
                                 (unsigned long long) esr, fault_ec);
                         signal_set_fault_info(LINUX_ILL_ILLOPC, elr_addr, esr);
-                        signal_queue(LINUX_SIGILL);
-                        int sig_ret = signal_deliver(vcpu, g, &exit_code);
+                        int sig_ret = signal_deliver_fault(
+                            vcpu, g, LINUX_SIGILL, &exit_code);
                         /* HVC #11 consumes X8 as the post-fault TLBI opcode.
                          * signal_deliver() may leave it unchanged when no
                          * handler is materialized, or set the syscall-path
@@ -1799,8 +1799,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                             (unsigned long long) esr, fsc, code_name);
                     }
                     signal_set_fault_info(si_code, far_addr, esr);
-                    signal_queue(LINUX_SIGSEGV);
-                    int sig_ret = signal_deliver(vcpu, g, &exit_code);
+                    int sig_ret = signal_deliver_fault(vcpu, g, LINUX_SIGSEGV,
+                                                       &exit_code);
                     /* HVC #11 consumes X8 as the post-fault TLBI opcode.
                      * signal_deliver() may leave it unchanged when no handler
                      * is materialized, or set the syscall-path frame-drop

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -1311,37 +1311,27 @@ static void build_sigcontext_reserved(uint8_t *reserved,
     memset(reserved + off, 0, 8);
 }
 
-int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
+/* Build and install the rt_sigframe for `signum` on the current thread, with
+ * sig_lock held on entry and released on every return path. Shared by
+ * signal_deliver() (signal selected from the process-wide pending set) and
+ * signal_deliver_fault() (synchronous fault forced onto the faulting thread).
+ * rt_info supplies si_code/si_pid/sigval when no thread-local pending_fault is
+ * set; the pending_fault is consumed (one-shot) when valid. Returns 1 if a
+ * handler frame was installed, 0 if the signal was ignored, and -1 (with
+ * *exit_code set) when the default disposition terminates the guest.
+ */
+static int deliver_signal_locked(hv_vcpu_t vcpu,
+                                 guest_t *g,
+                                 int signum,
+                                 signal_rt_info_t rt_info,
+                                 int *exit_code)
 {
-    pthread_mutex_lock(&sig_lock);
     uint64_t *blocked = thread_blocked_ptr();
     uint64_t *saved_ptr = thread_saved_blocked_ptr();
     bool *valid_ptr = thread_saved_valid_ptr();
-    uint64_t deliverable = sig_state.pending & ~*blocked;
-    if (deliverable == 0) {
-        pthread_mutex_unlock(&sig_lock);
-        return 0;
-    }
 
-    /* Find lowest pending unblocked signal */
-    int signum = bit_ctz64(deliverable) + 1;
-    signal_rt_info_t rt_info = signal_default_info(signum);
-
-    /* Dequeue: for RT signals, decrement count and only clear the pending bit
-     * when the queue is empty. Standard signals are always cleared (single
-     * instance, bitmask semantics).
-     */
-    if (signum >= LINUX_SIGRTMIN) {
-        signal_rt_dequeue_locked(signum, &rt_info);
-    } else {
-        rt_info = signal_standard_peek_locked(signum);
-        sig_state.std_info_valid[signum - 1] = false;
-        sig_state.pending &= ~sig_bit(signum);
-    }
-
-    /* signum is bit_ctz64(deliverable) + 1, bounded 1..64 by the 64-bit pending
-     * mask. The static analyzer cannot see the bound, so gate the array access
-     * defensively.
+    /* signum is 1..64 from the caller; the static analyzer cannot see the
+     * bound, so gate the array access defensively.
      */
     int idx = signum - 1;
     if (!RANGE_CHECK(idx, 0, LINUX_NSIG)) {
@@ -1622,6 +1612,71 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
 
     pthread_mutex_unlock(&sig_lock);
     return 1;
+}
+
+int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
+{
+    pthread_mutex_lock(&sig_lock);
+    uint64_t *blocked = thread_blocked_ptr();
+    uint64_t deliverable = sig_state.pending & ~*blocked;
+    if (deliverable == 0) {
+        pthread_mutex_unlock(&sig_lock);
+        return 0;
+    }
+
+    /* Find lowest pending unblocked signal */
+    int signum = bit_ctz64(deliverable) + 1;
+    signal_rt_info_t rt_info = signal_default_info(signum);
+
+    /* Dequeue: for RT signals, decrement count and only clear the
+     * pending bit when the queue is empty. Standard signals are
+     * always cleared (single instance, bitmask semantics).
+     */
+    if (signum >= LINUX_SIGRTMIN) {
+        signal_rt_dequeue_locked(signum, &rt_info);
+    } else {
+        rt_info = signal_standard_peek_locked(signum);
+        sig_state.std_info_valid[signum - 1] = false;
+        sig_state.pending &= ~sig_bit(signum);
+    }
+
+    return deliver_signal_locked(vcpu, g, signum, rt_info, exit_code);
+}
+
+int signal_deliver_fault(hv_vcpu_t vcpu, guest_t *g, int signum, int *exit_code)
+{
+    /* Synchronous faults (SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP) are specific to
+     * the thread that triggered them and must be delivered to that thread with
+     * the thread-local fault info set by signal_set_fault_info(). Routing them
+     * through the process-wide pending bitmask (signal_queue + signal_deliver)
+     * is racy: another vCPU thread can dequeue the bit and deliver it with no
+     * fault info (si_code becomes SI_USER, which makes a JVM treat a
+     * recoverable implicit null-check as a fatal external signal), and two
+     * threads faulting on the same signal collapse into one bit so one fault is
+     * lost. Deliver directly here, never touching sig_state.pending.
+     */
+    pthread_mutex_lock(&sig_lock);
+
+    /* Linux force_sig_info_to_task(): a forced synchronous fault cannot be
+     * postponed or ignored. If the disposition is SIG_IGN or the signum is
+     * blocked, reset to SIG_DFL and unblock before delivery, so the default
+     * disposition terminates the process instead of resuming at the faulting
+     * PC (SIG_IGN would re-fault forever) or running a handler the guest
+     * asked to block.
+     */
+    int idx = signum - 1;
+    if (RANGE_CHECK(idx, 0, LINUX_NSIG)) {
+        uint64_t *blocked = thread_blocked_ptr();
+        linux_sigaction_t *act = &sig_state.actions[idx];
+        if (act->sa_handler == LINUX_SIG_IGN || (*blocked & sig_bit(signum))) {
+            act->sa_handler = LINUX_SIG_DFL;
+            act->sa_flags &= ~LINUX_SA_SIGINFO;
+            *blocked &= ~sig_bit(signum);
+        }
+    }
+
+    signal_rt_info_t rt_info = signal_default_info(signum);
+    return deliver_signal_locked(vcpu, g, signum, rt_info, exit_code);
 }
 
 /* rt_sigreturn. */

--- a/src/syscall/signal.h
+++ b/src/syscall/signal.h
@@ -274,6 +274,24 @@ void signal_set_shim_globals_guest(guest_t *g);
  */
 int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code);
 
+/* Deliver a synchronous fault signal directly to the faulting (current) thread,
+ * bypassing the process-wide pending set. The caller must have set the fault
+ * info via signal_set_fault_info() immediately before. Same return convention
+ * as signal_deliver(). Use this for SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP raised
+ * from a guest exception, never signal_queue()+signal_deliver(): a queued fault
+ * can be stolen by another vCPU thread (delivered as SI_USER, no si_addr) or
+ * coalesced with another thread's fault into one bitmask bit.
+ *
+ * Follows Linux force_sig_info_to_task() semantics: a SIG_IGN or blocked
+ * disposition is reset to SIG_DFL and unblocked before delivery, so an
+ * unhandleable fault terminates the process rather than re-faulting forever
+ * or invoking a handler the guest asked to block.
+ */
+int signal_deliver_fault(hv_vcpu_t vcpu,
+                         guest_t *g,
+                         int signum,
+                         int *exit_code);
+
 /* Handle rt_sigreturn (SYS 139): restore registers from rt_sigframe on the
  * guest stack.
  *

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -94,6 +94,7 @@ test-negative                  # diff=skip
 
 [section] Signal + thread tests
 test-signal-thread
+test-fault-signal-mt           # diff=skip
 
 [section] Fork edge cases
 test-clone3                    # diff=skip

--- a/tests/test-fault-signal-mt.c
+++ b/tests/test-fault-signal-mt.c
@@ -1,0 +1,229 @@
+/* Multi-threaded synchronous-fault delivery test
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression lock-in for synchronous fault (SIGSEGV) delivery in a
+ * multi-threaded guest. Faults were routed through the process-wide pending
+ * bitmask (signal_queue + signal_deliver), so a fault raised by one vCPU
+ * thread could be dequeued and delivered by another: the other thread had no
+ * thread-local fault info, so the kernel-visible siginfo became si_code=SI_USER
+ * with no si_addr instead of SEGV_MAPERR. A JVM treats such a SIGSEGV as a
+ * fatal external signal rather than a recoverable implicit null check, so javac
+ * crashed. Two threads faulting at once also collapsed into a single bitmask
+ * bit, dropping one fault entirely.
+ *
+ * Each thread repeatedly takes a recoverable SIGSEGV (read from a known bad
+ * address) and the handler asserts the siginfo is the correct synchronous-fault
+ * shape. Under the bug, a fault delivered to the wrong thread is seen either as
+ * SI_USER or on a thread with no armed recovery point, which this test flags.
+ *
+ * Also locks in Linux force_sig_info_to_task() semantics for unhandleable
+ * faults: a synchronous SIGSEGV whose disposition is SIG_IGN, or which is
+ * blocked, resets to SIG_DFL + unblocked and terminates the process. Without
+ * the reset, SIG_IGN resumes at the faulting PC and re-faults forever, and a
+ * blocked fault either stalls the same way or runs a handler the guest asked
+ * to block. Each case runs in a forked child that must die by SIGSEGV.
+ *
+ * Syscalls exercised: rt_sigaction, rt_sigprocmask, clone (pthreads), fork,
+ * wait4, the fault delivery path.
+ */
+
+#include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define NTHREADS 4
+#define NFAULTS 4000
+
+/* The bad address every thread reads. Page zero is never mapped, so the read
+ * faults with a translation fault -> SEGV_MAPERR and si_addr == FAULT_ADDR. */
+#define FAULT_ADDR ((volatile int *) (uintptr_t) 0x8)
+
+static _Thread_local sigjmp_buf recover;
+static _Thread_local volatile int armed;
+
+/* Set by the handler when it observes a malformed delivery. async-signal-safe
+ * stores to sig_atomic_t/int flags only. */
+static volatile sig_atomic_t bad_si_code = 0;
+static volatile sig_atomic_t bad_si_addr = 0;
+static volatile sig_atomic_t unarmed_delivery = 0;
+
+static void segv_handler(int sig, siginfo_t *info, void *uc)
+{
+    (void) sig;
+    (void) uc;
+    /* A synchronous fault must report a fault si_code (SEGV_MAPERR for an
+     * unmapped address), never SI_USER (0), which is what a stolen/cross-thread
+     * delivery produced. */
+    if (info->si_code != SEGV_MAPERR && info->si_code != SEGV_ACCERR)
+        bad_si_code = 1;
+    if (info->si_addr != (void *) FAULT_ADDR)
+        bad_si_addr = 1;
+    if (!armed) {
+        /* Delivered to a thread that is not currently faulting: the fault was
+         * misrouted. Cannot recover (no jmp target), so fail and exit. */
+        unarmed_delivery = 1;
+        _exit(2);
+    }
+    siglongjmp(recover, 1);
+}
+
+static void *fault_loop(void *arg)
+{
+    (void) arg;
+    for (int i = 0; i < NFAULTS; i++) {
+        armed = 1;
+        if (sigsetjmp(recover, 1) == 0) {
+            /* Trigger the fault. volatile so the read is not optimized away. */
+            volatile int v = *FAULT_ADDR;
+            (void) v;
+        }
+        armed = 0;
+    }
+    return NULL;
+}
+
+/* Fork a child that faults under the disposition installed by `setup` and
+ * return its wait status. Returns -1 on fork/waitpid failure, -2 if the child
+ * had to be killed: a re-fault-forever regression spins the child on the
+ * faulting PC without reaching a signal poll point, so no in-child alarm can
+ * interrupt it -- the parent must bound the wait and kill. */
+#define CHILD_WAIT_MS 8000
+
+static int fault_child_status(void (*setup)(void))
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        setup();
+        volatile int v = *FAULT_ADDR;
+        (void) v;
+        _exit(0); /* Reached only if the fault did not fire at all */
+    }
+    if (pid < 0)
+        return -1;
+    int status = 0;
+    for (int waited = 0; waited < CHILD_WAIT_MS; waited += 50) {
+        pid_t r = waitpid(pid, &status, WNOHANG);
+        if (r == pid)
+            return status;
+        if (r < 0)
+            return -1;
+        usleep(50 * 1000);
+    }
+    kill(pid, SIGKILL);
+    waitpid(pid, &status, 0);
+    return -2;
+}
+
+/* elfuse fork children report signal deaths as exit(128+signum); accept the
+ * native WIFSIGNALED form too. */
+static int died_by(int status, int sig)
+{
+    if (WIFSIGNALED(status) && WTERMSIG(status) == sig)
+        return 1;
+    return WIFEXITED(status) && WEXITSTATUS(status) == 128 + sig;
+}
+
+static void setup_ign(void)
+{
+    signal(SIGSEGV, SIG_IGN);
+}
+
+static void blocked_handler(int sig, siginfo_t *info, void *uc)
+{
+    (void) sig;
+    (void) info;
+    (void) uc;
+    /* Must never run: SIGSEGV was blocked when the fault hit, so Linux
+     * force_sig semantics reset to SIG_DFL and terminate instead. */
+    _exit(3);
+}
+
+static void setup_blocked(void)
+{
+    struct sigaction sa;
+    sa.sa_sigaction = blocked_handler;
+    sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGSEGV, &sa, NULL);
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGSEGV);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+}
+
+int main(void)
+{
+    printf("test-fault-signal-mt: multi-threaded SIGSEGV delivery\n\n");
+
+    /* Forced-fault disposition cases run first, in forked children, before
+     * this process installs its own SIGSEGV handler or spawns threads. */
+    TEST("SIG_IGN'd synchronous SIGSEGV terminates");
+    int status = fault_child_status(setup_ign);
+    if (status == -2)
+        FAIL("child re-faulted forever under SIG_IGN (killed)");
+    else if (status < 0)
+        FAIL("fork/waitpid failed");
+    else if (died_by(status, SIGSEGV))
+        PASS();
+    else
+        FAIL("child did not die by SIGSEGV");
+
+    TEST("blocked synchronous SIGSEGV terminates, handler not run");
+    status = fault_child_status(setup_blocked);
+    if (status == -2)
+        FAIL("child re-faulted forever with SIGSEGV blocked (killed)");
+    else if (status < 0)
+        FAIL("fork/waitpid failed");
+    else if (died_by(status, SIGSEGV))
+        PASS();
+    else if (WIFEXITED(status) && WEXITSTATUS(status) == 3)
+        FAIL("handler ran despite SIGSEGV being blocked");
+    else
+        FAIL("child did not die by SIGSEGV");
+
+    struct sigaction sa;
+    sa.sa_sigaction = segv_handler;
+    sa.sa_flags = SA_SIGINFO | SA_NODEFER;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSEGV, &sa, NULL) != 0) {
+        printf("  %-34s FAIL: sigaction (errno=%d)\n", "setup", errno);
+        return 1;
+    }
+
+    TEST("concurrent recoverable SIGSEGV faults");
+    pthread_t th[NTHREADS];
+    int spawned = 0;
+    for (int i = 0; i < NTHREADS; i++) {
+        if (pthread_create(&th[i], NULL, fault_loop, NULL) != 0)
+            break;
+        spawned++;
+    }
+    for (int i = 0; i < spawned; i++)
+        pthread_join(th[i], NULL);
+
+    if (spawned != NTHREADS)
+        FAIL("could not spawn all threads");
+    else if (bad_si_code)
+        FAIL("fault delivered with si_code != SEGV_MAPERR/ACCERR (SI_USER?)");
+    else if (bad_si_addr)
+        FAIL("fault delivered with wrong si_addr");
+    else if (unarmed_delivery)
+        FAIL("fault delivered to a non-faulting thread");
+    else
+        PASS();
+
+    SUMMARY("test-fault-signal-mt");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #76.** This branch is based on `fix-cross-process-signal-el0` (#76),
> whose commit appears here until #76 merges; afterwards this PR auto-reduces to the
> single fault-delivery commit. Review #76 first.

A guest exception (SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP) was delivered via
`signal_set_fault_info()` (which records si_code/si_addr in a `_Thread_local` slot)
followed by `signal_queue()` + `signal_deliver()`. But `signal_queue()` sets a bit in
the process-wide pending mask, and every vCPU thread runs `signal_deliver()` at its own
poll points, so a fault raised by thread A could be dequeued and delivered by thread B —
whose thread-local fault info is empty. The siginfo then degraded to `si_code=SI_USER`
with no `si_addr` instead of `SEGV_MAPERR`/si_addr. A JVM treats such a SIGSEGV as a
fatal external signal rather than a recoverable implicit null check, so `javac` crashed.
Two threads faulting on the same signal also collapsed into one bitmask bit, dropping
one fault.

Add `signal_deliver_fault()`, which delivers a given signal directly to the current
thread using its thread-local fault info and never touches the process-wide pending set.
`signal_deliver()`'s frame-building tail is factored into `deliver_signal_locked()` and
shared. All four synchronous-fault sites in the vCPU loop (SEGV_ACCERR, BRK→SIGTRAP,
SIGILL, data-abort SIGSEGV) route through it.

Adds `test-fault-signal-mt`: N threads each take recoverable SIGSEGVs and assert every
delivery is `SEGV_MAPERR` with the right `si_addr` on the faulting thread. It fails
deterministically (rc=2) on the old queue-based path and passes on the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deliver synchronous fault signals to the faulting vCPU thread to preserve correct si_code/si_addr and prevent cross‑thread delivery or dropped faults. Fixes JVM crashes where SIGSEGV arrived as SI_USER and makes multi‑threaded faults reliable.

- **Bug Fixes**
  - Added `signal_deliver_fault()` to deliver SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP directly to the current thread, bypassing the process‑wide pending set. Follows Linux force_sig semantics: if disposition is `SIG_IGN` or the signal is blocked, reset to `SIG_DFL` and unblock before delivery.
  - Factored handler frame build into `deliver_signal_locked()`; shared by `signal_deliver()` and `signal_deliver_fault()` and preserves EL0 PC/CPSR state.
  - Routed all synchronous guest exceptions in `vcpu_run_loop` (SEGV_ACCERR, BRK→SIGTRAP, SIGILL, data‑abort SIGSEGV) through the new path. Added `test-fault-signal-mt` to validate per‑thread SIGSEGV delivery (correct si_code/si_addr) and to lock in forced‑fault semantics (SIG_IGN/blocked SIGSEGV must terminate). Makefile and manifest updated.

<sup>Written for commit 2d998edd2816fee79f529cd98d571b739e8caeba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

