### PR TITLE
Add self-hosted macOS HVF runtime job to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -333,3 +333,192 @@ jobs:
           path: infer-out/report.txt
           retention-days: 7
           if-no-files-found: warn
+
+  runtime-macos:
+    name: Runtime (macOS Apple Silicon, HVF)
+    needs: build-macos
+    if: >
+      github.repository == 'sysprog21/elfuse' &&
+      (github.event_name == 'push' || github.event_name == 'pull_request')
+    runs-on: [self-hosted, macOS, arm64]
+    timeout-minutes: 20
+
+    # contents: read for the checkout; pull-requests: read so the guard can
+    # query the PR's current HEAD. (actions: write would let the guard
+    # cancel the run instead of failing it, but repo policy caps the token
+    # at actions: read, so the guard fails fast with a clear reason instead.)
+    permissions:
+      contents: read
+      pull-requests: read
+
+    concurrency:
+      group: runtime-macos-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+    env:
+      LINUX_TOOLCHAIN: /opt/toolchain/aarch64-linux-gnu
+      GNU_OBJCOPY: /opt/homebrew/opt/binutils/bin/objcopy
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      BREW_PKGS: binutils qemu
+
+    steps:
+      # Fail fast if this run targets a commit that is no longer the PR's
+      # HEAD. cancel-in-progress covers "commit 2 pushed while commit 1 is
+      # still running", but NOT a manual "Re-run jobs" on an old run: a
+      # re-run replays the original event payload (a frozen head.sha)
+      # against this single self-hosted runner, which would otherwise burn
+      # the full job timeout re-testing stale code. Compare the frozen
+      # head.sha against the live PR HEAD; when they differ, exit 1 with a
+      # clear "commit is no longer the latest" message. We fail (rather than
+      # cancel) because repo policy caps the token at actions: read, so the
+      # cancel API is unavailable. exit 1 also stops the job, so the later
+      # steps are skipped automatically -- no per-step guard needed. The
+      # lookup fails open: if HEAD can't be determined the job runs.
+      - name: Fail fast if superseded by a newer PR commit
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          # curl and system python3 are always present on macOS; jq/gh are
+          # not guaranteed on a self-hosted runner, so don't depend on them.
+          latest=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["head"]["sha"])') \
+            || latest=""
+          echo "Run targets : $RUN_SHA"
+          echo "PR HEAD now : ${latest:-<unknown>}"
+          if [ -n "$latest" ] && [ "$latest" != "$RUN_SHA" ]; then
+            echo "::error::This run targets $RUN_SHA, but PR #$PR_NUMBER HEAD is now $latest -- the commit is no longer the latest. Failing instead of re-testing stale code on the self-hosted runner; re-run CI on the current commit."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Restore cached test fixtures
+        # actions/checkout's default clean:true runs `git clean -ffdx`, which
+        # wipes externals/test-fixtures (gitignored) on this self-hosted
+        # runner even though its disk otherwise persists across runs.
+        # fetch-fixtures.sh is already idempotent -- it skips re-downloading
+        # Alpine packages when externals/test-fixtures/versions.lock still
+        # matches -- so stash that tree outside the workspace and restore it
+        # here as a real directory. The qemu lane in tests/test-matrix.sh
+        # shares the workspace root with the guest over virtio-9p, and a
+        # symlink pointing outside that root does not resolve inside the
+        # guest, so this must be a real copy, not a symlink.
+        run: |
+          cache="$HOME/.cache/elfuse-ci/test-fixtures"
+          if [ -d "$cache" ]; then
+            mkdir -p externals
+            rm -rf externals/test-fixtures
+            cp -Rc "$cache" externals/test-fixtures
+            echo "Restored test fixtures ($(du -sh externals/test-fixtures | cut -f1), lock: $(head -1 externals/test-fixtures/versions.lock 2>/dev/null || echo none))"
+          else
+            echo "No fixtures cache at $cache; tests fetch on demand"
+          fi
+
+      - name: Host info
+        run: |
+          sw_vers
+          uname -a
+          uname -m
+          sysctl kern.hv_support || true
+          test "$(uname -m)" = "arm64"
+
+      - name: Cache Homebrew downloads
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: brew-runtime-${{ runner.os }}-${{ runner.arch }}-${{ env.BREW_PKGS }}
+
+      - name: Install missing Homebrew packages
+        run: |
+          missing=()
+
+          for pkg in $BREW_PKGS; do
+            if ! brew list --formula "$pkg" >/dev/null 2>&1; then
+              missing+=("$pkg")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            brew install --quiet "${missing[@]}"
+          else
+            echo "All Homebrew packages are already installed: $BREW_PKGS"
+          fi
+
+      - name: Tool versions
+        run: |
+          command -v make
+          command -v "$GNU_OBJCOPY"
+          make -V .MAKE.VERSION 2>/dev/null || true
+          "$GNU_OBJCOPY" --version | head -1
+          qemu-aarch64 --version | head -1 || true
+          python3 --version
+
+      - name: Check Rosetta for Linux
+        run: |
+          ROSETTA=/Library/Apple/usr/libexec/oah/RosettaLinux/rosetta
+
+          if [ ! -x "$ROSETTA" ]; then
+            echo "::error::Rosetta for Linux runtime was not found at $ROSETTA"
+            echo
+            echo "Install Rosetta on the self-hosted Mac runner first:"
+            echo "  sudo softwareupdate --install-rosetta --agree-to-license"
+            echo
+            echo "Current /Library/Apple/usr/libexec/oah contents:"
+            ls -R /Library/Apple/usr/libexec/oah || true
+            exit 1
+          fi
+
+          ls -l "$ROSETTA"
+
+      - name: Build elfuse
+        run: |
+          make elfuse
+
+      - name: Verify HVF entitlement is embedded
+        run: |
+          codesign -d --entitlements - build/elfuse 2>&1 \
+            | grep -q 'com\.apple\.security\.hypervisor'
+
+      - name: test-hello
+        run: |
+          make test-hello
+
+      - name: test-multi-vcpu
+        run: |
+          make test-multi-vcpu
+
+      - name: make check
+        run: |
+          make check
+
+      - name: Test matrix
+        run: |
+          bash tests/test-matrix.sh all
+
+      - name: Save test fixtures cache
+        # Persist externals/test-fixtures outside the workspace so the next
+        # run's "Restore cached test fixtures" step can skip re-downloading
+        # unchanged Alpine packages. Runs even if an earlier step failed, as
+        # long as the job wasn't cancelled, so a fixture-unrelated test
+        # failure doesn't cost the next run its cache.
+        if: ${{ !cancelled() }}
+        run: |
+          if [ -d externals/test-fixtures ]; then
+            cache="$HOME/.cache/elfuse-ci/test-fixtures"
+            mkdir -p "$(dirname "$cache")"
+            rm -rf "$cache"
+            cp -Rc externals/test-fixtures "$cache"
+            echo "Saved test fixtures ($(du -sh "$cache" | cut -f1))"
+          else
+            echo "No externals/test-fixtures to save"
+          fi

