### PR TITLE
Track virtual file ownership through chown EPERM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ SRCS := \
     syscall/path.c \
     syscall/fuse.c \
     syscall/sidecar.c \
+    syscall/chown-overlay.c \
     syscall/fs.c \
     syscall/fs-stat.c \
     syscall/fs-xattr.c \
@@ -139,6 +140,14 @@ $(BUILD_DIR)/test-rwx: $(BUILD_DIR)/test-rwx.o | $(BUILD_DIR)
 # immediately.
 $(BUILD_DIR)/test-tlbi-encoder-host: $(BUILD_DIR)/test-tlbi-encoder-host.o \
 		| $(BUILD_DIR)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(CFLAGS) -o $@ $^
+
+## Build the fork IPC protocol identity unit test (native macOS binary).
+# Pure C; no HVF entitlement needed. Pins the first header word as the
+# cross-version protocol discriminator after IPC_VERSION removal.
+$(BUILD_DIR)/test-fork-ipc-protocol-host: \
+		$(BUILD_DIR)/test-fork-ipc-protocol-host.o | $(BUILD_DIR)
 	@echo "  LD      $@"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -20,7 +20,8 @@ endif
 
 # Exclude native macOS test files from cross-compilation
 NATIVE_TESTS := tests/test-multi-vcpu.c tests/test-rwx.c \
-                tests/test-tlbi-encoder-host.c
+                tests/test-tlbi-encoder-host.c \
+                tests/test-fork-ipc-protocol-host.c
 SPECIAL_TEST_SRCS := tests/test-lowbase-mem.c
 SPECIAL_TEST_BINS := $(BUILD_DIR)/test-lowbase-mem-200000 $(BUILD_DIR)/test-lowbase-mem-300000
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -10,7 +10,7 @@
         test-matrix test-matrix-elfuse-aarch64 test-matrix-qemu-aarch64 \
         test-full test-multi-vcpu test-rwx test-sysroot-rename \
         test-case-collision test-case-collision-fallback test-getdents64-overlong \
-        test-sysroot-create-paths \
+        test-sysroot-create-paths test-fork-ipc-protocol-host \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-timeout-disable test-fuse-alpine \
         test-sysroot-nofollow test-sysroot-chdir perf
@@ -37,10 +37,13 @@ endef
 
 ## Run the unit test suite plus busybox applet validation
 check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
-		$(BUILD_DIR)/test-tlbi-encoder-host
+		$(BUILD_DIR)/test-tlbi-encoder-host \
+		$(BUILD_DIR)/test-fork-ipc-protocol-host
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
 	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-tlbi-encoder-host
+	@printf "\n$(BLUE)━━━ fork IPC protocol identity unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-fork-ipc-protocol-host
 	@printf "\n$(BLUE)━━━ proctitle argv-tail regression ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-proctitle-host
 	@printf "\n$(BLUE)━━━ proctitle low-stack regression ━━━$(RESET)\n"
@@ -568,6 +571,11 @@ test-multi-vcpu: $(BUILD_DIR)/test-multi-vcpu
 ## Run RWX page table entry test (does HVF allow W+X?)
 test-rwx: $(BUILD_DIR)/test-rwx
 	$(BUILD_DIR)/test-rwx
+
+# Fork IPC protocol identity regression
+## Run the fork IPC protocol identity unit test
+test-fork-ipc-protocol-host: $(BUILD_DIR)/test-fork-ipc-protocol-host
+	$(BUILD_DIR)/test-fork-ipc-protocol-host
 
 # Proctitle argv-tail regression
 ## Run the deterministic argv-tail overshoot guard test

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -36,6 +36,7 @@ int fork_ipc_write_all(int fd, const void *buf, size_t len)
                 continue;
             return -1;
         }
+
         if (n == 0) {
             /* Defensive: an unexpected zero return on a blocking socket would
              * otherwise spin forever, since p and len stay at the same offset.

--- a/src/runtime/fork-state.h
+++ b/src/runtime/fork-state.h
@@ -15,23 +15,18 @@
 #include "syscall/abi.h"
 #include "syscall/signal.h"
 
-/* Magic values for IPC frame delimiters */
-#define IPC_MAGIC_HEADER 0x454C464BU   /* "ELFK" */
-#define IPC_MAGIC_SENTINEL 0x454C4F4BU /* "ELOK" */
-/* Bumped to 11 when regions_tracker_stale was added to process state so forked
- * children preserve mprotect fast-path correctness.
- *
- * Bumped to 10 when the rosetta placement / kbuf / ttbr1 tuple was added so a
- * rosetta-aware child rejects an older parent's header instead of trying to
- * interpret unknown trailing fields.
+/* Fork IPC protocol identity. Bump this whenever the header layout or ordered
+ * fork payload changes incompatibly.
  */
-#define IPC_VERSION 11
+#define FORK_IPC_PROTOCOL_MAGIC 0x454C464CU /* "ELFL" */
+
+#define IPC_MAGIC_HEADER FORK_IPC_PROTOCOL_MAGIC
+#define IPC_MAGIC_SENTINEL 0x454C4F4BU /* "ELOK" */
 
 typedef struct {
     uint32_t magic;
-    uint32_t version;
     uint32_t ipa_bits;
-    uint32_t has_shm;
+    bool has_shm;
     int64_t child_pid, parent_pid;
     uint64_t guest_size;
     uint64_t elf_load_min;
@@ -46,14 +41,14 @@ typedef struct {
     uint32_t _pad;
     uint64_t absock_namespace_id;
     int64_t sid, pgid;
+
     /* Rosetta placement fields. All zero for aarch64 guests; populated when the
      * parent is_rosetta. The child rebuilds the TTBR1 kbuf tree from the PT
      * pool that came across in the memory transfer; rosetta_guest_base /
      * va_base / size pin the segments at the same primary-buffer location so
      * the non-identity page-table mapping remains coherent across the fork.
      */
-    uint32_t is_rosetta;
-    uint32_t _rosetta_pad;
+    bool is_rosetta;
     uint64_t rosetta_guest_base;
     uint64_t rosetta_va_base;
     uint64_t rosetta_size;

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -37,6 +37,7 @@
 #include "runtime/futex.h"
 
 #include "syscall/abi.h"
+#include "syscall/chown-overlay.h"
 #include "syscall/internal.h"
 #include "syscall/mem.h"
 #include "syscall/net.h"  /* absock namespace IPC state */
@@ -89,8 +90,8 @@ int fork_child_main(int ipc_fd,
     proc_init();
     fork_child_vfork_notify_fd = vfork_notify_fd;
 
-    /* The header fixes the IPC protocol version and the guest identity before
-     * any variable-length state is trusted.
+    /* The header magic identifies the fork IPC protocol before any
+     * variable-length state is trusted.
      */
     ipc_header_t hdr;
     if (fork_ipc_read_all(ipc_fd, &hdr, sizeof(hdr)) < 0) {
@@ -101,14 +102,6 @@ int fork_child_main(int ipc_fd,
         log_error("fork-child: bad magic 0x%x", hdr.magic);
         return 1;
     }
-    if (hdr.version != IPC_VERSION) {
-        log_error(
-            "fork-child: IPC version mismatch "
-            "(got %u, expected %u)",
-            hdr.version, IPC_VERSION);
-        return 1;
-    }
-
     log_debug("fork-child: pid=%lld ppid=%lld", (long long) hdr.child_pid,
               (long long) hdr.parent_pid);
 
@@ -228,7 +221,7 @@ int fork_child_main(int ipc_fd,
      * primary buffer and is copied by the region transfer below, so the child
      * can reuse it without rebuilding the tree.
      */
-    g.is_rosetta = (hdr.is_rosetta != 0);
+    g.is_rosetta = hdr.is_rosetta;
     proc_set_rosetta_active(g.is_rosetta);
     g.rosetta_guest_base = hdr.rosetta_guest_base;
     g.rosetta_va_base = hdr.rosetta_va_base;
@@ -271,6 +264,12 @@ int fork_child_main(int ipc_fd,
     signal_state_t sig;
     if (fork_ipc_recv_process_state(ipc_fd, &g, &sig) < 0) {
         log_error("fork-child: failed to receive process state");
+        guest_destroy(&g);
+        return 1;
+    }
+
+    if (chown_overlay_recv(ipc_fd) < 0) {
+        log_error("fork-child: failed to receive chown overlay");
         guest_destroy(&g);
         return 1;
     }
@@ -1494,9 +1493,8 @@ int64_t sys_clone(hv_vcpu_t vcpu,
     /* Header */
     ipc_header_t hdr = {
         .magic = IPC_MAGIC_HEADER,
-        .version = IPC_VERSION,
         .ipa_bits = g->ipa_bits,
-        .has_shm = (uint32_t) use_shm,
+        .has_shm = use_shm,
         .child_pid = child_guest_pid,
         .parent_pid = proc_get_pid(),
         .guest_size = g->guest_size,
@@ -1521,7 +1519,7 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         .absock_namespace_id = absock_get_namespace_id(),
         .sid = proc_get_sid(),
         .pgid = proc_get_pgid(),
-        .is_rosetta = g->is_rosetta ? 1 : 0,
+        .is_rosetta = g->is_rosetta,
         .rosetta_guest_base = g->rosetta_guest_base,
         .rosetta_va_base = g->rosetta_va_base,
         .rosetta_size = g->rosetta_size,
@@ -1618,6 +1616,11 @@ int64_t sys_clone(hv_vcpu_t vcpu,
             regions_tracker_stale_snapshot, preannounced_snapshot,
             num_preannounced) < 0) {
         log_error("clone: failed to send process state");
+        goto fail_snapshot;
+    }
+
+    if (chown_overlay_send(ipc_sock) < 0) {
+        log_error("clone: failed to send chown overlay");
         goto fail_snapshot;
     }
 

--- a/src/syscall/chown-overlay.c
+++ b/src/syscall/chown-overlay.c
@@ -1,0 +1,282 @@
+/* Virtual chown overlay (fakeroot-style)
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "runtime/fork-state.h"
+#include "syscall/chown-overlay.h"
+
+/* Open-chained hash table on (dev, ino). The stat fast path has to stay cheap,
+ * so an atomic entry counter lets chown_overlay_apply skip the lock entirely
+ * when nothing has been recorded yet (the common case before any guest chown).
+ * Once the table is non-empty, readers (apply, send) take the lock in shared
+ * mode and writers (set, clear, recv) take it exclusively, so stat-heavy
+ * workloads scale across vCPU threads instead of serializing on a global mutex.
+ */
+#define CHOWN_OVERLAY_BUCKETS 512u
+
+/* Wire-format guardrail. 24 bytes per record (dev, ino, uid, gid), so the cap
+ * bounds the recv-side allocation regardless of what the IPC stream claims. 1M
+ * entries is far above any plausible package-installer workload (dpkg etc.) but
+ * small enough that a corrupted count cannot allocate gigabytes.
+ */
+#define CHOWN_OVERLAY_MAX_ENTRIES (1u << 20)
+
+typedef struct overlay_entry {
+    struct overlay_entry *next;
+    uint64_t dev;
+    uint64_t ino;
+    uint32_t uid;
+    uint32_t gid;
+} overlay_entry_t;
+
+static overlay_entry_t *buckets[CHOWN_OVERLAY_BUCKETS];
+static pthread_rwlock_t overlay_lock = PTHREAD_RWLOCK_INITIALIZER;
+static _Atomic size_t entry_count = 0;
+
+/* fnv-1a-style mix; (dev, ino) is unique per host file but ino values cluster
+ * low so spread before masking.
+ */
+static unsigned int bucket_index(uint64_t dev, uint64_t ino)
+{
+    uint64_t h = 0xcbf29ce484222325ULL;
+    h = (h ^ dev) * 0x100000001b3ULL;
+    h = (h ^ ino) * 0x100000001b3ULL;
+    return (unsigned int) ((h ^ (h >> 32)) & (CHOWN_OVERLAY_BUCKETS - 1));
+}
+
+static overlay_entry_t *find_locked(uint64_t dev, uint64_t ino)
+{
+    unsigned int idx = bucket_index(dev, ino);
+    for (overlay_entry_t *e = buckets[idx]; e; e = e->next) {
+        if (e->dev == dev && e->ino == ino)
+            return e;
+    }
+    return NULL;
+}
+
+static void remove_locked(uint64_t dev, uint64_t ino)
+{
+    unsigned int idx = bucket_index(dev, ino);
+    overlay_entry_t **prev = &buckets[idx];
+    for (overlay_entry_t *e = *prev; e; prev = &e->next, e = e->next) {
+        if (e->dev == dev && e->ino == ino) {
+            *prev = e->next;
+            free(e);
+            atomic_fetch_sub_explicit(&entry_count, 1, memory_order_release);
+            break;
+        }
+    }
+}
+
+static void clear_all_locked(void)
+{
+    for (unsigned int i = 0; i < CHOWN_OVERLAY_BUCKETS; i++) {
+        overlay_entry_t *e = buckets[i];
+        while (e) {
+            overlay_entry_t *next = e->next;
+            free(e);
+            e = next;
+        }
+        buckets[i] = NULL;
+    }
+    atomic_store_explicit(&entry_count, 0, memory_order_release);
+}
+
+int chown_overlay_set(uint64_t dev,
+                      uint64_t ino,
+                      uint32_t new_owner,
+                      uint32_t new_group,
+                      uint32_t cur_uid,
+                      uint32_t cur_gid)
+{
+    int rc = 0;
+
+    pthread_rwlock_wrlock(&overlay_lock);
+
+    overlay_entry_t *e = find_locked(dev, ino);
+    if (!e) {
+        uint32_t next_uid = new_owner == (uint32_t) -1 ? cur_uid : new_owner;
+        uint32_t next_gid = new_group == (uint32_t) -1 ? cur_gid : new_group;
+        if (next_uid == cur_uid && next_gid == cur_gid)
+            goto out;
+
+        e = calloc(1, sizeof(*e));
+        if (!e) {
+            rc = -1;
+            goto out;
+        }
+        e->dev = dev;
+        e->ino = ino;
+        e->uid = cur_uid;
+        e->gid = cur_gid;
+        unsigned int idx = bucket_index(dev, ino);
+        e->next = buckets[idx];
+        buckets[idx] = e;
+        atomic_fetch_add_explicit(&entry_count, 1, memory_order_release);
+    }
+
+    /* Linux chown semantic: -1 means "do not change this field". */
+    if (new_owner != (uint32_t) -1)
+        e->uid = new_owner;
+    if (new_group != (uint32_t) -1)
+        e->gid = new_group;
+
+    if (e->uid == cur_uid && e->gid == cur_gid)
+        remove_locked(dev, ino);
+
+out:
+    pthread_rwlock_unlock(&overlay_lock);
+    return rc;
+}
+
+void chown_overlay_clear(uint64_t dev, uint64_t ino)
+{
+    /* Skipping the lock when the table is empty saves one rwlock op when no
+     * overrides exist.
+     */
+    if (atomic_load_explicit(&entry_count, memory_order_acquire) == 0)
+        return;
+
+    pthread_rwlock_wrlock(&overlay_lock);
+
+    remove_locked(dev, ino);
+
+    pthread_rwlock_unlock(&overlay_lock);
+}
+
+void chown_overlay_apply(struct stat *st)
+{
+    if (atomic_load_explicit(&entry_count, memory_order_acquire) == 0)
+        return;
+
+    pthread_rwlock_rdlock(&overlay_lock);
+
+    overlay_entry_t *e =
+        find_locked((uint64_t) st->st_dev, (uint64_t) st->st_ino);
+    if (e) {
+        st->st_uid = e->uid;
+        st->st_gid = e->gid;
+    }
+
+    pthread_rwlock_unlock(&overlay_lock);
+}
+
+/* Wire format: uint32_t count, followed by count records of { uint64_t dev;
+ * uint64_t ino; uint32_t uid; uint32_t gid; }. Matches the in-memory layout so
+ * the child can install the table without an intermediate translation step.
+ */
+typedef struct {
+    uint64_t dev;
+    uint64_t ino;
+    uint32_t uid;
+    uint32_t gid;
+} overlay_wire_t;
+
+int chown_overlay_send(int ipc_sock)
+{
+    pthread_rwlock_rdlock(&overlay_lock);
+
+    size_t n = atomic_load_explicit(&entry_count, memory_order_acquire);
+    /* The cap is well above any realistic chown-heavy workload (dpkg, OCI layer
+     * commit). Hitting it indicates a runaway table or a bug, not a legitimate
+     * parent; refuse to truncate-on-success and fail the fork so the caller
+     * sees the problem.
+     */
+    if (n > CHOWN_OVERLAY_MAX_ENTRIES) {
+        pthread_rwlock_unlock(&overlay_lock);
+        return -1;
+    }
+    uint32_t count = (uint32_t) n;
+
+    if (fork_ipc_write_all(ipc_sock, &count, sizeof(count)) < 0) {
+        pthread_rwlock_unlock(&overlay_lock);
+        return -1;
+    }
+    if (count == 0) {
+        pthread_rwlock_unlock(&overlay_lock);
+        return 0;
+    }
+
+    uint32_t emitted = 0;
+    for (unsigned int i = 0; i < CHOWN_OVERLAY_BUCKETS; i++) {
+        for (overlay_entry_t *e = buckets[i]; e; e = e->next) {
+            overlay_wire_t w = {
+                .dev = e->dev,
+                .ino = e->ino,
+                .uid = e->uid,
+                .gid = e->gid,
+            };
+            if (fork_ipc_write_all(ipc_sock, &w, sizeof(w)) < 0) {
+                pthread_rwlock_unlock(&overlay_lock);
+                return -1;
+            }
+            emitted++;
+        }
+    }
+
+    /* entry_count under the rwlock cannot drift; emitted must equal the count
+     * we wrote.
+     */
+    int rc = (emitted == count) ? 0 : -1;
+    pthread_rwlock_unlock(&overlay_lock);
+    return rc;
+}
+
+int chown_overlay_recv(int ipc_sock)
+{
+    uint32_t count;
+    if (fork_ipc_read_all(ipc_sock, &count, sizeof(count)) < 0)
+        return -1;
+    if (count > CHOWN_OVERLAY_MAX_ENTRIES)
+        return -1;
+
+    /* Read every record into a transient buffer before touching the live table.
+     * Keeps the rwlock free for siblings during the blocking IO, and a partial
+     * read just drops the buffer without leaving a half-built table behind.
+     */
+    overlay_wire_t *records = NULL;
+    if (count > 0) {
+        records = calloc(count, sizeof(*records));
+        if (!records)
+            return -1;
+        if (fork_ipc_read_all(ipc_sock, records,
+                              (size_t) count * sizeof(*records)) < 0) {
+            free(records);
+            return -1;
+        }
+    }
+
+    pthread_rwlock_wrlock(&overlay_lock);
+    clear_all_locked();
+
+    for (uint32_t i = 0; i < count; i++) {
+        overlay_entry_t *e = calloc(1, sizeof(*e));
+        if (!e) {
+            clear_all_locked();
+            pthread_rwlock_unlock(&overlay_lock);
+            free(records);
+            return -1;
+        }
+        e->dev = records[i].dev;
+        e->ino = records[i].ino;
+        e->uid = records[i].uid;
+        e->gid = records[i].gid;
+        unsigned int idx = bucket_index(e->dev, e->ino);
+        e->next = buckets[idx];
+        buckets[idx] = e;
+        atomic_fetch_add_explicit(&entry_count, 1, memory_order_release);
+    }
+
+    pthread_rwlock_unlock(&overlay_lock);
+    free(records);
+    return 0;
+}

--- a/src/syscall/chown-overlay.h
+++ b/src/syscall/chown-overlay.h
@@ -1,0 +1,55 @@
+/* Virtual chown overlay (fakeroot-style)
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Records intended owner/group for files whose host chown returned EPERM
+ * (rootless macOS cannot chown to arbitrary uids/gids) so a subsequent
+ * stat/statx/fstat from the guest returns the value the program just "chowned"
+ * to instead of the host's real owner.
+ *
+ * Keyed by host (st_dev, st_ino) so overrides survive rename and apply
+ * uniformly to every hard link.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/stat.h>
+
+/* Record an intended owner/group for the (dev, ino) pair. owner/group of
+ * (uint32_t)-1 means "leave that field unchanged" (Linux chown sentinel).
+ * cur_uid/cur_gid supply the defaults for unchanged fields when no entry exists
+ * yet (typically the host stat result for the same file). If the resulting
+ * virtual owner matches cur_uid/cur_gid, the entry is removed.
+ * Returns 0 on success, -1 if a fresh entry could not be allocated.
+ */
+int chown_overlay_set(uint64_t dev,
+                      uint64_t ino,
+                      uint32_t new_owner,
+                      uint32_t new_group,
+                      uint32_t cur_uid,
+                      uint32_t cur_gid);
+
+/* Drop any recorded override for (dev, ino). */
+void chown_overlay_clear(uint64_t dev, uint64_t ino);
+
+/* If (st->st_dev, st->st_ino) has a recorded override, substitute st->st_uid
+ * and st->st_gid in place. Cheap atomic-load fast path when the table is empty.
+ */
+void chown_overlay_apply(struct stat *st);
+
+/* Fork IPC: serialize the table to ipc_sock.
+ *
+ * Returns 0 on success, -1 on transport failure or when the live table exceeds
+ * the in-build cap (refused rather than truncated, so the caller sees the
+ * problem instead of inheriting a partial state).
+ */
+int chown_overlay_send(int ipc_sock);
+
+/* Fork IPC: rebuild the table from ipc_sock.
+ *
+ * Returns 0 on success, -1 on transport failure, a record count above the
+ * in-build cap (malformed wire), or allocation failure during install.
+ */
+int chown_overlay_recv(int ipc_sock);

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -14,6 +14,7 @@
 #include "runtime/procemu.h"
 
 #include "syscall/abi.h"
+#include "syscall/chown-overlay.h"
 #include "syscall/fuse.h"
 #include "syscall/fs.h"
 #include "syscall/internal.h"
@@ -120,9 +121,12 @@ static int write_linux_stat(guest_t *g,
                             uint64_t stat_gva,
                             const struct stat *mac_st)
 {
+    struct stat overlaid = *mac_st;
+    chown_overlay_apply(&overlaid);
+
     linux_stat_t lin_st;
 
-    translate_stat(mac_st, &lin_st);
+    translate_stat(&overlaid, &lin_st);
     return guest_write_small(g, stat_gva, &lin_st, sizeof(lin_st));
 }
 
@@ -131,9 +135,12 @@ static int write_linux_statx(guest_t *g,
                              const struct stat *mac_st,
                              unsigned int mask)
 {
+    struct stat overlaid = *mac_st;
+    chown_overlay_apply(&overlaid);
+
     linux_statx_t sx;
 
-    translate_statx(mac_st, &sx, normalize_statx_mask(mask));
+    translate_statx(&overlaid, &sx, normalize_statx_mask(mask));
     return guest_write_small(g, statx_gva, &sx, sizeof(sx));
 }
 

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -28,6 +28,7 @@
 #include "runtime/procemu.h"
 
 #include "syscall/abi.h"
+#include "syscall/chown-overlay.h"
 #include "syscall/fd.h" /* eventfd_dup_fd */
 #include "syscall/fuse.h"
 #include "syscall/fs.h"
@@ -72,6 +73,25 @@ static int intercepted_fd_type(const char *path, int host_fd, int linux_flags)
     if (type == FD_REGULAR && path && !strcmp(path, "/dev/urandom"))
         return FD_URANDOM;
     return type;
+}
+
+static bool same_stat_identity(const struct stat *a, const struct stat *b)
+{
+    return a->st_dev == b->st_dev && a->st_ino == b->st_ino;
+}
+
+typedef struct removed_overlay_identity {
+    struct removed_overlay_identity *next;
+    uint64_t dev;
+    uint64_t ino;
+} removed_overlay_identity_t;
+
+static pthread_mutex_t removed_overlay_lock = PTHREAD_MUTEX_INITIALIZER;
+static removed_overlay_identity_t *removed_overlay_identities;
+
+static bool stat_identity_will_disappear(const struct stat *st)
+{
+    return S_ISDIR(st->st_mode) || st->st_nlink <= 1;
 }
 
 static const char *proc_virtual_dir_path(const char *path,
@@ -451,6 +471,121 @@ int64_t sys_openat(guest_t *g,
     return sys_openat_path(g, dirfd, pathp, linux_flags, mode);
 }
 
+static bool stat_identity_has_open_fd(const struct stat *target)
+{
+    bool found = false;
+
+    pthread_mutex_lock(&fd_lock);
+    for (int i = 0; i < FD_TABLE_SIZE; i++) {
+        if (fd_table[i].type == FD_CLOSED)
+            continue;
+
+        struct stat candidate;
+        if (fstat(fd_table[i].host_fd, &candidate) == 0 &&
+            same_stat_identity(target, &candidate)) {
+            found = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&fd_lock);
+
+    return found;
+}
+
+static bool removed_overlay_identity_contains(const struct stat *st)
+{
+    bool found = false;
+    uint64_t dev = (uint64_t) st->st_dev;
+    uint64_t ino = (uint64_t) st->st_ino;
+
+    pthread_mutex_lock(&removed_overlay_lock);
+    for (removed_overlay_identity_t *e = removed_overlay_identities; e;
+         e = e->next) {
+        if (e->dev == dev && e->ino == ino) {
+            found = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&removed_overlay_lock);
+
+    return found;
+}
+
+static void removed_overlay_identity_remove(const struct stat *st)
+{
+    uint64_t dev = (uint64_t) st->st_dev;
+    uint64_t ino = (uint64_t) st->st_ino;
+
+    pthread_mutex_lock(&removed_overlay_lock);
+    removed_overlay_identity_t **prev = &removed_overlay_identities;
+    for (removed_overlay_identity_t *e = *prev; e;
+         prev = &e->next, e = e->next) {
+        if (e->dev == dev && e->ino == ino) {
+            *prev = e->next;
+            free(e);
+            break;
+        }
+    }
+    pthread_mutex_unlock(&removed_overlay_lock);
+}
+
+static void removed_overlay_identity_add(const struct stat *st)
+{
+    uint64_t dev = (uint64_t) st->st_dev;
+    uint64_t ino = (uint64_t) st->st_ino;
+
+    pthread_mutex_lock(&removed_overlay_lock);
+    for (removed_overlay_identity_t *e = removed_overlay_identities; e;
+         e = e->next) {
+        if (e->dev == dev && e->ino == ino) {
+            pthread_mutex_unlock(&removed_overlay_lock);
+            return;
+        }
+    }
+
+    removed_overlay_identity_t *e = calloc(1, sizeof(*e));
+    if (e) {
+        e->dev = dev;
+        e->ino = ino;
+        e->next = removed_overlay_identities;
+        removed_overlay_identities = e;
+    }
+    pthread_mutex_unlock(&removed_overlay_lock);
+}
+
+static void chown_overlay_clear_removed_identity(const struct stat *st)
+{
+    if (stat_identity_has_open_fd(st)) {
+        removed_overlay_identity_add(st);
+        if (!stat_identity_has_open_fd(st)) {
+            removed_overlay_identity_remove(st);
+            chown_overlay_clear((uint64_t) st->st_dev, (uint64_t) st->st_ino);
+        }
+        return;
+    }
+
+    chown_overlay_clear((uint64_t) st->st_dev, (uint64_t) st->st_ino);
+}
+
+static void chown_overlay_clear_closed_unlinked_fd(int host_fd)
+{
+    struct stat st;
+    if (fstat(host_fd, &st) < 0)
+        return;
+
+    if (st.st_nlink == 0 && !stat_identity_has_open_fd(&st)) {
+        removed_overlay_identity_remove(&st);
+        chown_overlay_clear((uint64_t) st.st_dev, (uint64_t) st.st_ino);
+        return;
+    }
+
+    if (removed_overlay_identity_contains(&st) &&
+        !stat_identity_has_open_fd(&st)) {
+        removed_overlay_identity_remove(&st);
+        chown_overlay_clear((uint64_t) st.st_dev, (uint64_t) st.st_ino);
+    }
+}
+
 int64_t sys_close(int fd)
 {
     if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
@@ -468,6 +603,7 @@ int64_t sys_close(int fd)
          * no per-type cleanup is registered.
          */
         proc_pty_close_keepalive(host_fd);
+        chown_overlay_clear_closed_unlinked_fd(host_fd);
         if (close(host_fd) < 0)
             return linux_errno();
         return 0;
@@ -481,6 +617,7 @@ int64_t sys_close(int fd)
     if (!fd_snapshot_and_close_relaxed(fd, &snap))
         return -LINUX_EBADF;
 
+    chown_overlay_clear_closed_unlinked_fd(snap.host_fd);
     fd_cleanup_entry(fd, &snap);
     return 0;
 }
@@ -1109,19 +1246,17 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
             continue;
         if (name_rc < 0) {
             /* macOS APFS accepts UTF-8 filenames whose byte length exceeds
-             * Linux NAME_MAX (255). A guest libc cannot represent such a
-             * name in its 256-byte dirent buffer at all, so elfuse silently
-             * skips the unrepresentable entry and keeps the rest of the
-             * stream intact. This is an elfuse compatibility policy, not
-             * Linux kernel behavior: real getdents64 has no equivalent
-             * skip path because Linux NAME_MAX is enforced at the
-             * filesystem layer, so no oversize entry ever reaches
-             * verify_dirent_name. Aborting the whole stream the way the
-             * pre-fix code did truncated ls / find / coreutils listings
-             * against APFS-mounted source trees. Skip on ENAMETOOLONG;
-             * keep the existing partial-return path for any other
-             * translation failure so genuine errors are not silently
-             * dropped.
+             * Linux NAME_MAX (255). A guest libc cannot represent such a name
+             * in its 256-byte dirent buffer at all, so elfuse silently skips
+             * the unrepresentable entry and keeps the rest of the stream
+             * intact. This is an elfuse compatibility policy, not Linux kernel
+             * behavior: real getdents64 has no equivalent skip path because
+             * Linux NAME_MAX is enforced at the filesystem layer, so no
+             * oversize entry ever reaches verify_dirent_name. Aborting the
+             * whole stream the way the pre-fix code did truncated ls / find /
+             * coreutils listings against APFS-mounted source trees. Skip on
+             * ENAMETOOLONG; keep the existing partial-return path for any other
+             * translation failure so genuine errors are not silently dropped.
              */
             if (errno == ENAMETOOLONG) {
                 static bool overlong_warned;
@@ -1429,11 +1564,20 @@ int64_t sys_unlinkat(guest_t *g, int dirfd, uint64_t path_gva, int flags)
         unlink_path = tx.host_path;
     }
 
+    struct stat removed_st;
+    bool clear_removed_overlay =
+        fstatat(dir_ref.fd, unlink_path, &removed_st, AT_SYMLINK_NOFOLLOW) ==
+            0 &&
+        (removed_st.st_nlink <= 1 || (flags & LINUX_AT_REMOVEDIR));
+
     int host_flags = translate_at_flags(flags);
     if (unlinkat(dir_ref.fd, unlink_path, host_flags) < 0) {
         host_fd_ref_close(&dir_ref);
         return linux_errno();
     }
+
+    if (clear_removed_overlay)
+        chown_overlay_clear_removed_identity(&removed_st);
 
     host_fd_ref_close(&dir_ref);
     return 0;
@@ -1571,11 +1715,23 @@ int64_t sys_renameat2(guest_t *g,
             -LINUX_EINVAL); /* RENAME_EXCHANGE requires AT_FDCWD on macOS */
     }
 
+    struct stat old_st;
+    bool have_old_st = fstatat(olddir_ref.fd, old_tx.host_path, &old_st,
+                               AT_SYMLINK_NOFOLLOW) == 0;
+    struct stat overwritten_st;
+    bool clear_overwritten_overlay =
+        fstatat(newdir_ref.fd, new_tx.host_path, &overwritten_st,
+                AT_SYMLINK_NOFOLLOW) == 0 &&
+        stat_identity_will_disappear(&overwritten_st) &&
+        (!have_old_st || !same_stat_identity(&old_st, &overwritten_st));
+
     if (olddirfd == LINUX_AT_FDCWD && newdirfd == LINUX_AT_FDCWD) {
         if (rename(old_tx.host_path, new_tx.host_path) < 0) {
             return close_dir_refs_result(&olddir_ref, &newdir_ref,
                                          linux_errno());
         }
+        if (clear_overwritten_overlay)
+            chown_overlay_clear_removed_identity(&overwritten_st);
         return close_dir_refs_result(&olddir_ref, &newdir_ref, 0);
     }
 
@@ -1583,6 +1739,8 @@ int64_t sys_renameat2(guest_t *g,
                  new_tx.host_path) < 0) {
         return close_dir_refs_result(&olddir_ref, &newdir_ref, linux_errno());
     }
+    if (clear_overwritten_overlay)
+        chown_overlay_clear_removed_identity(&overwritten_st);
     return close_dir_refs_result(&olddir_ref, &newdir_ref, 0);
 }
 
@@ -1898,11 +2056,37 @@ int64_t sys_fchmodat(guest_t *g,
     return 0;
 }
 
-/* Fake success on EPERM: emulated-root guests expect chown to succeed. */
-static int64_t chown_result(int rc)
+/* Update the virtual-owner overlay for the file the chown call just touched.
+ * host_rc is the return value of fchown/fchownat, host_st is a fresh stat of
+ * the same file (NULL if the host stat failed: the file is gone and an empty
+ * entry would not survive a follow-up access anyway).
+ *
+ * Maps a host EPERM to no-op success because macOS only lets the superuser
+ * chown to an arbitrary uid/gid, but an emulated-root guest expects chown(2) to
+ * succeed. The overlay then ensures the next stat round-trip returns the value
+ * the guest intended.
+ *
+ * The success and EPERM cases share the same update so a partial chown (e.g.
+ * owner=-1) preserves the prior override for the field the caller did not
+ * touch, even when the host actually changed the other field.
+ */
+static int64_t chown_result(int host_rc,
+                            const struct stat *host_st,
+                            uint32_t owner,
+                            uint32_t group)
 {
-    if (rc < 0)
-        return (errno == EPERM) ? 0 : linux_errno();
+    if (host_rc < 0 && errno != EPERM)
+        return linux_errno();
+    if (host_st && chown_overlay_set((uint64_t) host_st->st_dev,
+                                     (uint64_t) host_st->st_ino, owner, group,
+                                     host_st->st_uid, host_st->st_gid) < 0) {
+        /* Override allocation failed; reporting success would lie about the
+         * post-call stat round-trip. Linux's chown(2) lists ENOMEM among its
+         * possible errors for related allocation paths, so surface that to the
+         * guest instead.
+         */
+        return -LINUX_ENOMEM;
+    }
     return 0;
 }
 
@@ -1932,8 +2116,32 @@ int64_t sys_fchownat(guest_t *g,
         return -LINUX_EBADF;
 
     int mac_flags = translate_at_flags(flags);
-    int64_t out = chown_result(
-        fchownat(dir_ref.fd, tx.host_path, owner, group, mac_flags));
+    struct stat before_st;
+    bool before_ok =
+        fstatat(dir_ref.fd, tx.host_path, &before_st, mac_flags) == 0;
+
+    int host_rc = fchownat(dir_ref.fd, tx.host_path, owner, group, mac_flags);
+    int saved_errno = errno;
+
+    struct stat after_st;
+    const struct stat *st_ptr = NULL;
+    if (fstatat(dir_ref.fd, tx.host_path, &after_st, mac_flags) == 0 &&
+        before_ok && same_stat_identity(&before_st, &after_st)) {
+        st_ptr = &after_st;
+    }
+
+    errno = saved_errno;
+    int64_t out;
+    if (host_rc < 0 && saved_errno == EPERM && !st_ptr) {
+        /* fchownat does not give us a stable handle to the object it checked.
+         * If the path was replaced while the host syscall was in flight, a
+         * post-call stat could attach the virtual owner to the replacement
+         * inode. Refuse the fakeroot success in that race instead.
+         */
+        out = -LINUX_EAGAIN;
+    } else {
+        out = chown_result(host_rc, st_ptr, owner, group);
+    }
     host_fd_ref_close(&dir_ref);
     return out;
 }
@@ -1947,7 +2155,17 @@ int64_t sys_fchown(int fd, uint32_t owner, uint32_t group)
     host_fd_ref_t host_ref;
     if (host_fd_ref_open(fd, &host_ref) < 0)
         return -LINUX_EBADF;
-    int64_t out = chown_result(fchown(host_ref.fd, owner, group));
+
+    int host_rc = fchown(host_ref.fd, owner, group);
+    int saved_errno = errno;
+
+    struct stat host_st;
+    const struct stat *st_ptr = NULL;
+    if (fstat(host_ref.fd, &host_st) == 0)
+        st_ptr = &host_st;
+
+    errno = saved_errno;
+    int64_t out = chown_result(host_rc, st_ptr, owner, group);
     host_fd_ref_close(&host_ref);
     return out;
 }

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -203,3 +203,6 @@ test-fd-family                     # diff=skip
 
 [section] SCM_CREDENTIALS tests
 test-scm-creds                     # diff=skip
+
+[section] Virtual chown overlay tests
+test-chown-overlay                 # diff=skip

--- a/tests/test-chown-overlay.c
+++ b/tests/test-chown-overlay.c
@@ -1,0 +1,282 @@
+/* Virtual chown overlay round-trip tests
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * An emulated-root guest expects chown(2)/fchown(2)/fchownat(2) to succeed
+ * even when rootless macOS cannot satisfy the change, and the follow-up
+ * stat(2)/statx(2)/fstat(2) must observe the intended owner/group rather
+ * than the host's real owner.
+ *
+ * Exercises the round-trip across the chown family, the -1 sentinel,
+ * AT_SYMLINK_NOFOLLOW on a symlink, the regression guard for non-EPERM
+ * failures, and survival across fork/execve.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+static char tmp_file[256];
+static char tmp_link[256];
+static char tmp_target[256];
+static char tmp_dir[256];
+
+static int setup_fixtures(void)
+{
+    snprintf(tmp_file, sizeof(tmp_file), "/tmp/elfuse-chown-%d.txt",
+             (int) getpid());
+    snprintf(tmp_target, sizeof(tmp_target), "/tmp/elfuse-chown-tgt-%d.txt",
+             (int) getpid());
+    snprintf(tmp_link, sizeof(tmp_link), "/tmp/elfuse-chown-link-%d",
+             (int) getpid());
+    snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/elfuse-chown-dir-%d",
+             (int) getpid());
+
+    int fd = open(tmp_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("setup: open tmp_file");
+        return -1;
+    }
+    if (write(fd, "x\n", 2) != 2) {
+        perror("setup: write tmp_file");
+        close(fd);
+        return -1;
+    }
+    close(fd);
+
+    fd = open(tmp_target, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("setup: open tmp_target");
+        return -1;
+    }
+    close(fd);
+
+    unlink(tmp_link);
+    if (symlink(tmp_target, tmp_link) < 0) {
+        perror("setup: symlink");
+        return -1;
+    }
+    if (mkdir(tmp_dir, 0755) < 0) {
+        perror("setup: mkdir tmp_dir");
+        return -1;
+    }
+    return 0;
+}
+
+static void teardown_fixtures(void)
+{
+    unlink(tmp_file);
+    unlink(tmp_link);
+    unlink(tmp_target);
+    rmdir(tmp_dir);
+}
+
+static void test_chown_then_stat(void)
+{
+    TEST("chown(uid,gid) then stat reflects both");
+    if (chown(tmp_file, 1000, 1001) != 0) {
+        FAIL("chown");
+        return;
+    }
+    struct stat st;
+    if (stat(tmp_file, &st) != 0) {
+        FAIL("stat");
+        return;
+    }
+    EXPECT_TRUE(st.st_uid == 1000 && st.st_gid == 1001, "uid/gid mismatch");
+}
+
+static void test_chown_minus_one_keeps_gid(void)
+{
+    /* The earlier test already set (1000, 1001). chown(uid, -1) must
+     * change uid only and keep the prior gid override visible to stat.
+     */
+    TEST("chown(uid,-1) keeps prior gid override");
+    if (chown(tmp_file, 2000, (gid_t) -1) != 0) {
+        FAIL("chown");
+        return;
+    }
+    struct stat st;
+    if (stat(tmp_file, &st) != 0) {
+        FAIL("stat");
+        return;
+    }
+    EXPECT_TRUE(st.st_uid == 2000 && st.st_gid == 1001, "uid/gid mismatch");
+}
+
+static void test_successful_group_chown_keeps_virtual_uid(void)
+{
+    TEST("chown(-1,gid) host success keeps prior uid override");
+    if (chown(tmp_file, 3000, 3001) != 0) {
+        FAIL("chown setup");
+        return;
+    }
+    gid_t gid = getgid();
+    if (chown(tmp_file, (uid_t) -1, gid) != 0) {
+        FAIL("chown group");
+        return;
+    }
+    struct stat st;
+    if (stat(tmp_file, &st) != 0) {
+        FAIL("stat");
+        return;
+    }
+    EXPECT_TRUE(st.st_uid == 3000 && st.st_gid == gid, "uid/gid mismatch");
+}
+
+static void test_fchown_then_fstat(void)
+{
+    TEST("fchown(fd) then fstat(fd) reflects override");
+    int fd = open(tmp_file, O_RDONLY);
+    if (fd < 0) {
+        FAIL("open");
+        return;
+    }
+    if (fchown(fd, 0, 0) != 0) {
+        FAIL("fchown");
+        close(fd);
+        return;
+    }
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        FAIL("fstat");
+        close(fd);
+        return;
+    }
+    close(fd);
+    EXPECT_TRUE(st.st_uid == 0 && st.st_gid == 0, "uid/gid mismatch");
+}
+
+static void test_open_removed_dir_keeps_overlay_until_last_close(void)
+{
+    TEST("open removed dir keeps overlay until last close");
+    int fd = open(tmp_dir, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        FAIL("open dir");
+        return;
+    }
+    int dupfd = dup(fd);
+    if (dupfd < 0) {
+        FAIL("dup dir");
+        close(fd);
+        return;
+    }
+    if (fchown(fd, 6060, 7070) != 0) {
+        FAIL("fchown dir");
+        close(dupfd);
+        close(fd);
+        return;
+    }
+    if (rmdir(tmp_dir) != 0) {
+        FAIL("rmdir dir");
+        close(dupfd);
+        close(fd);
+        return;
+    }
+    close(fd);
+
+    struct stat st;
+    if (fstat(dupfd, &st) != 0) {
+        FAIL("fstat removed dir");
+        close(dupfd);
+        return;
+    }
+    close(dupfd);
+    EXPECT_TRUE(st.st_uid == 6060 && st.st_gid == 7070, "uid/gid mismatch");
+}
+
+static void test_lchown_on_symlink(void)
+{
+    TEST("lchown(link) leaves target unchanged");
+    /* Reset target ownership through the existing path so test ordering
+     * does not leak overrides from earlier asserts.
+     */
+    if (chown(tmp_target, 100, 100) != 0) {
+        FAIL("chown target");
+        return;
+    }
+    if (fchownat(AT_FDCWD, tmp_link, 9, 9, AT_SYMLINK_NOFOLLOW) != 0) {
+        FAIL("fchownat link");
+        return;
+    }
+    struct stat link_st, tgt_st;
+    if (lstat(tmp_link, &link_st) != 0 || stat(tmp_target, &tgt_st) != 0) {
+        FAIL("stat");
+        return;
+    }
+    EXPECT_TRUE(link_st.st_uid == 9 && link_st.st_gid == 9 &&
+                    tgt_st.st_uid == 100 && tgt_st.st_gid == 100,
+                "symlink override leaked to target");
+}
+
+static void test_enoent_propagates(void)
+{
+    TEST("chown on missing file returns ENOENT");
+    EXPECT_ERRNO(chown("/tmp/elfuse-chown-no-such-file", 0, 0), ENOENT,
+                 "chown");
+}
+
+static void test_fork_inherits_overlay(void)
+{
+    TEST("forked child observes parent's override");
+
+    /* Re-establish a known override so the child's assertion is precise. */
+    if (chown(tmp_file, 4242, 4243) != 0) {
+        FAIL("chown");
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork");
+        return;
+    }
+    if (pid == 0) {
+        struct stat st;
+        if (stat(tmp_file, &st) != 0)
+            _exit(2);
+        if (st.st_uid != 4242 || st.st_gid != 4243)
+            _exit(3);
+        _exit(0);
+    }
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        FAIL("waitpid");
+        return;
+    }
+    EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+                "child saw wrong uid/gid");
+}
+
+int main(void)
+{
+    printf("test-chown-overlay: chown round-trip via virtual ownership\n");
+
+    if (setup_fixtures() < 0) {
+        printf("test-chown-overlay: fixture setup failed\n");
+        return 1;
+    }
+    test_chown_then_stat();
+    test_chown_minus_one_keeps_gid();
+    test_successful_group_chown_keeps_virtual_uid();
+    test_fchown_then_fstat();
+    test_open_removed_dir_keeps_overlay_until_last_close();
+    test_lchown_on_symlink();
+    test_enoent_propagates();
+    test_fork_inherits_overlay();
+    teardown_fixtures();
+
+    SUMMARY("test-chown-overlay");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-fork-ipc-protocol-host.c
+++ b/tests/test-fork-ipc-protocol-host.c
@@ -1,0 +1,57 @@
+/* Native-host unit test for fork IPC protocol identity.
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The fork child is spawned from elfuse_path, so a long-running parent can
+ * handshake with a newer on-disk child after an upgrade. The first header
+ * word is therefore the protocol identity, not just a frame delimiter.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "runtime/fork-state.h"
+
+#define LEGACY_ELFK_MAGIC 0x454C464BU
+
+_Static_assert(FORK_IPC_PROTOCOL_MAGIC == 0x454C464CU,
+               "fork IPC protocol magic must remain ELFL until the next "
+               "incompatible wire-format change");
+_Static_assert(IPC_MAGIC_HEADER == FORK_IPC_PROTOCOL_MAGIC,
+               "header magic must be the protocol identity");
+_Static_assert(FORK_IPC_PROTOCOL_MAGIC != LEGACY_ELFK_MAGIC,
+               "current protocol must reject old ELFK children/parents");
+_Static_assert(IPC_MAGIC_SENTINEL != FORK_IPC_PROTOCOL_MAGIC,
+               "process-state sentinel must not alias the header protocol");
+
+_Static_assert(offsetof(ipc_header_t, magic) == 0,
+               "protocol magic must be the first header field");
+_Static_assert(offsetof(ipc_header_t, ipa_bits) == sizeof(uint32_t),
+               "ipa_bits must immediately follow magic; there is no version "
+               "slot in the fork IPC header");
+/* Enforce the bool typing of has_shm / is_rosetta via _Generic so a silent
+ * widening to uint8_t / uint32_t (which would still match sizeof(bool)) fails
+ * the build instead of accidentally re-shaping the wire.
+ */
+_Static_assert(_Generic(((ipc_header_t *) 0)->has_shm, bool: 1, default: 0),
+               "has_shm must remain a bool field");
+_Static_assert(_Generic(((ipc_header_t *) 0)->is_rosetta, bool: 1, default: 0),
+               "is_rosetta must remain a bool field");
+/* The wire is private to one build (FORK_IPC_PROTOCOL_MAGIC bumps on every
+ * incompatible layout change), but parent and child still need to agree on
+ * the width of the bool flags they exchange. Pin the assumption so a future
+ * toolchain that widens _Bool fails the build instead of silently desyncing.
+ */
+_Static_assert(sizeof(bool) == 1,
+               "fork IPC bool fields assume a 1-byte _Bool; pin this width "
+               "until the wire format uses uint8_t explicitly");
+
+int main(void)
+{
+    printf("test-fork-ipc-protocol-host: protocol magic 0x%08x\n",
+           FORK_IPC_PROTOCOL_MAGIC);
+    return 0;
+}


### PR DESCRIPTION
A rootless macOS host cannot chown a file to an arbitrary uid/gid, so the existing fallback turns the host EPERM into no-op success. Follow-up stat still returns the host's real owner instead of the value the guest just chowned to, which trips programs that diff metadata after extraction (tar --same-owner, cp -p, rsync -a, install -o user, dpkg, Python shutil.chown + os.stat).

Add a small (dev, ino) -> (uid, gid) overlay keyed by host stat. sys_fchownat and sys_fchown record the intent on EPERM and on host success alike, with the partial-chown -1 sentinel preserving the prior field. The stat-family wrappers in src/syscall/fs-stat.c consult the overlay once before translating struct stat into linux_stat[x]_t, so fstat / newfstatat / statx all pick up the override automatically. The set helper auto-prunes entries whose final (uid, gid) matches host's current values, so a guest that resets to the host owner walks away with a clean table.

Host inode reuse is defended by hooks in sys_unlinkat, sys_renameat2, and sys_close: stat the identity before the operation, and clear the overlay only when no other path or open fd still references the same (dev, ino). Forked children inherit the overlay through a new chown_overlay_send / chown_overlay_recv pair on the existing fork IPC socket. The recv helper reads records into a transient heap buffer before taking the lock so blocking IO does not serialize sibling stats; it also rejects out-of-band record counts.

stat is hot. The lock is a pthread_rwlock_t with apply / send taking the read lock and set / clear / recv taking the write lock; an atomic entry counter lets apply skip the lock entirely when no overrides exist.

The fork IPC header drops the standalone version field. The first header word is the protocol identity: bumping FORK_IPC_PROTOCOL_MAGIC (0x454C464C, "ELFL") replaces what bumping IPC_VERSION used to do, with one fewer field on the wire and one fewer concept in the code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a virtual ownership overlay so `chown` on rootless macOS records intended uid/gid even when the host returns EPERM, and the `stat` family returns those values. Also moves fork IPC to a protocol magic, carries the overlay across `fork`, and adds tests.

- **New Features**
  - Record owner/group on `chown` success or EPERM; honor `-1` partial updates; auto-prune when matching the host.
  - Apply overrides in `stat`/`fstat`/`newfstatat`/`statx`, keyed by `(st_dev, st_ino)` so it survives renames and covers hard links.
  - Clear entries on `unlink`, rename-overwrite, and when the last open fd to an unlinked inode closes.
  - Fork: send/recv the overlay over IPC; recv pre-reads outside the lock and caps record count; readers use an rwlock with an empty fast path.
  - Errors: non-EPERM `chown` errors propagate; `fchownat` on EPERM returns `EAGAIN` if the path changed during the call; return `ENOMEM` if an overlay entry cannot be allocated. Tests: add `test-chown-overlay` (chown/fchown/fchownat, `-1`, symlink nofollow, unlink/last-fd, fork), wired into `make check`.

- **Refactors**
  - Fork IPC header now uses `FORK_IPC_PROTOCOL_MAGIC` ("ELFL") as the protocol identity; removed `IPC_VERSION`; `has_shm` and `is_rosetta` are `bool`.
  - Added native `test-fork-ipc-protocol-host` and build/test targets; run as part of `make check`.

<sup>Written for commit c0e6de99d71bb6f9181472884884405b44827021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