--- a/tests/lib/test-runner.sh
+++ b/tests/lib/test-runner.sh
@@ -103,7 +103,9 @@ test_report()
 test_excerpt()
 {
     local output="$1"
-    printf "  %.120s\n" "$output" | head -3
+    # The closing lines carry the actual assertion failure; the opening line
+    # is usually just an elfuse WARN banner.
+    printf "%s\n" "$output" | tail -10 | cut -c -200 | sed 's/^/  /'
 }
 
 test_tool_path()


### PR DESCRIPTION
GitHub-hosted macOS runners do not expose Apple's Hypervisor.framework (HVF):
the hosted runner OS itself runs inside a virtualization layer that withholds
HVF, so `hv_vm_create()` returns `HV_UNSUPPORTED`. Because of this, the existing
`build-macos` job can only compile elfuse and verify the HVF entitlement — it
can never actually boot a guest.

This PR adds a `runtime-macos` job that runs on a **self-hosted Apple Silicon
runner** (an M4 machine) where HVF *is* available, so the real runtime path —
booting a Linux guest under HVF + Rosetta — is exercised in CI for the first
time. The hosted `build-macos` job is unchanged and keeps gating builds as
before; this job runs *after* it (`needs: build-macos`).

Closes #51.

> [!NOTE]
> **Known failure:** the `runtime-macos` job currently fails in the
> **`make check`**. Once #76 lands (or is merged into / rebased onto this branch), 
> it is expected to go green.

## What the `runtime-macos` job does

- `runs-on: [self-hosted, macOS, arm64]`, `needs: build-macos`, 20-minute
  timeout.
- Per-ref concurrency: cancels in-progress runs for the same PR, but lets
  `main` runs finish.

### Where it runs (trigger gating)

- **PR targeting `main` — runs.** A `pull_request` from any fork is evaluated
  in the upstream (`sysprog21/elfuse`) Actions context, so a collaborator who
  pushes a branch to their own fork and opens a PR against upstream gets the
  full runtime suite. This is the normal contributor flow and must work.
- **Push to `main` — runs.** Post-merge validation on the mainline.
- **Activity in a fork's own context — skipped.

### Failing fast on superseded re-runs

There is only one self-hosted runner, so a wasted run on it blocks every other
PR. Per-ref `concurrency` already cancels an in-progress run when a newer commit
is pushed to the same PR, but it does **not** cover a manual *Re-run jobs* on an
old run: a re-run replays the original (now stale) commit and would otherwise
occupy the runner for the full timeout re-testing code that is no longer HEAD.

The job's first step compares the run's frozen `head.sha` against the PR's live
HEAD (via the REST API) and, when they differ, prints a `::error::` saying *the
commit is no longer the latest* and `exit 1`, end up failed.
