### PR TITLE
Style tweaks

### DIFF
--- a/src/core/bootstrap.c
+++ b/src/core/bootstrap.c
@@ -57,7 +57,9 @@ static bool append_boot_region(mem_region_t *regions,
 }
 
 /* Emit one mem_region_t per PT_LOAD segment of an ELF image, offset by the
- * caller-supplied load base. Returns false if the boot region array fills up.
+ * caller-supplied load base.
+ *
+ * Returns false if the boot region array fills up.
  */
 static bool append_elf_segment_regions(mem_region_t *regions,
                                        int *nregions,
@@ -77,8 +79,8 @@ static bool append_elf_segment_regions(mem_region_t *regions,
 
 /* Register one semantic guest_region_t per PT_LOAD segment of an ELF image.
  * va_load_base controls the guest-visible range, gpa_load_base controls the
- * backing GPA recorded in region metadata, and path is used for
- * /proc/self/maps reporting.
+ * backing GPA recorded in region metadata, and path is used for /proc/self/maps
+ * reporting.
  */
 static void register_elf_segment_regions(guest_t *g,
                                          const elf_info_t *info,
@@ -519,10 +521,10 @@ int guest_bootstrap_prepare(guest_t *g,
 
     t0 = startup_trace_now_ns();
     if (want_rosetta) {
-        /* /proc/self/maps for a rosetta guest reports the rosetta translator
-         * as a single anonymous region covering [VA, VA+size). The original
-         * x86_64 binary is not loaded into guest memory; rosetta exposes it
-         * via fd 3 once rosetta_finalize pre-opens it.
+        /* /proc/self/maps for a rosetta guest reports the rosetta translator as
+         * a single anonymous region covering [VA, VA+size). The original x86_64
+         * binary is not loaded into guest memory; rosetta exposes it via fd 3
+         * once rosetta_finalize pre-opens it.
          */
         register_elf_segment_regions(g, &rr.rosetta_info, 0,
                                      g->rosetta_guest_base - g->rosetta_va_base,
@@ -612,10 +614,10 @@ int guest_bootstrap_prepare(guest_t *g,
         return -1;
     }
     startup_trace_step("build_linux_stack", t0);
-    /* rosetta_argv was copied into the guest stack; the host allocation is
-     * no longer needed. The strings themselves are constants (ROSETTA_PATH)
-     * or owned by the caller (binary_path, guest_argv entries) so freeing
-     * just the array is safe.
+    /* rosetta_argv was copied into the guest stack; the host allocation is no
+     * longer needed. The strings themselves are constants (ROSETTA_PATH) or
+     * owned by the caller (binary_path, guest_argv entries) so freeing just the
+     * array is safe.
      */
     free(rosetta_argv);
 
@@ -650,8 +652,8 @@ int guest_bootstrap_create_vcpu(guest_t *g,
     uint64_t t0;
     /* Rosetta needs TTBR1 walks enabled and TBI1=1 so the kbuf window at
      * KBUF_VA_BASE (bits-63-set) resolves and TaggedPointer extraction keeps
-     * working. Aarch64 guests stay on the EPD1=1 variant which keeps the
-     * upper VA range fault-clean.
+     * working. Aarch64 guests stay on the EPD1=1 variant which keeps the upper
+     * VA range fault-clean.
      */
     uint64_t tcr_value = g->is_rosetta ? TCR_EL1_VALUE_KBUF : TCR_EL1_VALUE;
     uint64_t ttbr1_value = g->is_rosetta ? g->ttbr1 : 0;
@@ -684,10 +686,10 @@ int guest_bootstrap_create_vcpu(guest_t *g,
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL0, sp_ipa));
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL1, el1_sp));
 
-    /* Round-trip a sentinel through TPIDR_EL1 before installing the real
-     * value. Validates only the hv_vcpu_{set,get}_sys_reg pre-run round
-     * trip, not preservation across hv_vcpu_run -- the test-shim-identity
-     * microbench is the end-to-end check for that.
+    /* Round-trip a sentinel through TPIDR_EL1 before installing the real value.
+     * Validates only the hv_vcpu_{set,get}_sys_reg pre-run round trip, not
+     * preservation across hv_vcpu_run -- the test-shim-identity microbench is
+     * the end-to-end check for that.
      */
     if (shim_globals_self_test(vcpu) < 0)
         return -1;
@@ -790,11 +792,11 @@ int guest_bootstrap_rosetta_post_reset(guest_t *g,
         !out_stack_pointer || !out_ttbr0)
         return -1;
 
-    /* Re-anchor brk/stack to the Rosetta defaults. guest_reset already
-     * restored mmap_next/mmap_end/mmap_rx_* to their initial values, but
-     * brk/stack were tuned for the previous image, so reset them here.
-     * The x86_64 target binary lives behind fd 3, not in guest memory,
-     * so brk_base does not move with the target's load_max.
+    /* Re-anchor brk/stack to the Rosetta defaults. guest_reset already restored
+     * mmap_next/mmap_end/mmap_rx_* to their initial values, but brk/stack were
+     * tuned for the previous image, so reset them here. The x86_64 target
+     * binary lives behind fd 3, not in guest memory, so brk_base does not move
+     * with the target's load_max.
      */
     g->elf_load_min = ELF_DEFAULT_BASE;
     g->brk_base = BRK_BASE_DEFAULT;

--- a/src/core/bootstrap.h
+++ b/src/core/bootstrap.h
@@ -60,23 +60,24 @@ int guest_bootstrap_create_vcpu(guest_t *g,
  *     proc_set_rosetta_active(true) so rosetta_prepare and rosettad gates
  *     see the right runtime state
  *
- * elf_host_path is the macOS filesystem path used by rosetta_prepare to
- * open the binary (after sysroot/FUSE resolution). elf_guest_path is the
- * unresolved guest-visible path published through proc_set_elf_path and
- * rosetta_finalize's /proc/self/cmdline rewrite.
+ * elf_host_path is the macOS filesystem path used by rosetta_prepare to open
+ * the binary (after sysroot/FUSE resolution). elf_guest_path is the unresolved
+ * guest-visible path published through proc_set_elf_path and rosetta_finalize's
+ * /proc/self/cmdline rewrite.
  *
- * The helper runs rosetta_prepare, appends every region the page-table
- * builder needs, rebuilds page tables, registers guest_region_t entries
- * for /proc/self/maps, runs rosetta_finalize (pre-opens fd 3, installs the
- * kbuf user alias, publishes the binfmt-misc argv via proc_set_cmdline),
- * and builds the initial Linux stack using the rosetta image as the
- * AT_PHDR/AT_BASE ELF metadata. It does NOT touch the vCPU sysregs --
- * the caller writes TCR_EL1, TTBR0_EL1, TTBR1_EL1, ELR_EL1, SP_EL0, and
- * PC itself once the out_* fields are returned.
+ * The helper runs rosetta_prepare, appends every region the page-table builder
+ * needs, rebuilds page tables, registers guest_region_t entries for
+ * /proc/self/maps, runs rosetta_finalize (pre-opens fd 3, installs the kbuf
+ * user alias, publishes the binfmt-misc argv via proc_set_cmdline), and builds
+ * the initial Linux stack using the rosetta image as the AT_PHDR/AT_BASE ELF
+ * metadata. It does NOT touch the vCPU sysregs -- the caller writes TCR_EL1,
+ * TTBR0_EL1, TTBR1_EL1, ELR_EL1, SP_EL0, and PC itself once the out_* fields
+ * are returned.
  *
- * Returns 0 on success with out_entry_point, out_stack_pointer, out_ttbr0
- * set. Returns -1 on any internal failure; the caller is past the point of
- * no return and treats that as fatal.
+ * Returns 0 on success with out_entry_point, out_stack_pointer, out_ttbr0 set.
+ *
+ * Returns -1 on any internal failure; the caller is past the point of no return
+ * and treats that as fatal.
  */
 int guest_bootstrap_rosetta_post_reset(guest_t *g,
                                        const char *elf_host_path,

--- a/src/core/elf.c
+++ b/src/core/elf.c
@@ -145,8 +145,8 @@ int elf_load(const char *path, elf_info_t *info)
                 long saved_pos = ftell(f);
                 if (fseek(f, (long) ph->p_offset, SEEK_SET) == 0) {
                     size_t n = fread(info->interp_path, 1, interp_len, f);
-                    /* interp_len includes the NUL from the ELF file.
-                     * On short read, clear the path (unusable). On full read,
+                    /* interp_len includes the NUL from the ELF file. On short
+                     * read, clear the path (unusable). On full read,
                      * force-terminate as insurance.
                      */
                     if (n < interp_len)
@@ -193,9 +193,9 @@ int elf_load(const char *path, elf_info_t *info)
         return -1;
     }
 
-    /* Store program header file offset for later phdr_gpa calculation.
-     * The loader places program headers at the same GPA as they would be in
-     * the first PT_LOAD segment (they are typically within it).
+    /* Store program header file offset for later phdr_gpa calculation. The
+     * loader places program headers at the same GPA as they would be in the
+     * first PT_LOAD segment (they are typically within it).
      */
     info->phdr_gpa = info->load_min + ehdr.e_phoff;
 
@@ -213,9 +213,9 @@ int elf_map_segments(const elf_info_t *info,
                      uint64_t infra_hi)
 {
     /* Half-open intersection test for [a, a+alen) and [b, b+blen). When
-     * infra_lo == infra_hi the caller opted out (early bring-up before
-     * guest_t is wired up); the host-side writes that follow still get
-     * the existing guest_size bound check.
+     * infra_lo == infra_hi the caller opted out (early bring-up before guest_t
+     * is wired up); the host-side writes that follow still get the existing
+     * guest_size bound check.
      */
     bool infra_active = infra_lo < infra_hi;
     FILE *f = fopen(path, "rb");
@@ -231,9 +231,9 @@ int elf_map_segments(const elf_info_t *info,
         return -1;
     }
 
-    /* Read and parse program headers again to get file offsets. The size
-     * was already bound-checked during elf_load(); recheck defensively in
-     * case the header sizes changed since (e.g. corrupt file races).
+    /* Read and parse program headers again to get file offsets. The size was
+     * already bound-checked during elf_load(); recheck defensively in case the
+     * header sizes changed since (e.g. corrupt file races).
      */
     size_t ph_total = (size_t) ehdr.e_phnum * ehdr.e_phentsize;
     if (ph_total == 0 || ph_total > 65536) {
@@ -327,28 +327,28 @@ int elf_map_segments(const elf_info_t *info,
             return -1;
         }
 
-        /* PT_LOAD with memsz == 0 maps no bytes, but the page-tail zero
-         * extent below still rounds up to the next page boundary. For an
-         * unaligned gpa that means a crafted ELF could splat zeros across
-         * the tail of a previously loaded segment in the same page, or
-         * trip the infra-overlap check with no live mapping behind it.
-         * Linux ignores zero-memsz PT_LOADs; mirror that here.
+        /* PT_LOAD with memsz == 0 maps no bytes, but the page-tail zero extent
+         * below still rounds up to the next page boundary. For an unaligned gpa
+         * that means a crafted ELF could splat zeros across the tail of a
+         * previously loaded segment in the same page, or trip the infra-overlap
+         * check with no live mapping behind it. Linux ignores zero-memsz
+         * PT_LOADs; mirror that here.
          */
         if (memsz == 0) {
             seg_idx++;
             continue;
         }
 
-        /* The host memset zeros up to the next page boundary AFTER the
-         * segment ends, so the infra-overlap check has to use the same
-         * rounded extent. The end is PAGE_ALIGN_UP(gpa + memsz) rather
-         * than gpa + PAGE_ALIGN_UP(memsz) because gpa is not always
-         * page-aligned (e.g. ld.so's RW segment at vaddr 0x2f650): with
-         * the older bytes-from-gpa formula the page covering the last
-         * memsz byte kept its mid-page tail untouched, and execve into a
-         * dynamic-linked target then read stale state from the prior
-         * incarnation of the same interpreter at offsets ld.so allocates
-         * from beyond memsz (e.g. the first link_map in _dl_new_object).
+        /* The host memset zeros up to the next page boundary AFTER the segment
+         * ends, so the infra-overlap check has to use the same rounded extent.
+         * The end is PAGE_ALIGN_UP(gpa + memsz) rather than gpa +
+         * PAGE_ALIGN_UP(memsz) because gpa is not always page-aligned (e.g.
+         * ld.so's RW segment at vaddr 0x2f650): with the older bytes-from-gpa
+         * formula the page covering the last memsz byte kept its mid-page tail
+         * untouched, and execve into a dynamic-linked target then read stale
+         * state from the prior incarnation of the same interpreter at offsets
+         * ld.so allocates from beyond memsz (e.g. the first link_map in
+         * _dl_new_object).
          */
         uint64_t zero_len = PAGE_ALIGN_UP(gpa + memsz) - gpa;
         if (gpa + zero_len > guest_size)
@@ -415,8 +415,8 @@ void elf_resolve_interp(const char *sysroot,
         if (access(out, F_OK) == 0)
             return;
 
-        /* Strategy 2: sysroot/lib/basename. Handles store-style
-         * interpreter paths such as /.../lib/ld-musl-aarch64.so.1
+        /* Strategy 2: sysroot/lib/basename. Handles store-style interpreter
+         * paths such as /.../lib/ld-musl-aarch64.so.1
          */
         const char *base = strrchr(interp_path, '/');
         base = base ? base + 1 : interp_path;

--- a/src/core/elf.h
+++ b/src/core/elf.h
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Parses aarch64-linux ELF64 executables (static and dynamic), extracts
- * PT_LOAD segments, and copies them into guest memory.
+ * Parses aarch64-linux ELF64 executables (static and dynamic), extracts PT_LOAD
+ * segments, and copies them into guest memory.
  */
 
 #pragma once
@@ -107,14 +107,14 @@ typedef struct {
 int elf_load(const char *path, elf_info_t *info);
 
 /* Copy ELF segments into guest memory. Call after elf_load() and guest_init().
- * Also copies program headers into guest memory for AT_PHDR.
- * load_base is added to all virtual addresses (0 for ET_EXEC at link addr,
- * non-zero for ET_DYN loaded at a chosen base).
- * infra_lo and infra_hi delimit the runtime infra reserve (page-table pool,
- * shim text, shim_data, vDSO). Any PT_LOAD or PT_PHDR copy whose destination
- * intersects [infra_lo, infra_hi) is rejected: those writes go through
- * host_base directly and would otherwise bypass the EL1-only page-table
- * protection on shim_data. Pass 0,0 only when the guest_t is not yet built.
+ * Also copies program headers into guest memory for AT_PHDR. load_base is added
+ * to all virtual addresses (0 for ET_EXEC at link addr, non-zero for ET_DYN
+ * loaded at a chosen base). infra_lo and infra_hi delimit the runtime infra
+ * reserve (page-table pool, shim text, shim_data, vDSO). Any PT_LOAD or PT_PHDR
+ * copy whose destination intersects [infra_lo, infra_hi) is rejected: those
+ * writes go through host_base directly and would otherwise bypass the EL1-only
+ * page-table protection on shim_data. Pass 0,0 only when the guest_t is not yet
+ * built.
  * Returns 0 on success, -1 on failure.
  */
 int elf_map_segments(const elf_info_t *info,
@@ -125,8 +125,7 @@ int elf_map_segments(const elf_info_t *info,
                      uint64_t infra_lo,
                      uint64_t infra_hi);
 
-/* Resolve a PT_INTERP path against a sysroot directory.
- * Tries three strategies:
+/* Resolve a PT_INTERP path against a sysroot directory. Tries three strategies:
  *   1. sysroot + interp_path  (standard /lib/ld-musl-*.so.1)
  *   2. sysroot/lib/basename(interp_path)  (store-style paths)
  *   3. interp_path as-is  (no sysroot or fallback)
@@ -138,11 +137,11 @@ void elf_resolve_interp(const char *sysroot,
                         size_t out_sz);
 
 /* Translate ELF program-header flags (PF_R=4, PF_W=2, PF_X=1) into the
- * R=1/W=2/X=4 bitset shared by both MEM_PERM_R/W/X (page-table permissions)
- * and LINUX_PROT_READ/WRITE/EXEC (mmap prot bits).
+ * R=1/W=2/X=4 bitset shared by both MEM_PERM_R/W/X (page-table permissions) and
+ * LINUX_PROT_READ/WRITE/EXEC (mmap prot bits).
  *
- * READ is implicit: every loaded segment gets the R bit even if PF_R is
- * absent, mirroring the kernel's behavior for ELF loading.
+ * READ is implicit: every loaded segment gets the R bit even if PF_R is absent,
+ * mirroring the kernel's behavior for ELF loading.
  */
 static inline int elf_pf_to_prot(int pf)
 {

--- a/src/core/guest.c
+++ b/src/core/guest.c
@@ -4,11 +4,11 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Identity-mapped guest memory: GVA == GPA == offset into host_base.
- * The guest address space size is determined by the VM's configured IPA width
- * (capped at 40-bit = 1TiB): 64GiB for native aarch64 on M2 (36-bit), 1TiB for
- * M3+ (40-bit). Reserved via mmap(MAP_ANON); macOS demand-pages physical memory
- * on first touch, so only used pages consume RAM. The slab is mapped RWX to
+ * Identity-mapped guest memory: GVA == GPA == offset into host_base. The guest
+ * address space size is determined by the VM's configured IPA width (capped at
+ * 40-bit = 1TiB): 64GiB for native aarch64 on M2 (36-bit), 1TiB for M3+
+ * (40-bit). Reserved via mmap(MAP_ANON); macOS demand-pages physical memory on
+ * first touch, so only used pages consume RAM. The slab is mapped RWX to
  * Hypervisor.framework. The guest's own page tables (built here) enforce
  * per-region permissions using 2MiB block descriptors, which are mandatory for
  * transparent misaligned access. Page tables can be extended at runtime via
@@ -47,16 +47,17 @@
 #include "syscall/poll.h"   /* wakeup_pipe_signal */
 #include "syscall/proc.h"   /* proc_request_exit_group */
 
-/* Per-vCPU pending TLBI request. Zero-initialized in every host pthread
- * by virtue of TLS default-zeroing, which maps to TLBI_NONE.
+/* Per-vCPU pending TLBI request. Zero-initialized in every host pthread by
+ * virtue of TLS default-zeroing, which maps to TLBI_NONE.
  */
 _Thread_local tlbi_request_t cpu_tlbi_req;
 
 /* FEAT_TLBIRANGE host capability flag. Set once at bootstrap by
- * guest_probe_tlbi_range and treated as read-only thereafter. Apple Silicon
- * M1+ implements ARMv8.5-A which mandates FEAT_TLBIRANGE; the probe stays
- * conservative and defaults to false until the flag is explicitly set so
- * future ports to non-Apple aarch64 hosts inherit the safe fallback. */
+ * guest_probe_tlbi_range and treated as read-only thereafter. Apple Silicon M1+
+ * implements ARMv8.5-A which mandates FEAT_TLBIRANGE; the probe stays
+ * conservative and defaults to false until the flag is explicitly set so future
+ * ports to non-Apple aarch64 hosts inherit the safe fallback.
+ */
 bool g_tlbi_range_supported = false;
 
 static void guest_region_clear(guest_t *g);
@@ -87,8 +88,8 @@ static int desc_to_perms(uint64_t desc);
 
 /* Page table pool allocator. */
 
-/* Protects the page table pool bump allocator. Multiple threads may
- * trigger page table extension concurrently (via mmap/brk/mprotect).
+/* Protects the page table pool bump allocator. Multiple threads may trigger
+ * page table extension concurrently (via mmap/brk/mprotect).
  */
 static pthread_mutex_t pt_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 2 */
 
@@ -167,8 +168,8 @@ static int compute_infra_layout(guest_t *g)
 }
 
 /* Allocate a zeroed 4KiB page from the page table pool.
- * Returns GPA of the page, or 0 on pool exhaustion.
- * Acquires pt_lock internally. Caller typically holds mmap_lock.
+ * Returns GPA of the page, or 0 on pool exhaustion. Acquires pt_lock
+ * internally. Caller typically holds mmap_lock.
  */
 static uint64_t pt_alloc_page(guest_t *g)
 {
@@ -214,27 +215,26 @@ static uint64_t *pt_at(const guest_t *g, uint64_t gpa)
 /* Public API */
 
 /* FEAT_TLBIRANGE probe -- runs exactly once via pthread_once. ARMv8.4
- * introduced TLBI RVAE1IS for single-shot range invalidation; ARMv8.5+
- * makes it mandatory. macOS does not surface a sysctl entry for
- * FEAT_TLBIRANGE directly, so use FEAT_LSE2 as a proxy -- both became
- * mandatory in ARMv8.4 and Apple ships them together across the entire
- * M-series. A future non-Apple aarch64 host or an older ARM PE without
- * FEAT_TLBIRANGE would otherwise trap the shim's `tlbi rvae1is, x9` to
- * BAD_VEC; the proxy probe keeps the accumulator on the per-page VAE1IS /
- * VMALLE1IS path in that case.
+ * introduced TLBI RVAE1IS for single-shot range invalidation; ARMv8.5+ makes it
+ * mandatory. macOS does not surface a sysctl entry for FEAT_TLBIRANGE directly,
+ * so use FEAT_LSE2 as a proxy -- both became mandatory in ARMv8.4 and Apple
+ * ships them together across the entire M-series. A future non-Apple aarch64
+ * host or an older ARM PE without FEAT_TLBIRANGE would otherwise trap the
+ * shim's TLBI RVAE1IS, X9 to BAD_VEC; the proxy probe keeps the accumulator on
+ * the per-page VAE1IS / VMALLE1IS path in that case.
  *
- * Width-tolerant read: macOS currently exposes the boolean as a 4-byte int,
- * but a future kernel could widen it to uint64_t. Read into a 64-bit slot
- * and accept any non-zero answer for any length sysctl actually returned.
+ * Width-tolerant read: macOS currently exposes the boolean as a 4-byte int, but
+ * a future kernel could widen it to uint64_t. Read into a 64-bit slot and
+ * accept any non-zero answer for any length sysctl actually returned.
  *
- * ELFUSE_DISABLE_TLBI_RANGE=1 forces the broadcast fallback so the
- * VAE1IS-only / VMALLE1IS path stays exercisable in CI on Apple Silicon --
- * otherwise the fallback is unreachable on any host where the sysctl probe
- * succeeds.
+ * ELFUSE_DISABLE_TLBI_RANGE=1 forces the broadcast fallback so the VAE1IS-only
+ * / VMALLE1IS path stays exercisable in CI on Apple Silicon -- otherwise the
+ * fallback is unreachable on any host where the sysctl probe succeeds.
  *
- * pthread_once gates the probe so a re-bootstrap path (sys_execve, fork
- * IPC restore) cannot race a live vCPU reading the flag. The first
- * guest_init wins and the result is immutable for the process lifetime. */
+ * pthread_once gates the probe so a re-bootstrap path (sys_execve, fork IPC
+ * restore) cannot race a live vCPU reading the flag. The first guest_init wins
+ * and the result is immutable for the process lifetime.
+ */
 static pthread_once_t tlbi_range_probe_once = PTHREAD_ONCE_INIT;
 
 static void tlbi_range_probe_run(void)
@@ -278,11 +278,11 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
 
     /* Determine VM IPA width: the Stage-2 width passed to
      * hv_vm_config_set_ipa_size. Distinct from the primary slab size below
-     * because Rosetta needs 48-bit guest VAs (image at 128 TiB) even when
-     * HVF rejects a 1 TiB Stage-2 mapping.
+     * because Rosetta needs 48-bit guest VAs (image at 128 TiB) even when HVF
+     * rejects a 1 TiB Stage-2 mapping.
      *
-     * ipa_bits = 0 : auto-detect (40-bit on macOS 15+, else 36-bit).
-     * ipa_bits > 0 : use that exact value.
+     * ipa_bits = 0 : auto-detect (40-bit on macOS 15+, else 36-bit). ipa_bits >
+     * 0 : use that exact value.
      */
     uint32_t vm_ipa;
     if (ipa_bits > 0)
@@ -293,24 +293,24 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
         vm_ipa = 36;
     g->ipa_bits = vm_ipa;
 
-    /* Primary slab size is decoupled from the VM IPA width. The slab is
-     * what gets mmap'd and what hv_vm_map maps; some Apple Silicon hosts
-     * (including M5 in field reports) reject a 1 TiB primary slab with
-     * HV_BAD_ARGUMENT even when max_ipa >= 40, so a bisecting retry from
-     * 40-bit (1 TiB) down to 36-bit (64 GiB) is necessary.
+    /* Primary slab size is decoupled from the VM IPA width. The slab is what
+     * gets mmap'd and what hv_vm_map maps; some Apple Silicon hosts (including
+     * M5 in field reports) reject a 1 TiB primary slab with HV_BAD_ARGUMENT
+     * even when max_ipa >= 40, so a bisecting retry from 40-bit (1 TiB) down to
+     * 36-bit (64 GiB) is necessary.
      */
     uint32_t initial_slab_bits = (max_ipa > 40) ? 40 : max_ipa;
     if (initial_slab_bits < 36)
         initial_slab_bits = 36;
 
-    /* Create the HVF VM once at the requested IPA width. The slab retry
-     * loop below remaps within this VM; only the slab side resizes.
+    /* Create the HVF VM once at the requested IPA width. The slab retry loop
+     * below remaps within this VM; only the slab side resizes.
      *
-     * macOS may not release HVF VM resources immediately after
-     * hv_vm_destroy(), so rapid sequential VM creation (e.g. running
-     * many test binaries) can hit transient resource exhaustion. Retry
-     * with linear backoff (500ms intervals, up to 30 attempts = 15
-     * seconds max wait) to handle this gracefully.
+     * macOS may not release HVF VM resources immediately after hv_vm_destroy(),
+     * so rapid sequential VM creation (e.g. running many test binaries) can hit
+     * transient resource exhaustion. Retry with linear backoff (500ms
+     * intervals, up to 30 attempts = 15 seconds max wait) to handle this
+     * gracefully.
      */
     hv_return_t ret = HV_ERROR;
     t0 = startup_trace_now_ns();
@@ -330,10 +330,10 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
         return -1;
     }
 
-    /* Bisecting slab retry: try the largest slab first, halve on each
-     * failure down to a known-safe 64 GiB floor. The shm_fd CoW upgrade
-     * is attempted on every successful slab so file-backed memory is
-     * preserved at any size HVF accepts.
+    /* Bisecting slab retry: try the largest slab first, halve on each failure
+     * down to a known-safe 64 GiB floor. The shm_fd CoW upgrade is attempted on
+     * every successful slab so file-backed memory is preserved at any size HVF
+     * accepts.
      */
     static const uint32_t slab_attempt_bits[] = {40, 38, 36};
     bool mapped = false;
@@ -345,8 +345,8 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
             continue;
 
         uint64_t try_size = 1ULL << bits;
-        /* Respect a caller-supplied size cap (size > 0 means "no larger
-         * than this"). Skip slab attempts that exceed the cap.
+        /* Respect a caller-supplied size cap (size > 0 means "no larger than
+         * this"). Skip slab attempts that exceed the cap.
          */
         if (size > 0 && try_size > size)
             continue;
@@ -360,10 +360,9 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
             continue;
         g->pt_pool_next = g->pt_pool_base;
 
-        /* Reserve primary address space via mmap(MAP_ANON). macOS
-         * demand-pages this so an unused 1 TiB reservation costs no
-         * physical memory. Do NOT memset because that would touch every
-         * page and defeat demand paging.
+        /* Reserve primary address space via mmap(MAP_ANON). macOS demand-pages
+         * this so an unused 1 TiB reservation costs no physical memory. Do NOT
+         * memset because that would touch every page and defeat demand paging.
          */
         t0 = startup_trace_now_ns();
         g->host_base = mmap(NULL, try_size, PROT_READ | PROT_WRITE,
@@ -376,8 +375,8 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
         }
 
         /* Try the file-backed CoW upgrade. If any step fails, fall back
-         * silently to MAP_ANON; fork will then use the IPC region-copy
-         * path instead of SCM_RIGHTS fd passing.
+         * silently to MAP_ANON; fork will then use the IPC region-copy path
+         * instead of SCM_RIGHTS fd passing.
          */
         char tmppath[] = "/tmp/elfuse-XXXXXX";
         t0 = startup_trace_now_ns();
@@ -430,8 +429,8 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
     }
     size = mapped_size;
 
-    /* Seed HVF segment list with one entry covering the whole slab.
-     * sys_mmap may later split this for MAP_SHARED file overlays.
+    /* Seed HVF segment list with one entry covering the whole slab. sys_mmap
+     * may later split this for MAP_SHARED file overlays.
      */
     g->segments[0] = (hvf_segment_t) {.ipa = GUEST_IPA_BASE, .len = size};
     g->n_segments = 1;
@@ -472,9 +471,9 @@ int guest_init_from_shm(guest_t *g,
     }
     g->pt_pool_next = g->pt_pool_base;
 
-    /* Map the shm fd MAP_PRIVATE: copy-on-write semantics. Reads see
-     * the parent's frozen snapshot; writes are private to this process.
-     * macOS CoW is page-granular: only modified pages are duplicated.
+    /* Map the shm fd MAP_PRIVATE: copy-on-write semantics. Reads see the
+     * parent's frozen snapshot; writes are private to this process. macOS CoW
+     * is page-granular: only modified pages are duplicated.
      */
     t0 = startup_trace_now_ns();
     g->host_base =
@@ -538,9 +537,9 @@ int guest_init_from_shm(guest_t *g,
 }
 
 /* Tear down all overflow segments. Each segment is owned by
- * guest_overflow_alloc, so the host buffer and its Stage-2 mapping are
- * released here. Resets noverflow and overflow_ipa_next to the supplied
- * anchor (guest_size for guest_reset, 0 for guest_destroy).
+ * guest_overflow_alloc, so the host buffer and its Stage-2 mapping are released
+ * here. Resets noverflow and overflow_ipa_next to the supplied anchor
+ * (guest_size for guest_reset, 0 for guest_destroy).
  */
 static void release_overflow_segments(guest_t *g, uint64_t reset_anchor)
 {
@@ -559,8 +558,8 @@ static void release_overflow_segments(guest_t *g, uint64_t reset_anchor)
 
 /* Tear down all extra (non-primary) IPA mappings recorded in g->mappings[].
  * Each owned host buffer is freed; unowned mappings (host VA supplied by the
- * caller of guest_add_mapping) only have their Stage-2 entry torn down.
- * Resets n_mappings to 0.
+ * caller of guest_add_mapping) only have their Stage-2 entry torn down. Resets
+ * n_mappings to 0.
  */
 static void release_extra_mappings(guest_t *g)
 {
@@ -580,9 +579,9 @@ void guest_destroy(guest_t *g)
 {
     /* Quiesce worker vCPUs before unmapping stage-2. thread_destroy_all_vcpus
      * only releases vCPU handles; it does not wait for the owning pthread to
-     * leave hv_vcpu_run. A worker still inside the guest at unmap time takes
-     * a stage-2 translation fault on its next instruction fetch and surfaces
-     * as "unexpected exception EC=0x20" in the crash report. PR #89's foot
+     * leave hv_vcpu_run. A worker still inside the guest at unmap time takes a
+     * stage-2 translation fault on its next instruction fetch and surfaces as
+     * "unexpected exception EC=0x20" in the crash report. The foot terminal
      * reproduction tripped exactly that race. The exit_group syscall handler
      * already runs request, interrupt, and join before its own teardown; the
      * destroy path needs the same prefix because forkipc.c:vcpu_run_loop
@@ -590,12 +589,12 @@ void guest_destroy(guest_t *g)
      * exit_group handler. The request is guarded on the prior state so a
      * process that already chose its exit code keeps it intact.
      *
-     * The wake signals cover workers blocked outside hv_vcpu_run: futex
-     * waiters poll futex_interrupt_requested, and any thread parked in
-     * epoll or poll wakes off the shared pipe. Without them, host-blocked
-     * workers miss the hv_vcpus_exit kick (which only affects threads
-     * inside hv_vcpu_run) and the 100ms join cap in thread_join_workers
-     * detaches them, leaving live pthreads to crash on the imminent munmap.
+     * The wake signals cover workers blocked outside hv_vcpu_run: futex waiters
+     * poll futex_interrupt_requested, and any thread parked in epoll or poll
+     * wakes off the shared pipe. Without them, host-blocked workers miss the
+     * hv_vcpus_exit kick (which only affects threads inside hv_vcpu_run) and
+     * the 100ms join cap in thread_join_workers detaches them, leaving live
+     * pthreads to crash on the imminent munmap.
      */
     if (!proc_exit_group_requested())
         proc_request_exit_group(0);
@@ -603,9 +602,9 @@ void guest_destroy(guest_t *g)
     wakeup_pipe_signal();
     thread_interrupt_all();
     thread_join_workers();
-    /* Destroy all remaining worker vCPUs (thread table) before tearing down
-     * the VM. This prevents hv_vm_destroy from racing with active vCPUs that
-     * may still be running if thread join timed out during exit_group.
+    /* Destroy all remaining worker vCPUs (thread table) before tearing down the
+     * VM. This prevents hv_vm_destroy from racing with active vCPUs that may
+     * still be running if thread join timed out during exit_group.
      */
     thread_destroy_all_vcpus();
     if (g->vcpu) {
@@ -648,7 +647,9 @@ void guest_destroy(guest_t *g)
 }
 
 /* Check whether a candidate IPA range [gpa, gpa+size) overlaps the primary
- * buffer or any existing extra mapping. Returns true on overlap.
+ * buffer or any existing extra mapping.
+ *
+ * Returns true on overlap.
  */
 static bool guest_mapping_overlaps(const guest_t *g, uint64_t gpa, size_t size)
 {
@@ -665,10 +666,10 @@ static bool guest_mapping_overlaps(const guest_t *g, uint64_t gpa, size_t size)
             return true;
     }
     /* Overflow segments occupy IPA ranges stacked above guest_size on a
-     * first-come basis. An explicit mapping added later must not silently
-     * land on top of an already-allocated overflow segment; HVF would
-     * accept the duplicate hv_vm_map but software bookkeeping (resolve
-     * order, destroy/reset ownership) would become ambiguous.
+     * first-come basis. An explicit mapping added later must not silently land
+     * on top of an already-allocated overflow segment; HVF would accept the
+     * duplicate hv_vm_map but software bookkeeping (resolve order,
+     * destroy/reset ownership) would become ambiguous.
      */
     for (int i = 0; i < g->noverflow; i++) {
         const guest_overflow_t *o = &g->overflow[i];
@@ -794,10 +795,10 @@ bool guest_is_valid_range(const guest_t *g, uint64_t gpa, uint64_t len)
     if (end <= g->guest_size)
         return true;
 
-    /* For an extra-region or overflow match the WHOLE range must live inside
-     * a single region; host pointers cannot safely span discontiguous backing.
-     * gpa must be the entry point of that lookup so a straddling range
-     * (primary plus extra, or extra plus extra) is rejected.
+    /* For an extra-region or overflow match the WHOLE range must live inside a
+     * single region; host pointers cannot safely span discontiguous backing.
+     * gpa must be the entry point of that lookup so a straddling range (primary
+     * plus extra, or extra plus extra) is rejected.
      */
     if (gpa >= g->guest_size) {
         for (int i = 0; i < g->n_mappings; i++) {
@@ -835,9 +836,9 @@ uint64_t guest_overflow_alloc(guest_t *g)
         return UINT64_MAX;
     }
 
-    /* overflow_ipa_next is anchored at guest_size by guest_init; ensure it
-     * also stays clear of any explicitly-registered extra mapping so the new
-     * segment does not collide with rosetta or kbuf placements.
+    /* overflow_ipa_next is anchored at guest_size by guest_init; ensure it also
+     * stays clear of any explicitly-registered extra mapping so the new segment
+     * does not collide with rosetta or kbuf placements.
      */
     uint64_t seg_ipa = g->overflow_ipa_next;
     if (seg_ipa < g->guest_size)
@@ -849,11 +850,11 @@ uint64_t guest_overflow_alloc(guest_t *g)
                   (unsigned long long) seg_ipa);
         return UINT64_MAX;
     }
-    /* Skip past every extra mapping that overlaps the candidate placement.
-     * Each skip moves seg_ipa forward, so the scan must restart to catch any
-     * mapping the new position now overlaps. The loop is bounded by
-     * n_mappings -- each iteration that skips advances past at least one
-     * mapping, so termination is guaranteed.
+    /* Skip past every extra mapping that overlaps the candidate placement. Each
+     * skip moves seg_ipa forward, so the scan must restart to catch any mapping
+     * the new position now overlaps. The loop is bounded by n_mappings -- each
+     * iteration that skips advances past at least one mapping, so termination
+     * is guaranteed.
      */
     bool moved;
     do {
@@ -902,10 +903,10 @@ uint64_t guest_overflow_alloc(guest_t *g)
 
 /* Write 128 x 2 MiB kbuf block descriptors into the supplied L2 page table
  * starting at slot 384 (the first slot covering KBUF_VA_BASE / KBUF_USER_VA).
- * Each descriptor maps the next 2 MiB of [kbuf_gpa, kbuf_gpa + KBUF_SIZE)
- * with RW + UXN + PXN: the kbuf must stay data-only under both the kernel
- * TTBR1 mirror and the user-VA TTBR0 alias to preserve the aliasing-proof
- * W^X invariant.
+ * Each descriptor maps the next 2 MiB of [kbuf_gpa, kbuf_gpa + KBUF_SIZE) with
+ * RW + UXN + PXN: the kbuf must stay data-only under both the kernel TTBR1
+ * mirror and the user-VA TTBR0 alias to preserve the aliasing-proof W^X
+ * invariant.
  */
 static void populate_kbuf_l2_blocks(uint64_t *l2, uint64_t kbuf_gpa)
 {
@@ -921,9 +922,9 @@ int guest_init_kbuf(guest_t *g, uint64_t kbuf_gpa)
     if (!g)
         return -1;
     /* Scrub kbuf state up-front so partial failure leaves the guest in a
-     * fully-zeroed state rather than a stale half-initialized one. The
-     * caller must treat a -1 return as "kbuf is unconfigured" and must not
-     * read g->ttbr1 / g->kbuf_base / g->kbuf_gpa.
+     * fully-zeroed state rather than a stale half-initialized one. The caller
+     * must treat a -1 return as "kbuf is unconfigured" and must not read
+     * g->ttbr1 / g->kbuf_base / g->kbuf_gpa.
      */
     g->ttbr1 = 0;
     g->kbuf_gpa = 0;
@@ -945,17 +946,16 @@ int guest_init_kbuf(guest_t *g, uint64_t kbuf_gpa)
         return -1;
     }
 
-    /* kbuf lives inside the primary buffer; the existing Stage-2 mapping at
-     * IPA 0 already covers the GPA range, so no extra hv_vm_map is needed.
-     * macOS demand-pages the host buffer, so untouched 256 MiB cost nothing.
-     * kbuf_gpa and kbuf_base are published after the PT pool allocation
-     * succeeds below.
+    /* kbuf lives inside the primary buffer; the existing Stage-2 mapping at IPA
+     * 0 already covers the GPA range, so no extra hv_vm_map is needed. macOS
+     * demand-pages the host buffer, so untouched 256 MiB cost nothing. kbuf_gpa
+     * and kbuf_base are published after the PT pool allocation succeeds below.
      */
 
-    /* Build TTBR1 page-table tree: L0[511] -> L1 -> L1[511] -> L2.
-     * L2 entries 384..511 cover [KBUF_VA_BASE, KBUF_VA_BASE+KBUF_SIZE) with
-     * 128 x 2 MiB block descriptors. RW + UXN + PXN: kbuf is data-only, so
-     * no executable alias can exist via TTBR1.
+    /* Build TTBR1 page-table tree: L0[511] -> L1 -> L1[511] -> L2. L2 entries
+     * 384..511 cover [KBUF_VA_BASE, KBUF_VA_BASE+KBUF_SIZE) with 128 x 2 MiB
+     * block descriptors. RW + UXN + PXN: kbuf is data-only, so no executable
+     * alias can exist via TTBR1.
      */
     uint64_t l0_gpa = pt_alloc_page(g);
     uint64_t l1_gpa = pt_alloc_page(g);
@@ -1072,11 +1072,11 @@ int guest_map_va_range(guest_t *g,
         }
     }
 
-    /* The new entries are visible to the host immediately; the shim flushes
-     * the matching TLBs on syscall return via the per-vCPU accumulator. Skip
-     * the request when every block was already mapped (no negative TLB
-     * entries can apply since the prior install already invalidated them),
-     * or when the accumulator already promised a broadcast.
+    /* The new entries are visible to the host immediately; the shim flushes the
+     * matching TLBs on syscall return via the per-vCPU accumulator. Skip the
+     * request when every block was already mapped (no negative TLB entries can
+     * apply since the prior install already invalidated them), or when the
+     * accumulator already promised a broadcast.
      */
     if (!bcast && changed_hi > changed_lo)
         tlbi_request_range(changed_lo, changed_hi);
@@ -1131,8 +1131,8 @@ int guest_install_kbuf_user_alias(guest_t *g)
     if (!l2)
         return -1;
 
-    /* Reject overlap before any descriptor is written so a collision leaves
-     * the existing mapping intact.
+    /* Reject overlap before any descriptor is written so a collision leaves the
+     * existing mapping intact.
      */
     for (int i = 384; i < 512; i++) {
         if (l2[i] & PT_VALID) {
@@ -1224,13 +1224,12 @@ static int gva_translate_perm(const guest_t *g,
             return -1;
 
         int perms = desc_to_perms(l3[l3_idx]);
-        /* EL1-only pages (shim_data) are inaccessible to guest EL0 in the
-         * page tables; the host accessors that act on a guest-supplied GVA
-         * must refuse them too, otherwise a guest could pass a shim_data
-         * GVA as a syscall buffer and have the host write into the identity
-         * cache or entropy ring on its behalf. The host's own publishers
-         * use direct host_base+shim_data_base arithmetic and bypass this
-         * walker entirely.
+        /* EL1-only pages (shim_data) are inaccessible to guest EL0 in the page
+         * tables; the host accessors that act on a guest-supplied GVA must
+         * refuse them too, otherwise a guest could pass a shim_data GVA as a
+         * syscall buffer and have the host write into the identity cache or
+         * entropy ring on its behalf. The host's own publishers use direct
+         * host_base+shim_data_base arithmetic and bypass this walker entirely.
          */
         if (perms & MEM_PERM_EL1_ONLY)
             return -1;
@@ -1242,8 +1241,8 @@ static int gva_translate_perm(const guest_t *g,
             return -1;
         uint64_t gpa = (page_ipa - base) + (gva & (PAGE_SIZE - 1));
         /* Accept GPAs inside the primary buffer or covered by an extra IPA
-         * mapping (rosetta segments, kbuf, etc.). Anything else is a
-         * dangling page-table entry pointing at unmapped Stage-2 IPA.
+         * mapping (rosetta segments, kbuf, etc.). Anything else is a dangling
+         * page-table entry pointing at unmapped Stage-2 IPA.
          */
         if (gpa >= g->guest_size && !guest_find_mapping(g, gpa) &&
             !guest_find_overflow(g, gpa))
@@ -1264,9 +1263,9 @@ static int gva_translate_perm(const guest_t *g,
 
     /* L2 block descriptor: 2MiB granularity. */
     int perms = desc_to_perms(l2[l2_idx]);
-    /* See the L3 page-descriptor branch above: EL1-only blocks are
-     * inaccessible to host-on-behalf-of-guest accesses for the same
-     * reason. shim_data is mapped as a 2MiB EL1-only block at boot.
+    /* See the L3 page-descriptor branch above: EL1-only blocks are inaccessible
+     * to host-on-behalf-of-guest accesses for the same reason. shim_data is
+     * mapped as a 2MiB EL1-only block at boot.
      */
     if (perms & MEM_PERM_EL1_ONLY)
         return -1;
@@ -1359,7 +1358,7 @@ static uint64_t gva_contiguous_avail(const guest_t *g,
  *
  * If avail is non-NULL, stores the number of physically contiguous bytes from
  * gva whose page-table entries are valid and satisfy required_perms
- * (MEM_PERM_R/W/X bitmask).  The walk continues across adjacent L2/L3 entries
+ * (MEM_PERM_R/W/X bitmask). The walk continues across adjacent L2/L3 entries
  * until a mapping, permission, or physical-contiguity break is found.
  */
 static void *gva_resolve_perm(const guest_t *g,
@@ -1368,11 +1367,11 @@ static void *gva_resolve_perm(const guest_t *g,
                               int required_perms,
                               uint64_t avail_limit)
 {
-    /* Always walk page tables to enforce permissions.  The guest slab is
+    /* Always walk page tables to enforce permissions. The guest slab is
      * identity-mapped (GVA == GPA == offset), but L2 block descriptors carry
      * permission bits and L3 page tables have per-4KiB permissions after
-     * guest_split_block.  Skipping the walk would bypass W^X enforcement for
-     * all normal guest addresses.
+     * guest_split_block. Skipping the walk would bypass W^X enforcement for all
+     * normal guest addresses.
      */
     gva_translation_t first;
     if (gva_translate_perm(g, gva, required_perms, &first) < 0)
@@ -1387,9 +1386,9 @@ static void *gva_resolve_perm(const guest_t *g,
 
     /* GPA outside the primary buffer: consult the extra IPA mappings (rosetta
      * segments, kbuf) first, then the overflow segments (lazy 1 GiB bump
-     * allocator for high-VA 2 MiB blocks). gva_contiguous_avail naturally
-     * stops at GPA-discontinuity boundaries between regions, so a single
-     * region match suffices for the host pointer translation.
+     * allocator for high-VA 2 MiB blocks). gva_contiguous_avail naturally stops
+     * at GPA-discontinuity boundaries between regions, so a single region match
+     * suffices for the host pointer translation.
      */
     const guest_mapping_t *m = guest_find_mapping(g, first.gpa);
     if (m) {
@@ -1571,14 +1570,14 @@ void guest_reset(guest_t *g)
      * zero-fill-on-demand state.
      */
 
-    /* Zero tracked regions (ELF segments, heap, stack, mmap allocations).
-     * Skip PROT_NONE regions because they were never touched.
+    /* Zero tracked regions (ELF segments, heap, stack, mmap allocations). Skip
+     * PROT_NONE regions because they were never touched.
      *
-     * Scrub by backing GPA, not by VA: identity-mapped regions have
-     * gpa_base == start, but high-VA regions (rosetta) carry their VA in
-     * start/end and the real primary-buffer offset in gpa_base. Filtering
-     * by end <= guest_size alone would silently skip high-VA backing and
-     * leak bytes across a rosetta-to-rosetta execve.
+     * Scrub by backing GPA, not by VA: identity-mapped regions have gpa_base ==
+     * start, but high-VA regions (rosetta) carry their VA in start/end and the
+     * real primary-buffer offset in gpa_base. Filtering by end <= guest_size
+     * alone would silently skip high-VA backing and leak bytes across a
+     * rosetta-to-rosetta execve.
      */
     for (int i = 0; i < g->nregions; i++) {
         guest_region_t *r = &g->regions[i];
@@ -1602,12 +1601,12 @@ void guest_reset(guest_t *g)
     memset((uint8_t *) g->host_base + g->shim_base, 0,
            g->shim_data_base + BLOCK_2MIB - g->shim_base);
 
-    /* Release overflow segments. The page tables that referenced them are
-     * about to be rebuilt by the exec path, so the GPA space is no longer
-     * needed. New segments will be allocated lazily when the next binary
-     * exercises the high-VA path. Rosetta placement (g->mappings[]) is
-     * intentionally NOT touched: it survives execve so that re-execing
-     * another x86_64 binary keeps the same rosetta image in place.
+    /* Release overflow segments. The page tables that referenced them are about
+     * to be rebuilt by the exec path, so the GPA space is no longer needed. New
+     * segments will be allocated lazily when the next binary exercises the
+     * high-VA path. Rosetta placement (g->mappings[]) is intentionally NOT
+     * touched: it survives execve so that re-execing another x86_64 binary
+     * keeps the same rosetta image in place.
      */
     release_overflow_segments(g, g->guest_size);
 
@@ -1701,9 +1700,9 @@ int guest_get_used_regions(const guest_t *g,
 
     /* Rosetta image and TTBR1 kbuf live near the top of the primary buffer
      * (between the mmap RW high-water mark and the infra reserve), so the
-     * MMAP_BASE..mmap_next range above misses them. Snapshot each as its
-     * own block so the fork child inherits the translator image and the
-     * kernel-VA scratchpad without rebuilding either.
+     * MMAP_BASE..mmap_next range above misses them. Snapshot each as its own
+     * block so the fork child inherits the translator image and the kernel-VA
+     * scratchpad without rebuilding either.
      */
     if (g->is_rosetta) {
         if (n < max && g->rosetta_guest_base && g->rosetta_size) {
@@ -1942,9 +1941,9 @@ int guest_region_add_ex_owned_gpa(guest_t *g,
     }
     g->nregions++;
 
-    /* Try to merge with adjacent regions to reduce table pressure.
-     * Merge right first, then left (order matters: right merge does not change
-     * the index of the left neighbor).
+    /* Try to merge with adjacent regions to reduce table pressure. Merge right
+     * first, then left (order matters: right merge does not change the index of
+     * the left neighbor).
      */
     try_merge_right(g, i);
     try_merge_left(g, i);
@@ -2007,12 +2006,11 @@ void guest_region_remove(guest_t *g, uint64_t start, uint64_t end)
         bool keep_left = r->start < start;
         bool keep_right = r->end > end;
 
-        /* Interior split: removal range lies strictly inside *r, producing
-         * two output entries from one input slot. This is the only growth
-         * path; handle it explicitly so the untouched suffix is shifted out
-         * of the way before either half is written. After this branch no
-         * further input regions can overlap [start, end), so the loop is
-         * done.
+        /* Interior split: removal range lies strictly inside *r, producing two
+         * output entries from one input slot. This is the only growth path;
+         * handle it explicitly so the untouched suffix is shifted out of the
+         * way before either half is written. After this branch no further input
+         * regions can overlap [start, end), so the loop is done.
          */
         if (keep_left && keep_right) {
             if (g->nregions >= GUEST_MAX_REGIONS) {
@@ -2089,8 +2087,8 @@ void guest_region_remove(guest_t *g, uint64_t start, uint64_t end)
         in++;
     }
 
-    /* Append the unread suffix (regions whose start >= end) after the
-     * compacted overlap area, shifting only if compaction left a hole.
+    /* Append the unread suffix (regions whose start >= end) after the compacted
+     * overlap area, shifting only if compaction left a hole.
      */
     int tail = g->nregions - in;
     if (tail > 0 && out != in)
@@ -2167,8 +2165,8 @@ void guest_region_set_prot(guest_t *g, uint64_t start, uint64_t end, int prot)
                 /* The region keeps its old prot in the tracker, but PTEs for
                  * [start, r->end) have already been updated. Mark the tracker
                  * permanently stale so the mprotect fast path falls back to
-                 * unconditional PTE work and cannot be fooled by a tracker
-                 * that lags actual PTE state.
+                 * unconditional PTE work and cannot be fooled by a tracker that
+                 * lags actual PTE state.
                  */
                 log_error(
                     "guest: region table full, "
@@ -2205,9 +2203,9 @@ void guest_region_set_prot(guest_t *g, uint64_t start, uint64_t end, int prot)
         if (r->end > end) {
             if (g->nregions >= GUEST_MAX_REGIONS) {
                 /* Over-apply prot to the whole region: the tail [end, r->end)
-                 * now claims new prot in the tracker even though PTE work
-                 * did not cover it. Mark the tracker stale so the mprotect
-                 * fast path stops trusting prot uniformity.
+                 * now claims new prot in the tracker even though PTE work did
+                 * not cover it. Mark the tracker stale so the mprotect fast
+                 * path stops trusting prot uniformity.
                  */
                 log_error(
                     "guest: region table full, "
@@ -2256,8 +2254,8 @@ void guest_region_set_prot(guest_t *g, uint64_t start, uint64_t end, int prot)
         last_modified = i;
     }
 
-    /* After updating prot, try to merge modified regions with neighbors.
-     * Work right-to-left so index shifts do not invalidate earlier indices.
+    /* After updating prot, try to merge modified regions with neighbors. Work
+     * right-to-left so index shifts do not invalidate earlier indices.
      */
     if (first_modified >= 0) {
         /* Merge last modified with its right neighbor */
@@ -2297,18 +2295,16 @@ static uint64_t make_block_desc(uint64_t gpa, int perms)
         desc |= PT_UXN | PT_PXN;
     }
 
-    /* Write permissions via AP bits:
-     * AP[2:1]=00 -> RW for EL1 only (no EL0 access)
-     * AP[2:1]=01 -> RW for EL1 and EL0
-     * AP[2:1]=11 -> RO for EL1 and EL0
-     * MEM_PERM_EL1_ONLY drops EL0 access entirely; used for shim_data
-     * so the guest cannot directly read or store to the cache, ring,
-     * bitmap, or attention flag.
+    /* Write permissions via AP bits: AP[2:1]=00 -> RW for EL1 only (no EL0
+     * access) AP[2:1]=01 -> RW for EL1 and EL0 AP[2:1]=11 -> RO for EL1 and EL0
+     * MEM_PERM_EL1_ONLY drops EL0 access entirely; used for shim_data so the
+     * guest cannot directly read or store to the cache, ring, bitmap, or
+     * attention flag.
      */
     if (perms & MEM_PERM_EL1_ONLY) {
         desc |= PT_AP_RW_EL1;
-        /* EL1-only data: never EL0-executable (already set above if
-         * MEM_PERM_X is unset, but assert defensively).
+        /* EL1-only data: never EL0-executable (already set above if MEM_PERM_X
+         * is unset, but assert defensively).
          */
         desc |= PT_UXN | PT_PXN;
     } else if (perms & MEM_PERM_W) {
@@ -2340,16 +2336,16 @@ static bool finalize_block_perms(guest_t *g, const mem_region_t *regions, int n)
 {
     /* Walk every 2MiB block touched by any region. Blocks shared by multiple
      * regions are processed multiple times; the underlying split / invalidate /
-     * re-validate sequence is idempotent (guest_split_block is a no-op once
-     * the L2 entry is a table descriptor; guest_invalidate_ptes + per-region
+     * re-validate sequence is idempotent (guest_split_block is a no-op once the
+     * L2 entry is a table descriptor; guest_invalidate_ptes + per-region
      * guest_update_perms produce the same final L3 state on every pass), so
      * dedup is an optimization the heap-region scale (~127 blocks for the
      * default brk window) does not justify against a fixed-size visited set.
      *
      * Non-identity (va_base != 0) rosetta regions are skipped: the maintenance
-     * helpers below (guest_split_block, guest_update_perms) navigate by GPA
-     * but rosetta's L2 entries live at high-VA indices, so a GPA-keyed walk
-     * lands in the wrong slot. Rosetta uses a single full-coverage RWX block
+     * helpers below (guest_split_block, guest_update_perms) navigate by GPA but
+     * rosetta's L2 entries live at high-VA indices, so a GPA-keyed walk lands
+     * in the wrong slot. Rosetta uses a single full-coverage RWX block
      * descriptor by design, so no L3 splitting is needed; if a later workload
      * requires per-segment perms inside the rosetta image, the maintenance
      * helpers must learn va_base first.
@@ -2371,11 +2367,10 @@ static bool finalize_block_perms(guest_t *g, const mem_region_t *regions, int n)
             bool same_perm = true;
 
             for (int s = 0; s < n; s++) {
-                /* Non-identity regions are excluded from the coverage sweep
-                 * for the same reason as the outer skip: their L2 entries
-                 * live at a different VA-index than their GPA suggests, so
-                 * mixing them into a GPA-keyed split would corrupt either
-                 * tree.
+                /* Non-identity regions are excluded from the coverage sweep for
+                 * the same reason as the outer skip: their L2 entries live at a
+                 * different VA-index than their GPA suggests, so mixing them
+                 * into a GPA-keyed split would corrupt either tree.
                  */
                 if (regions[s].va_base != 0)
                     continue;
@@ -2553,10 +2548,10 @@ uint64_t guest_build_page_tables(guest_t *g, const mem_region_t *regions, int n)
             unsigned l2_idx =
                 (unsigned) ((lookup_addr % BLOCK_1GIB) / BLOCK_2MIB);
 
-            /* If block already mapped, merge permissions (most permissive).
-             * Use a local variable for the merged perms. Do NOT modify the
-             * outer perms variable, which would leak accumulated permissions
-             * to subsequent 2MiB blocks in the same region.
+            /* If block already mapped, merge permissions (most permissive). Use
+             * a local variable for the merged perms. Do NOT modify the outer
+             * perms variable, which would leak accumulated permissions to
+             * subsequent 2MiB blocks in the same region.
              */
             int block_perms = perms;
             if (l2[l2_idx] & PT_BLOCK) {
@@ -2569,10 +2564,10 @@ uint64_t guest_build_page_tables(guest_t *g, const mem_region_t *regions, int n)
                 block_perms |= old_perms;
             }
 
-            /* Block descriptor: output IPA (where data physically lives).
-             * For identity regions output_ipa == lookup_addr; for non-identity
-             * (rosetta) the entry sits at the high VA but the descriptor
-             * points to the primary-buffer GPA where the bytes actually are.
+            /* Block descriptor: output IPA (where data physically lives). For
+             * identity regions output_ipa == lookup_addr; for non-identity
+             * (rosetta) the entry sits at the high VA but the descriptor points
+             * to the primary-buffer GPA where the bytes actually are.
              */
             l2[l2_idx] = make_block_desc(output_ipa, block_perms);
         }
@@ -2592,26 +2587,25 @@ uint64_t guest_build_page_tables(guest_t *g, const mem_region_t *regions, int n)
     return ttbr0;
 }
 
-/* Extend page tables to cover [start, end) with 2MiB block descriptors.
- * Walks the existing L0->L1 structure (from g->ttbr0) and allocates new
- * L2 tables as needed. This is safe to call while the vCPU is paused
- * (during HVC #5 handling). Records a TLBI request covering the new range
- * so the shim flushes the matching TLB entries before returning to EL0.
+/* Extend page tables to cover [start, end) with 2MiB block descriptors. Walks
+ * the existing L0->L1 structure (from g->ttbr0) and allocates new L2 tables as
+ * needed. This is safe to call while the vCPU is paused (during HVC #5
+ * handling). Records a TLBI request covering the new range so the shim flushes
+ * the matching TLB entries before returning to EL0.
  */
 int guest_extend_page_tables(guest_t *g,
                              uint64_t start,
                              uint64_t end,
                              int perms)
 {
-    /* Identity-only by construction: the L2 block descriptor's output IPA
-     * is identical to the VA index, so the new mapping puts data at the
-     * same GPA as the VA. That assumption breaks for non-identity rosetta
-     * ranges, where data lives at a low GPA below interp_base while the
-     * VA sits at 128 TiB. Such ranges already have entries installed by
-     * guest_map_va_range during rosetta_prepare; an extension request at
-     * a non-identity VA would silently fabricate a dangling block
-     * descriptor. Refuse cleanly so the misuse surfaces in logs rather
-     * than in a post-mortem stage-2 fault.
+    /* Identity-only by construction: the L2 block descriptor's output IPA is
+     * identical to the VA index, so the new mapping puts data at the same GPA
+     * as the VA. That assumption breaks for non-identity rosetta ranges, where
+     * data lives at a low GPA below interp_base while the VA sits at 128 TiB.
+     * Such ranges already have entries installed by guest_map_va_range during
+     * rosetta_prepare; an extension request at a non-identity VA would silently
+     * fabricate a dangling block descriptor. Refuse cleanly so the misuse
+     * surfaces in logs rather than in a post-mortem stage-2 fault.
      */
     if (start >= g->guest_size || end > g->guest_size) {
         log_error(
@@ -2621,11 +2615,12 @@ int guest_extend_page_tables(guest_t *g,
             (unsigned long long) start, (unsigned long long) end);
         return -1;
     }
-    /* Defensive: end is bounded by guest_size above, so the ALIGN_2MIB_UP
-     * below cannot wrap on any reachable input. The explicit guard documents
-     * the contract and matches the wrap guards in guest_invalidate_ptes /
+    /* Defensive: end is bounded by guest_size above, so the ALIGN_2MIB_UP below
+     * cannot wrap on any reachable input. The explicit guard documents the
+     * contract and matches the wrap guards in guest_invalidate_ptes /
      * guest_update_perms; keeps the three sites in sync if a future caller
-     * lifts the guest_size cap. */
+     * lifts the guest_size cap.
+     */
     if (end > UINT64_MAX - (BLOCK_2MIB - 1))
         return -1;
 
@@ -2635,12 +2630,11 @@ int guest_extend_page_tables(guest_t *g,
     uint64_t l0_gpa_off = g->ttbr0 - base;
     uint64_t *l0 = pt_at(g, l0_gpa_off);
 
-    /* Walk 2MiB blocks in [start, end). Track the smallest sub-range whose
-     * L2 entry actually transitioned from unmapped to mapped; blocks that
-     * were already valid get no new descriptor and need no TLBI
-     * (false-positive elimination mirrors guest_update_perms). Once the
-     * accumulator is already TLBI_BROADCAST, the bookkeeping is wasted
-     * work.
+    /* Walk 2MiB blocks in [start, end). Track the smallest sub-range whose L2
+     * entry actually transitioned from unmapped to mapped; blocks that were
+     * already valid get no new descriptor and need no TLBI (false-positive
+     * elimination mirrors guest_update_perms). Once the accumulator is already
+     * TLBI_BROADCAST, the bookkeeping is wasted work.
      */
     if (perms & MEM_PERM_X)
         tlbi_request_mark_icache();
@@ -2693,17 +2687,17 @@ int guest_extend_page_tables(guest_t *g,
         unsigned l2_idx = (unsigned) ((ipa % BLOCK_1GIB) / BLOCK_2MIB);
 
         /* Only map if not already mapped. A negative TLB entry from a prior
-         * translation fault is possible only for VAs that were unmapped at
-         * the time of the fault, so the TLBI is only needed for blocks
-         * actually installed by this call.
+         * translation fault is possible only for VAs that were unmapped at the
+         * time of the fault, so the TLBI is only needed for blocks actually
+         * installed by this call.
          */
-        /* At L2 a valid descriptor is either a 2 MiB block (bits[1:0] = 01)
-         * or a table descriptor pointing to an L3 page table (bits[1:0] = 11).
+        /* At L2 a valid descriptor is either a 2 MiB block (bits[1:0] = 01) or
+         * a table descriptor pointing to an L3 page table (bits[1:0] = 11).
          * Both indicate the slot is already mapped at some granule, so the
-         * extend has nothing to install; skip without flushing. The previous
-         * `& PT_BLOCK` test relied on PT_BLOCK == PT_VALID == bit 0 to cover
-         * both cases by coincidence -- write it as an explicit PT_VALID test
-         * so the intent survives a future descriptor-bit renumbering.
+         * extend has nothing to install; skip without flushing. The previous "&
+         * PT_BLOCK" test relied on PT_BLOCK == PT_VALID == bit 0 to cover both
+         * cases by coincidence -- write it as an explicit PT_VALID test so the
+         * intent survives a future descriptor-bit renumbering.
          */
         if (l2[l2_idx] & PT_VALID)
             continue;
@@ -2757,14 +2751,14 @@ bool guest_va_block_mapped(const guest_t *g, uint64_t va)
 
 /* L3 page table splitting. */
 
-/* L3 page descriptor: bits[1:0]=11 = valid page at level 3.
- * This is distinct from L2 block descriptors (bits[1:0]=01).
+/* L3 page descriptor: bits[1:0]=11 = valid page at level 3. This is distinct
+ * from L2 block descriptors (bits[1:0]=01).
  */
 #define PT_L3_PAGE (3ULL)
 
-/* Build a 4KiB L3 page descriptor with the given permissions.
- * Layout matches block descriptors (AF, SH, NS, MAIR, AP, XN) except
- * bits[1:0]=11 instead of 01.
+/* Build a 4KiB L3 page descriptor with the given permissions. Layout matches
+ * block descriptors (AF, SH, NS, MAIR, AP, XN) except bits[1:0]=11 instead of
+ * 01.
  */
 static uint64_t make_page_desc(uint64_t pa, int perms)
 {
@@ -2786,10 +2780,10 @@ static uint64_t make_page_desc(uint64_t pa, int perms)
     return desc;
 }
 
-/* Extract MEM_PERM_* flags from a page table descriptor (block or page).
- * The AP[2:1] field encodes the EL1/EL0 access matrix; map 00 to
- * MEM_PERM_RW | MEM_PERM_EL1_ONLY so callers see the privileged-only
- * shim_data slots correctly instead of treating them as read-only.
+/* Extract MEM_PERM_* flags from a page table descriptor (block or page). The
+ * AP[2:1] field encodes the EL1/EL0 access matrix; map 00 to MEM_PERM_RW |
+ * MEM_PERM_EL1_ONLY so callers see the privileged-only shim_data slots
+ * correctly instead of treating them as read-only.
  */
 static int desc_to_perms(uint64_t desc)
 {
@@ -2806,14 +2800,13 @@ static int desc_to_perms(uint64_t desc)
     return perms;
 }
 
-/* Locate the L2 descriptor that covers a 2 MiB block at the given guest
- * virtual address. The walk is VA-driven (L0/L1/L2 indices come from bits
- * 47:21 of va), so it locates the correct entry for non-identity rosetta
- * regions too as long as the caller passes the guest VA rather than the
- * data's backing GPA. Callers iterating regions[] by gpa_start MUST
- * translate to the region's va_base when va_base != 0 before invoking
- * this helper, or skip the region entirely (see finalize_block_perms for
- * the prevailing pattern).
+/* Locate the L2 descriptor that covers a 2 MiB block at the given guest virtual
+ * address. The walk is VA-driven (L0/L1/L2 indices come from bits 47:21 of va),
+ * so it locates the correct entry for non-identity rosetta regions too as long
+ * as the caller passes the guest VA rather than the data's backing GPA. Callers
+ * iterating regions[] by gpa_start MUST translate to the region's va_base when
+ * va_base != 0 before invoking this helper, or skip the region entirely (see
+ * finalize_block_perms for the prevailing pattern).
  *
  * Returns NULL if the VA falls outside the L0 range or no entry has been
  * installed along the L0 to L1 to L2 chain.
@@ -2825,8 +2818,8 @@ static uint64_t *find_l2_entry(guest_t *g, uint64_t va)
     uint64_t l0_gpa_off = g->ttbr0 - base;
     uint64_t *l0 = pt_at(g, l0_gpa_off);
 
-    /* L0 index from the full VA (not just the IPA-offset slice); correct
-     * for entries above the primary buffer (rosetta at 128 TiB, etc.).
+    /* L0 index from the full VA (not just the IPA-offset slice); correct for
+     * entries above the primary buffer (rosetta at 128 TiB, etc.).
      */
     unsigned l0_idx = (unsigned) (ipa / (512ULL * BLOCK_1GIB));
     if (l0_idx >= 512 || !(l0[l0_idx] & PT_VALID))
@@ -2846,24 +2839,23 @@ static uint64_t *find_l2_entry(guest_t *g, uint64_t va)
     return &l2[l2_idx];
 }
 
-/* Split a 2MiB L2 block descriptor into 512 x 4KiB L3 page descriptors.
- * The caller provides the L2 entry via find_l2_entry. Extracts the output
- * IPA from the existing descriptor.
+/* Split a 2MiB L2 block descriptor into 512 x 4KiB L3 page descriptors. The
+ * caller provides the L2 entry via find_l2_entry. Extracts the output IPA from
+ * the existing descriptor.
  *
  * No TLBI is issued by the split itself. The block-to-table transition
- * preserves the output address, permissions, and attributes of every page
- * in the 2 MiB range, so any cached translation from the old block
- * descriptor remains semantically correct. Per ARM ARM (FEAT_BBM Level 2),
- * a CPU that implements level-2 break-before-make support allows
- * block <-> table changes that preserve the resulting translation in all
- * other respects without a BBM sequence. Apple Silicon implements
- * FEAT_BBM Level 2 across M1+; the split-heavy stress paths in tests/
- * (test-stress mprotect cycling, test-shim-urandom-toctou rapid flips,
- * test-mprotect-mt R<->RW toggling, plus dynamic-linker RELRO setup)
- * run cleanly. A future PE without FEAT_BBM Level 2 would need either
- * a real BBM sequence here (invalidate, TLBI, write table) or an
- * unconditional broadcast TLBI on every split; revisit if that ever
- * surfaces a TLB conflict abort.
+ * preserves the output address, permissions, and attributes of every page in
+ * the 2 MiB range, so any cached translation from the old block descriptor
+ * remains semantically correct. Per ARM ARM (FEAT_BBM Level 2), a CPU that
+ * implements level-2 break-before-make support allows block <-> table changes
+ * that preserve the resulting translation in all other respects without a BBM
+ * sequence. Apple Silicon implements FEAT_BBM Level 2 across M1+; the
+ * split-heavy stress paths in tests/ (test-stress mprotect cycling,
+ * test-shim-urandom-toctou rapid flips, test-mprotect-mt R<->RW toggling, plus
+ * dynamic-linker RELRO setup) run cleanly. A future PE without FEAT_BBM Level 2
+ * would need either a real BBM sequence here (invalidate, TLBI, write table) or
+ * an unconditional broadcast TLBI on every split; revisit if that ever surfaces
+ * a TLB conflict abort.
  */
 static int split_l2_block(guest_t *g, uint64_t *l2_entry)
 {
@@ -2885,9 +2877,9 @@ static int split_l2_block(guest_t *g, uint64_t *l2_entry)
         return -1;
     uint64_t *l3 = pt_at(g, l3_gpa);
 
-    /* Fill 512 L3 entries with 4KiB page descriptors inheriting the
-     * block's permissions.  Extract the output IPA from bits [47:21]
-     * of the existing descriptor (not from the caller's address).
+    /* Fill 512 L3 entries with 4KiB page descriptors inheriting the block's
+     * permissions. Extract the output IPA from bits [47:21] of the existing
+     * descriptor (not from the caller's address).
      */
     uint64_t block_ipa = *l2_entry & L2_BLOCK_ADDR_MASK;
     for (int i = 0; i < 512; i++)
@@ -2911,10 +2903,10 @@ int guest_invalidate_ptes(guest_t *g, uint64_t start, uint64_t end)
 {
     uint64_t base = g->ipa_base;
 
-    /* Page-align the range. The ALIGN_UP step on end could wrap to 0 for
-     * inputs within PAGE_SIZE-1 of UINT64_MAX, silently turning the
-     * invalidation into a no-op against a 0-length loop. Reject the
-     * pathological input rather than allow a stale mapping to survive.
+    /* Page-align the range. The ALIGN_UP step on end could wrap to 0 for inputs
+     * within PAGE_SIZE-1 of UINT64_MAX, silently turning the invalidation into
+     * a no-op against a 0-length loop. Reject the pathological input rather
+     * than allow a stale mapping to survive.
      */
     if (end > UINT64_MAX - (PAGE_SIZE - 1))
         return -1;
@@ -2944,9 +2936,9 @@ int guest_invalidate_ptes(guest_t *g, uint64_t start, uint64_t end)
         if ((*l2_entry & 3) == 1) {
             /* 2MiB block descriptor */
             if (start <= block_start && end >= block_end) {
-                /* Invalidating the entire 2MiB block: clear the L2 entry.
-                 * The 2 MiB range exceeds the selective cap and upgrades
-                 * to broadcast.
+                /* Invalidating the entire 2MiB block: clear the L2 entry. The 2
+                 * MiB range exceeds the selective cap and upgrades to
+                 * broadcast.
                  */
                 *l2_entry = 0;
                 tlbi_request_range(base + block_start, base + block_end);
@@ -2954,18 +2946,18 @@ int guest_invalidate_ptes(guest_t *g, uint64_t start, uint64_t end)
                 continue;
             }
 
-            /* Partial invalidation within a 2MiB block: split first,
-             * then invalidate individual L3 pages below.
+            /* Partial invalidation within a 2MiB block: split first, then
+             * invalidate individual L3 pages below.
              */
             if (guest_split_block(g, block_start) < 0)
                 return -1;
         }
 
         /* L3 table: invalidate individual 4KiB page descriptors. Track the
-         * smallest sub-range whose descriptor actually transitioned from
-         * mapped to invalid; a page that was already 0 needs no TLBI
-         * (false-positive elimination mirrors the guest_update_perms path).
-         * Skip the per-page bookkeeping once a broadcast is already pending.
+         * smallest sub-range whose descriptor actually transitioned from mapped
+         * to invalid; a page that was already 0 needs no TLBI (false-positive
+         * elimination mirrors the guest_update_perms path). Skip the per-page
+         * bookkeeping once a broadcast is already pending.
          */
         uint64_t l3_ipa = *l2_entry & 0xFFFFFFFFF000ULL;
         uint64_t *l3 = pt_at(g, l3_ipa - base);
@@ -3003,9 +2995,9 @@ int guest_update_perms(guest_t *g, uint64_t start, uint64_t end, int perms)
     uint64_t base = g->ipa_base;
 
     /* Page-align the range. The ALIGN_UP on end could wrap to 0 for inputs
-     * within PAGE_SIZE-1 of UINT64_MAX, silently degrading the call to a
-     * no-op against a 0-length loop. Reject the pathological input rather
-     * than leave stale perms in place.
+     * within PAGE_SIZE-1 of UINT64_MAX, silently degrading the call to a no-op
+     * against a 0-length loop. Reject the pathological input rather than leave
+     * stale perms in place.
      */
     if (end > UINT64_MAX - (PAGE_SIZE - 1))
         return -1;
@@ -3014,9 +3006,10 @@ int guest_update_perms(guest_t *g, uint64_t start, uint64_t end, int perms)
     if (end <= start)
         return 0;
 
-    /* New perms include exec: the shim must IC IALLU on syscall return so a
-     * VA that previously held NX content fetches the new instructions. The
-     * inverse (removing exec) leaves no new code visible. */
+    /* New perms include exec: the shim must IC IALLU on syscall return so a VA
+     * that previously held NX content fetches the new instructions. The inverse
+     * (removing exec) leaves no new code visible.
+     */
     if (perms & MEM_PERM_X)
         tlbi_request_mark_icache();
 
@@ -3095,8 +3088,8 @@ int guest_update_perms(guest_t *g, uint64_t start, uint64_t end, int perms)
          * covers descriptors whose value changed (false-positive elimination).
          * Once the accumulator has already promoted to TLBI_BROADCAST, the
          * bounding-box bookkeeping is wasted work -- the broadcast invalidates
-         * everything regardless -- so the loop skips the compares in that
-         * mode while still writing every changed descriptor.
+         * everything regardless -- so the loop skips the compares in that mode
+         * while still writing every changed descriptor.
          */
         uint64_t page_start = (addr > block_start) ? addr : block_start;
         uint64_t page_end = (end < block_end) ? end : block_end;
@@ -3107,8 +3100,8 @@ int guest_update_perms(guest_t *g, uint64_t start, uint64_t end, int perms)
             unsigned l3_idx =
                 (unsigned) (((base + pa) % BLOCK_2MIB) / PAGE_SIZE);
             /* Extract the existing output IPA from the L3 entry. For
-             * non-identity mapped regions, pa is a VA not a GPA, so the
-             * builder must use the IPA already stored in the descriptor (set by
+             * non-identity mapped regions, pa is a VA not a GPA, so the builder
+             * must use the IPA already stored in the descriptor (set by
              * guest_split_block).
              *
              * For invalidated entries (set to 0 by guest_invalidate_ptes), the
@@ -3159,10 +3152,10 @@ int guest_install_va_pages(guest_t *g,
         return -1;
     if ((va | length | gpa) & (PAGE_SIZE - 1))
         return -1;
-    /* Reject wrap on both the VA side and the GPA side. Without the gpa
-     * guard, a caller could pass a near-UINT64_MAX gpa with a non-zero
-     * length and the loop would wrap p back to a low GPA, silently
-     * installing descriptors pointing at the wrong physical pages.
+    /* Reject wrap on both the VA side and the GPA side. Without the gpa guard,
+     * a caller could pass a near-UINT64_MAX gpa with a non-zero length and the
+     * loop would wrap p back to a low GPA, silently installing descriptors
+     * pointing at the wrong physical pages.
      */
     if (va > UINT64_MAX - length || gpa > UINT64_MAX - length)
         return -1;
@@ -3170,8 +3163,8 @@ int guest_install_va_pages(guest_t *g,
     /* Aliasing-proof invariant: TTBR1 maps the kbuf RW + UXN + PXN, and the
      * same physical pages are mirrored at KBUF_USER_VA under TTBR0. An
      * executable alias inside the user-VA kbuf window would defeat HVF's
-     * per-mapping W^X enforcement (the kernel-VA mirror is writable). Match
-     * the equivalent check in guest_update_perms before touching pages.
+     * per-mapping W^X enforcement (the kernel-VA mirror is writable). Match the
+     * equivalent check in guest_update_perms before touching pages.
      */
     if ((perms & MEM_PERM_X) && guest_kbuf_user_va_overlap(va, length)) {
         log_error(
@@ -3188,13 +3181,13 @@ int guest_install_va_pages(guest_t *g,
     if (perms & MEM_PERM_X)
         tlbi_request_mark_icache();
 
-    /* Walk one 4 KiB page at a time. find_l2_entry locates the L2 slot for
-     * each VA; split_l2_block converts an L2 block descriptor into a table
-     * lazily so individual L3 entries can be written. The L3 entry is then
+    /* Walk one 4 KiB page at a time. find_l2_entry locates the L2 slot for each
+     * VA; split_l2_block converts an L2 block descriptor into a table lazily so
+     * individual L3 entries can be written. The L3 entry is then
      * unconditionally overwritten with the requested gpa + perms, so a prior
-     * invalidation (or a fresh split inheriting the wrong block address)
-     * cannot leave behind a stale or zero descriptor. Pages whose descriptor
-     * is already identical are no-ops for TLBI purposes; skip them. Skip the
+     * invalidation (or a fresh split inheriting the wrong block address) cannot
+     * leave behind a stale or zero descriptor. Pages whose descriptor is
+     * already identical are no-ops for TLBI purposes; skip them. Skip the
      * per-page bookkeeping once a broadcast is already pending.
      */
     for (uint64_t v = va, p = gpa; v < end; v += PAGE_SIZE, p += PAGE_SIZE) {
@@ -3247,11 +3240,11 @@ int guest_materialize_lazy(guest_t *g, uint64_t fault_offset)
     if (!region)
         return -1; /* Not a noreserve region */
 
-    /* Materialize one 2MiB block containing the fault address. This is
-     * the smallest granule that guest_extend_page_tables works with.
-     * For the common case (sparse heap touch), materializing one block
-     * at a time is the right trade-off: it avoids over-committing the
-     * large reservation while keeping the fault rate manageable.
+    /* Materialize one 2MiB block containing the fault address. This is the
+     * smallest granule that guest_extend_page_tables works with. For the common
+     * case (sparse heap touch), materializing one block at a time is the right
+     * trade-off: it avoids over-committing the large reservation while keeping
+     * the fault rate manageable.
      */
     uint64_t block_start = fault_offset & ~(BLOCK_2MIB - 1);
     uint64_t block_end = block_start + BLOCK_2MIB;
@@ -3282,8 +3275,8 @@ int guest_materialize_lazy(guest_t *g, uint64_t fault_offset)
     /* Create page table entries. guest_extend_page_tables creates L2 block
      * descriptors but skips existing table descriptors (L2->L3 splits).
      * guest_update_perms handles the L3 case: if guest_invalidate_ptes
-     * previously split the block and invalidated the L3 entries,
-     * update_perms recreates them with correct perms.
+     * previously split the block and invalidated the L3 entries, update_perms
+     * recreates them with correct perms.
      */
     if (guest_extend_page_tables(g, block_start, block_end, perms) < 0)
         return -1;
@@ -3317,8 +3310,8 @@ int guest_materialize_lazy(guest_t *g, uint64_t fault_offset)
         memset((uint8_t *) g->host_base + materialize_start, 0,
                materialize_end - materialize_start);
 
-    /* The page-table helpers above already requested the matching TLBI;
-     * no additional flush is needed here.
+    /* The page-table helpers above already requested the matching TLBI; no
+     * additional flush is needed here.
      */
     return 0;
 }

--- a/src/core/guest.h
+++ b/src/core/guest.h
@@ -26,16 +26,16 @@
 
 /* Memory layout constants.
  *
- * Guest memory size is determined dynamically from the VM's IPA width (36-bit
- * = 64GiB on M2, 40-bit = 1TiB on M3+). See guest.c for the runtime probe that
+ * Guest memory size is determined dynamically from the VM's IPA width (36-bit =
+ * 64GiB on M2, 40-bit = 1TiB on M3+). See guest.c for the runtime probe that
  * selects the correct size.
  *
  * Infrastructure layout (page-table pool, shim code, shim data): a 16MiB
  * reserve placed just below g->interp_base, in the dead zone between
  * g->mmap_limit and g->interp_base. The exact base is computed at guest_init
  * time and stored in guest_t.pt_pool_base / pt_pool_end / shim_base /
- * shim_data_base. EL0 user binaries are therefore free to load at low
- * addresses (down to 64KiB) without colliding with the runtime.
+ * shim_data_base. EL0 user binaries are therefore free to load at low addresses
+ * (down to 64KiB) without colliding with the runtime.
  *
  * The reserve is demand-paged (MAP_ANON): unused page-table-pool pages cost no
  * host RAM, and the whole reserve consumes a negligible slice of the ~4 GiB
@@ -60,14 +60,14 @@
  *   +0x0E00000 .. +0x1000000  shim data + EL1 stack (full 2MiB L2 block, RW)
  *
  * Invariant: shim_data occupies the top 2MiB block of the reserve, so
- * INFRA_SHIM_DATA_OFF == INFRA_RESERVE - BLOCK_2MIB and
- * shim_data_base + BLOCK_2MIB == interp_base. The PT pool ends where the shim
- * code slot begins (INFRA_PT_POOL_END_OFF == INFRA_SHIM_OFF), and the slot is
- * INFRA_SHIM_SLOT == INFRA_SHIM_DATA_OFF - INFRA_SHIM_OFF wide.
+ * INFRA_SHIM_DATA_OFF == INFRA_RESERVE - BLOCK_2MIB and shim_data_base +
+ * BLOCK_2MIB == interp_base. The PT pool ends where the shim code slot begins
+ * (INFRA_PT_POOL_END_OFF == INFRA_SHIM_OFF), and the slot is INFRA_SHIM_SLOT ==
+ * INFRA_SHIM_DATA_OFF - INFRA_SHIM_OFF wide.
  */
 
-/* Total size of the runtime infrastructure reserve. Shifted to
- * [g->interp_base - INFRA_RESERVE, g->interp_base) at guest_init.
+/* Total size of the runtime infrastructure reserve. Shifted to [g->interp_base
+ * - INFRA_RESERVE, g->interp_base) at guest_init.
  */
 #define INFRA_RESERVE 0x01000000ULL         /* 16MiB */
 #define INFRA_PT_POOL_OFF 0x00010000ULL     /* PT pool start */
@@ -112,11 +112,11 @@
  */
 #define BLOCK_2MIB (2ULL * 1024 * 1024)
 
-/* IPA base: guest memory is mapped at this IPA in the hypervisor.
- * All guest physical addresses = GUEST_IPA_BASE + offset.
- * Must be 0 so that guest virtual addresses match ELF link addresses (e.g.
- * 0x400000). A non-zero IPA base would require all ELF binaries to be linked at
- * IPA_BASE+vaddr, which is impractical.
+/* IPA base: guest memory is mapped at this IPA in the hypervisor. All guest
+ * physical addresses = GUEST_IPA_BASE + offset. Must be 0 so that guest virtual
+ * addresses match ELF link addresses (e.g. 0x400000). A non-zero IPA base would
+ * require all ELF binaries to be linked at IPA_BASE+vaddr, which is
+ * impractical.
  */
 #define GUEST_IPA_BASE 0x0ULL
 
@@ -124,13 +124,13 @@
  *
  * Rosetta issues MAP_FIXED at bits-63-set addresses (0xFFFFFFFFF0000000+) for
  * its internal kernel-VA allocations. With EPD1=1 (default TCR), TTBR1 walks
- * are disabled and such VAs fault. The kbuf window enables TTBR1, backs a
- * 256 MiB region in the primary buffer at kbuf_gpa, and installs an L0[511]/
+ * are disabled and such VAs fault. The kbuf window enables TTBR1, backs a 256
+ * MiB region in the primary buffer at kbuf_gpa, and installs an L0[511]/
  * L1[511]/L2[384..511] page-table tree.
  *
  * KBUF_USER_VA is the bits-47:0 alias used by rosetta's TaggedPointer
- * extraction (which strips bits 63:48). Mapping the SAME physical kbuf pages
- * at both KBUF_VA_BASE under TTBR1 and KBUF_USER_VA under TTBR0 lets a single
+ * extraction (which strips bits 63:48). Mapping the SAME physical kbuf pages at
+ * both KBUF_VA_BASE under TTBR1 and KBUF_USER_VA under TTBR0 lets a single
  * physical region service both views.
  *
  * Aliasing-proof invariant: the kbuf is RW under both mappings; nothing
@@ -182,12 +182,12 @@ typedef struct {
 
 /* Semantic region tracking. */
 
-/* Maximum number of tracked memory regions (heap/stack/mmap/ELF/etc.).
- * Adjacent anonymous regions with matching permissions are automatically
- * coalesced (see regions_mergeable in core/guest.c). Threaded runtimes create
- * many thread stacks with guard pages; with coalescing, typical workloads use
- * ~50 regions. 4096 provides ample headroom for edge cases (many interleaved
- * guard pages, file-backed mappings, etc.).
+/* Maximum number of tracked memory regions (heap/stack/mmap/ELF/etc.). Adjacent
+ * anonymous regions with matching permissions are automatically coalesced (see
+ * regions_mergeable in core/guest.c). Threaded runtimes create many thread
+ * stacks with guard pages; with coalescing, typical workloads use ~50 regions.
+ * 4096 provides ample headroom for edge cases (many interleaved guard pages,
+ * file-backed mappings, etc.).
  */
 #define GUEST_MAX_REGIONS 4096
 
@@ -200,9 +200,9 @@ typedef struct {
 
 /* HVF stage-2 mapping segment. The slab is mapped to HVF in pieces so that
  * file-backed MAP_SHARED regions can have real host-VA overlays applied via
- * mmap MAP_FIXED|MAP_SHARED of a file fd. HVF requires hv_vm_unmap to target
- * an exactly-previously-mapped range; sub-range unmap of a larger map fails
- * with HV_BAD_ARGUMENT. To allow a 2 MiB-aligned middle range to be unmapped +
+ * mmap MAP_FIXED|MAP_SHARED of a file fd. HVF requires hv_vm_unmap to target an
+ * exactly-previously-mapped range; sub-range unmap of a larger map fails with
+ * HV_BAD_ARGUMENT. To allow a 2 MiB-aligned middle range to be unmapped +
  * remapped (refreshing HVF stage-2 caching after a host mmap MAP_FIXED), the
  * slab is split into 2 MiB-aligned segments around each affected block. All
  * segments are 2 MiB-aligned and 2 MiB-sized at minimum.
@@ -250,12 +250,12 @@ typedef struct {
     char name[64];          /* Label: "[heap]", "[stack]", ELF path, etc. */
 } guest_region_t;
 
-/* TLB invalidation request kinds. After every page-table modification, the
- * shim flushes the TLB on syscall return. The host accumulates the smallest
- * sufficient request across the syscall and emits it via the X8/X9/X10
- * register channel. Kind values are an internal enum independent of the
- * X8 wire codes; the syscall epilogue does the mapping (src/syscall/syscall.c
- * holds the canonical table):
+/* TLB invalidation request kinds. After every page-table modification, the shim
+ * flushes the TLB on syscall return. The host accumulates the smallest
+ * sufficient request across the syscall and emits it via the X8/X9/X10 register
+ * channel. Kind values are an internal enum independent of the X8 wire codes;
+ * the syscall epilogue does the mapping (src/syscall/syscall.c holds the
+ * canonical table):
  *   TLBI_NONE      -> X8 = 0  (no TLB flush)
  *   TLBI_BROADCAST -> X8 = 1  (TLBI VMALLE1IS, broadest)
  *   TLBI_RANGE     -> X8 = 3, X9 = start VA, X10 = page count
@@ -273,11 +273,11 @@ typedef enum {
                            * X8 = 4 on the wire. */
 } tlbi_kind_t;
 
-/* Cap selective per-page TLBI VAE1IS at this many 4 KiB pages. Beyond this,
- * use TLBI RVAE1IS if FEAT_TLBIRANGE is available, else fall back to
+/* Cap selective per-page TLBI VAE1IS at this many 4 KiB pages. Beyond this, use
+ * TLBI RVAE1IS if FEAT_TLBIRANGE is available, else fall back to
  * TLBI_BROADCAST: per-instruction issue cost outweighs the benefit once the
- * range is large. 16 pages == 64 KiB covers RELRO and other typical mprotect
- * / munmap targets.
+ * range is large. 16 pages == 64 KiB covers RELRO and other typical mprotect /
+ * munmap targets.
  */
 #define TLBI_SELECTIVE_MAX_PAGES 16
 
@@ -285,13 +285,13 @@ typedef enum {
  * RVAE1IS operand encoding covers (NUM+1)*2 pages with NUM in [0..31], so a
  * single instruction reaches 64 pages == 256 KiB. Beyond that the host would
  * need SCALE=1 (NUM*64 step), which over-invalidates for the typical
- * dynamic-linker RELRO / glibc-bring-up storm sizes seen in practice; stay
- * at SCALE=0 for now and broadcast above 64 pages.
+ * dynamic-linker RELRO / glibc-bring-up storm sizes seen in practice; stay at
+ * SCALE=0 for now and broadcast above 64 pages.
  */
 #define TLBI_RVAE_MAX_PAGES 64
 
-/* TLBI RVAE1IS operand bit-field constants. Per ARM ARM DDI 0487J.a D8.7.6
- * the operand layout is:
+/* TLBI RVAE1IS operand bit-field constants. Per ARM ARM DDI 0487J.a D8.7.6 the
+ * operand layout is:
  *   bits [36:0]   BaseADDR  (VA[48:12] for 4 KiB granule, DS=0)
  *   bits [38:37]  TTL       (0 = any level)
  *   bits [43:39]  NUM
@@ -299,23 +299,24 @@ typedef enum {
  *   bits [47:46]  TG        (00 = RESERVED, 01 = 4 KiB, 10 = 16 KiB,
  *                            11 = 64 KiB)
  *   bits [63:48]  ASID
- * elfuse only ever issues 4 KiB-granule TLBIs (TCR_EL1.TG0 = 4 KiB), so
- * TG is hard-pinned to 01 and the corresponding bit is named here. */
+ * elfuse only ever issues 4 KiB-granule TLBIs (TCR_EL1.TG0 = 4 KiB), so TG is
+ * hard-pinned to 01 and the corresponding bit is named here.
+ */
 #define RVAE_OPERAND_BADDR_MASK ((1ULL << 37) - 1)
 #define RVAE_OPERAND_NUM_SHIFT 39
 #define RVAE_OPERAND_TG_4KB (1ULL << 46)
 
-/* Pure encoder: build the TLBI RVAE1IS Xt operand from a 4 KiB-aligned VA
- * and a page count in the SCALE=0 range (1..TLBI_RVAE_MAX_PAGES). Lives in
- * the header as `static inline` so tlbi_request_emit_to_vcpu and any
- * future caller (host-side unit tests included) compile to the same
- * expression. NUM = ceil(pages / 2) - 1 over-invalidates odd page counts
- * by exactly one page, which is a perf-only side effect (the extra
- * invalidation evicts a neighbour TLB entry that the guest's next access
- * reloads). pages < 2 is clamped to 2 because SCALE=0 NUM=0 means 2
- * pages -- the encoder cannot represent a single page through RVAE1IS;
- * single-page callers go through the per-page VAE1IS path instead, but
- * the clamp keeps the encoder total in any pathological input. */
+/* Pure encoder: build the TLBI RVAE1IS Xt operand from a 4 KiB-aligned VA and a
+ * page count in the SCALE=0 range (1..TLBI_RVAE_MAX_PAGES). Lives in the header
+ * as static inline so tlbi_request_emit_to_vcpu and any future caller
+ * (host-side unit tests included) compile to the same expression. NUM =
+ * ceil(pages / 2) - 1 over-invalidates odd page counts by exactly one page,
+ * which is a perf-only side effect (the extra invalidation evicts a neighbour
+ * TLB entry that the guest's next access reloads). pages < 2 is clamped to 2
+ * because SCALE=0 NUM=0 means 2 pages -- the encoder cannot represent a single
+ * page through RVAE1IS; single-page callers go through the per-page VAE1IS path
+ * instead, but the clamp keeps the encoder total in any pathological input.
+ */
 static inline uint64_t tlbi_rvae1is_operand(uint64_t start_va, uint16_t pages)
 {
     if (pages < 2)
@@ -329,7 +330,8 @@ static inline uint64_t tlbi_rvae1is_operand(uint64_t start_va, uint16_t pages)
 
 /* Runtime feature flag: TRUE when the host PE implements FEAT_TLBIRANGE
  * (ARMv8.4+, present on every Apple Silicon M1+). Probed once at bootstrap.
- * Read-only after startup so callers do not need an atomic load. */
+ * Read-only after startup so callers do not need an atomic load.
+ */
 extern bool g_tlbi_range_supported;
 
 typedef struct {
@@ -341,9 +343,10 @@ typedef struct {
     uint16_t pages;       /* Page count when kind == TLBI_RANGE (1..MAX) */
     uint64_t start;       /* Page-aligned VA when kind == TLBI_RANGE */
 } tlbi_request_t;
-/* Layout contract: 16 bytes (1+1+2+4 padding+8). Documents the padding and
- * pins the TLS slot size so future field additions surface as a build break
- * rather than silently growing the per-vCPU footprint. */
+/* Layout contract: 16 bytes (1+1+2+4 padding+8). Documents the padding and pins
+ * the TLS slot size so future field additions surface as a build break rather
+ * than silently growing the per-vCPU footprint.
+ */
 _Static_assert(sizeof(tlbi_request_t) == 16,
                "tlbi_request_t must stay 16 bytes; update tlbi_request_clear "
                "and the syscall epilogue if the layout changes");
@@ -357,8 +360,8 @@ _Static_assert(sizeof(tlbi_request_t) == 16,
  * recorded in guest_t.mappings[] so guest_ptr / gva_resolve can translate
  * page-table-walk results that land outside the primary buffer.
  *
- * macOS user-space cannot directly mmap at host VA 128 TiB, so the host VA
- * is unrelated to the guest IPA. The mapping records both.
+ * macOS user-space cannot directly mmap at host VA 128 TiB, so the host VA is
+ * unrelated to the guest IPA. The mapping records both.
  */
 #define GUEST_MAX_MAPPINGS 8
 typedef struct {
@@ -375,8 +378,8 @@ typedef struct {
  * 1016 GiB on M3+) but rosetta JIT/PIE/slab traffic at 85 TB / 240 TB issues
  * many 2 MiB blocks that consume the pool quickly on hosts where Stage-2 caps
  * the primary buffer at 36-bit IPA. Overflow segments are 1 GiB host buffers
- * mapped at IPAs stacked just above guest_size; a bump allocator hands out
- * 2 MiB blocks. New segments are created lazily so untouched overflow costs
+ * mapped at IPAs stacked just above guest_size; a bump allocator hands out 2
+ * MiB blocks. New segments are created lazily so untouched overflow costs
  * nothing.
  */
 #define GUEST_MAX_OVERFLOW 4
@@ -443,10 +446,10 @@ typedef struct {
     hv_vcpu_exit_t *exit; /* vCPU exit info */
     uint32_t ipa_bits;    /* IPA bits requested from HVF */
 
-    /* x86_64-via-Rosetta state. All zero for aarch64 guests. Populated when
-     * the rosetta feature flag is on and an EM_X86_64 binary is loaded.
-     * Survives guest_reset so execve of another x86_64 binary keeps the same
-     * placement and kbuf wiring.
+    /* x86_64-via-Rosetta state. All zero for aarch64 guests. Populated when the
+     * rosetta feature flag is on and an EM_X86_64 binary is loaded. Survives
+     * guest_reset so execve of another x86_64 binary keeps the same placement
+     * and kbuf wiring.
      *
      *   rosetta_guest_base : Stage-2 GPA where rosetta segments are installed
      *                        via guest_add_mapping (typically 128 TiB).
@@ -489,11 +492,11 @@ typedef struct {
     guest_region_t regions[GUEST_MAX_REGIONS];
     int nregions; /* Number of active regions */
     /* Sticky flag set when guest_region_set_prot could not honor a request
-     * because the region table was full. After this point the tracker no
-     * longer faithfully reflects PTE state, so the mprotect fast path must
-     * fall back to unconditional PTE work. Propagated across fork IPC with
-     * the semantic region snapshot so children inherit the same fast-path
-     * guard as the parent.
+     * because the region table was full. After this point the tracker no longer
+     * faithfully reflects PTE state, so the mprotect fast path must fall back
+     * to unconditional PTE work. Propagated across fork IPC with the semantic
+     * region snapshot so children inherit the same fast-path guard as the
+     * parent.
      */
     bool regions_tracker_stale;
     guest_region_t preannounced[GUEST_MAX_PREANNOUNCED];
@@ -507,9 +510,9 @@ typedef struct {
     hvf_segment_t segments[GUEST_MAX_HVF_SEGMENTS];
     int n_segments;
 
-    /* Page table generation counter: incremented on every PT modification.
-     * Used by the per-thread GVA TLB cache to detect stale entries.
-     * 64-bit to avoid wrap-around stale hits over long-running sessions.
+    /* Page table generation counter: incremented on every PT modification. Used
+     * by the per-thread GVA TLB cache to detect stale entries. 64-bit to avoid
+     * wrap-around stale hits over long-running sessions.
      */
     _Atomic uint64_t pt_gen;
 
@@ -536,8 +539,8 @@ typedef struct {
     void *hvc6_userdata;
 } guest_t;
 
-/* Bump the page table generation counter (call after any PT modification).
- * This invalidates all per-thread GVA TLB caches.
+/* Bump the page table generation counter (call after any PT modification). This
+ * invalidates all per-thread GVA TLB caches.
  */
 static inline void guest_pt_gen_bump(guest_t *g)
 {
@@ -547,35 +550,34 @@ static inline void guest_pt_gen_bump(guest_t *g)
 /* TLB invalidation request helpers.
  *
  * Per-vCPU TLS slot. Each guest thread (= one host pthread + one HVF vCPU)
- * accumulates its own pending TLBI request as its syscall handlers mutate
- * the page tables. The syscall epilogue (src/syscall/syscall.c) reads its
- * own thread's slot, emits the X8/X9/X10 protocol, and clears it.
+ * accumulates its own pending TLBI request as its syscall handlers mutate the
+ * page tables. The syscall epilogue (src/syscall/syscall.c) reads its own
+ * thread's slot, emits the X8/X9/X10 protocol, and clears it.
  *
  * Why per-vCPU and not a guest_t-global accumulator: a global slot lets one
  * vCPU's syscall epilogue drain (and clear) another vCPU's pending request
- * before that vCPU has eret'd back to EL0, allowing the second vCPU to use
- * a stale TLB until the broadcast TLBI from the first vCPU's shim catches
- * up. A per-vCPU slot makes each thread strictly responsible for issuing
- * the TLBI for its own changes before its own eret. Page-table changes are
- * still global (guest memory and page tables are shared), but TLBI VAE1IS
- * and TLBI VMALLE1IS in the inner-shareable domain broadcast to all PEs,
- * so one vCPU's own TLBI is sufficient to invalidate stale entries on its
- * own PE before resuming guest code.
+ * before that vCPU has eret'd back to EL0, allowing the second vCPU to use a
+ * stale TLB until the broadcast TLBI from the first vCPU's shim catches up. A
+ * per-vCPU slot makes each thread strictly responsible for issuing the TLBI for
+ * its own changes before its own eret. Page-table changes are still global
+ * (guest memory and page tables are shared), but TLBI VAE1IS and TLBI VMALLE1IS
+ * in the inner-shareable domain broadcast to all PEs, so one vCPU's own TLBI is
+ * sufficient to invalidate stale entries on its own PE before resuming guest
+ * code.
  *
- * No locking is needed for the slot itself; only the owning thread reads
- * or writes it. Page-table updates remain serialized by mmap_lock.
+ * No locking is needed for the slot itself; only the owning thread reads or
+ * writes it. Page-table updates remain serialized by mmap_lock.
  *
- * Cross-vCPU shootdown window: between vCPU A releasing mmap_lock at the
- * end of an mprotect/munmap and the shim on A issuing the TLBI, sibling
- * vCPU B may continue executing EL0 code that hits A's now-stale TLB
- * entries. Real Linux closes this with cross-CPU IPI synchronization in
- * the kernel; user-space emulation on Hypervisor.framework cannot inject
- * a synchronous IPI into a sibling vCPU thread, so the window remains.
- * The guest is responsible for serializing concurrent PT mutations
- * against concurrent accesses (futex / pthread_mutex), which is the same
- * contract real Linux requires of well-behaved multi-threaded code. A
- * bounded-retry on stale-TLB data aborts is a known hardening direction
- * if a workload ever surfaces an actual reproducer.
+ * Cross-vCPU shootdown window: between vCPU A releasing mmap_lock at the end of
+ * an mprotect/munmap and the shim on A issuing the TLBI, sibling vCPU B may
+ * continue executing EL0 code that hits A's now-stale TLB entries. Real Linux
+ * closes this with cross-CPU IPI synchronization in the kernel; user-space
+ * emulation on Hypervisor.framework cannot inject a synchronous IPI into a
+ * sibling vCPU thread, so the window remains. The guest is responsible for
+ * serializing concurrent PT mutations against concurrent accesses (futex /
+ * pthread_mutex), which is the same contract real Linux requires of
+ * well-behaved multi-threaded code. A bounded-retry on stale-TLB data aborts is
+ * a known hardening direction if a workload ever surfaces an actual reproducer.
  */
 extern _Thread_local tlbi_request_t cpu_tlbi_req;
 
@@ -592,11 +594,11 @@ static inline void tlbi_request_broadcast(void)
     cpu_tlbi_req.kind = TLBI_BROADCAST;
 }
 
-/* True if the accumulator is already at TLBI_BROADCAST. PT mutation helpers
- * use this to skip the per-page bounding-box bookkeeping (changed_lo /
- * changed_hi tracking and the final tlbi_request_range call) once a broadcast
- * is already promised; the inline tlbi_request_range itself short-circuits
- * for the same reason but the call-site loops still pay for the compares.
+/* True if the accumulator is already at TLBI_BROADCAST. PT mutation helpers use
+ * this to skip the per-page bounding-box bookkeeping (changed_lo / changed_hi
+ * tracking and the final tlbi_request_range call) once a broadcast is already
+ * promised; the inline tlbi_request_range itself short-circuits for the same
+ * reason but the call-site loops still pay for the compares.
  */
 static inline bool tlbi_request_is_broadcast(void)
 {
@@ -604,23 +606,23 @@ static inline bool tlbi_request_is_broadcast(void)
 }
 
 /* Mark that the current syscall's PT mutation introduced executable content
- * visible to EL0 (a new X mapping, or an mprotect that added MEM_PERM_X to
- * a previously-NX page). The shim consults this via X11 on syscall return
- * to decide whether IC IALLU is needed after the TLBI sequence. Data-only
- * page-table changes (mprotect RW<->R, munmap of data, etc.) leave this
- * cleared so the I-cache invalidation is skipped.
+ * visible to EL0 (a new X mapping, or an mprotect that added MEM_PERM_X to a
+ * previously-NX page). The shim consults this via X11 on syscall return to
+ * decide whether IC IALLU is needed after the TLBI sequence. Data-only
+ * page-table changes (mprotect RW<->R, munmap of data, etc.) leave this cleared
+ * so the I-cache invalidation is skipped.
  */
 static inline void tlbi_request_mark_icache(void)
 {
     cpu_tlbi_req.icache_flush = 1;
 }
 
-/* Encode the pending TLBI request into the vCPU's X8/X9/X10/X11 registers
- * for the shim's post-HVC dispatch and clear the per-vCPU accumulator.
- * Both the syscall HVC #5 epilogue and the HVC #11 EL0-fault handler use
- * this so the same X8 wire codes (and X11 I-cache hint) drive every TLBI
- * the host issues on behalf of the guest. Keeping the helper inline lets
- * the call sites compile to the same switch in both files.
+/* Encode the pending TLBI request into the vCPU's X8/X9/X10/X11 registers for
+ * the shim's post-HVC dispatch and clear the per-vCPU accumulator. Both the
+ * syscall HVC #5 epilogue and the HVC #11 EL0-fault handler use this so the
+ * same X8 wire codes (and X11 I-cache hint) drive every TLBI the host issues on
+ * behalf of the guest. Keeping the helper inline lets the call sites compile to
+ * the same switch in both files.
  */
 static inline void tlbi_request_emit_to_vcpu(hv_vcpu_t vcpu)
 {
@@ -636,13 +638,14 @@ static inline void tlbi_request_emit_to_vcpu(hv_vcpu_t vcpu)
         hv_vcpu_set_reg(vcpu, HV_REG_X11, cpu_tlbi_req.icache_flush ? 1 : 0);
         break;
     case TLBI_RANGE_LARGE: {
-        /* Single-shot TLBI RVAE1IS for ranges in (16..64] pages. The
-         * operand format and the SCALE=0 / TG=01 / ASID=0 assumptions are
-         * documented at tlbi_rvae1is_operand above. ASID stays 0 because
-         * the shim runs single-ASID (TCR_EL1.A1=0, TTBR0 ASID=0; rosetta
-         * does not allocate a separate ASID). If a future change
-         * introduces non-zero ASIDs, the helper signature and the
-         * tlbi_request_t accumulator both need an ASID field. */
+        /* Single-shot TLBI RVAE1IS for ranges in (16..64] pages. The operand
+         * format and the SCALE=0 / TG=01 / ASID=0 assumptions are documented at
+         * tlbi_rvae1is_operand above. ASID stays 0 because the shim runs
+         * single-ASID (TCR_EL1.A1=0, TTBR0 ASID=0; rosetta does not allocate a
+         * separate ASID). If a future change introduces non-zero ASIDs, the
+         * helper signature and the tlbi_request_t accumulator both need an ASID
+         * field.
+         */
         uint64_t operand =
             tlbi_rvae1is_operand(cpu_tlbi_req.start, cpu_tlbi_req.pages);
         hv_vcpu_set_reg(vcpu, HV_REG_X8, 4);
@@ -664,9 +667,9 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
         return;
     if (end <= start)
         return;
-    /* Page-align: TLBI VAE1IS operates on 4 KiB granules. ALIGN_UP can
-     * overflow if end is within PAGE_SIZE-1 of UINT64_MAX; saturate to
-     * broadcast in that pathological case rather than wrap to 0.
+    /* Page-align: TLBI VAE1IS operates on 4 KiB granules. ALIGN_UP can overflow
+     * if end is within PAGE_SIZE-1 of UINT64_MAX; saturate to broadcast in that
+     * pathological case rather than wrap to 0.
      */
     const uint64_t mask = 0xFFFULL;
     if (end > UINT64_MAX - mask) {
@@ -676,12 +679,13 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
     uint64_t s = start & ~mask;
     uint64_t e = (end + mask) & ~mask;
     uint64_t n = (e - s) >> 12;
-    /* Two thresholds. (a) <= TLBI_SELECTIVE_MAX_PAGES uses the per-page
-     * VAE1IS loop, which preserves the most TLB entries. (b) <=
-     * TLBI_RVAE_MAX_PAGES uses a single TLBI RVAE1IS via FEAT_TLBIRANGE,
-     * which still preserves unrelated TLB entries but costs only one
-     * instruction issue. Above TLBI_RVAE_MAX_PAGES or when the feature is
-     * absent, broadcast (TLBI VMALLE1IS). */
+    /* Two thresholds. (a) <= TLBI_SELECTIVE_MAX_PAGES uses the per-page VAE1IS
+     * loop, which preserves the most TLB entries. (b) <= TLBI_RVAE_MAX_PAGES
+     * uses a single TLBI RVAE1IS via FEAT_TLBIRANGE, which still preserves
+     * unrelated TLB entries but costs only one instruction issue. Above
+     * TLBI_RVAE_MAX_PAGES or when the feature is absent, broadcast (TLBI
+     * VMALLE1IS).
+     */
     uint64_t large_cap =
         g_tlbi_range_supported ? TLBI_RVAE_MAX_PAGES : TLBI_SELECTIVE_MAX_PAGES;
     if (n > large_cap) {
@@ -696,14 +700,15 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
         return;
     }
     /* Coalesce by union. Disjoint ranges still produce a single bounding
-     * interval; if it stays within the active cap, the range TLBI still
-     * wins over a full flush by preserving unrelated TLB entries.
+     * interval; if it stays within the active cap, the range TLBI still wins
+     * over a full flush by preserving unrelated TLB entries.
      */
     uint64_t es = cpu_tlbi_req.start;
     uint64_t pe = (uint64_t) cpu_tlbi_req.pages * 4096ULL;
-    /* The accumulator only ever holds page counts <= large_cap (enforced by
-     * the cap check above), so es + pe never overflows on real callers, but
-     * be explicit. */
+    /* The accumulator only ever holds page counts <= large_cap (enforced by the
+     * cap check above), so es + pe never overflows on real callers, but be
+     * explicit.
+     */
     if (es > UINT64_MAX - pe) {
         tlbi_request_broadcast();
         return;
@@ -720,7 +725,8 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
     cpu_tlbi_req.pages = (uint16_t) un;
     /* Promote kind if the coalesced range now exceeds the per-page cap. The
      * inverse direction (LARGE -> RANGE) is impossible because un >= pe / 4096
-     * after coalescing. */
+     * after coalescing.
+     */
     if (un > TLBI_SELECTIVE_MAX_PAGES)
         cpu_tlbi_req.kind = TLBI_RANGE_LARGE;
 }
@@ -731,13 +737,12 @@ static inline uint64_t guest_ipa(const guest_t *g, uint64_t offset)
     return g->ipa_base + offset;
 }
 
-/* True iff [start, end) overlaps the runtime infra reserve
- * [interp_base - INFRA_RESERVE, interp_base). Covers the full
- * reserve including the 64 KiB null-guard slot at the bottom (which
- * has no PT entries but must not become semantically reachable from
- * guest mmap state). Used by sys_mmap (MAP_FIXED), sys_munmap, and
- * sys_mprotect to reject guest attempts to touch page tables, shim
- * code, or shim data through the syscall surface.
+/* True iff [start, end) overlaps the runtime infra reserve [interp_base -
+ * INFRA_RESERVE, interp_base). Covers the full reserve including the 64 KiB
+ * null-guard slot at the bottom (which has no PT entries but must not become
+ * semantically reachable from guest mmap state). Used by sys_mmap (MAP_FIXED),
+ * sys_munmap, and sys_mprotect to reject guest attempts to touch page tables,
+ * shim code, or shim data through the syscall surface.
  */
 static inline bool guest_range_hits_infra(const guest_t *g,
                                           uint64_t start,
@@ -762,17 +767,17 @@ static inline bool guest_addr_in_infra(const guest_t *g, uint64_t addr)
 
 /* API */
 
-/* Allocate guest memory, create VM, map to hypervisor.
- * size: primary buffer size (0 = auto-detect from IPA capacity).
- * ipa_bits: IPA width for HVF VM (0 = auto-detect).
+/* Allocate guest memory, create VM, map to hypervisor. size: primary buffer
+ * size (0 = auto-detect from IPA capacity). ipa_bits: IPA width for HVF VM (0 =
+ * auto-detect).
  * Returns 0 on success, -1 on failure.
  */
 int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits);
 
-/* Initialize guest from a POSIX shared memory fd (CoW fork path).
- * Maps shm_fd MAP_PRIVATE (copy-on-write), creates HVF VM, maps to
- * hypervisor. The child gets an instant CoW snapshot of parent's guest
- * memory without copying. shm_fd is closed after mapping.
+/* Initialize guest from a POSIX shared memory fd (CoW fork path). Maps shm_fd
+ * MAP_PRIVATE (copy-on-write), creates HVF VM, maps to hypervisor. The child
+ * gets an instant CoW snapshot of parent's guest memory without copying. shm_fd
+ * is closed after mapping.
  * Returns 0 on success, -1 on failure.
  */
 int guest_init_from_shm(guest_t *g,
@@ -785,19 +790,21 @@ void guest_destroy(guest_t *g);
 
 /* Install a Stage-2 mapping for a high IPA range that the primary buffer does
  * not cover (e.g. rosetta's segments at 128 TiB). Calls hv_vm_map with the
- * supplied permissions. If host_va_inout points to NULL, allocates an anon
- * host buffer of the requested size and records ownership so guest_destroy
- * frees it. Otherwise the caller-supplied host_va is mapped as-is and the
- * mapping does not own it. size and gpa must be page-aligned.
+ * supplied permissions. If host_va_inout points to NULL, allocates an anon host
+ * buffer of the requested size and records ownership so guest_destroy frees it.
+ * Otherwise the caller-supplied host_va is mapped as-is and the mapping does
+ * not own it. size and gpa must be page-aligned.
  *
  * The new region is appended to g->mappings[] for guest_ptr / gva_resolve
- * fall-through. Returns 0 on success, -1 if GUEST_MAX_MAPPINGS is exhausted,
- * if the allocation/mapping fails, or if the range collides with the primary
- * buffer or an existing extra mapping.
+ * fall-through.
+ *
+ * Returns 0 on success, -1 if GUEST_MAX_MAPPINGS is exhausted, if the
+ * allocation/mapping fails, or if the range collides with the primary buffer or
+ * an existing extra mapping.
  *
  * Locking: callers MUST hold mmap_lock. gva_resolve_perm reads mappings[]
- * lock-free during page-table walks, so mutating n_mappings / mappings[]
- * from concurrent vCPUs without serialization would race.
+ * lock-free during page-table walks, so mutating n_mappings / mappings[] from
+ * concurrent vCPUs without serialization would race.
  */
 int guest_add_mapping(guest_t *g,
                       uint64_t gpa,
@@ -814,39 +821,43 @@ int guest_add_mapping(guest_t *g,
  */
 void guest_clear_rosetta_state(guest_t *g);
 
-/* Linear scan of g->mappings[] for the entry covering gpa. Returns NULL if
- * gpa is below g->guest_size (i.e. inside the primary buffer) or not covered
- * by any extra mapping.
+/* Linear scan of g->mappings[] for the entry covering gpa.
+ *
+ * Returns NULL if gpa is below g->guest_size (i.e. inside the primary buffer)
+ * or not covered by any extra mapping.
  */
 const guest_mapping_t *guest_find_mapping(const guest_t *g, uint64_t gpa);
 
-/* Bump-allocate a 2 MiB block from the overflow segments. Lazily creates a
- * new 1 GiB segment (via mmap + hv_vm_map at g->overflow_ipa_next) when the
- * existing segments are exhausted. Returns the GPA of the allocated block,
- * or UINT64_MAX if all GUEST_MAX_OVERFLOW segments are full or a host/HVF
- * allocation step failed. Callers should treat UINT64_MAX as -ENOMEM.
+/* Bump-allocate a 2 MiB block from the overflow segments. Lazily creates a new
+ * 1 GiB segment (via mmap + hv_vm_map at g->overflow_ipa_next) when the
+ * existing segments are exhausted.
+ *
+ * Returns the GPA of the allocated block, or UINT64_MAX if all
+ * GUEST_MAX_OVERFLOW segments are full or a host/HVF allocation step failed.
+ * Callers should treat UINT64_MAX as -ENOMEM.
  *
  * Locking: callers MUST hold mmap_lock. gva_resolve_perm reads overflow[]
  * lock-free during page-table walks.
  */
 uint64_t guest_overflow_alloc(guest_t *g);
 
-/* Locate the overflow segment covering gpa. Returns NULL if gpa is not within
- * any overflow segment.
+/* Locate the overflow segment covering gpa.
+ *
+ * Returns NULL if gpa is not within any overflow segment.
  */
 const guest_overflow_t *guest_find_overflow(const guest_t *g, uint64_t gpa);
 
 /* Returns true when [gpa, gpa+len) is fully contained within the primary
- * buffer, OR fully contained within a single extra mapping, OR fully
- * contained within a single overflow segment. The check rejects ranges that
- * straddle region boundaries -- host pointers cannot safely span discontiguous
- * backing regions. len == 0 returns true (zero-length ranges are well-formed
- * by convention; syscall handlers that disallow them check separately).
+ * buffer, OR fully contained within a single extra mapping, OR fully contained
+ * within a single overflow segment. The check rejects ranges that straddle
+ * region boundaries -- host pointers cannot safely span discontiguous backing
+ * regions. len == 0 returns true (zero-length ranges are well-formed by
+ * convention; syscall handlers that disallow them check separately).
  *
  * Use this for syscalls that need to validate a guest IPA range without
  * coupling to the primary-buffer-only assumption: sys_mmap MAP_FIXED,
- * sys_munmap, sys_mremap, sys_mprotect, sys_msync, and any future caller
- * that handles rosetta high-VA traffic.
+ * sys_munmap, sys_mremap, sys_mprotect, sys_msync, and any future caller that
+ * handles rosetta high-VA traffic.
  */
 bool guest_is_valid_range(const guest_t *g, uint64_t gpa, uint64_t len);
 
@@ -856,49 +867,48 @@ bool guest_is_valid_range(const guest_t *g, uint64_t gpa, uint64_t len);
  * L0[511] -> L1, L1[511] -> L2, and L2[384..511] = 128 x 2 MiB block
  * descriptors with PT_AP_RW_EL0 | PT_UXN | PT_PXN (RW, non-executable).
  * Stores the resulting TTBR1 IPA in g->ttbr1 and sets g->kbuf_gpa /
- * g->kbuf_base. On any failure all three fields are scrubbed to 0/NULL
- * so the caller cannot read stale state.
+ * g->kbuf_base. On any failure all three fields are scrubbed to 0/NULL so the
+ * caller cannot read stale state.
  *
  * Returns 0 on success, -1 on alignment / bounds / PT-pool-exhaustion failure.
  *
- * Locking: callers MUST hold mmap_lock. The function mutates the PT pool
- * and the kbuf fields; gva translation reads ttbr1 lock-free.
+ * Locking: callers MUST hold mmap_lock. The function mutates the PT pool and
+ * the kbuf fields; gva translation reads ttbr1 lock-free.
  */
 int guest_init_kbuf(guest_t *g, uint64_t kbuf_gpa);
 
-/* Install the TTBR0 user-VA mirror of the kbuf window. Walks the existing
- * TTBR0 tree (at g->ttbr0) to L0[511]/L1[511]/L2[384..511] and writes
- * 128 x 2 MiB block descriptors mapping [KBUF_USER_VA, KBUF_USER_VA +
- * KBUF_SIZE) to [g->kbuf_gpa, g->kbuf_gpa + KBUF_SIZE) with RW + UXN + PXN
- * perms. Rosetta's TaggedPointer extraction strips bits 63:48 so the same
- * physical pages must be reachable through both TTBR1 (kernel VA) and
- * TTBR0 (the user-VA alias).
+/* Install the TTBR0 user-VA mirror of the kbuf window. Walks the existing TTBR0
+ * tree (at g->ttbr0) to L0[511]/L1[511]/L2[384..511] and writes 128 x 2 MiB
+ * block descriptors mapping [KBUF_USER_VA, KBUF_USER_VA + KBUF_SIZE) to
+ * [g->kbuf_gpa, g->kbuf_gpa + KBUF_SIZE) with RW + UXN + PXN perms. Rosetta's
+ * TaggedPointer extraction strips bits 63:48 so the same physical pages must be
+ * reachable through both TTBR1 (kernel VA) and TTBR0 (the user-VA alias).
  *
- * Must be called after guest_build_page_tables (g->ttbr0 must point at a
- * valid L0 page) and after guest_init_kbuf (g->kbuf_gpa must be set).
+ * Must be called after guest_build_page_tables (g->ttbr0 must point at a valid
+ * L0 page) and after guest_init_kbuf (g->kbuf_gpa must be set).
  * Returns 0 on success, -1 on PT-pool exhaustion or invalid state.
  *
  * Locking: callers MUST hold mmap_lock.
  */
 int guest_install_kbuf_user_alias(guest_t *g);
 
-/* Install L2 block descriptors mapping [va_start, va_end) to
- * [gpa_start, gpa_start + (va_end-va_start)) under TTBR0. Both addresses
- * and the size must be 2 MiB-aligned. Walks the existing TTBR0 tree at
- * g->ttbr0 and allocates L1/L2 tables from the PT pool as needed.
+/* Install L2 block descriptors mapping [va_start, va_end) to [gpa_start,
+ * gpa_start + (va_end-va_start)) under TTBR0. Both addresses and the size must
+ * be 2 MiB-aligned. Walks the existing TTBR0 tree at g->ttbr0 and allocates
+ * L1/L2 tables from the PT pool as needed.
  *
- * If an L2 slot is already populated, the function leaves it untouched
- * and continues with the next block; the caller is expected to use
+ * If an L2 slot is already populated, the function leaves it untouched and
+ * continues with the next block; the caller is expected to use
  * guest_update_perms (or split + update_perms) if it needs to refine
  * permissions on an already-mapped 2 MiB block.
  *
- * Records a guest_pt_gen_bump and a TLBI request covering the new range
- * so the shim invalidates matching TLB entries on the way back to EL0.
+ * Records a guest_pt_gen_bump and a TLBI request covering the new range so the
+ * shim invalidates matching TLB entries on the way back to EL0.
  *
  * Returns 0 on success, -1 on alignment, PT-pool-exhaustion, or out-of-L0
- * failure. Used by sys_mmap for high-VA MAP_FIXED requests (rosetta's
- * JIT slabs at 240 TiB, code caches at 85 TiB) where the VA lives outside
- * the primary buffer but the GPA still does.
+ * failure. Used by sys_mmap for high-VA MAP_FIXED requests (rosetta's JIT slabs
+ * at 240 TiB, code caches at 85 TiB) where the VA lives outside the primary
+ * buffer but the GPA still does.
  *
  * Locking: callers MUST hold mmap_lock.
  */
@@ -908,16 +918,16 @@ int guest_map_va_range(guest_t *g,
                        uint64_t gpa_start,
                        int perms);
 
-/* Install (or overwrite) 4 KiB L3 page descriptors mapping [va, va+length)
- * to [gpa, gpa+length) with the requested perms. Unlike guest_update_perms,
- * which only edits existing descriptors and falls back to region metadata
- * for invalid entries, this helper always writes a fresh make_page_desc so
- * a previously-invalidated L3 slot is restored without consulting the
- * region table. Splits L2 block descriptors on the path lazily.
+/* Install (or overwrite) 4 KiB L3 page descriptors mapping [va, va+length) to
+ * [gpa, gpa+length) with the requested perms. Unlike guest_update_perms, which
+ * only edits existing descriptors and falls back to region metadata for invalid
+ * entries, this helper always writes a fresh make_page_desc so a
+ * previously-invalidated L3 slot is restored without consulting the region
+ * table. Splits L2 block descriptors on the path lazily.
  *
- * All three arguments (va, length, gpa) must be PAGE_SIZE aligned. The L2
- * chain (L0->L1->L2) must already be in place (caller's responsibility,
- * typically via a prior guest_map_va_range).
+ * All three arguments (va, length, gpa) must be PAGE_SIZE aligned. The L2 chain
+ * (L0->L1->L2) must already be in place (caller's responsibility, typically via
+ * a prior guest_map_va_range).
  *
  * Returns 0 on success, -1 on alignment, missing L2 chain, or PT-pool
  * exhaustion.
@@ -935,12 +945,12 @@ int guest_install_va_pages(guest_t *g,
  */
 bool guest_va_block_mapped(const guest_t *g, uint64_t va);
 
-/* Returns true when the VA range [va, va+size) overlaps the user-VA kbuf
- * alias window [KBUF_USER_VA, KBUF_USER_VA+KBUF_SIZE). Callers that install
- * TTBR0 mappings (the future rosetta_finalize, sys_mmap MAP_FIXED touching
- * this range, the page-table-build pass) must reject MEM_PERM_X when this
- * helper returns true: TTBR1 maps the same physical pages RW only, and an
- * executable TTBR0 alias would defeat HVF's per-mapping W^X enforcement.
+/* Returns true when the VA range [va, va+size) overlaps the user-VA kbuf alias
+ * window [KBUF_USER_VA, KBUF_USER_VA+KBUF_SIZE). Callers that install TTBR0
+ * mappings (the future rosetta_finalize, sys_mmap MAP_FIXED touching this
+ * range, the page-table-build pass) must reject MEM_PERM_X when this helper
+ * returns true: TTBR1 maps the same physical pages RW only, and an executable
+ * TTBR0 alias would defeat HVF's per-mapping W^X enforcement.
  */
 static inline bool guest_kbuf_user_va_overlap(uint64_t va, uint64_t size)
 {
@@ -964,9 +974,9 @@ void *guest_ptr_w(const guest_t *g, uint64_t gva);
 
 /* Get a host pointer for a guest virtual address, with available byte count.
  * *avail receives the number of contiguous bytes from gva whose page table
- * entries are valid and satisfy required_perms (MEM_PERM_R/W/X bitmask).
- * The function walks forward across adjacent L2 blocks and L3 pages until it
- * hits an invalid, permission-mismatched, or physically non-contiguous entry.
+ * entries are valid and satisfy required_perms (MEM_PERM_R/W/X bitmask). The
+ * function walks forward across adjacent L2 blocks and L3 pages until it hits
+ * an invalid, permission-mismatched, or physically non-contiguous entry.
  * Returns NULL if the starting page is unmapped or lacks required_perms.
  */
 void *guest_ptr_avail(const guest_t *g,
@@ -976,7 +986,9 @@ void *guest_ptr_avail(const guest_t *g,
 
 /* Get a host pointer for a guest range, capped to a caller-provided limit.
  * *avail receives the number of contiguous bytes available from gva, up to
- * len_limit. Returns NULL if the starting address is unmapped or lacks perms.
+ * len_limit.
+ *
+ * Returns NULL if the starting address is unmapped or lacks perms.
  */
 void *guest_ptr_bound(const guest_t *g,
                       uint64_t gva,
@@ -989,9 +1001,9 @@ void *guest_ptr_bound(const guest_t *g,
  */
 int guest_read(const guest_t *g, uint64_t gva, void *dst, size_t len);
 
-/* Optimized guest-to-host copy for small fixed-size inputs.
- * Uses a direct guest pointer when the full range is contiguous and readable,
- * otherwise falls back to guest_read() for boundary-crossing safety.
+/* Optimized guest-to-host copy for small fixed-size inputs. Uses a direct guest
+ * pointer when the full range is contiguous and readable, otherwise falls back
+ * to guest_read() for boundary-crossing safety.
  */
 int guest_read_small(const guest_t *g, uint64_t gva, void *dst, size_t len);
 
@@ -1000,36 +1012,37 @@ int guest_read_small(const guest_t *g, uint64_t gva, void *dst, size_t len);
  */
 int guest_write(guest_t *g, uint64_t gva, const void *src, size_t len);
 
-/* Optimized host-to-guest copy for small fixed-size outputs.
- * Uses a direct guest pointer when the full range is contiguous and writable,
- * otherwise falls back to guest_write() for boundary-crossing safety.
+/* Optimized host-to-guest copy for small fixed-size outputs. Uses a direct
+ * guest pointer when the full range is contiguous and writable, otherwise falls
+ * back to guest_write() for boundary-crossing safety.
  */
 int guest_write_small(guest_t *g, uint64_t gva, const void *src, size_t len);
 
-/* Read a null-terminated string from guest memory.
- * Copies up to max-1 bytes + NUL into dst.
+/* Read a null-terminated string from guest memory. Copies up to max-1 bytes +
+ * NUL into dst.
  * Returns string length or -1 if out of bounds / unterminated.
  */
 int guest_read_str(const guest_t *g, uint64_t gva, char *dst, size_t max);
 
-/* Optimized guest string read for short, contiguous paths.
- * Uses a direct guest pointer when a full max-1-byte window is readable,
- * otherwise falls back to guest_read_str() for boundary-safe scanning.
+/* Optimized guest string read for short, contiguous paths. Uses a direct guest
+ * pointer when a full max-1-byte window is readable, otherwise falls back to
+ * guest_read_str() for boundary-safe scanning.
  */
 int guest_read_str_small(const guest_t *g, uint64_t gva, char *dst, size_t max);
 
-/* Build L0->L1->L2 page tables from an array of memory regions.
- * Uses 2MiB block descriptors. Returns the TTBR0 value (GPA of L0 table),
- * or 0 on failure.
+/* Build L0->L1->L2 page tables from an array of memory regions. Uses 2MiB block
+ * descriptors.
+ *
+ * Returns the TTBR0 value (GPA of L0 table), or 0 on failure.
  */
 uint64_t guest_build_page_tables(guest_t *g,
                                  const mem_region_t *regions,
                                  int n);
 
-/* Extend page tables to cover a new address range [start, end) with 2MiB
- * block descriptors. Reuses the existing L0->L1 table structure and
- * allocates new L2 tables as needed. Records a TLBI request covering the
- * affected range (range or broadcast).
+/* Extend page tables to cover a new address range [start, end) with 2MiB block
+ * descriptors. Reuses the existing L0->L1 table structure and allocates new L2
+ * tables as needed. Records a TLBI request covering the affected range (range
+ * or broadcast).
  * Returns 0 on success, -1 on failure.
  */
 int guest_extend_page_tables(guest_t *g,
@@ -1037,49 +1050,47 @@ int guest_extend_page_tables(guest_t *g,
                              uint64_t end,
                              int perms);
 
-/* Split a 2MiB block descriptor into 512 x 4KiB L3 page descriptors.
- * block_gpa must be within a currently-mapped 2MiB block. The block's
- * permissions are inherited by all 512 page entries. If the block is
- * already split (L2 entry is a table descriptor), this is a no-op.
+/* Split a 2MiB block descriptor into 512 x 4KiB L3 page descriptors. block_gpa
+ * must be within a currently-mapped 2MiB block. The block's permissions are
+ * inherited by all 512 page entries. If the block is already split (L2 entry is
+ * a table descriptor), this is a no-op.
  *
- * No TLBI request is issued: the split alone preserves every VA->PA
- * translation in the block (each L3 page descriptor inherits the block's
- * permissions). Every caller follows the split with guest_invalidate_ptes
- * or guest_update_perms on the actually-changing range; that subsequent
- * call records the TLBI, and TLBI VAE1IS for any VA in the block also
- * invalidates the cached 2 MiB block entry covering that VA (ARM ARM
- * B2.2.5.6), so a single per-page TLBI suffices to retire the stale
- * block translation as soon as any affected page is accessed.
+ * No TLBI request is issued: the split alone preserves every VA->PA translation
+ * in the block (each L3 page descriptor inherits the block's permissions).
+ * Every caller follows the split with guest_invalidate_ptes or
+ * guest_update_perms on the actually-changing range; that subsequent call
+ * records the TLBI, and TLBI VAE1IS for any VA in the block also invalidates
+ * the cached 2 MiB block entry covering that VA (ARM ARM B2.2.5.6), so a single
+ * per-page TLBI suffices to retire the stale block translation as soon as any
+ * affected page is accessed.
  *
  * Returns 0 on success, -1 on failure.
  */
 int guest_split_block(guest_t *g, uint64_t block_gpa);
 
-/* Invalidate page table entries for the range [start, end).
- * Sets L2 block descriptors and L3 page descriptors to 0 (invalid),
- * causing translation faults on access. Used when mprotect sets
- * PROT_NONE; the correct behavior is for the guest to fault.
- * If a 2MiB block is only partially invalidated, the block is split
- * into L3 pages first (preserving the non-invalidated pages).
+/* Invalidate page table entries for the range [start, end). Sets L2 block
+ * descriptors and L3 page descriptors to 0 (invalid), causing translation
+ * faults on access. Used when mprotect sets PROT_NONE; the correct behavior is
+ * for the guest to fault. If a 2MiB block is only partially invalidated, the
+ * block is split into L3 pages first (preserving the non-invalidated pages).
  * Records a TLBI request covering the invalidated range.
  * Returns 0 on success, -1 on failure.
  */
 int guest_invalidate_ptes(guest_t *g, uint64_t start, uint64_t end);
 
-/* Update page table permissions for the range [start, end).
- * If a 2MiB block needs mixed permissions (only part of it is being
- * updated), the block is automatically split into 4KiB L3 pages first.
- * If the entire 2MiB block is being updated, the block descriptor is
- * modified in place without splitting.
- * perms is a MEM_PERM_R/W/X combination. Records a TLBI request only for
- * pages whose descriptor actually changed.
+/* Update page table permissions for the range [start, end). If a 2MiB block
+ * needs mixed permissions (only part of it is being updated), the block is
+ * automatically split into 4KiB L3 pages first. If the entire 2MiB block is
+ * being updated, the block descriptor is modified in place without splitting.
+ * perms is a MEM_PERM_R/W/X combination. Records a TLBI request only for pages
+ * whose descriptor actually changed.
  * Returns 0 on success, -1 on failure.
  */
 int guest_update_perms(guest_t *g, uint64_t start, uint64_t end, int perms);
 
-/* Reset guest memory for execve. Zeros ELF, brk, stack, mmap regions and
- * resets page table pool, brk, and mmap allocation state. Preserves the
- * host_base mapping and VM/vCPU handles.
+/* Reset guest memory for execve. Zeros ELF, brk, stack, mmap regions and resets
+ * page table pool, brk, and mmap allocation state. Preserves the host_base
+ * mapping and VM/vCPU handles.
  */
 void guest_reset(guest_t *g);
 
@@ -1089,9 +1100,11 @@ typedef struct {
     uint64_t size;   /* Size in bytes */
 } used_region_t;
 
-/* Enumerate used memory regions for fork state transfer.
- * Writes up to max entries into out[]. Returns the count written.
- * shim_size is the shim binary size (needed to determine shim region).
+/* Enumerate used memory regions for fork state transfer. Writes up to max
+ * entries into out[].
+ *
+ * Returns the count written. shim_size is the shim binary size (needed to
+ * determine shim region).
  */
 int guest_get_used_regions(const guest_t *g,
                            unsigned int shim_size,
@@ -1101,8 +1114,10 @@ int guest_get_used_regions(const guest_t *g,
 /* Semantic region tracking API. */
 
 /* Add a region to the sorted tracking array. Overlapping regions are NOT
- * merged; each call adds a distinct entry. Returns 0 on success, -1 if the
- * region table is full or backing fd duplication fails.
+ * merged; each call adds a distinct entry.
+ *
+ * Returns 0 on success, -1 if the region table is full or backing fd
+ * duplication fails.
  */
 int guest_region_add(guest_t *g,
                      uint64_t start,
@@ -1149,16 +1164,15 @@ int guest_region_add_ex_owned_gpa(guest_t *g,
                                   const char *name,
                                   int owned_backing_fd);
 
-/* Add a preannounced region that appears in /proc/self/maps only.
- * These entries are kept separate from regions[] so they do not cause
- * -EEXIST on guest MAP_FIXED_NOREPLACE reservations.
+/* Add a preannounced region that appears in /proc/self/maps only. These entries
+ * are kept separate from regions[] so they do not cause -EEXIST on guest
+ * MAP_FIXED_NOREPLACE reservations.
  *
- * No producer wires this up today. The storage, fork-IPC, and
- * /proc/self/maps consumer are kept as scaffolding for runtimes that
- * consult /proc/self/maps before reserving VA ranges. Preannouncing
- * the x86_64 image during Rosetta bring-up was tried and rejected: it
- * perturbed Rosetta's internal allocation tracker. The hook stays
- * until a workload needs an advertise-only entry.
+ * No producer wires this up today. The storage, fork-IPC, and /proc/self/maps
+ * consumer are kept as scaffolding for runtimes that consult /proc/self/maps
+ * before reserving VA ranges. Preannouncing the x86_64 image during Rosetta
+ * bring-up was tried and rejected: it perturbed Rosetta's internal allocation
+ * tracker. The hook stays until a workload needs an advertise-only entry.
  */
 int guest_preannounce(guest_t *g,
                       uint64_t start,
@@ -1173,47 +1187,49 @@ int guest_preannounce(guest_t *g,
  */
 void guest_region_remove(guest_t *g, uint64_t start, uint64_t end);
 
-/* Find the region containing addr. Returns a pointer to the region (inside
- * the guest_t regions array) or NULL if addr is not in any tracked region.
+/* Find the region containing addr.
+ *
+ * Returns a pointer to the region (inside the guest_t regions array) or NULL if
+ * addr is not in any tracked region.
  */
 const guest_region_t *guest_region_find(const guest_t *g, uint64_t addr);
 
-/* Update protection bits for all region coverage in [start, end).
- * Splits regions at boundaries as needed.
+/* Update protection bits for all region coverage in [start, end). Splits
+ * regions at boundaries as needed.
  */
 void guest_region_set_prot(guest_t *g, uint64_t start, uint64_t end, int prot);
 
-/* Index of the first region whose end is strictly above addr. Earlier
- * regions sort entirely below addr (regions[] is start-sorted and
- * non-overlapping, so ends are monotonic). Callers use this to skip the
- * untouched prefix in O(log n) before a linear walk over the overlap.
+/* Index of the first region whose end is strictly above addr. Earlier regions
+ * sort entirely below addr (regions[] is start-sorted and non-overlapping, so
+ * ends are monotonic). Callers use this to skip the untouched prefix in O(log
+ * n) before a linear walk over the overlap.
  */
 int guest_region_first_end_above(const guest_t *g, uint64_t addr);
 
 /* True if every tracked region overlapping [start, end) already has prot.
- * Returns true vacuously when no region overlaps the range, since callers
- * use this to decide whether page-table maintenance can be skipped and an
- * untracked sub-range has no PTEs of its own to update.
+ * Returns true vacuously when no region overlaps the range, since callers use
+ * this to decide whether page-table maintenance can be skipped and an untracked
+ * sub-range has no PTEs of its own to update.
  */
 bool guest_region_range_prot_uniform(const guest_t *g,
                                      uint64_t start,
                                      uint64_t end,
                                      int prot);
 
-/* True if any tracked region overlapping [start, end) is MAP_NORESERVE.
- * Callers must run page-table maintenance for such ranges even when prot
- * already matches, because lazy materialization may have produced PTEs
- * that need re-permissioning.
+/* True if any tracked region overlapping [start, end) is MAP_NORESERVE. Callers
+ * must run page-table maintenance for such ranges even when prot already
+ * matches, because lazy materialization may have produced PTEs that need
+ * re-permissioning.
  */
 bool guest_region_range_has_noreserve(const guest_t *g,
                                       uint64_t start,
                                       uint64_t end);
 
-/* Try to materialize a lazy (MAP_NORESERVE) page at the given offset.
- * Called from the data/instruction abort handler when the faulting address
- * falls within a noreserve region. Creates page table entries for one 2MiB
- * block containing the fault address, zeros the memory, and clears the
- * noreserve flag for the materialized sub-range.
+/* Try to materialize a lazy (MAP_NORESERVE) page at the given offset. Called
+ * from the data/instruction abort handler when the faulting address falls
+ * within a noreserve region. Creates page table entries for one 2MiB block
+ * containing the fault address, zeros the memory, and clears the noreserve flag
+ * for the materialized sub-range.
  * Returns 0 on success (caller should TLBI and retry), -1 if the offset is not
  * in a noreserve region.
  */

--- a/src/core/rosetta.c
+++ b/src/core/rosetta.c
@@ -4,14 +4,14 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * rosetta_prepare loads the Apple Rosetta binary into the primary buffer at
- * a low GPA and exposes it at its statically-linked high VA (0x800000000000)
- * via a non-identity mem_region_t.va_base. The TTBR1 kbuf is initialized at
- * a 256 MiB window just below the rosetta image. rosetta_finalize wires the
+ * rosetta_prepare loads the Apple Rosetta binary into the primary buffer at a
+ * low GPA and exposes it at its statically-linked high VA (0x800000000000) via
+ * a non-identity mem_region_t.va_base. The TTBR1 kbuf is initialized at a 256
+ * MiB window just below the rosetta image. rosetta_finalize wires the
  * bootstrap-visible pieces needed to enter the translator: fd 3 setup,
  * binfmt-style argv construction, cmdline refresh, and the TTBR0 kbuf alias.
- * The runtime still depends on the high-VA mmap path in mem.c for Rosetta's
- * own slab and JIT allocations.
+ * The runtime still depends on the high-VA mmap path in mem.c for Rosetta's own
+ * slab and JIT allocations.
  *
  * Elfuse extends mem_region_t with a va_base field instead, so the page-table
  * builder handles non-identity placement in a single pass.
@@ -62,24 +62,25 @@ static inline uint64_t align2m_down(uint64_t v)
 /* The VZ_CAPS payload only has room for a 42-byte inline path. Publish
  * /proc/self/fd/3 there when the real host path is longer so rosetta sees a
  * valid reopenable path without truncation, while the host-side translator
- * subprocess still retains the full original binary path. Both buffers are
- * read by the VZ_CAPS ioctl handler from any vCPU; writes happen during
- * rosetta_finalize on execve. A pthread_mutex covers both setter and
- * snapshot reader so a multi-vCPU guest doing concurrent execves cannot
- * observe a torn or stale string.
+ * subprocess still retains the full original binary path. Both buffers are read
+ * by the VZ_CAPS ioctl handler from any vCPU; writes happen during
+ * rosetta_finalize on execve. A pthread_mutex covers both setter and snapshot
+ * reader so a multi-vCPU guest doing concurrent execves cannot observe a torn
+ * or stale string.
  */
 static pthread_mutex_t rosettad_path_lock = PTHREAD_MUTEX_INITIALIZER;
 static char rosettad_binary_path[PATH_MAX];
 static char rosettad_caps_binary_path[ROSETTA_CAPS_BINARY_PATH_LEN];
 static char rosettad_owned_binary_path[PATH_MAX];
 
-/* Move any owned path out of rosettad_owned_binary_path into out (which
- * the caller can then unlink after dropping the lock). Returns true if a
- * path was drained. The path lock must be held by the caller. The unlink
- * itself is deferred to the caller because it can block on slow
- * filesystems (NFS, FUSE), and the path lock is also taken by the
- * VZ_CAPS snapshot helpers on every vCPU; running the syscall inside the
- * critical section would stall those readers.
+/* Move any owned path out of rosettad_owned_binary_path into out (which the
+ * caller can then unlink after dropping the lock).
+ *
+ * Returns true if a path was drained. The path lock must be held by the caller.
+ * The unlink itself is deferred to the caller because it can block on slow
+ * filesystems (NFS, FUSE), and the path lock is also taken by the VZ_CAPS
+ * snapshot helpers on every vCPU; running the syscall inside the critical
+ * section would stall those readers.
  */
 static bool rosettad_drain_owned_path_locked(char out[PATH_MAX])
 {
@@ -146,9 +147,9 @@ void rosettad_clear_binary_path(void)
         unlink(prev_owned);
 }
 
-/* Common body for the two snapshot helpers below. Copies src into out_buf
- * with NUL termination while holding the rosetta path lock so the reader
- * cannot observe a torn write from a concurrent execve.
+/* Common body for the two snapshot helpers below. Copies src into out_buf with
+ * NUL termination while holding the rosetta path lock so the reader cannot
+ * observe a torn write from a concurrent execve.
  */
 static size_t rosettad_snapshot_locked(const char *src,
                                        char *out_buf,
@@ -218,8 +219,8 @@ int rosetta_prepare(guest_t *g,
 
     /* Compute 2 MiB-aligned placement covering all rosetta PT_LOAD segments.
      * rosetta is statically linked at 0x800000000000; segments span a small
-     * range above that. The mapping must cover the entire span so all
-     * segments resolve through a single Stage-2 region.
+     * range above that. The mapping must cover the entire span so all segments
+     * resolve through a single Stage-2 region.
      */
     uint64_t va_base = align2m_down(ri->load_min);
     uint64_t va_end = align2m_up(ri->load_max);
@@ -229,13 +230,13 @@ int rosetta_prepare(guest_t *g,
     }
     uint64_t size = va_end - va_base;
 
-    /* Pick a primary-buffer placement below the full high-IPA infra reserve,
-     * 2 MiB aligned. guest_init() has already reserved
-     * [interp_base - INFRA_RESERVE, interp_base) for the page-table pool,
-     * shim text, and shim data, so rosetta must stay below that window.
+    /* Pick a primary-buffer placement below the full high-IPA infra reserve, 2
+     * MiB aligned. guest_init() has already reserved [interp_base -
+     * INFRA_RESERVE, interp_base) for the page-table pool, shim text, and shim
+     * data, so rosetta must stay below that window.
      *
-     * HVF on M1 caps Stage-2 hv_vm_map at the hardware-default IPA width
-     * (36 bits on this host); a separate Stage-2 mapping at 128 TiB via
+     * HVF on M1 caps Stage-2 hv_vm_map at the hardware-default IPA width (36
+     * bits on this host); a separate Stage-2 mapping at 128 TiB via
      * guest_add_mapping is rejected with HV_BAD_ARGUMENT. Load rosetta into the
      * primary buffer at a low GPA and use the non-identity page-table mapping
      * (mem_region_t.va_base) to expose it at its statically-linked high VA.
@@ -263,9 +264,9 @@ int rosetta_prepare(guest_t *g,
         }
 
         /* Load rosetta into the primary buffer. load_base = guest_base -
-         * va_base places p_vaddr+load_base inside host_base+guest_base.
-         * The wrap math is the same trick elf.c documents for high-VA
-         * binaries: uint64_t arithmetic, two's-complement intentional.
+         * va_base places p_vaddr+load_base inside host_base+guest_base. The
+         * wrap math is the same trick elf.c documents for high-VA binaries:
+         * uint64_t arithmetic, two's-complement intentional.
          */
         uint64_t load_base = guest_base - va_base;
         uint64_t infra_lo = g->interp_base - INFRA_RESERVE;
@@ -276,11 +277,11 @@ int rosetta_prepare(guest_t *g,
             return -1;
         }
 
-        /* Place TTBR1 kbuf in the primary buffer just below the rosetta
-         * image. The kbuf needs to fit in [kbuf_gpa, kbuf_gpa + 256 MiB);
-         * brk and stack live below it, rosetta above. Validate the gap
-         * before subtracting so the underflow case (guest_base near 0)
-         * cannot wrap into a huge uint64_t that defeats the gap check.
+        /* Place TTBR1 kbuf in the primary buffer just below the rosetta image.
+         * The kbuf needs to fit in [kbuf_gpa, kbuf_gpa + 256 MiB); brk and
+         * stack live below it, rosetta above. Validate the gap before
+         * subtracting so the underflow case (guest_base near 0) cannot wrap
+         * into a huge uint64_t that defeats the gap check.
          */
         if (guest_base < KBUF_SIZE + g->stack_top + BLOCK_2MIB) {
             log_error(
@@ -313,8 +314,8 @@ int rosetta_prepare(guest_t *g,
         }
     } else {
         /* execve re-entry. The placement (guest_base, va_base, kbuf_gpa)
-         * survived guest_reset; the PT pool was zeroed so the TTBR1 tree
-         * must be rebuilt. Segments get reloaded in place.
+         * survived guest_reset; the PT pool was zeroed so the TTBR1 tree must
+         * be rebuilt. Segments get reloaded in place.
          */
         guest_base = g->rosetta_guest_base;
         uint64_t load_base = guest_base - va_base;
@@ -333,8 +334,8 @@ int rosetta_prepare(guest_t *g,
         }
     }
 
-    /* I-cache invalidation for the loaded executable segments. macOS wrote
-     * the bytes via the data side; without explicit invalidation the first
+    /* I-cache invalidation for the loaded executable segments. macOS wrote the
+     * bytes via the data side; without explicit invalidation the first
      * execution can hit stale I-cache entries.
      */
     for (int i = 0; i < ri->num_segments; i++) {
@@ -352,10 +353,10 @@ int rosetta_prepare(guest_t *g,
 
     /* One mem_region_t covering the whole rosetta image with the union of
      * segment permissions. The page-table builder honours va_base for
-     * non-identity placement: entry indices come from va_base + offset,
-     * block descriptors point at guest_base + offset (the primary buffer).
-     * RWX is acceptable because rosetta is a static binary whose JIT writes
-     * code into separate mmap regions (not into its own image).
+     * non-identity placement: entry indices come from va_base + offset, block
+     * descriptors point at guest_base + offset (the primary buffer). RWX is
+     * acceptable because rosetta is a static binary whose JIT writes code into
+     * separate mmap regions (not into its own image).
      */
     int perms = MEM_PERM_R;
     for (int i = 0; i < ri->num_segments; i++) {
@@ -402,16 +403,16 @@ int rosetta_finalize(guest_t *g,
     *out_argv = NULL;
 
     /* Defer every externally-visible state change (guest fd 3, cmdline,
-     * out_argc/out_argv) until after every fallible setup step succeeds.
-     * Any failure before commit goes through the fail label and tears down
-     * only the host-local resources allocated so far.
+     * out_argc/out_argv) until after every fallible setup step succeeds. Any
+     * failure before commit goes through the fail label and tears down only the
+     * host-local resources allocated so far.
      */
     int bin_host_fd = -1;
     const char **rosetta_argv = NULL;
     int rosetta_argc = 0;
 
-    /* Pre-open the x86_64 binary so it can be installed at guest fd 3 once
-     * the full setup succeeds. Rosetta locates its target via /proc/self/fd/3
+    /* Pre-open the x86_64 binary so it can be installed at guest fd 3 once the
+     * full setup succeeds. Rosetta locates its target via /proc/self/fd/3
      * (binfmt_misc convention).
      */
     bin_host_fd = open(binary_host_path, O_RDONLY);
@@ -433,13 +434,12 @@ int rosetta_finalize(guest_t *g,
      *     (-sh, -bash) lose the dash.
      *   - execve(path, "altname", ...) loses "altname"; the guest sees
      *     binary_path as argv[0].
-     * If a real workload surfaces either pain point, switch to the
-     * preserving form (4 slots: rosetta, binary, original_argv[0],
-     * original_argv[1..]) and verify rosetta strips both leading slots
-     * rather than one.
+     * If a real workload surfaces either pain point, switch to the preserving
+     * form (4 slots: rosetta, binary, original_argv[0], original_argv[1..]) and
+     * verify rosetta strips both leading slots rather than one.
      *
-     * Minimum argc is 2 (rosetta + binary) so rosetta always sees argv[1]
-     * even when the caller supplied no argv.
+     * Minimum argc is 2 (rosetta + binary) so rosetta always sees argv[1] even
+     * when the caller supplied no argv.
      */
     rosetta_argc = (guest_argc > 0) ? guest_argc + 1 : 2;
     rosetta_argv = malloc(sizeof(char *) * (rosetta_argc + 1));
@@ -457,8 +457,8 @@ int rosetta_finalize(guest_t *g,
     /* Install the TTBR0 user-VA alias for the kbuf so rosetta's TaggedPointer
      * extraction (which strips bits 63:48) resolves to the same physical pages
      * as the TTBR1 kernel-VA window. The aliasing-proof invariant (RW + UXN +
-     * PXN under both mappings) is enforced inside the helper.
-     * An installed-but-unused alias is harmless (read-write pages aliasing the
+     * PXN under both mappings) is enforced inside the helper. An
+     * installed-but-unused alias is harmless (read-write pages aliasing the
      * same physical kbuf), so the commit step below does not need to roll it
      * back if a later allocation fails.
      */
@@ -479,10 +479,9 @@ int rosetta_finalize(guest_t *g,
         goto fail;
     }
 
-    /* Ownership of bin_host_fd is now held by the guest fd table.
-     * Mark the rosetta target fd CLOEXEC so a rosetta-to-native execve does not
-     * leak it into the new image. fd_alloc_at clears linux_flags, so the OR is
-     * safe.
+    /* Ownership of bin_host_fd is now held by the guest fd table. Mark the
+     * rosetta target fd CLOEXEC so a rosetta-to-native execve does not leak it
+     * into the new image. fd_alloc_at clears linux_flags, so the OR is safe.
      */
     fd_table[bin_guest_fd].linux_flags |= LINUX_O_CLOEXEC;
 
@@ -559,10 +558,11 @@ static void digest_to_hex(const uint8_t digest[ROSETTAD_DIGEST_SIZE],
 /* AOT cache paths */
 
 /* Build <HOME>/.cache/elfuse-rosettad[/suffix] into out. When suffix is NULL,
- * write the bare cache directory; otherwise append "/<suffix>". Lazily
- * creates ~/.cache and the elfuse-rosettad subdirectory; EEXIST on either is
- * fine. Returns 0 on success, -1 on any failure (HOME unset, snprintf
- * truncation, mkdir denied for a reason other than EEXIST).
+ * write the bare cache directory; otherwise append "/<suffix>". Lazily creates
+ * ~/.cache and the elfuse-rosettad subdirectory; EEXIST on either is fine.
+ *
+ * Returns 0 on success, -1 on any failure (HOME unset, snprintf truncation,
+ * mkdir denied for a reason other than EEXIST).
  */
 static int aot_cache_path(const char *suffix, char *out, size_t outsz)
 {
@@ -570,9 +570,9 @@ static int aot_cache_path(const char *suffix, char *out, size_t outsz)
     if (!home || !*home)
         return -1;
 
-    /* Make ~/.cache first (fresh-user case), then the elfuse subdirectory.
-     * The intermediate path lives in a scratch buffer so out is only written
-     * once -- callers may pass the same buffer for both phases.
+    /* Make ~/.cache first (fresh-user case), then the elfuse subdirectory. The
+     * intermediate path lives in a scratch buffer so out is only written once
+     * -- callers may pass the same buffer for both phases.
      */
     char parent[PATH_MAX];
     int pn = snprintf(parent, sizeof(parent), "%s/.cache", home);
@@ -610,8 +610,9 @@ static int aot_cache_path_for_digest(const uint8_t digest[ROSETTAD_DIGEST_SIZE],
     return aot_cache_path(leaf, out, outsz);
 }
 
-/* Open the cached AOT file for a binary with the given digest. Returns
- * the open fd (O_RDONLY) on hit, -1 on miss or any other error. The fd
+/* Open the cached AOT file for a binary with the given digest.
+ *
+ * Returns the open fd (O_RDONLY) on hit, -1 on miss or any other error. The fd
  * is positioned at offset 0 so the caller can hand it straight back via
  * SCM_RIGHTS.
  */
@@ -682,21 +683,21 @@ out:
 }
 
 /* Translator publishes via rename() of its temp file -- a content copy is
- * unnecessary because the AOT output is already in the cache directory.
- * Keeping the cache-store step as a single rename inline in
- * rosettad_translate; a separate copy helper would only be needed for
- * paths that produce the AOT bytes outside the cache directory.
+ * unnecessary because the AOT output is already in the cache directory. Keeping
+ * the cache-store step as a single rename inline in rosettad_translate; a
+ * separate copy helper would only be needed for paths that produce the AOT
+ * bytes outside the cache directory.
  */
 
 /* SCM_RIGHTS fd-passing */
 
-/* Receive exactly one fd alongside buflen bytes of normal data. On
- * success returns the number of normal bytes received and writes the fd
- * to *out_fd. EINTR is retried. The protocol requires exactly one
- * SCM_RIGHTS cmsg carrying exactly one fd; anything weaker (truncation,
- * extra cmsgs, multiple fds, wrong cmsg payload size) is a malformed
- * peer and rejected. On rejection any kernel-allocated fds are closed
- * to avoid leaking them into the elfuse process.
+/* Receive exactly one fd alongside buflen bytes of normal data. On success
+ * returns the number of normal bytes received and writes the fd to *out_fd.
+ * EINTR is retried. The protocol requires exactly one SCM_RIGHTS cmsg carrying
+ * exactly one fd; anything weaker (truncation, extra cmsgs, multiple fds, wrong
+ * cmsg payload size) is a malformed peer and rejected. On rejection any
+ * kernel-allocated fds are closed to avoid leaking them into the elfuse
+ * process.
  */
 static ssize_t rosettad_recv_fd(int sock, void *buf, size_t buflen, int *out_fd)
 {
@@ -716,11 +717,11 @@ static ssize_t rosettad_recv_fd(int sock, void *buf, size_t buflen, int *out_fd)
     if (n <= 0)
         return n;
 
-    /* Walk every cmsg first, closing kernel-allocated fds in malformed or
-     * extra payloads. Defer the MSG_CTRUNC bailout until after the walk so
-     * fds that fit in cmsg_buf are closed instead of leaked into the elfuse
-     * process. cmsg_len is validated against CMSG_LEN(0) before any payload
-     * arithmetic to keep a hostile peer from underflowing the size_t.
+    /* Walk every cmsg first, closing kernel-allocated fds in malformed or extra
+     * payloads. Defer the MSG_CTRUNC bailout until after the walk so fds that
+     * fit in cmsg_buf are closed instead of leaked into the elfuse process.
+     * cmsg_len is validated against CMSG_LEN(0) before any payload arithmetic
+     * to keep a hostile peer from underflowing the size_t.
      */
     int n_rights = 0;
     bool malformed = false;
@@ -729,10 +730,10 @@ static ssize_t rosettad_recv_fd(int sock, void *buf, size_t buflen, int *out_fd)
             malformed = true;
             continue;
         }
-        /* cmsg_len must cover at least the cmsghdr header; the macro
-         * captures any alignment padding the platform inserts. Anything
-         * smaller is structurally invalid and the payload arithmetic
-         * below would underflow into a huge size_t.
+        /* cmsg_len must cover at least the cmsghdr header; the macro captures
+         * any alignment padding the platform inserts. Anything smaller is
+         * structurally invalid and the payload arithmetic below would underflow
+         * into a huge size_t.
          */
         if (c->cmsg_len < CMSG_LEN(0)) {
             malformed = true;
@@ -747,10 +748,9 @@ static ssize_t rosettad_recv_fd(int sock, void *buf, size_t buflen, int *out_fd)
         for (size_t i = 0; i < nfd; i++) {
             int fd;
             memcpy(&fd, (uint8_t *) CMSG_DATA(c) + i * sizeof(int), sizeof(fd));
-            /* Canonical case: exactly one fd in exactly one SCM_RIGHTS
-             * cmsg. Anything else (extra cmsgs, extra fds per cmsg) is
-             * malformed; close every fd that does not fit the canonical
-             * slot so none leak.
+            /* Canonical case: exactly one fd in exactly one SCM_RIGHTS cmsg.
+             * Anything else (extra cmsgs, extra fds per cmsg) is malformed;
+             * close every fd that does not fit the canonical slot so none leak.
              */
             if (n_rights == 0 && nfd == 1) {
                 *out_fd = fd;
@@ -762,11 +762,11 @@ static ssize_t rosettad_recv_fd(int sock, void *buf, size_t buflen, int *out_fd)
         }
     }
 
-    /* MSG_CTRUNC means the kernel discarded part of the ancillary data
-     * because cmsg_buf was too small. fds in the discarded portion were
-     * dropped by the kernel without ever entering this process; fds in
-     * the surviving cmsgs were walked above. Treat as a hard protocol
-     * error because the message framing is no longer reliable.
+    /* MSG_CTRUNC means the kernel discarded part of the ancillary data because
+     * cmsg_buf was too small. fds in the discarded portion were dropped by the
+     * kernel without ever entering this process; fds in the surviving cmsgs
+     * were walked above. Treat as a hard protocol error because the message
+     * framing is no longer reliable.
      */
     if ((msg.msg_flags & MSG_CTRUNC) || malformed || n_rights != 1) {
         if (*out_fd >= 0) {
@@ -780,8 +780,8 @@ static ssize_t rosettad_recv_fd(int sock, void *buf, size_t buflen, int *out_fd)
 }
 
 /* Send one fd alongside a 1-byte normal-data payload. Rosetta's recv_fd
- * counterpart allocates a 1-byte iov buffer and silently drops anything
- * larger; matching that exactly keeps the protocol bit-compatible.
+ * counterpart allocates a 1-byte iov buffer and silently drops anything larger;
+ * matching that exactly keeps the protocol bit-compatible.
  */
 static ssize_t rosettad_send_fd(int sock, uint8_t payload, int send_fd)
 {
@@ -808,9 +808,11 @@ static ssize_t rosettad_send_fd(int sock, uint8_t payload, int send_fd)
 
 /* Translate subprocess */
 
-/* Spawn 'elfuse rosettad translate <in_path> <out_path>' and wait for it
- * to exit. Returns 0 if the translator exited successfully and the
- * output file is non-empty, -1 otherwise.
+/* Spawn 'elfuse rosettad translate <in_path> <out_path>' and wait for it to
+ * exit.
+ *
+ * Returns 0 if the translator exited successfully and the output file is
+ * non-empty, -1 otherwise.
  */
 static int translate_via_rosettad(const char *in_path, const char *out_path)
 {
@@ -832,11 +834,11 @@ static int translate_via_rosettad(const char *in_path, const char *out_path)
         return -1;
     }
 
-    /* Bounded wait: a hung translator must not stall the handler thread
-     * that owns the rosetta socket. ROSETTAD_TRANSLATE_TIMEOUT_SEC bounds
-     * the wall-clock budget; on expiry, SIGKILL the child and report MISS
-     * to the caller so rosetta falls through to its JIT path. Override via
-     * the ELFUSE_ROSETTAD_TIMEOUT env var (seconds) for stress testing.
+    /* Bounded wait: a hung translator must not stall the handler thread that
+     * owns the rosetta socket. ROSETTAD_TRANSLATE_TIMEOUT_SEC bounds the
+     * wall-clock budget; on expiry, SIGKILL the child and report MISS to the
+     * caller so rosetta falls through to its JIT path. Override via the
+     * ELFUSE_ROSETTAD_TIMEOUT env var (seconds) for stress testing.
      */
     int timeout_sec = 120;
     const char *to_env = getenv("ELFUSE_ROSETTAD_TIMEOUT");
@@ -888,22 +890,22 @@ static int translate_via_rosettad(const char *in_path, const char *out_path)
     return 0;
 }
 
-/* Run the translate pipeline for a binary fd: SHA-256, cache lookup
- * (hit -> return cached fd), or spawn the translator and publish the
- * result. Returns an O_RDONLY fd pointing at the AOT file on success,
- * -1 on any failure. *out_digest is always written when the SHA-256
- * succeeds; the caller passes it back to rosetta so subsequent 'd'
- * lookups reuse the same key.
+/* Run the translate pipeline for a binary fd: SHA-256, cache lookup (hit ->
+ * return cached fd), or spawn the translator and publish the result.
+ *
+ * Returns an O_RDONLY fd pointing at the AOT file on success, -1 on any
+ * failure. *out_digest is always written when the SHA-256 succeeds; the caller
+ * passes it back to rosetta so subsequent 'd' lookups reuse the same key.
  */
 static int rosettad_translate(int bin_fd,
                               uint8_t out_digest[ROSETTAD_DIGEST_SIZE])
 {
-    /* Materialise first, hash second. Hashing bin_fd directly and then
-     * copying its bytes later opens a TOCTOU window: a concurrent writer
-     * mutating the inode between the two reads can poison the cache with
-     * bytes whose digest does not match. Snapshot the contents into an
-     * elfuse-owned temp file, then compute the digest from that snapshot
-     * so (hash, bytes) are taken from the same on-disk state.
+    /* Materialise first, hash second. Hashing bin_fd directly and then copying
+     * its bytes later opens a TOCTOU window: a concurrent writer mutating the
+     * inode between the two reads can poison the cache with bytes whose digest
+     * does not match. Snapshot the contents into an elfuse-owned temp file,
+     * then compute the digest from that snapshot so (hash, bytes) are taken
+     * from the same on-disk state.
      */
     char in_path[PATH_MAX];
     if (aot_materialize_input_fd(bin_fd, in_path) < 0) {
@@ -958,9 +960,9 @@ static int rosettad_translate(int bin_fd,
         return -1;
     }
 
-    /* Publish to the persistent cache; if rename fails another translator
-     * is racing this one, but aot_fd still points at the temp file's data
-     * and is safe to return.
+    /* Publish to the persistent cache; if rename fails another translator is
+     * racing this one, but aot_fd still points at the temp file's data and is
+     * safe to return.
      */
     char final_path[PATH_MAX];
     if (aot_cache_path_for_digest(out_digest, ".aot", final_path,
@@ -973,21 +975,21 @@ static int rosettad_translate(int bin_fd,
 
 /* rosettad handler thread */
 
-/* Maximum size of the per-translate params buffer rosetta sends alongside
- * the binary fd. The protocol allows up to this many bytes of opaque data;
- * the handler reads them but does not interpret them today.
+/* Maximum size of the per-translate params buffer rosetta sends alongside the
+ * binary fd. The protocol allows up to this many bytes of opaque data; the
+ * handler reads them but does not interpret them today.
  */
 #define ROSETTAD_PARAMS_MAX 256
 
-/* Rosetta's view of the socketpair: the fd it received via sys_socket.
- * Recorded so sys_connect / recvmsg / sendmsg can short-circuit the
- * connect (the socketpair is pre-wired) and pick rosettad-aware paths.
- * Static visibility: at most one rosettad bridge per elfuse process.
+/* Rosetta's view of the socketpair: the fd it received via sys_socket. Recorded
+ * so sys_connect / recvmsg / sendmsg can short-circuit the connect (the
+ * socketpair is pre-wired) and pick rosettad-aware paths. Static visibility: at
+ * most one rosettad bridge per elfuse process.
  *
  * The handler thread writes -1 to this field at termination while syscall
  * threads keep reading it via rosettad_is_socket. Plain int would let the
- * compiler tear or fold the load; atomic load/store with relaxed ordering
- * is enough since each read is independent of any other state.
+ * compiler tear or fold the load; atomic load/store with relaxed ordering is
+ * enough since each read is independent of any other state.
  */
 static _Atomic int rosettad_client_fd = -1;
 
@@ -1000,9 +1002,9 @@ bool rosettad_is_socket(int host_fd)
 
 bool rosettad_wait_for_idle(unsigned int max_ms)
 {
-    /* 1 ms granularity poll on the atomic. The handler thread clears the
-     * marker on EOF or on explicit QUIT; both paths run inside the
-     * detached worker, which the caller cannot join.
+    /* 1 ms granularity poll on the atomic. The handler thread clears the marker
+     * on EOF or on explicit QUIT; both paths run inside the detached worker,
+     * which the caller cannot join.
      */
     for (unsigned int i = 0; i < max_ms; i++) {
         if (atomic_load_explicit(&rosettad_client_fd, memory_order_acquire) ==
@@ -1061,9 +1063,9 @@ static int rosettad_write_full(int fd, const void *buf, size_t len)
     return 0;
 }
 
-/* Send the success reply for a TRANSLATE or DIGEST command:
- * {HIT byte, optional 32-byte digest, AOT fd via SCM_RIGHTS in a 1-byte iov}.
- * Pass digest=NULL on the DIGEST path (rosetta already knows the key).
+/* Send the success reply for a TRANSLATE or DIGEST command: {HIT byte, optional
+ * 32-byte digest, AOT fd via SCM_RIGHTS in a 1-byte iov}. Pass digest=NULL on
+ * the DIGEST path (rosetta already knows the key).
  * Returns 0 on success, -1 if any wire write failed.
  */
 static int rosettad_send_aot(int fd, const uint8_t *digest, int aot_fd)
@@ -1083,8 +1085,8 @@ static void *rosettad_handler_thread(void *arg)
 
     /* Block the host-directed signals elfuse uses internally so the handler
      * thread is not interrupted in the middle of a protocol exchange. The
-     * SIGPIPE / SIGCHLD masking matches the rest of elfuse's worker
-     * threads; SIGUSR1 is the vCPU timer kick.
+     * SIGPIPE / SIGCHLD masking matches the rest of elfuse's worker threads;
+     * SIGUSR1 is the vCPU timer kick.
      */
     sigset_t mask;
     sigemptyset(&mask);
@@ -1110,10 +1112,10 @@ static void *rosettad_handler_thread(void *arg)
             break;
 
         case ROSETTAD_CMD_TRANSLATE: {
-            /* Translate request: rosetta sends the binary fd via sendmsg
-             * with up to ROSETTAD_PARAMS_MAX bytes of params. Compute the
-             * SHA-256, look up the persistent AOT cache, and on miss invoke
-             * the translator subprocess. Reply is {HIT, digest[32], fd via
+            /* Translate request: rosetta sends the binary fd via sendmsg with
+             * up to ROSETTAD_PARAMS_MAX bytes of params. Compute the SHA-256,
+             * look up the persistent AOT cache, and on miss invoke the
+             * translator subprocess. Reply is {HIT, digest[32], fd via
              * SCM_RIGHTS in a 1-byte iov payload} or MISS on any failure.
              *
              * recv_fd failure means protocol desync (no way to tell what
@@ -1145,10 +1147,10 @@ static void *rosettad_handler_thread(void *arg)
         }
 
         case ROSETTAD_CMD_DIGEST: {
-            /* Digest lookup: rosetta caches its own .flu digests across
-             * runs and asks here first to skip re-translation. Cache hit
-             * sends back the AOT fd; miss makes rosetta fall through to a
-             * full translate request.
+            /* Digest lookup: rosetta caches its own .flu digests across runs
+             * and asks here first to skip re-translation. Cache hit sends back
+             * the AOT fd; miss makes rosetta fall through to a full translate
+             * request.
              */
             uint8_t digest[ROSETTAD_DIGEST_SIZE];
             if (rosettad_read_full(fd, digest, sizeof(digest)) !=
@@ -1171,9 +1173,9 @@ static void *rosettad_handler_thread(void *arg)
             goto done;
 
         default:
-            /* Unknown command: reply MISS to keep the wire balanced and
-             * hope rosetta recovers. A real cache miss / handshake noise
-             * landing in this branch would otherwise hang the protocol.
+            /* Unknown command: reply MISS to keep the wire balanced and hope
+             * rosetta recovers. A real cache miss / handshake noise landing in
+             * this branch would otherwise hang the protocol.
              */
             if (rosettad_write_byte(fd, ROSETTAD_RESP_MISS) < 0)
                 goto done;
@@ -1182,11 +1184,11 @@ static void *rosettad_handler_thread(void *arg)
     }
 
 done:
-    /* Drop the client-fd marker so rosettad_is_socket stops misclassifying
-     * a recycled fd number. The actual client fd was closed by the guest
-     * (or will be) -- this just retracts the bridge claim. The handler
-     * does not race with sys_socket starting another bridge: at most one
-     * rosetta bridge per elfuse process by design.
+    /* Drop the client-fd marker so rosettad_is_socket stops misclassifying a
+     * recycled fd number. The actual client fd was closed by the guest (or will
+     * be) -- this just retracts the bridge claim. The handler does not race
+     * with sys_socket starting another bridge: at most one rosetta bridge per
+     * elfuse process by design.
      */
     atomic_store_explicit(&rosettad_client_fd, -1, memory_order_relaxed);
     close(fd);

--- a/src/core/rosetta.h
+++ b/src/core/rosetta.h
@@ -34,25 +34,24 @@
 
 /* Apple Rosetta Linux translator path. The OS ships the binary inside the
  * platform image; users who have not run 'softwareupdate --install-rosetta'
- * will not have this file and elfuse must refuse the load with a helpful
- * error.
+ * will not have this file and elfuse must refuse the load with a helpful error.
  */
 #define ROSETTA_PATH "/Library/Apple/usr/libexec/oah/RosettaLinux/rosetta"
 
-/* Path of Apple's standalone translator daemon. The 'elfuse rosettad
- * translate' subcommand re-execs into this binary inside an aarch64-linux
- * guest to materialise an AOT translation on cache miss.
+/* Path of Apple's standalone translator daemon. The 'elfuse rosettad translate'
+ * subcommand re-execs into this binary inside an aarch64-linux guest to
+ * materialise an AOT translation on cache miss.
  */
 #define ROSETTAD_TRANSLATOR_PATH \
     "/Library/Apple/usr/libexec/oah/RosettaLinux/rosettad"
 
-/* Rosetta's Virtualization.framework probe ioctls. Rosetta issues these on
- * an open fd very early at startup to verify that it is running inside a
- * supported VZ environment. Without affirmative responses, rosetta prints
- * "Rosetta is only intended to run on Apple Silicon ..." and exits.
+/* Rosetta's Virtualization.framework probe ioctls. Rosetta issues these on an
+ * open fd very early at startup to verify that it is running inside a supported
+ * VZ environment. Without affirmative responses, rosetta prints "Rosetta is
+ * only intended to run on Apple Silicon ..." and exits.
  *
- * Reverse-engineered from the rosetta binary; values match what the
- * Lima-on-VZ Linux VM observes via strace.
+ * Reverse-engineered from the rosetta binary; values match what the Lima-on-VZ
+ * Linux VM observes via strace.
  */
 #define ROSETTA_VZ_CHECK 0x80456125 /* Returns 69-byte signature */
 #define ROSETTA_VZ_CAPS 0x80806123  /* Returns 128-byte capability blob */
@@ -73,17 +72,18 @@
  * - VZ_CAPS exposes a 42-byte inline path field to rosetta itself. When the
  *   original host path is longer, publish a short runtime alias instead of a
  *   truncated string.
- * - The host-side translate subprocess needs the full original path.
- * Subsequent calls overwrite the previous value (execve into a different
- * x86_64 binary).
+ * - The host-side translate subprocess needs the full original path. Subsequent
+ * calls overwrite the previous value (execve into a different x86_64 binary).
  */
 void rosettad_set_binary_path(const char *path, bool take_ownership);
 void rosettad_clear_binary_path(void);
 
-/* Snapshot the published paths into caller-supplied buffers under the
- * setter's mutex. Returns the byte count written (excluding NUL). The
- * lock keeps the VZ_CAPS reader (any vCPU) and the execve writer from
- * racing on the static buffer contents.
+/* Snapshot the published paths into caller-supplied buffers under the setter's
+ * mutex.
+ *
+ * Returns the byte count written (excluding NUL). The lock keeps the VZ_CAPS
+ * reader (any vCPU) and the execve writer from racing on the static buffer
+ * contents.
  *
  * Caller buffers:
  *   rosettad_snapshot_binary_path        - PATH_MAX wide for full host path
@@ -94,10 +94,10 @@ size_t rosettad_snapshot_caps_binary_path(char *out_buf, size_t out_size);
 
 /* rosettad wire protocol.
  *
- * Rosetta opens AF_UNIX SOCK_SEQPACKET and connects to a socket; macOS
- * lacks SOCK_SEQPACKET for AF_UNIX so elfuse intercepts socket(SEQPACKET)
- * with socketpair(SOCK_STREAM) and runs a handler thread on the other
- * end. The thread implements the single-byte command protocol below.
+ * Rosetta opens AF_UNIX SOCK_SEQPACKET and connects to a socket; macOS lacks
+ * SOCK_SEQPACKET for AF_UNIX so elfuse intercepts socket(SEQPACKET) with
+ * socketpair(SOCK_STREAM) and runs a handler thread on the other end. The
+ * thread implements the single-byte command protocol below.
  *
  * Wire sequence (rosetta is the client, handler is the daemon):
  *   '?' (HANDSHAKE): handler replies one byte HIT (0x01) when ready.
@@ -122,37 +122,37 @@ size_t rosettad_snapshot_caps_binary_path(char *out_buf, size_t out_size);
 #define ROSETTAD_DIGEST_HEX_LEN (ROSETTAD_DIGEST_SIZE * 2 + 1)
 
 /* Persistent AOT cache directory, relative to $HOME. Real rosettad uses
- * ~/.cache/rosetta/ for its own .flu cache; elfuse's intercept runs in
- * parallel under a separate subdirectory to keep the two from colliding.
+ * ~/.cache/rosetta/ for its own .flu cache; elfuse's intercept runs in parallel
+ * under a separate subdirectory to keep the two from colliding.
  */
 #define ROSETTAD_CACHE_SUBDIR ".cache/elfuse-rosettad"
 
-/* Spawn the rosettad handler thread on the elfuse-side end of the
- * socketpair. handler_fd is the host fd the thread reads/writes; client_fd
- * is the rosetta-visible side, recorded so rosettad_is_socket can later
- * identify it (sys_recvmsg / sys_sendmsg paths use this to decide whether
- * to take the rosettad-aware code branch).
+/* Spawn the rosettad handler thread on the elfuse-side end of the socketpair.
+ * handler_fd is the host fd the thread reads/writes; client_fd is the
+ * rosetta-visible side, recorded so rosettad_is_socket can later identify it
+ * (sys_recvmsg / sys_sendmsg paths use this to decide whether to take the
+ * rosettad-aware code branch).
  *
- * Returns 0 on success, -1 on pthread_create failure. The thread runs
- * detached; its lifetime is bounded by the client closing its fd (read
- * returns 0) or by an explicit ROSETTAD_CMD_QUIT.
+ * Returns 0 on success, -1 on pthread_create failure. The thread runs detached;
+ * its lifetime is bounded by the client closing its fd (read returns 0) or by
+ * an explicit ROSETTAD_CMD_QUIT.
  */
 int rosettad_start_handler(int handler_fd, int client_fd);
 
-/* True when host_fd is the rosetta-visible end of a socketpair installed
- * by rosettad_start_handler. Used by sys_connect to short-circuit the
- * connect (the socketpair is pre-wired) and by sendmsg/recvmsg to pick
- * the rosettad-aware code paths.
+/* True when host_fd is the rosetta-visible end of a socketpair installed by
+ * rosettad_start_handler. Used by sys_connect to short-circuit the connect (the
+ * socketpair is pre-wired) and by sendmsg/recvmsg to pick the rosettad-aware
+ * code paths.
  */
 bool rosettad_is_socket(int host_fd);
 
-/* Block (with a short poll loop) until the rosettad bridge handler thread
- * has cleared its process-global client-fd marker, OR the timeout elapses.
- * Used by sys_execve before installing a fresh bridge so a stale handler
- * winding down does not collide with the new rosettad_start_handler CAS.
+/* Block (with a short poll loop) until the rosettad bridge handler thread has
+ * cleared its process-global client-fd marker, OR the timeout elapses. Used by
+ * sys_execve before installing a fresh bridge so a stale handler winding down
+ * does not collide with the new rosettad_start_handler CAS.
  *
- * Returns true if the bridge is idle on return, false if the timeout
- * expired with the bridge still claimed.
+ * Returns true if the bridge is idle on return, false if the timeout expired
+ * with the bridge still claimed.
  */
 bool rosettad_wait_for_idle(unsigned int max_ms);
 
@@ -167,16 +167,17 @@ typedef struct {
     uint64_t entry_point; /* High-VA entry from rosetta ELF */
 } rosetta_result_t;
 
-/* First-pass rosetta setup, runs before guest_build_page_tables(): parse
- * the rosetta binary, place its segments in the primary buffer (or reload
- * into the existing placement on execve), initialize the TTBR1 kbuf, and
- * append page-table regions for the builder. A single non-identity
- * mem_region_t covers the rosetta image, mapping its statically-linked high
- * VA to the chosen low GPA via mem_region_t.va_base.
+/* First-pass rosetta setup, runs before guest_build_page_tables(): parse the
+ * rosetta binary, place its segments in the primary buffer (or reload into the
+ * existing placement on execve), initialize the TTBR1 kbuf, and append
+ * page-table regions for the builder. A single non-identity mem_region_t covers
+ * the rosetta image, mapping its statically-linked high VA to the chosen low
+ * GPA via mem_region_t.va_base.
  *
- * The caller's regions array and *nregions cursor are updated. Returns 0 on
- * success, -1 on any failure; on failure g->rosetta_* state is left in the
- * configuration it had on entry (so a retry can succeed).
+ * The caller's regions array and *nregions cursor are updated.
+ *
+ * Returns 0 on success, -1 on any failure; on failure g->rosetta_* state is
+ * left in the configuration it had on entry (so a retry can succeed).
  */
 int rosetta_prepare(guest_t *g,
                     const char *binary_path,
@@ -186,12 +187,12 @@ int rosetta_prepare(guest_t *g,
                     bool verbose,
                     rosetta_result_t *result);
 
-/* Second-pass rosetta setup, runs after guest_build_page_tables(): install
- * the TTBR0 user-VA alias for the kbuf, pre-open the x86_64 binary at fd 3,
- * build the binfmt_misc argv ([ROSETTA_PATH, binary, original argv[1..]])
- * for build_linux_stack to consume, and refresh proc state. The remaining
- * runtime blocker after this stage is high-VA mmap support for Rosetta's
- * own internal fixed-address allocations.
+/* Second-pass rosetta setup, runs after guest_build_page_tables(): install the
+ * TTBR0 user-VA alias for the kbuf, pre-open the x86_64 binary at fd 3, build
+ * the binfmt_misc argv ([ROSETTA_PATH, binary, original argv[1..]]) for
+ * build_linux_stack to consume, and refresh proc state. The remaining runtime
+ * blocker after this stage is high-VA mmap support for Rosetta's own internal
+ * fixed-address allocations.
  */
 int rosetta_finalize(guest_t *g,
                      hv_vcpu_t vcpu,

--- a/src/core/shim-globals.c
+++ b/src/core/shim-globals.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * See core/shim-globals.h for the cache layout, threat model, and
- * memory-ordering rules. This file implements the host-side publish
- * and TPIDR_EL1 setup helpers. The shim assembly side is in
- * src/core/shim.S.
+ * memory-ordering rules. This file implements the host-side publish and
+ * TPIDR_EL1 setup helpers. The shim assembly side is in src/core/shim.S.
  */
 
 #include <pthread.h>
@@ -44,9 +43,9 @@
 #define HV_SYS_REG_CONTEXTIDR_EL1 ((hv_sys_reg_t) 0xc681)
 #endif
 
-/* shim.S hard-codes these offsets and sizes in its urandom-read
- * fast path; if they drift here the shim reads from the wrong
- * place. Catch the drift at compile time.
+/* shim.S hard-codes these offsets and sizes in its urandom-read fast path; if
+ * they drift here the shim reads from the wrong place. Catch the drift at
+ * compile time.
  */
 _Static_assert(SHIM_GLOBALS_OFF_STATS_EN == 0x04,
                "shim.S COUNTER_INC hard-codes STATS_EN byte off 0x04");
@@ -70,16 +69,16 @@ _Static_assert(FD_TABLE_SIZE == 1024,
 _Static_assert(SHIM_URANDOM_INLINE_LIMIT == 256,
                "shim.S urandom/getrandom fast path hard-codes 256-byte cap");
 
-/* shim.S COUNTER_INC macro hardcodes (SHIM_COUNTERS_OFF & 0xFFF) and the
- * 0x1, lsl #12 carry. Keep the literal in sync so a layout shift fails
- * the build rather than silently routing increments to the wrong slot.
+/* shim.S COUNTER_INC macro hardcodes (SHIM_COUNTERS_OFF & 0xFFF) and the 0x1,
+ * lsl #12 carry. Keep the literal in sync so a layout shift fails the build
+ * rather than silently routing increments to the wrong slot.
  */
 _Static_assert(SHIM_COUNTERS_OFF == 0x10C8,
                "shim.S COUNTER_INC hard-codes SHIM_COUNTERS_OFF=0x10C8");
-/* shim.S splits SHIM_COUNTERS_OFF into a shifted-add carry (0x1000) plus
- * an imm12 load/store offset (0xC8 + slot byte). Pin the split so any
- * future layout shift fails the build instead of silently routing
- * increments to the wrong slot.
+/* shim.S splits SHIM_COUNTERS_OFF into a shifted-add carry (0x1000) plus an
+ * imm12 load/store offset (0xC8 + slot byte). Pin the split so any future
+ * layout shift fails the build instead of silently routing increments to the
+ * wrong slot.
  */
 _Static_assert((SHIM_COUNTERS_OFF & 0xFFF) == 0xC8,
                "shim.S SHIM_COUNTERS_OFF_LO12 hard-coded to 0xC8");
@@ -99,11 +98,10 @@ _Static_assert(SHIM_COUNTERS_OFF + SHIM_COUNTERS_N * 8 <=
 
 static uint8_t *cache_base(const guest_t *g)
 {
-    /* The cache lives at the start of the shim_data block, which is
-     * mapped into the host buffer at host_base + shim_data_base.
-     * Direct buffer access bypasses the guest-page-table walk used by
-     * guest_ptr, which is intentional: the host owns shim_data
-     * unconditionally.
+    /* The cache lives at the start of the shim_data block, which is mapped into
+     * the host buffer at host_base + shim_data_base. Direct buffer access
+     * bypasses the guest-page-table walk used by guest_ptr, which is
+     * intentional: the host owns shim_data unconditionally.
      */
     return (uint8_t *) g->host_base + g->shim_data_base;
 }
@@ -218,10 +216,10 @@ int shim_globals_install_per_vcpu(hv_vcpu_t vcpu, const guest_t *g, int64_t tid)
     return shim_globals_install_tid(vcpu, tid);
 }
 
-/* Singleton guest pointer for the urandom-bitmap hooks called from
- * the fd table. elfuse runs one VM per process so a single global is
- * correct; the NULL-or-same-g assertion catches a lifecycle bug.
- * Mirrors the pattern signal.c uses for the attention-flag singleton.
+/* Singleton guest pointer for the urandom-bitmap hooks called from the fd
+ * table. elfuse runs one VM per process so a single global is correct; the
+ * NULL-or-same-g assertion catches a lifecycle bug. Mirrors the pattern
+ * signal.c uses for the attention-flag singleton.
  */
 static guest_t *singleton_g;
 
@@ -268,35 +266,33 @@ void shim_globals_rebuild_urandom_bitmap(void)
 {
     if (!singleton_g)
         return;
-    /* Wipe the bitmap region first; concurrent fd_alloc / close from
-     * other vCPUs is impossible during fork-child init (the child has
-     * not yet started executing guest code), so a non-atomic memset
-     * is safe here.
+    /* Wipe the bitmap region first; concurrent fd_alloc / close from other
+     * vCPUs is impossible during fork-child init (the child has not yet started
+     * executing guest code), so a non-atomic memset is safe here.
      */
     memset(cache_base(singleton_g) + SHIM_URANDOM_OFF_BITMAP, 0,
            SHIM_URANDOM_BITMAP_BYTES);
-    /* Walk the fd table; mark every readable FD_URANDOM slot. Reuses
-     * the atomic-OR setter so the visible memory order matches the
-     * normal fd_alloc path.
+    /* Walk the fd table; mark every readable FD_URANDOM slot. Reuses the
+     * atomic-OR setter so the visible memory order matches the normal fd_alloc
+     * path.
      */
     for (int fd = 0; fd < FD_TABLE_SIZE; fd++) {
         fd_refresh_urandom_bitmap(fd);
     }
 }
 
-/* arc4random_buf is documented as deadlock-free and re-entrant. Used
- * by the initial fill at bootstrap and by the slow-path refill that
- * runs from sys_read/sys_getrandom when the shim's fast path falls
- * through due to an empty ring.
+/* arc4random_buf is documented as deadlock-free and re-entrant. Used by the
+ * initial fill at bootstrap and by the slow-path refill that runs from
+ * sys_read/sys_getrandom when the shim's fast path falls through due to an
+ * empty ring.
  *
  * Entropy is generated OUTSIDE the ring_lock: arc4random_buf can take
- * microseconds, and any sibling vCPU that hits the fast path while the
- * lock is held spins (yield) until release. Generate up to a full ring
- * into a stack scratch buffer, then take the lock only to re-read
- * head/fill and copy the publishable prefix into the ring. The recheck
- * after lock acquire matters: a concurrent fast path may have advanced
- * head while entropy was being generated, raising the publishable
- * count beyond the pre-lock estimate.
+ * microseconds, and any sibling vCPU that hits the fast path while the lock is
+ * held spins (yield) until release. Generate up to a full ring into a stack
+ * scratch buffer, then take the lock only to re-read head/fill and copy the
+ * publishable prefix into the ring. The recheck after lock acquire matters: a
+ * concurrent fast path may have advanced head while entropy was being
+ * generated, raising the publishable count beyond the pre-lock estimate.
  */
 void shim_globals_refill_urandom_ring(guest_t *g)
 {
@@ -306,14 +302,14 @@ void shim_globals_refill_urandom_ring(guest_t *g)
     uint32_t *lock_p = (uint32_t *) (base + SHIM_URANDOM_OFF_RING_LOCK);
     uint8_t *ring = base + SHIM_URANDOM_OFF_RING;
 
-    /* Pre-lock estimate: skip the arc4random_buf + lock when the ring
-     * is already full. Both cursors are read RELAXED so a torn snapshot
-     * (head_pre observed past a producer step but tail_pre observed
-     * before it) can make tail_pre - head_pre wrap to a huge unsigned
-     * value. A loose ">= RING_SIZE" check would treat that garbage as
-     * "already full" and skip a genuinely-needed refill. Only the exact
-     * == RING_SIZE value is a safe full-detection; any other (valid or
-     * torn) reading falls through to the lock-held recheck below.
+    /* Pre-lock estimate: skip the arc4random_buf + lock when the ring is
+     * already full. Both cursors are read RELAXED so a torn snapshot (head_pre
+     * observed past a producer step but tail_pre observed before it) can make
+     * tail_pre - head_pre wrap to a huge unsigned value. A loose ">= RING_SIZE"
+     * check would treat that garbage as "already full" and skip a
+     * genuinely-needed refill. Only the exact == RING_SIZE value is a safe
+     * full-detection; any other (valid or torn) reading falls through to the
+     * lock-held recheck below.
      */
     uint32_t head_pre = __atomic_load_n(head_p, __ATOMIC_RELAXED);
     uint32_t tail_pre = __atomic_load_n(tail_p, __ATOMIC_RELAXED);
@@ -333,8 +329,8 @@ void shim_globals_refill_urandom_ring(guest_t *g)
         goto out; /* concurrent refill caught up */
     uint32_t to_fill = SHIM_URANDOM_RING_SIZE - fill;
 
-    /* Producer writes from ring[tail & (SIZE-1)] forward, wrapping
-     * once when needed. Two memcpys at most.
+    /* Producer writes from ring[tail & (SIZE-1)] forward, wrapping once when
+     * needed. Two memcpys at most.
      */
     uint32_t pos = tail & (SHIM_URANDOM_RING_SIZE - 1);
     uint32_t first = SHIM_URANDOM_RING_SIZE - pos;
@@ -344,8 +340,8 @@ void shim_globals_refill_urandom_ring(guest_t *g)
     if (to_fill > first)
         memcpy(ring, scratch + first, to_fill - first);
 
-    /* Release-store the new tail so any fast-path consumer that loads
-     * tail with an acquiring read sees the bytes already in the ring.
+    /* Release-store the new tail so any fast-path consumer that loads tail with
+     * an acquiring read sees the bytes already in the ring.
      */
     __atomic_store_n(tail_p, tail + to_fill, __ATOMIC_RELEASE);
 
@@ -353,25 +349,23 @@ out:
     urandom_ring_unlock(lock_p);
 }
 
-/* Bitmask helpers. The slot lives at SHIM_GLOBALS_OFF_ATTN as a
- * uint32; ATTN_BIT_SIGTIMER and ATTN_BIT_CRED partition ownership so
- * the signal/timer lane and the cred-publish lane cannot clobber
- * each other.
+/* Bitmask helpers. The slot lives at SHIM_GLOBALS_OFF_ATTN as a uint32;
+ * ATTN_BIT_SIGTIMER and ATTN_BIT_CRED partition ownership so the signal/timer
+ * lane and the cred-publish lane cannot clobber each other.
  */
 void shim_globals_attn_or(guest_t *g, uint32_t bits)
 {
     uint32_t *slot = (uint32_t *) (cache_base(g) + SHIM_GLOBALS_OFF_ATTN);
-    /* SEQ_CST, not ACQ_REL. The CRED_BRACKETED invariant is the
-     * contrapositive of release-acquire: 'if a sibling vCPU LDAR-loads
-     * attn and sees 0, that sibling also does not yet observe any of
-     * the post-OR publish_creds stores.' Acquire-release only guarantees
-     * the forward direction (if you see the OR, you see prior stores);
-     * the contrapositive needs a total order across atomics, which on
-     * ARM64 SEQ_CST provides via DMB ISH. The OR runs only on rare
-     * setuid/setgid/etc paths so the extra barrier is not a hot-path
-     * cost. shim_globals_attn_and stays RELEASE because it runs after
-     * publish_creds and only needs to order those prior stores before
-     * the clear.
+    /* SEQ_CST, not ACQ_REL. The CRED_BRACKETED invariant is the contrapositive
+     * of release-acquire: if a sibling vCPU LDAR-loads attn and sees 0, that
+     * sibling also does not yet observe any of the post-OR publish_creds
+     * stores. Acquire-release only guarantees the forward direction (observing
+     * the OR guarantees observing prior stores); the contrapositive needs a
+     * total order across atomics, which on ARM64 SEQ_CST provides via DMB ISH.
+     * The OR runs only on rare setuid/setgid/etc paths so the extra barrier is
+     * not a hot-path cost. shim_globals_attn_and stays RELEASE because it runs
+     * after publish_creds and only needs to order those prior stores before the
+     * clear.
      */
     __atomic_fetch_or(slot, bits, __ATOMIC_SEQ_CST);
     vdso_attention_or(g, bits);
@@ -380,10 +374,9 @@ void shim_globals_attn_or(guest_t *g, uint32_t bits)
 void shim_globals_attn_and(guest_t *g, uint32_t mask)
 {
     uint32_t *slot = (uint32_t *) (cache_base(g) + SHIM_GLOBALS_OFF_ATTN);
-    /* RELEASE is sufficient for the clear path: the bracket runs
-     * publish_creds BEFORE this clear, and RELEASE here pairs with the
-     * shim's LDAR so any sibling that observes the cleared bit also sees
-     * the published cred slots.
+    /* RELEASE is sufficient for the clear path: the bracket runs publish_creds
+     * BEFORE this clear, and RELEASE here pairs with the shim's LDAR so any
+     * sibling that observes the cleared bit also sees the published cred slots.
      */
     __atomic_fetch_and(slot, mask, __ATOMIC_RELEASE);
     vdso_attention_and(g, mask);
@@ -391,19 +384,18 @@ void shim_globals_attn_and(guest_t *g, uint32_t mask)
 
 void shim_globals_raise_attention(guest_t *g)
 {
-    /* Signal/timer/exit-group lane. OR-only update so a concurrent
-     * cred publish's ATTN_BIT_CRED stays set. The release-store
-     * pairs with the shim's LDAR on the same address.
+    /* Signal/timer/exit-group lane. OR-only update so a concurrent cred
+     * publish's ATTN_BIT_CRED stays set. The release-store pairs with the
+     * shim's LDAR on the same address.
      */
     shim_globals_attn_or(g, ATTN_BIT_SIGTIMER);
 
-    /* Kick any vCPU spinning in EL0 on the identity fast path. Without
-     * the exit, the spinning vCPU never traps into EL1 and never
-     * reads the new attention value, so a SIGALRM queued for it
-     * waits until its host-thread timeslice ends. Reusing the
-     * existing signal-preemption helper (which iterates the live
-     * vCPU set under thread_lock) avoids duplicating the iteration
-     * logic; on a single-vCPU guest the loop is essentially a no-op.
+    /* Kick any vCPU spinning in EL0 on the identity fast path. Without the
+     * exit, the spinning vCPU never traps into EL1 and never reads the new
+     * attention value, so a SIGALRM queued for it waits until its host-thread
+     * timeslice ends. Reusing the existing signal-preemption helper (which
+     * iterates the live vCPU set under thread_lock) avoids duplicating the
+     * iteration logic; on a single-vCPU guest the loop is essentially a no-op.
      */
     thread_interrupt_all();
 }
@@ -412,8 +404,8 @@ void shim_globals_recompute_attention(guest_t *g)
 {
     /* Only owns the SIGTIMER lane; CRED and TRACE stay untouched so a
      * concurrent setuid/setgid bracket or persistent verbose-tracing gate
-     * cannot be undone by the HVC #5 epilogue dropping signal attention.
-     * Set or clear ATTN_BIT_SIGTIMER atomically.
+     * cannot be undone by the HVC #5 epilogue dropping signal attention. Set or
+     * clear ATTN_BIT_SIGTIMER atomically.
      */
     bool need = proc_exit_group_requested() || signal_attention_needed();
     if (need)
@@ -443,10 +435,10 @@ static const char *const counter_names[SHIM_COUNTERS_N] = {
     [SHIM_COUNTER_URANDOM_HIT] = "URANDOM_HIT",
     [SHIM_COUNTER_GETRANDOM_HIT] = "GETRANDOM_HIT",
     [SHIM_COUNTER_PGSID_HIT] = "PGSID_HIT",
-    /* Slots 12..15 (SHIM_COUNTERS_N == 16) are intentionally unnamed;
-     * the dump prints "(reserved)" so they appear in the output when
-     * non-zero, which would flag an out-of-band increment. Bind a name
-     * here when a future EL1 service claims one of these slots.
+    /* Slots 12..15 (SHIM_COUNTERS_N == 16) are intentionally unnamed; the dump
+     * prints "(reserved)" so they appear in the output when non-zero, which
+     * would flag an out-of-band increment. Bind a name here when a future EL1
+     * service claims one of these slots.
      */
 };
 
@@ -492,15 +484,14 @@ void shim_globals_publish_stats_gate(guest_t *g)
 {
     uint8_t *slot = cache_base(g) + SHIM_GLOBALS_OFF_STATS_EN;
     uint8_t v = shim_globals_stats_enabled() ? 1 : 0;
-    /* One-shot bring-up publish. Every caller (bootstrap, fork-child
-     * receive, execve) runs before the guest vCPU starts executing,
-     * so the host-side ordering between this store and the first
-     * hv_vcpu_run is what makes the shim observe the published value;
-     * the release semantics here are conservative, not load-bearing.
-     * A future runtime setter that mutates the gate after guest entry
-     * would also need the shim side to upgrade its ldrb to ldarb (or
-     * gate the read on the attention flag) -- a release-store alone
-     * does not synchronize with a plain ldrb on the same address.
+    /* One-shot bring-up publish. Every caller (bootstrap, fork-child receive,
+     * execve) runs before the guest vCPU starts executing, so the host-side
+     * ordering between this store and the first hv_vcpu_run is what makes the
+     * shim observe the published value; the release semantics here are
+     * conservative, not load-bearing. A future runtime setter that mutates the
+     * gate after guest entry would also need the shim side to upgrade its ldrb
+     * to ldarb (or gate the read on the attention flag) -- a release-store
+     * alone does not synchronize with a plain ldrb on the same address.
      */
     __atomic_store_n(slot, v, __ATOMIC_RELEASE);
 }

--- a/src/core/shim-globals.h
+++ b/src/core/shim-globals.h
@@ -3,37 +3,36 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * A small struct of host-published values that the EL1 shim consumes
- * to serve identity syscalls (getpid 172, getppid 173, getuid 174,
- * geteuid 175, getgid 176, getegid 177) without an HVC round-trip.
+ * A small struct of host-published values that the EL1 shim consumes to serve
+ * identity syscalls (getpid 172, getppid 173, getuid 174, geteuid 175, getgid
+ * 176, getegid 177) without an HVC round-trip.
  *
- * The cache lives at the start of the shim_data block (high IPA,
- * inside the infra reserve). Three layered protections keep guest
- * EL0 code from MAP_FIXED / MREMAP / MADVISE-spoofing the cache:
+ * The cache lives at the start of the shim_data block (high IPA, inside the
+ * infra reserve). Three layered protections keep guest EL0 code from MAP_FIXED
+ * / MREMAP / MADVISE-spoofing the cache:
  *
  *   - sys_mmap MAP_FIXED rejects ranges hitting infra
  *   - sys_munmap and sys_mprotect reject infra ranges
  *   - sys_mremap (all variants) and sys_madvise reject infra ranges
  *
- * Not yet defended: direct EL0 store to the cache GVA. The shim_data
- * block is mapped PT_AP_RW_EL0 (RW at both ELs), and /proc/self/maps
- * exposes [shim-data]. A guest that knows the layout can store the
- * cache base into a register and write spoofed values directly. This
- * is documented as out of scope; closing it requires a new AP[2:1]=00
- * permission level (RW at EL1, no EL0 access) which is a separate
- * hardening item. The elfuse threat model treats the guest as the
- * user's own binary, not adversarial, so direct-write spoofing is a
- * defense-in-depth gap rather than an active vulnerability.
+ * Not yet defended: direct EL0 store to the cache GVA. The shim_data block is
+ * mapped PT_AP_RW_EL0 (RW at both ELs), and /proc/self/maps exposes
+ * [shim-data]. A guest that knows the layout can store the cache base into a
+ * register and write spoofed values directly. This is documented as out of
+ * scope; closing it requires a new AP[2:1]=00 permission level (RW at EL1, no
+ * EL0 access) which is a separate hardening item. The elfuse threat model
+ * treats the guest as the user's own binary, not adversarial, so direct-write
+ * spoofing is a defense-in-depth gap rather than an active vulnerability.
  *
- * The shim addresses the cache via TPIDR_EL1, which the host sets at
- * every vCPU init point (bootstrap, fork-child, CLONE_THREAD, exec
- * re-init). TPIDR_EL1 is unused by elfuse aside from this and is not
- * trapped under default HCR_EL2 settings at EL1.
+ * The shim addresses the cache via TPIDR_EL1, which the host sets at every vCPU
+ * init point (bootstrap, fork-child, CLONE_THREAD, exec re-init). TPIDR_EL1 is
+ * unused by elfuse aside from this and is not trapped under default HCR_EL2
+ * settings at EL1.
  *
- * Memory ordering: each publish uses __ATOMIC_RELEASE. The shim reads
- * the attention flag with LDAR (acquire) to pair with the release.
- * Identity slot reads stay plain LDR -- each is independent and
- * naturally-aligned 64-bit loads are single-copy atomic on AArch64.
+ * Memory ordering: each publish uses __ATOMIC_RELEASE. The shim reads the
+ * attention flag with LDAR (acquire) to pair with the release. Identity slot
+ * reads stay plain LDR -- each is independent and naturally-aligned 64-bit
+ * loads are single-copy atomic on AArch64.
  */
 
 #pragma once
@@ -43,46 +42,43 @@
 
 #include "core/guest.h"
 
-/* Layout within shim_data_base (offsets are bytes from the cache base
- * which equals shim_data_base; the shim's TPIDR_EL1 holds exactly this
- * address).
+/* Layout within shim_data_base (offsets are bytes from the cache base which
+ * equals shim_data_base; the shim's TPIDR_EL1 holds exactly this address).
  *
- * Attention flag sits at offset 0 so the shim's LDAR (which only
- * supports a register base with no immediate offset) can load it via
- * 'ldar w_, [x12]' where x12 = mrs tpidr_el1. Identity slots follow
- * 8-byte-aligned, with PID at offset 0x08; the shim adds 8 to the
- * base and then indexes by (X8 - 172) * 8 to land on the requested
- * slot. Attention=0 takes the fast path; nonzero forces HVC.
+ * Attention flag sits at offset 0 so the shim's LDAR (which only supports a
+ * register base with no immediate offset) can load it via 'ldar w_, [x12]'
+ * where x12 = mrs tpidr_el1. Identity slots follow 8-byte-aligned, with PID at
+ * offset 0x08; the shim adds 8 to the base and then indexes by (X8 - 172) * 8
+ * to land on the requested slot. Attention=0 takes the fast path; nonzero
+ * forces HVC.
  *
- * Slice A ships attention as always-zero (the setter API exists but
- * is only called from cred publish in Slice B). The fast path is
- * gated already so Slice B can wire signal_queue / setitimer / exit-
- * group setters without further shim changes.
+ * Slice A ships attention as always-zero (the setter API exists but is only
+ * called from cred publish in Slice B). The fast path is gated already so Slice
+ * B can wire signal_queue / setitimer / exit- group setters without further
+ * shim changes.
  */
 #define SHIM_GLOBALS_OFF_ATTN 0x00
 
-/* Stats gate: single byte at offset 0x04 (inside the natural 4-byte pad
- * between the uint32 attention flag and the 8-byte-aligned identity
- * slots at 0x08). Nonzero enables the COUNTER_INC body in the EL1 shim;
- * zero (the default) makes COUNTER_INC a single ldrb + cbz so disabled
- * stats cost one cache-hot byte load instead of the full
- * load-add-store-to-shared-counter-line that was paid on every fast
- * path before. The byte lives in the same 64-byte cache line as the
- * attention flag, so the gate load piggybacks on the line the shim's
- * LDAR already pulls into L1 -- no extra coherence traffic in the
- * common case.
+/* Stats gate: single byte at offset 0x04 (inside the natural 4-byte pad between
+ * the uint32 attention flag and the 8-byte-aligned identity slots at 0x08).
+ * Nonzero enables the COUNTER_INC body in the EL1 shim; zero (the default)
+ * makes COUNTER_INC a single ldrb + cbz so disabled stats cost one cache-hot
+ * byte load instead of the full load-add-store-to-shared-counter-line that was
+ * paid on every fast path before. The byte lives in the same 64-byte cache line
+ * as the attention flag, so the gate load piggybacks on the line the shim's
+ * LDAR already pulls into L1 -- no extra coherence traffic in the common case.
  *
- * Plain release-store on publish: the gate is read once per fast-path
- * tail with relaxed semantics, and we accept a window after env-var
- * resolution where an in-flight syscall still sees the old value.
+ * Plain release-store on publish: the gate is read once per fast-path tail with
+ * relaxed semantics, and we accept a window after env-var resolution where an
+ * in-flight syscall still sees the old value.
  */
 #define SHIM_GLOBALS_OFF_STATS_EN 0x04
 
-/* Attention is a bitmask, not a boolean. Splitting it by owner lets the
- * HVC #5 epilogue's recompute (which polls signal/itimer state) coexist
- * with the cred-publish bracket without clobbering it. The shim still
- * does a single cbnz on the whole word: any bit set forces the slow
- * path. Bit ownership keeps recompute and cred bracket independent.
+/* Attention is a bitmask, not a boolean. Splitting it by owner lets the HVC #5
+ * epilogue's recompute (which polls signal/itimer state) coexist with the
+ * cred-publish bracket without clobbering it. The shim still does a single cbnz
+ * on the whole word: any bit set forces the slow path. Bit ownership keeps
+ * recompute and cred bracket independent.
  *
  *   ATTN_BIT_SIGTIMER   owned by signal_queue / setitimer / exit_group
  *                       and signal_check_timer's recompute. Set when
@@ -95,9 +91,9 @@
  *                       lifetime of a verbose run so EL1 shim fast paths
  *                       fall back to HVC and syscall_dispatch can log them.
  *
- * Earlier revisions used a single boolean: a sibling vCPU's recompute
- * dropping it to zero mid-publish reopened the torn-cred window the
- * bracket was meant to close.
+ * Earlier revisions used a single boolean: a sibling vCPU's recompute dropping
+ * it to zero mid-publish reopened the torn-cred window the bracket was meant to
+ * close.
  */
 #define ATTN_BIT_SIGTIMER 0x00000001u
 #define ATTN_BIT_CRED 0x00000002u
@@ -111,8 +107,8 @@
 #define SHIM_IDENTITY_OFF_GID 0x28
 #define SHIM_IDENTITY_OFF_EGID 0x30
 
-/* Urandom fast path (Slice D / P3): closes the /dev/urandom 1B read
- * band PR #48 left at the HVF round-trip floor.
+/* Urandom fast path: closes the /dev/urandom 1B read band at the HVF round-trip
+ * floor.
  *
  * Layout (continues from the identity section):
  *   0x38 .. 0xB7   URANDOM_FD_BITMAP   128 bytes = 1024 bits = FD_TABLE_SIZE
@@ -122,18 +118,17 @@
  *   0x10C0..0x10C3 URANDOM_RING_LOCK   uint32, producer/consumer lock
  *
  * The bitmap is bit N == 1 iff guest fd N currently refers to an
- * FD_URANDOM-typed entry. The shim's read fast path consults this
- * before serving from the ring; any other fd type falls through to
- * HVC. Host maintains the bitmap from fd_alloc / fd_mark_closed.
+ * FD_URANDOM-typed entry. The shim's read fast path consults this before
+ * serving from the ring; any other fd type falls through to HVC. Host maintains
+ * the bitmap from fd_alloc / fd_mark_closed.
  *
- * Ring head/tail are byte counters that grow monotonically (uint32);
- * fill = tail - head (uint32 subtract) is the available byte count,
- * pos = head & (URANDOM_RING_SIZE - 1) is the index in the ring.
- * Both cursors are atomic. The shim advances head via LDXR/STXR; the
- * host advances tail via release-store after writing fresh entropy.
- * The producer and shim consumer also take RING_LOCK while touching the
- * ring so the host cannot overwrite a slice after the shim reserves it
- * but before the EL1 copy has loaded it.
+ * Ring head/tail are byte counters that grow monotonically (uint32); fill =
+ * tail - head (uint32 subtract) is the available byte count, pos = head &
+ * (URANDOM_RING_SIZE - 1) is the index in the ring. Both cursors are atomic.
+ * The shim advances head via LDXR/STXR; the host advances tail via
+ * release-store after writing fresh entropy. The producer and shim consumer
+ * also take RING_LOCK while touching the ring so the host cannot overwrite a
+ * slice after the shim reserves it but before the EL1 copy has loaded it.
  *
  * Size must be a power of two so the index mask is AND of (SIZE - 1).
  */
@@ -145,34 +140,33 @@
 #define SHIM_URANDOM_RING_SIZE 4096
 #define SHIM_URANDOM_OFF_RING_LOCK 0x10C0
 
-/* Upper bound on the per-call byte count served by the shim's
- * urandom/getrandom fast paths. The probe coverage assumes the buffer
- * spans at most two host pages so a first+last byte AT probe suffices;
- * 256 fits comfortably within both 4 KiB and 16 KiB page sizes. The
- * shim itself hardcodes the literal; a static_assert in shim-globals.c
- * pins the C macro to the assembly. Ring wraps are handled inline by
- * splitting the byte copy at the 4 KiB boundary, so this cap is bounded
- * only by probe coverage and per-call ring-fill cost (256 keeps the
- * 4 KiB ring serviceable for 16 sequential reads before host refill).
+/* Upper bound on the per-call byte count served by the shim's urandom/getrandom
+ * fast paths. The probe coverage assumes the buffer spans at most two host
+ * pages so a first+last byte AT probe suffices; 256 fits comfortably within
+ * both 4 KiB and 16 KiB page sizes. The shim itself hardcodes the literal; a
+ * static_assert in shim-globals.c pins the C macro to the assembly. Ring wraps
+ * are handled inline by splitting the byte copy at the 4 KiB boundary, so this
+ * cap is bounded only by probe coverage and per-call ring-fill cost (256 keeps
+ * the 4 KiB ring serviceable for 16 sequential reads before host refill).
  */
 #define SHIM_URANDOM_INLINE_LIMIT 256
 
 /* Fast-path hit / miss counters.
  *
  * 16 uint64 slots placed after the urandom ring lock. The shim's
- * identity_class_fast and urandom_read_fast paths bump the relevant
- * slot on every entry and at every bail point so the host can attribute
- * fast-path activity instead of guessing. Counters are non-atomic plain
- * load-add-store -- under multi-vCPU concurrent bails a small fraction
- * of increments race and are lost, which is acceptable for diagnostic
- * ratios. Slots 0..7 cover the eight bail reasons the shim distinguishes
- * (sticky attention, fd out of range, fd not in urandom bitmap, len zero,
- * len over inline cap, ring fill below request, ring wrap, EL0 buffer
- * probe failure). Slots 8..11 record fast-path hits so bail rates can be
- * computed against a hit denominator. Slots 12..15 are reserved.
+ * identity_class_fast and urandom_read_fast paths bump the relevant slot on
+ * every entry and at every bail point so the host can attribute fast-path
+ * activity instead of guessing. Counters are non-atomic plain load-add-store --
+ * under multi-vCPU concurrent bails a small fraction of increments race and are
+ * lost, which is acceptable for diagnostic ratios. Slots 0..7 cover the eight
+ * bail reasons the shim distinguishes (sticky attention, fd out of range, fd
+ * not in urandom bitmap, len zero, len over inline cap, ring fill below
+ * request, ring wrap, EL0 buffer probe failure). Slots 8..11 record fast-path
+ * hits so bail rates can be computed against a hit denominator. Slots 12..15
+ * are reserved.
  *
- * The shim hardcodes the byte offset of each slot; the static_asserts
- * in shim-globals.c keep the C-side macros and the assembly in sync.
+ * The shim hardcodes the byte offset of each slot; the static_asserts in
+ * shim-globals.c keep the C-side macros and the assembly in sync.
  */
 #define SHIM_COUNTERS_OFF 0x10C8
 #define SHIM_COUNTERS_N 16
@@ -192,38 +186,36 @@
 
 /* Extended identity slots: pgid and sid.
  *
- * getpgid(0) and getsid(0) are pure cache reads when the argument is
- * zero; the shim serves them out of these slots whenever X0 == 0 and
- * the syscall number matches. The host re-publishes after setpgid /
- * setsid / exec / fork so the slots match guest_pgid / guest_sid in
- * proc-identity.c.
+ * getpgid(0) and getsid(0) are pure cache reads when the argument is zero; the
+ * shim serves them out of these slots whenever X0 == 0 and the syscall number
+ * matches. The host re-publishes after setpgid / setsid / exec / fork so the
+ * slots match guest_pgid / guest_sid in proc-identity.c.
  */
 #define SHIM_IDENTITY_OFF_PGID 0x1148
 #define SHIM_IDENTITY_OFF_SID 0x1150
 
 #define SHIM_GLOBALS_SIZE 0x1158
 
-/* Initialize the cache region to all-zero. Called once per process at
- * the same time the shim_data block is set up (initial bootstrap and
- * fork-child). The initial attention=0 means the shim takes the fast
- * path until a setter raises it.
+/* Initialize the cache region to all-zero. Called once per process at the same
+ * time the shim_data block is set up (initial bootstrap and fork-child). The
+ * initial attention=0 means the shim takes the fast path until a setter raises
+ * it.
  */
 void shim_globals_init(guest_t *g);
 
-/* Publish pid + ppid pair atomically (release-store per slot). Called
- * at process init, after fork-child identity is installed, and after
- * any future PID/PPID mutation. pid and ppid are int64 to match
+/* Publish pid + ppid pair atomically (release-store per slot). Called at
+ * process init, after fork-child identity is installed, and after any future
+ * PID/PPID mutation. pid and ppid are int64 to match
  * proc_get_pid/proc_get_ppid; values are stored zero/sign-extended.
  */
 void shim_globals_publish_pid(guest_t *g, int64_t pid, int64_t ppid);
 
-/* Publish all four credential slots. Slot writes are independent
- * 64-bit atomic stores; concurrent shim reads on another vCPU may
- * see partial updates. Slice B's attention bracket eliminates that
- * race; until then, callers must accept that a concurrent
- * getuid+geteuid sequence on a different vCPU can witness a torn
- * cred set across a setresuid moment. Linux semantics require an
- * atomic cred swap; bracket via attention closes that gap.
+/* Publish all four credential slots. Slot writes are independent 64-bit atomic
+ * stores; concurrent shim reads on another vCPU may see partial updates. Slice
+ * B's attention bracket eliminates that race; until then, callers must accept
+ * that a concurrent getuid+geteuid sequence on a different vCPU can witness a
+ * torn cred set across a setresuid moment. Linux semantics require an atomic
+ * cred swap; bracket via attention closes that gap.
  */
 void shim_globals_publish_creds(guest_t *g,
                                 uint32_t uid,
@@ -231,57 +223,54 @@ void shim_globals_publish_creds(guest_t *g,
                                 uint32_t gid,
                                 uint32_t egid);
 
-/* Publish pgid + sid so the shim's getpgid(0) / getsid(0) inline service
- * sees the current session/process-group state. Call from process init,
- * fork-child receive, exec, setsid, and setpgid. Slot writes are
- * independent 64-bit atomic release stores.
+/* Publish pgid + sid so the shim's getpgid(0) / getsid(0) inline service sees
+ * the current session/process-group state. Call from process init, fork-child
+ * receive, exec, setsid, and setpgid. Slot writes are independent 64-bit atomic
+ * release stores.
  *
- * No attention bit guards this publish: setpgid / setsid are infrequent
- * and the model accepts a brief window in which a concurrent
- * getpgid(0) / getsid(0) on a sibling vCPU observes the pre-publish
- * value (consistent with Linux's lockless session lookups). Session
- * mutators and cache-initialization callers publish through proc-identity
- * while holding session_lock, so successful setpgid / setsid calls cannot
- * overwrite the cache out of order.
+ * No attention bit guards this publish: setpgid / setsid are infrequent and the
+ * model accepts a brief window in which a concurrent getpgid(0) / getsid(0) on
+ * a sibling vCPU observes the pre-publish value (consistent with Linux's
+ * lockless session lookups). Session mutators and cache-initialization callers
+ * publish through proc-identity while holding session_lock, so successful
+ * setpgid / setsid calls cannot overwrite the cache out of order.
  */
 void shim_globals_publish_pgsid(guest_t *g, int64_t pgid, int64_t sid);
 
-/* GVA of the cache base. Equal to g->shim_data_base. Exposed so the
- * TPIDR_EL1 setup site and tests can reference one source of truth.
+/* GVA of the cache base. Equal to g->shim_data_base. Exposed so the TPIDR_EL1
+ * setup site and tests can reference one source of truth.
  */
 uint64_t shim_globals_gva(const guest_t *g);
 
 /* Pre-flight validation that hv_vcpu_set_sys_reg + hv_vcpu_get_sys_reg
- * round-trip on TPIDR_EL1. Writes a sentinel and reads it back via
- * the same HVF accessors the bootstrap uses; aborts (log_error + -1)
- * on mismatch. ARM documents TPIDR_EL1 as ordinary EL1 thread/CPU
- * pointer storage with no HCR trap on the EL1-side MRS/MSR.
+ * round-trip on TPIDR_EL1. Writes a sentinel and reads it back via the same HVF
+ * accessors the bootstrap uses; aborts (log_error + -1) on mismatch. ARM
+ * documents TPIDR_EL1 as ordinary EL1 thread/CPU pointer storage with no HCR
+ * trap on the EL1-side MRS/MSR.
  *
- * Note: this test runs BEFORE the first hv_vcpu_run; it does not
- * verify that HVF preserves the register across vCPU run/exit
- * boundaries. The existing test-shim-identity microbench is the
- * end-to-end check for that property -- if HVF clobbered TPIDR_EL1,
- * every identity-class fast path would observe a stale base and
- * test-shim-identity would fail on the first iteration after
+ * Note: this test runs BEFORE the first hv_vcpu_run; it does not verify that
+ * HVF preserves the register across vCPU run/exit boundaries. The existing
+ * test-shim-identity microbench is the end-to-end check for that property -- if
+ * HVF clobbered TPIDR_EL1, every identity-class fast path would observe a stale
+ * base and test-shim-identity would fail on the first iteration after
  * remap_vdso_page.
  *
  * Returns 0 on success, -1 on failure.
  */
 int shim_globals_self_test(hv_vcpu_t vcpu);
 
-/* Install TPIDR_EL1 = shim_globals_gva(g) on a vCPU. Called from the
- * four vCPU init sites listed in the file header.
+/* Install TPIDR_EL1 = shim_globals_gva(g) on a vCPU. Called from the four vCPU
+ * init sites listed in the file header.
  */
 int shim_globals_install_tpidr(hv_vcpu_t vcpu, const guest_t *g);
 
-/* Install CONTEXTIDR_EL1 = tid for the gettid shim fast path. The
- * register is per-vCPU and unused elsewhere in elfuse (HVF preserves
- * it across hv_vcpu_run alongside the rest of EL1 state). The shim
- * answers SVC #0 with X8 == 178 (gettid) by emitting a single
- * 'mrs x0, CONTEXTIDR_EL1' and an 'eret', skipping the HVC #5
- * round-trip the same way the identity slot loads do for syscalls
- * 172-177. Caller passes the Linux tid; it is zero/sign-extended
- * into the 64-bit sysreg slot.
+/* Install CONTEXTIDR_EL1 = tid for the gettid shim fast path. The register is
+ * per-vCPU and unused elsewhere in elfuse (HVF preserves it across hv_vcpu_run
+ * alongside the rest of EL1 state). The shim answers SVC #0 with X8 == 178
+ * (gettid) by emitting a single 'mrs x0, CONTEXTIDR_EL1' and an 'eret',
+ * skipping the HVC #5 round-trip the same way the identity slot loads do for
+ * syscalls 172-177. Caller passes the Linux tid; it is zero/sign-extended into
+ * the 64-bit sysreg slot.
  *
  * Setup sites:
  *   bootstrap.c                  initial main thread (tid == pid)
@@ -289,16 +278,17 @@ int shim_globals_install_tpidr(hv_vcpu_t vcpu, const guest_t *g);
  *   forkipc.c CLONE_THREAD       tid == thread's allocated guest_tid
  *   forkipc.c CLONE_VM           tid == child's guest_tid
  *
- * sys_execve reuses the vCPU and the main thread's tid does not
- * change across exec, so no re-set is required there.
+ * sys_execve reuses the vCPU and the main thread's tid does not change across
+ * exec, so no re-set is required there.
  */
 int shim_globals_install_tid(hv_vcpu_t vcpu, int64_t tid);
 
-/* Combined install: TPIDR_EL1 = shim_globals base, CONTEXTIDR_EL1 = tid.
- * Used by every vCPU init site (bootstrap, fork-child main, CLONE_THREAD
- * worker, CLONE_VM child). Returns 0 on success, -1 on either failure.
- * sys_execve uses install_tpidr alone because the tid is unchanged
- * across exec.
+/* Combined install: TPIDR_EL1 = shim_globals base, CONTEXTIDR_EL1 = tid. Used
+ * by every vCPU init site (bootstrap, fork-child main, CLONE_THREAD worker,
+ * CLONE_VM child).
+ *
+ * Returns 0 on success, -1 on either failure. sys_execve uses install_tpidr
+ * alone because the tid is unchanged across exec.
  */
 int shim_globals_install_per_vcpu(hv_vcpu_t vcpu,
                                   const guest_t *g,
@@ -306,119 +296,113 @@ int shim_globals_install_per_vcpu(hv_vcpu_t vcpu,
 
 /* Attention flag setters (Slice B).
  *
- * The shim's identity fast path reads the attention flag with LDAR
- * before doing anything else. When nonzero, the shim falls back to
- * HVC #5 so the host's post-syscall epilogue can deliver any pending
- * signal or itimer expiry.
+ * The shim's identity fast path reads the attention flag with LDAR before doing
+ * anything else. When nonzero, the shim falls back to HVC #5 so the host's
+ * post-syscall epilogue can deliver any pending signal or itimer expiry.
  *
- * shim_globals_raise_attention sets the flag to 1 atomically (release)
- * and also issues hv_vcpus_exit on every sibling vCPU so any vCPU
- * already spinning in EL0 drops out of hv_vcpu_run and re-checks the
- * flag on the next entry. Without the exit, a tight identity loop on
- * one vCPU could ignore an attention raise on another vCPU until its
- * timeslice ended.
+ * shim_globals_raise_attention sets the flag to 1 atomically (release) and also
+ * issues hv_vcpus_exit on every sibling vCPU so any vCPU already spinning in
+ * EL0 drops out of hv_vcpu_run and re-checks the flag on the next entry.
+ * Without the exit, a tight identity loop on one vCPU could ignore an attention
+ * raise on another vCPU until its timeslice ended.
  *
- * shim_globals_recompute_attention re-derives the flag from
- * (signal_pending OR any guest_itimer active OR exit_group requested).
- * Called from the HVC #5 epilogue after signal_check_timer to drop
- * the flag back to zero whenever the slow-path workload has drained.
+ * shim_globals_recompute_attention re-derives the flag from (signal_pending OR
+ * any guest_itimer active OR exit_group requested). Called from the HVC #5
+ * epilogue after signal_check_timer to drop the flag back to zero whenever the
+ * slow-path workload has drained.
  *
- * The g pointer in both is necessary because the cache is per-guest.
- * Slice B's signal.c hooks call these via a singleton guest pointer
- * registered at process init (see signal_set_shim_globals_guest in
- * src/syscall/signal.h).
+ * The g pointer in both is necessary because the cache is per-guest. Slice B's
+ * signal.c hooks call these via a singleton guest pointer registered at process
+ * init (see signal_set_shim_globals_guest in src/syscall/signal.h).
  */
 void shim_globals_raise_attention(guest_t *g);
 void shim_globals_recompute_attention(guest_t *g);
 void shim_globals_set_trace_enabled(guest_t *g, bool enabled);
 
-/* OR / AND specific attention bits without disturbing the others. Used
- * by the CRED_BRACKETED macro to set ATTN_BIT_CRED before mutating
- * host credentials and clear it after publish. signal_queue and the
- * itimer setters take the ATTN_BIT_SIGTIMER lane via raise_attention
- * and recompute_attention; --verbose owns ATTN_BIT_TRACE. The lanes do not
- * collide.
+/* OR / AND specific attention bits without disturbing the others. Used by the
+ * CRED_BRACKETED macro to set ATTN_BIT_CRED before mutating host credentials
+ * and clear it after publish. signal_queue and the itimer setters take the
+ * ATTN_BIT_SIGTIMER lane via raise_attention and recompute_attention; --verbose
+ * owns ATTN_BIT_TRACE. The lanes do not collide.
  */
 void shim_globals_attn_or(guest_t *g, uint32_t bits);
 void shim_globals_attn_and(guest_t *g, uint32_t mask);
 
-/* Urandom bitmap maintenance (Slice D / P3).
+/* Urandom bitmap maintenance.
  *
- * The fd-type bitmap is updated by the fd table whenever an FD_URANDOM
- * slot opens or closes (including dup, fork-IPC restore, etc.). The
- * shim's read-fast-path consults the bitmap with a single 64-bit load
- * and a bit test to decide whether the requested fd should hit the
- * urandom ring or fall through to HVC.
+ * The fd-type bitmap is updated by the fd table whenever an FD_URANDOM slot
+ * opens or closes (including dup, fork-IPC restore, etc.). The shim's
+ * read-fast-path consults the bitmap with a single 64-bit load and a bit test
+ * to decide whether the requested fd should hit the urandom ring or fall
+ * through to HVC.
  *
- * Updates use atomic OR/AND on the affected 64-bit word so concurrent
- * dup races (sibling vCPU dup'ing into a freshly-opened slot) cannot
- * lose either bit. Storing as uint64 rather than per-bit-CAS keeps
- * the host hook trivial.
+ * Updates use atomic OR/AND on the affected 64-bit word so concurrent dup races
+ * (sibling vCPU dup'ing into a freshly-opened slot) cannot lose either bit.
+ * Storing as uint64 rather than per-bit-CAS keeps the host hook trivial.
  *
- * shim_globals_set_singleton publishes the live guest_t * so the
- * fd-table hooks can update the bitmap without threading g through
- * every fd_alloc / fd_mark_closed call site. Same NULL-or-same
- * lifecycle assertion as the signal.c singleton. Call from bootstrap
- * (initial) and fork-child (after guest_init).
+ * shim_globals_set_singleton publishes the live guest_t * so the fd-table hooks
+ * can update the bitmap without threading g through every fd_alloc /
+ * fd_mark_closed call site. Same NULL-or-same lifecycle assertion as the
+ * signal.c singleton. Call from bootstrap (initial) and fork-child (after
+ * guest_init).
  */
 void shim_globals_set_singleton(guest_t *g);
 
-/* Reset the singleton to NULL. Called from syscall_init() at process
- * start so a stale parent-process pointer cannot survive across a
- * posix_spawn fork-child re-init and silently drop bitmap updates.
- * Mirrors signal_init()'s attention_guest=NULL reset.
+/* Reset the singleton to NULL. Called from syscall_init() at process start so a
+ * stale parent-process pointer cannot survive across a posix_spawn fork-child
+ * re-init and silently drop bitmap updates. Mirrors signal_init()'s
+ * attention_guest=NULL reset.
  */
 void shim_globals_reset_singleton(void);
 
 void shim_globals_mark_urandom_fd(int fd, bool is_urandom);
 
-/* Rebuild the urandom bitmap from the current fd table state. Used by
- * the fork-child path: the inherited fd table holds the parent's
- * FD_URANDOM slots but the child just zeroed its shim-globals via
- * shim_globals_init, so the bitmap must be re-populated to reflect
- * what the child actually has open. Acquires fd_lock internally.
+/* Rebuild the urandom bitmap from the current fd table state. Used by the
+ * fork-child path: the inherited fd table holds the parent's FD_URANDOM slots
+ * but the child just zeroed its shim-globals via shim_globals_init, so the
+ * bitmap must be re-populated to reflect what the child actually has open.
+ * Acquires fd_lock internally.
  */
 void shim_globals_rebuild_urandom_bitmap(void);
 
-/* Refill the entropy ring with fresh CSPRNG bytes from arc4random_buf.
- * Called from the host's sys_read slow path when a FD_URANDOM read
- * encounters an empty (or low-water) ring. The fill always brings tail
- * up to head + URANDOM_RING_SIZE so the ring is full after refill.
+/* Refill the entropy ring with fresh CSPRNG bytes from arc4random_buf. Called
+ * from the host's sys_read slow path when a FD_URANDOM read encounters an empty
+ * (or low-water) ring. The fill always brings tail up to head +
+ * URANDOM_RING_SIZE so the ring is full after refill.
  *
  * The initial fill is NOT done by shim_globals_init (which only zeros the
- * cache). Every bring-up path that uses the urandom fast path must call
- * this explicitly after shim_globals_init: bootstrap.c does it during VM
- * bring-up, src/syscall/exec.c does it on execve, and src/runtime/forkipc.c
- * does it on the fork-child receive path. Any future init site that forgets
- * this call leaves the ring empty, so the first urandom read on that vCPU is
- * forced through the host SVC.
+ * cache). Every bring-up path that uses the urandom fast path must call this
+ * explicitly after shim_globals_init: bootstrap.c does it during VM bring-up,
+ * src/syscall/exec.c does it on execve, and src/runtime/forkipc.c does it on
+ * the fork-child receive path. Any future init site that forgets this call
+ * leaves the ring empty, so the first urandom read on that vCPU is forced
+ * through the host SVC.
  */
 void shim_globals_refill_urandom_ring(guest_t *g);
 
 /* Counter access for diagnostics. shim_globals_counter_get returns the
  * cumulative slot value (lossy under multi-vCPU bail contention; see the
  * comment block on SHIM_COUNTERS_OFF). slot must be in [0, SHIM_COUNTERS_N).
- * shim_globals_counters_dump writes a one-line-per-slot summary to out
- * with the SHIM_COUNTER_* names and current values; intended for use at
- * process exit when ELFUSE_SHIM_STATS is set.
+ * shim_globals_counters_dump writes a one-line-per-slot summary to out with the
+ * SHIM_COUNTER_* names and current values; intended for use at process exit
+ * when ELFUSE_SHIM_STATS is set.
  */
 uint64_t shim_globals_counter_get(const guest_t *g, unsigned slot);
 void shim_globals_counters_dump(const guest_t *g);
 
-/* ELFUSE_SHIM_STATS env-var gate (idempotent / cached). When enabled the
- * exit path dumps the counter table to stderr so a single bench run
- * attributes every fast-path bail without rebuilds. Mirrors the
- * ELFUSE_STARTUP_TRACE pattern in core/startup-trace.h.
+/* ELFUSE_SHIM_STATS env-var gate (idempotent / cached). When enabled the exit
+ * path dumps the counter table to stderr so a single bench run attributes every
+ * fast-path bail without rebuilds. Mirrors the ELFUSE_STARTUP_TRACE pattern in
+ * core/startup-trace.h.
  */
 bool shim_globals_stats_enabled(void);
 
 /* Publish the stats gate byte at SHIM_GLOBALS_OFF_STATS_EN based on
- * shim_globals_stats_enabled(). The EL1 shim's COUNTER_INC loads this
- * byte and skips the counter increment when zero, so an unset
- * ELFUSE_SHIM_STATS pays only a single cache-hot ldrb on each fast-path
- * tail instead of a full load-add-store on a shared counter line.
- * Call after every shim_globals_init: bootstrap, fork-child receive,
- * and execve. The byte stays zero on a fresh shim_globals_init unless
- * this publisher runs.
+ * shim_globals_stats_enabled(). The EL1 shim's COUNTER_INC loads this byte and
+ * skips the counter increment when zero, so an unset ELFUSE_SHIM_STATS pays
+ * only a single cache-hot ldrb on each fast-path tail instead of a full
+ * load-add-store on a shared counter line. Call after every shim_globals_init:
+ * bootstrap, fork-child receive, and execve. The byte stays zero on a fresh
+ * shim_globals_init unless this publisher runs.
  */
 void shim_globals_publish_stats_gate(guest_t *g);

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -4,10 +4,10 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Constructs the initial stack layout that the Linux ABI requires at
- * process startup. The stack is built at the top of the guest stack
- * region and grows downward: string data at the top, then the structured
- * area (auxv, envp, argv, argc) below.
+ * Constructs the initial stack layout that the Linux ABI requires at process
+ * startup. The stack is built at the top of the guest stack region and grows
+ * downward: string data at the top, then the structured area (auxv, envp, argv,
+ * argc) below.
  */
 
 #include <stdlib.h>
@@ -160,17 +160,16 @@ uint64_t build_linux_stack(guest_t *g,
             envc++;
     }
 
-/* Bounds-check: Linux returns E2BIG for oversized argument/environment.
- * ARG_MAX on Linux is typically 2MiB; stack setup caps at reasonable stack
- * limits.
+/* Bounds-check: Linux returns E2BIG for oversized argument/environment. ARG_MAX
+ * on Linux is typically 2MiB; stack setup caps at reasonable stack limits.
  */
 #define MAX_ARGS 131072
 #define MAX_ENVS 131072
     if (argc > MAX_ARGS || envc > MAX_ENVS)
         return 0; /* Caller treats 0 as failure */
 
-    /* Phase 1: Write strings and random data at the top of the stack.
-     * stack setup works downward from stack_top.
+    /* Phase 1: Write strings and random data at the top of the stack. stack
+     * setup works downward from stack_top.
      */
     uint64_t str_ptr = stack_top;
 
@@ -225,27 +224,26 @@ uint64_t build_linux_stack(guest_t *g,
     /* AT_EXECFN: pointer to argv[0] string (write it near the top) */
     uint64_t execfn_ptr = (argc > 0) ? arg_ptrs[0] : 0;
 
-    /* Phase 2: Build the structured part of the stack.
-     * Align str_ptr down to 16 bytes first.
+    /* Phase 2: Build the structured part of the stack. Align str_ptr down to 16
+     * bytes first.
      */
     str_ptr &= ~15ULL;
     uint64_t sp = str_ptr;
 
     /* Count auxv entries: base 15 (always) + AT_EXECFN (always) + AT_BASE
      * (always, matching Linux kernel; see commit ba0b177) + optional
-     * AT_SYSINFO_EHDR + optional AT_EXECFD.
-     * Each auxv entry = 2 words. Plus AT_NULL = 2 words.
-     * Total words from auxv = (num_auxv_entries + 1) * 2.
-     * Plus envp_null(1) + envp_ptrs(envc) + argv_null(1) +
-     * argv_ptrs(argc) + argc(1).
+     * AT_SYSINFO_EHDR + optional AT_EXECFD. Each auxv entry = 2 words. Plus
+     * AT_NULL = 2 words. Total words from auxv = (num_auxv_entries + 1) * 2.
+     * Plus envp_null(1) + envp_ptrs(envc) + argv_null(1) + argv_ptrs(argc) +
+     * argc(1).
      *
-     * Base auxv: 15 entries = 30 words, AT_NULL = 2 words = 32.
-     * Always: AT_EXECFN = +2, AT_BASE = +2.
-     * Optional: AT_SYSINFO_EHDR (if vdso_base != 0) = +2,
+     * Base auxv: 15 entries = 30 words, AT_NULL = 2 words = 32. Always:
+     * AT_EXECFN = +2, AT_BASE = +2. Optional: AT_SYSINFO_EHDR (if vdso_base !=
+     * 0) = +2,
      *           AT_EXECFD (if execfd >= 0) = +2.
      * Plus envp_null(1) + envp(envc) + argv_null(1) + argv(argc) + argc(1) = 3.
-     * Total = 32 + extra + 3 + envc + argc = 35 + extra + envc + argc.
-     * For 16-byte alignment: total must be even.
+     * Total = 32 + extra + 3 + envc + argc = 35 + extra + envc + argc. For
+     * 16-byte alignment: total must be even.
      */
     int extra = 2 + 2; /* AT_EXECFN + AT_BASE (both always present) */
     if (vdso_base != 0)
@@ -254,8 +252,9 @@ uint64_t build_linux_stack(guest_t *g,
         extra += 2; /* AT_EXECFD (binfmt_misc binary fd) */
     int total_entries = 35 + extra + argc + envc;
 
-    /* Track cumulative write errors. Any failure means the stack
-     * is incomplete. Return 0 so the caller sees the failure.
+    /* Track cumulative write errors. Any failure means the stack is incomplete.
+     *
+     * Return 0 so the caller sees the failure.
      */
     int stack_err = str_err;
 
@@ -289,8 +288,8 @@ uint64_t build_linux_stack(guest_t *g,
     AUX(AT_EUID, GUEST_UID);
     AUX(AT_GID, GUEST_GID);
     AUX(AT_EGID, GUEST_GID);
-    /* Bionic's __libc_init_AT_SECURE aborts when AT_SECURE is absent.
-     * elfuse never elevates privileges, so AT_SECURE is always 0.
+    /* Bionic's __libc_init_AT_SECURE aborts when AT_SECURE is absent. elfuse
+     * never elevates privileges, so AT_SECURE is always 0.
      */
     AUX(AT_SECURE, 0);
     AUX(AT_HWCAP2, query_hwcap2());

--- a/src/core/stack.h
+++ b/src/core/stack.h
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Constructs the initial stack layout expected by the Linux ABI:
- * argc, argv pointers, envp pointers, auxiliary vector, and string data.
+ * Constructs the initial stack layout expected by the Linux ABI: argc, argv
+ * pointers, envp pointers, auxiliary vector, and string data.
  */
 
 #pragma once
@@ -47,8 +47,8 @@ typedef struct {
     size_t nwords;
 } linux_stack_auxv_t;
 
-/* Build a Linux-compatible initial stack at the given stack_top.
- * Passes argc/argv and envp (NULL-terminated array of "KEY=val" strings).
+/* Build a Linux-compatible initial stack at the given stack_top. Passes
+ * argc/argv and envp (NULL-terminated array of "KEY=val" strings).
  * elf_load_base is the base address PIE executables were loaded at (0 for
  * ET_EXEC). interp_base is the load base of the dynamic linker (0 if statically
  * linked). vdso_base is the guest address of the vDSO ELF image (0 if no vDSO).

--- a/src/core/startup-trace.h
+++ b/src/core/startup-trace.h
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Lightweight per-step wall-time tracer for VM bring-up. Gated by the
- * ELFUSE_STARTUP_TRACE environment variable so a release-build run pays
- * exactly one getenv + one branch per step when disabled. The helpers are
- * static inline so each translation unit can use them without pulling in a
- * separate object; the getenv check resolves once per translation unit but
- * the resolution itself is idempotent.
+ * ELFUSE_STARTUP_TRACE environment variable so a release-build run pays exactly
+ * one getenv + one branch per step when disabled. The helpers are static inline
+ * so each translation unit can use them without pulling in a separate object;
+ * the getenv check resolves once per translation unit but the resolution itself
+ * is idempotent.
  *
  * Accepted env values:
  *   unset, "", "0"  -> all tracing off
  *   "1", "steps"    -> per-step VM bring-up timings (this header)
  *   "syscalls"      -> per-syscall histogram (debug/syscall-hist.c)
  *   "all"           -> both, comma-separated tokens also accepted
- * "1" is preserved as a legacy alias for "steps" so old scripts keep
- * working. The histogram mode never enables the step tracer and vice
- * versa, so a user can ask for one without paying for the other.
+ * "1" is preserved as a legacy alias for "steps" so old scripts keep working.
+ * The histogram mode never enables the step tracer and vice versa, so a user
+ * can ask for one without paying for the other.
  */
 
 #ifndef ELFUSE_STARTUP_TRACE_H

--- a/src/core/sysroot.c
+++ b/src/core/sysroot.c
@@ -342,10 +342,10 @@ int sysroot_probe_case_sensitivity(const char *path,
                                               case_preserving);
 }
 
-/* Returns 1 if both sentinel paths exist under sysroot, 0 if at least one
- * is absent, -1 on error (e.g. path truncation). Truncation must fail
- * closed: returning 0 would silently admit a case-insensitive sysroot
- * that should be rejected for colliding Linux pathnames.
+/* Returns 1 if both sentinel paths exist under sysroot, 0 if at least one is
+ * absent, -1 on error (e.g. path truncation). Truncation must fail closed:
+ * returning 0 would silently admit a case-insensitive sysroot that should be
+ * rejected for colliding Linux pathnames.
  */
 static int collision_pair_exists(const char *sysroot,
                                  const char *rel_a,

--- a/src/core/vdso.c
+++ b/src/core/vdso.c
@@ -21,14 +21,14 @@
  * an arbitrary X9 value. A Linux-style seqlock (see the vvar layout block
  * below) keeps concurrent publishers and readers race-free.
  *
- * Anchor-age cap: the time trampolines refuse to interpolate once
- * (cntvct - anchor_cntvct) exceeds 2**31 cycles (~89 s at 24 MHz). That
- * forces an SVC fallback the host can use to re-anchor against fresh
- * macOS clocks, bounding any drift relative to a fresh REALTIME SVC after
- * an NTP step or long sleep. The host SVC path also computes a predicted
- * REALTIME from the anchor and invalidates whenever the delta against a
- * fresh REALTIME sample exceeds VDSO_ANCHOR_MAX_DRIFT_NS, so workloads
- * that do take an SVC for any reason re-anchor immediately.
+ * Anchor-age cap: the time trampolines refuse to interpolate once (cntvct -
+ * anchor_cntvct) exceeds 2**31 cycles (~89 s at 24 MHz). That forces an SVC
+ * fallback the host can use to re-anchor against fresh macOS clocks, bounding
+ * any drift relative to a fresh REALTIME SVC after an NTP step or long sleep.
+ * The host SVC path also computes a predicted REALTIME from the anchor and
+ * invalidates whenever the delta against a fresh REALTIME sample exceeds
+ * VDSO_ANCHOR_MAX_DRIFT_NS, so workloads that do take an SVC for any reason
+ * re-anchor immediately.
  */
 
 #include <stdint.h>
@@ -111,9 +111,9 @@ static uint8_t *vdso_host_page(guest_t *g)
 
 /* Layout.
  *
- * Symbol layout (sizes vary; the time trampolines are CNTVCT-fast paths,
- * getcpu / clock_getres are pure-arithmetic fast paths, rt_sigreturn is a
- * 12-byte SVC trampoline):
+ * Symbol layout (sizes vary; the time trampolines are CNTVCT-fast paths, getcpu
+ * / clock_getres are pure-arithmetic fast paths, rt_sigreturn is a 12-byte SVC
+ * trampoline):
  *   [0] __kernel_rt_sigreturn
  *   [1] __kernel_clock_getres
  *   [2] __kernel_clock_gettime
@@ -131,19 +131,19 @@ static uint8_t *vdso_host_page(guest_t *g)
  *   0x6B0  program header table (3 entries: PT_LOAD, PT_DYNAMIC, PT_NOTE)
  *
  * The PHDR table sits at the bottom of the structural area so that the
- * 4-byte-aligned NT_GNU_ABI_TAG note can occupy the old PHDR window and
- * glibc 2.41's dynamic-linker vDSO probe finds the expected note without
- * any of the trampoline / section offsets shifting.
+ * 4-byte-aligned NT_GNU_ABI_TAG note can occupy the old PHDR window and glibc
+ * 2.41's dynamic-linker vDSO probe finds the expected note without any of the
+ * trampoline / section offsets shifting.
  */
 
 /* Offsets within the 4KiB page.
  *
- * The PHDR table now sits past the SHDR area at 0x6B0 (the EHDR's e_phoff
- * field follows it there). This leaves the old PHDR slot at 0x040 free for
- * the NT_GNU_ABI_TAG note data that glibc 2.41 expects to find via the
- * PT_NOTE entry, without disturbing VVAR (0xB0), SIGRET (0xE0), or any of
- * the trampoline / section offsets. PT_LOAD still maps the whole page so
- * the note is loaded with the rest.
+ * The PHDR table now sits past the SHDR area at 0x6B0 (the EHDR's e_phoff field
+ * follows it there). This leaves the old PHDR slot at 0x040 free for the
+ * NT_GNU_ABI_TAG note data that glibc 2.41 expects to find via the PT_NOTE
+ * entry, without disturbing VVAR (0xB0), SIGRET (0xE0), or any of the
+ * trampoline / section offsets. PT_LOAD still maps the whole page so the note
+ * is loaded with the rest.
  */
 #define VDSO_OFF_EHDR 0x000
 /* NT_GNU_ABI_TAG note data lives at the old PHDR slot; 32 bytes fits
@@ -153,8 +153,8 @@ static uint8_t *vdso_host_page(guest_t *g)
 #define VDSO_NOTE_SIZE 0x20
 
 /* vvar at fixed offset; host writes the wall-clock anchor on first
- * clock_gettime SVC, after the guest trampoline has stored its own
- * CNTVCT_EL0 read into X9. Layout:
+ * clock_gettime SVC, after the guest trampoline has stored its own CNTVCT_EL0
+ * read into X9. Layout:
  *   +0   uint32 seq (Linux-style seqlock counter; see state machine below)
  *   +4   uint32 attention (host mirrors shim attention bits; nonzero -> SVC)
  *   +8   uint64 anchor_cntvct (guest frame, written by host from X9)
@@ -168,26 +168,26 @@ static uint8_t *vdso_host_page(guest_t *g)
  *   odd N >= 1  : writer reserved generation (N+1)/2; anchor fields in flux
  *   even N >= 2 : stable generation N/2; anchor fields readable
  *
- * Writers (vdso_seed_anchor) CAS seq from an even value (0 or 2K) to the
- * next odd, store new anchor fields, and release-store the next even.
- * This handles both initial seeding (0 -> 1 -> 2) and refresh (2K ->
- * 2K+1 -> 2K+2) atomically; no separate invalidate path is needed.
+ * Writers (vdso_seed_anchor) CAS seq from an even value (0 or 2K) to the next
+ * odd, store new anchor fields, and release-store the next even. This handles
+ * both initial seeding (0 -> 1 -> 2) and refresh (2K -> 2K+1 -> 2K+2)
+ * atomically; no separate invalidate path is needed.
  *
- * Trampoline readers LDAR seq into a snapshot register, bail on 0
- * (unseeded) or odd (writer in progress), read anchor fields with plain
- * loads, then LDAR seq again -- any change between the two reads means
- * a writer raced, so fall back to SVC.
+ * Trampoline readers LDAR seq into a snapshot register, bail on 0 (unseeded) or
+ * odd (writer in progress), read anchor fields with plain loads, then LDAR seq
+ * again -- any change between the two reads means a writer raced, so fall back
+ * to SVC.
  *
- * Both MONO and REAL anchor pairs are written together so a fast-path
- * caller for either clockid sees a consistent pair after observing an
- * even seq. The trampoline interpolates either pair from the shared
- * CNTVCT delta; the picking of MONO vs REAL is done by adding
- * VVAR_OFF_ANCHOR_MONO_SEC or VVAR_OFF_ANCHOR_REAL_SEC to the vvar base
- * and LDPing the two-doubleword anchor.
+ * Both MONO and REAL anchor pairs are written together so a fast-path caller
+ * for either clockid sees a consistent pair after observing an even seq. The
+ * trampoline interpolates either pair from the shared CNTVCT delta; the picking
+ * of MONO vs REAL is done by adding VVAR_OFF_ANCHOR_MONO_SEC or
+ * VVAR_OFF_ANCHOR_REAL_SEC to the vvar base and LDPing the two-doubleword
+ * anchor.
  *
- * The trampoline's anchor-age cap (LSR + CBNZ on the CNTVCT delta) and
- * the host's drift detector in sys_clock_gettime together bound drift
- * after a macOS NTP step or a long sleep.
+ * The trampoline's anchor-age cap (LSR + CBNZ on the CNTVCT delta) and the
+ * host's drift detector in sys_clock_gettime together bound drift after a macOS
+ * NTP step or a long sleep.
  */
 #define VDSO_OFF_VVAR 0x0B0
 /* Linux-style seqlock counter; see the state machine above. */
@@ -200,12 +200,11 @@ static uint8_t *vdso_host_page(guest_t *g)
 #define VVAR_OFF_ANCHOR_REAL_NSEC 0x28
 #define VVAR_SIZE 0x30
 
-/* .text trampoline offsets and sizes. rt_sigreturn is a 12-byte SVC
- * trampoline. clock_getres / getcpu are arithmetic fast paths.
- * clock_gettime / gettimeofday are CNTVCT fast paths that implement a
- * seqlock-style read against the vvar above (see the per-emitter
- * comments for instruction-level layout). Sizes are exact; the
- * static_asserts on each emitter catch drift.
+/* .text trampoline offsets and sizes. rt_sigreturn is a 12-byte SVC trampoline.
+ * clock_getres / getcpu are arithmetic fast paths. clock_gettime / gettimeofday
+ * are CNTVCT fast paths that implement a seqlock-style read against the vvar
+ * above (see the per-emitter comments for instruction-level layout). Sizes are
+ * exact; the static_asserts on each emitter catch drift.
  */
 #define TEXT_OFF_SIGRET 0x0E0
 #define TEXT_OFF_GETRES 0x0EC
@@ -218,33 +217,33 @@ static uint8_t *vdso_host_page(guest_t *g)
 #define TEXT_GETCPU_SIZE 0x34
 #define TEXT_END (TEXT_OFF_GETCPU + TEXT_GETCPU_SIZE)
 /* Offset of the SVC instruction inside __kernel_clock_gettime's svc_fallback
- * (svc_fallback opens at instruction 39 of 42, i.e. byte 0x9C; the SVC is
- * the second instruction of the fallback, at byte 0xA0). The host's
+ * (svc_fallback opens at instruction 39 of 42, i.e. byte 0x9C; the SVC is the
+ * second instruction of the fallback, at byte 0xA0). The host's
  * sys_clock_gettime uses this value to gate vvar seeding: only a trap whose
  * ELR_EL1 equals SVC_PC + 4 came from the trampoline and may carry a
  * trustworthy CNTVCT in X9.
  */
 #define VDSO_CLOCK_GETTIME_SVC_PC (TEXT_OFF_GETTIME + 0xA0)
-/* gettimeofday svc_fallback opens at instruction 37 of 40 (byte 0x94);
- * SVC at byte 0x98.
+/* gettimeofday svc_fallback opens at instruction 37 of 40 (byte 0x94); SVC at
+ * byte 0x98.
  */
 #define VDSO_GETTIMEOFDAY_SVC_PC (TEXT_OFF_GETTOD + 0x98)
 
-/* Anchor-age cap. The trampolines refuse to interpolate once
- * (cntvct - anchor_cntvct) exceeds (1ULL << ANCHOR_AGE_SHIFT) cycles,
- * checked via LSR + CBNZ on the delta. With CNTFRQ = 24 MHz, shift 22
- * caps the delta at ~0.175 s (~175e6 ns).
+/* Anchor-age cap. The trampolines refuse to interpolate once (cntvct -
+ * anchor_cntvct) exceeds (1ULL << ANCHOR_AGE_SHIFT) cycles, checked via LSR +
+ * CBNZ on the delta. With CNTFRQ = 24 MHz, shift 22 caps the delta at ~0.175 s
+ * (~175e6 ns).
  *
- * Shift 22 is load-bearing: it keeps delta_ns + anchor_nsec below 2e9,
- * so the sub-1e9 carry collapses to one SUBS + CSEL + CINC instead of a
- * UDIV-by-1e9. Loosening the cap or raising CNTFRQ past that bound
- * requires restoring a real division. The host drift check in
- * sys_clock_gettime must use the same shift to stay coherent.
+ * Shift 22 is load-bearing: it keeps delta_ns + anchor_nsec below 2e9, so the
+ * sub-1e9 carry collapses to one SUBS + CSEL + CINC instead of a UDIV-by-1e9.
+ * Loosening the cap or raising CNTFRQ past that bound requires restoring a real
+ * division. The host drift check in sys_clock_gettime must use the same shift
+ * to stay coherent.
  */
 #define VDSO_ANCHOR_AGE_SHIFT 22
 
-/* dynstr, dynsym, hash, GNU version metadata, dynamic, shdr follow.
- * TEXT_END is 0x2C4 after the dmb-ishld insertion in gettime/gettod.
+/* dynstr, dynsym, hash, GNU version metadata, dynamic, shdr follow. TEXT_END is
+ * 0x2C4 after the dmb-ishld insertion in gettime/gettod.
  */
 #define VDSO_OFF_DYNSTR TEXT_END
 
@@ -270,10 +269,10 @@ static uint8_t *vdso_host_page(guest_t *g)
 
 /* 8 * 64 = 512, 0x4B0 + 512 = 0x6B0 (fits in 4 KiB) */
 
-/* Program header table sits after the section headers so the old PHDR
- * window at 0x040 can host the NT_GNU_ABI_TAG note data. Three entries
- * (PT_LOAD, PT_DYNAMIC, PT_NOTE) at 56 bytes each end at 0x758, leaving
- * the rest of the page reserved for future growth.
+/* Program header table sits after the section headers so the old PHDR window at
+ * 0x040 can host the NT_GNU_ABI_TAG note data. Three entries (PT_LOAD,
+ * PT_DYNAMIC, PT_NOTE) at 56 bytes each end at 0x758, leaving the rest of the
+ * page reserved for future growth.
  */
 #define VDSO_OFF_PHDR 0x6B0
 #define VDSO_OFF_PHDR1 (VDSO_OFF_PHDR + 0x38)
@@ -288,12 +287,12 @@ static uint8_t *vdso_host_page(guest_t *g)
 #define VERDEF_SIZE (sizeof(elf64_verdef_t) + sizeof(elf64_verdaux_t))
 #define VDSO_NUM_DYN 9
 
-/* NT_GNU_ABI_TAG note. glibc 2.41's vDSO setup expects this entry to be
- * present alongside the dynamic symbol table; without it the dynamic
- * linker still maps the page but skips the per-symbol fast-path lookup,
- * forcing the dynamically-linked guest into the SVC tail of every
- * trampoline. The note layout matches what the upstream Linux kernel
- * emits from arch/arm64/kernel/vdso/note.S:
+/* NT_GNU_ABI_TAG note. glibc 2.41's vDSO setup expects this entry to be present
+ * alongside the dynamic symbol table; without it the dynamic linker still maps
+ * the page but skips the per-symbol fast-path lookup, forcing the
+ * dynamically-linked guest into the SVC tail of every trampoline. The note
+ * layout matches what the upstream Linux kernel emits from
+ * arch/arm64/kernel/vdso/note.S:
  *
  *   namesz : 4   (uint32, "GNU\0")
  *   descsz : 16  (uint32, four-word descriptor)
@@ -302,9 +301,9 @@ static uint8_t *vdso_host_page(guest_t *g)
  *   desc   : { 0 (Linux), major, minor, sublevel } as uint32 each
  *
  * The desc declares the minimum supported kernel ABI. 2.6.39 matches the
- * LINUX_2.6.39 symbol version already exposed through DT_VERDEF -- both
- * say "this vDSO speaks the 2.6.39 ABI" -- so a glibc that accepts the
- * symbol version also accepts the note.
+ * LINUX_2.6.39 symbol version already exposed through DT_VERDEF -- both say
+ * "this vDSO speaks the 2.6.39 ABI" -- so a glibc that accepts the symbol
+ * version also accepts the note.
  */
 #define NT_GNU_ABI_TAG 1
 #define ELF_NOTE_OS_LINUX 0
@@ -335,9 +334,9 @@ static const char dynstr_data[] =
 
 /* Symbol name offsets, derived from preceding string-literal lengths so a
  * future edit to dynstr_data shifts them in lockstep instead of silently
- * breaking the version lookup (sizeof("\0X") - 1 == bytes contributed when
- * X is concatenated into dynstr_data; only the very last literal's trailing
- * NUL survives concatenation).
+ * breaking the version lookup (sizeof("\0X") - 1 == bytes contributed when X is
+ * concatenated into dynstr_data; only the very last literal's trailing NUL
+ * survives concatenation).
  */
 #define DYNSTR_BYTES_RT_SIGRETURN (sizeof("\0__kernel_rt_sigreturn") - 1)
 #define DYNSTR_BYTES_CLOCK_GETRES (sizeof("\0__kernel_clock_getres") - 1)
@@ -445,8 +444,9 @@ static uint32_t enc_csel_x(unsigned rd, unsigned rn, unsigned rm, unsigned cond)
            ((rn & 0x1F) << 5) | (rd & 0x1F);
 }
 
-/* CSINC Xd, Xn, Xm, cond: if cond Xd=Xn else Xd=Xm+1.
- * Encodes CINC Xd, Xn, cond as CSINC Xd, Xn, Xn, invert(cond). */
+/* CSINC Xd, Xn, Xm, cond: if cond Xd=Xn else Xd=Xm+1. Encodes CINC Xd, Xn, cond
+ * as CSINC Xd, Xn, Xn, invert(cond).
+ */
 static uint32_t enc_csinc_x(unsigned rd,
                             unsigned rn,
                             unsigned rm,
@@ -560,8 +560,8 @@ static uint32_t enc_cbnz_x(unsigned rt, int32_t pc_rel)
 }
 
 /* TBNZ Rt, #bit, imm14 (byte-relative). When bit < 32 the encoder uses the
- * W-form (sf-bit of bit-number = 0); the seqlock checks only test bit 0 so
- * the W/X distinction is moot for callers here.
+ * W-form (sf-bit of bit-number = 0); the seqlock checks only test bit 0 so the
+ * W/X distinction is moot for callers here.
  */
 static uint32_t enc_tbnz(unsigned rt, unsigned bit, int32_t pc_rel)
 {
@@ -584,16 +584,16 @@ static uint32_t enc_cmp_w_reg(unsigned rn, unsigned rm)
 }
 
 /* DMB ISHLD: inner-shareable load-load barrier. Pairs the seqlock reader's
- * snapshot LDAR (forward acquire) with the plain anchor loads so a
- * subsequent recheck LDAR cannot be reordered before them. ARM ARM B2.3:
- * LDAR orders later memory ops after itself but does NOT order prior ops
- * before itself, so the recheck needs an explicit load barrier.
+ * snapshot LDAR (forward acquire) with the plain anchor loads so a subsequent
+ * recheck LDAR cannot be reordered before them. ARM ARM B2.3: LDAR orders later
+ * memory ops after itself but does NOT order prior ops before itself, so the
+ * recheck needs an explicit load barrier.
  */
 #define VDSO_INSN_DMB_ISHLD 0xD50339BFU
 
-/* Emit the CNTVCT fast-path clock_gettime trampoline at page+pc_off; the
- * vvar lives at page+vvar_off. The trampoline is exactly TEXT_GETTIME_SIZE
- * bytes; the static_assert below catches drift.
+/* Emit the CNTVCT fast-path clock_gettime trampoline at page+pc_off; the vvar
+ * lives at page+vvar_off. The trampoline is exactly TEXT_GETTIME_SIZE bytes;
+ * the static_assert below catches drift.
  *
  * Layout (42 instructions, 0xA8 bytes):
  *
@@ -635,21 +635,20 @@ static uint32_t enc_cmp_w_reg(unsigned rn, unsigned rm)
  *   0xA0  svc  #0                        ; ELR_EL1 + 4 == SVC_PC
  *   0xA4  ret
  *
- * Both clockids share the same CNTVCT delta math; only the anchor pair
- * loaded via LDP changes. Picking via a runtime offset register avoids
- * duplicating the entire math block per clockid. The age check clobbers
- * x7 (which has already been consumed by `add x8, x2, x7`) before the
- * math reloads x7 with the mult+shift constant.
+ * Both clockids share the same CNTVCT delta math; only the anchor pair loaded
+ * via LDP changes. Picking via a runtime offset register avoids duplicating the
+ * entire math block per clockid. The age check clobbers x7 (which has already
+ * been consumed by ADD X8, X2, X7) before the math reloads x7 with the
+ * mult+shift constant.
  *
- * The seqlock recheck runs after all anchor field reads and the math but
- * before the user-visible store. The preceding DMB ISHLD is critical:
- * LDAR-acquire orders later memory ops after itself but NOT prior ops
- * before itself (ARM ARM B2.3.4), so without the barrier the recheck
- * LDAR could be observed by other CPUs before the plain anchor LDR/LDP
- * have committed -- allowing seq == snap to pass while the field loads
- * raced with a host CAS-bump-publish. A mismatch with w11 means a host
- * refresher ran between the two LDARs, so the trampoline falls through
- * to SVC for a fresh sample.
+ * The seqlock recheck runs after all anchor field reads and the math but before
+ * the user-visible store. The preceding DMB ISHLD is critical: LDAR-acquire
+ * orders later memory ops after itself but NOT prior ops before itself (ARM ARM
+ * B2.3.4), so without the barrier the recheck LDAR could be observed by other
+ * CPUs before the plain anchor LDR/LDP have committed -- allowing seq == snap
+ * to pass while the field loads raced with a host CAS-bump-publish. A mismatch
+ * with w11 means a host refresher ran between the two LDARs, so the trampoline
+ * falls through to SVC for a fresh sample.
  */
 static void emit_clock_gettime_trampoline(uint32_t *code,
                                           uint32_t pc_off,
@@ -689,13 +688,12 @@ static void emit_clock_gettime_trampoline(uint32_t *code,
     /* lsr x7, x6, #ANCHOR_AGE_SHIFT */
     code[21] = enc_cbnz_x(7, svc_fallback_off - 0x54);
     /* cbnz x7, svc_fallback (age cap) */
-    /* delta_ns = (delta * 699050666) >> 24. 699050666 is floor((1e9 << 24)
-     * / 24e6), the mult+shift form Linux's arm64 vDSO uses for CNTFRQ =
-     * 24 MHz; an LSR (~1 cycle) in place of any 64-bit UDIV (~10-22 cycles
-     * on Apple Silicon). Rounding down keeps the trampoline tick slightly
-     * slower than the host so the next reseed never steps time backwards.
-     * The age cap bounds delta < 2^22, so delta * 699050666 < 2^52 -- no
-     * overflow.
+    /* delta_ns = (delta * 699050666) >> 24. 699050666 is floor((1e9 << 24) /
+     * 24e6), the mult+shift form Linux's arm64 vDSO uses for CNTFRQ = 24 MHz;
+     * an LSR (~1 cycle) in place of any 64-bit UDIV (~10-22 cycles on Apple
+     * Silicon). Rounding down keeps the trampoline tick slightly slower than
+     * the host so the next reseed never steps time backwards. The age cap
+     * bounds delta < 2^22, so delta * 699050666 < 2^52 -- no overflow.
      */
     code[22] = enc_movz_x(7, 0xAAAA);
     code[23] = enc_movk_x_lsl16(7, 0x29AA); /* w7 = 699050666     */
@@ -704,14 +702,14 @@ static void emit_clock_gettime_trampoline(uint32_t *code,
     code[26] = enc_add_x(5, 5, 6);          /* nsec += delta_ns   */
     code[27] = enc_movz_x(7, 0xCA00);
     code[28] = enc_movk_x_lsl16(7, 0x3B9A); /* x7 = 1e9           */
-    /* sub-1e9 carry: the age cap guarantees nsec < 2e9, so the /1e9
-     * quotient is always 0 or 1 and SUBS + CSEL + CINC suffices in place
-     * of a UDIV. Sequence:
+    /* sub-1e9 carry: the age cap guarantees nsec < 2e9, so the /1e9 quotient is
+     * always 0 or 1 and SUBS + CSEL + CINC suffices in place of a UDIV.
+     * Sequence:
      *   subs x8, x5, x7       ; x8 = nsec - 1e9, C set iff nsec >= 1e9
      *   csel x5, x8, x5, HS   ; if HS, nsec -= 1e9
      *   cinc x4, x4, HS       ; if HS, sec++
-     * CINC has no direct encoder; emit it as CSINC Xd, Xn, Xn with the
-     * inverted condition (HS -> LO).
+     * CINC has no direct encoder; emit it as CSINC Xd, Xn, Xn with the inverted
+     * condition (HS -> LO).
      */
     code[29] = enc_subs_x(8, 5, 7);
     code[30] = enc_csel_x(5, 8, 5, COND_HS);
@@ -733,13 +731,12 @@ static void emit_clock_gettime_trampoline(uint32_t *code,
 _Static_assert(TEXT_GETTIME_SIZE == 42 * sizeof(uint32_t),
                "clock_gettime trampoline size must match emitter");
 
-/* Emit the CNTVCT fast-path gettimeofday trampoline. Mirrors clock_gettime
- * but always uses the REALTIME anchor and converts the nanosecond residue
- * to microseconds for tv->tv_usec. tz, if non-NULL, gets a single 64-bit
- * store of zero (covers both timezone fields). NULL tv / tz are honored.
- * Uses the same seqlock protocol as clock_gettime, including a DMB ISHLD
- * before the recheck LDAR (see the clock_gettime emitter for the memory-
- * model justification).
+/* Emit the CNTVCT fast-path gettimeofday trampoline. Mirrors clock_gettime but
+ * always uses the REALTIME anchor and converts the nanosecond residue to
+ * microseconds for tv->tv_usec. tz, if non-NULL, gets a single 64-bit store of
+ * zero (covers both timezone fields). NULL tv / tz are honored. Uses the same
+ * seqlock protocol as clock_gettime, including a DMB ISHLD before the recheck
+ * LDAR (see the clock_gettime emitter for the memory- model justification).
  *
  * Layout (40 instructions, 0xA0 bytes):
  *
@@ -844,12 +841,13 @@ static void emit_gettimeofday_trampoline(uint32_t *code,
 _Static_assert(TEXT_GETTOD_SIZE == 40 * sizeof(uint32_t),
                "gettimeofday trampoline size must match emitter");
 
-/* Emit the arithmetic fast-path clock_getres trampoline. Returns {tv_sec=0,
- * tv_nsec=1} for the common high-resolution clockids and SVCs the rest.
- * Supported inline: REALTIME (0), MONOTONIC (1), MONOTONIC_RAW (4),
- * BOOTTIME (7). Coarse clocks (5, 6), CPUTIME clocks (2, 3), and dynamic
- * negative clockids fall through to SVC because their resolution differs
- * from the high-resolution constant or depends on host scheduler state.
+/* Emit the arithmetic fast-path clock_getres trampoline.
+ *
+ * Returns {tv_sec=0, tv_nsec=1} for the common high-resolution clockids and
+ * SVCs the rest. Supported inline: REALTIME (0), MONOTONIC (1), MONOTONIC_RAW
+ * (4), BOOTTIME (7). Coarse clocks (5, 6), CPUTIME clocks (2, 3), and dynamic
+ * negative clockids fall through to SVC because their resolution differs from
+ * the high-resolution constant or depends on host scheduler state.
  *
  * Layout (23 instructions, 0x5C bytes):
  *
@@ -914,9 +912,9 @@ static void emit_clock_getres_trampoline(uint32_t *code,
 _Static_assert(TEXT_GETRES_SIZE == 23 * sizeof(uint32_t),
                "clock_getres trampoline size must match emitter");
 
-/* Emit the arithmetic fast-path getcpu trampoline. elfuse models one
- * online CPU and one NUMA node, so cpu = node = 0 unconditionally; the
- * cache argument is ignored (binfmt/glibc both treat it as obsolete).
+/* Emit the arithmetic fast-path getcpu trampoline. elfuse models one online CPU
+ * and one NUMA node, so cpu = node = 0 unconditionally; the cache argument is
+ * ignored (binfmt/glibc both treat it as obsolete).
  *
  * Layout (13 instructions, 0x34 bytes):
  *
@@ -960,9 +958,9 @@ static void emit_getcpu_trampoline(uint32_t *code,
 _Static_assert(TEXT_GETCPU_SIZE == 13 * sizeof(uint32_t),
                "getcpu trampoline size must match emitter");
 
-/* The public sigret offset declared in core/vdso.h must match the
- * internal layout above; signal.c sets X30 to VDSO_BASE + VDSO_OFF_SIGRET
- * as the return-from-handler target.
+/* The public sigret offset declared in core/vdso.h must match the internal
+ * layout above; signal.c sets X30 to VDSO_BASE + VDSO_OFF_SIGRET as the
+ * return-from-handler target.
  */
 _Static_assert(VDSO_OFF_SIGRET == TEXT_OFF_SIGRET,
                "VDSO_OFF_SIGRET in core/vdso.h must equal TEXT_OFF_SIGRET");
@@ -984,11 +982,11 @@ static uint32_t elf_hash(const char *name)
 uint64_t vdso_build(guest_t *g)
 {
     /* The vDSO page is host-built into the guest backing buffer before any
-     * page-table entry covers it, so route through vdso_host_page which
-     * just bounds-checks against guest_size. The earlier guest_ptr walk
-     * worked by coincidence (the slot happened to be reachable) but tied
-     * host construction to whatever EL0 permission walker state existed
-     * at the time -- a fragile coupling for host-owned memory.
+     * page-table entry covers it, so route through vdso_host_page which just
+     * bounds-checks against guest_size. The earlier guest_ptr walk worked by
+     * coincidence (the slot happened to be reachable) but tied host
+     * construction to whatever EL0 permission walker state existed at the time
+     * -- a fragile coupling for host-owned memory.
      */
     uint8_t *page = vdso_host_page(g);
     if (!page) {
@@ -1028,9 +1026,9 @@ uint64_t vdso_build(guest_t *g)
     _Static_assert(VDSO_OFF_NOTE + VDSO_NOTE_SIZE <= VDSO_OFF_VVAR,
                    "GNU ABI tag note must not encroach on vvar");
 
-    /* NT_GNU_ABI_TAG note. PT_LOAD covers the whole page so the note is
-     * already mapped; PT_NOTE simply tags this offset for the dynamic
-     * linker's vDSO probe.
+    /* NT_GNU_ABI_TAG note. PT_LOAD covers the whole page so the note is already
+     * mapped; PT_NOTE simply tags this offset for the dynamic linker's vDSO
+     * probe.
      */
     elf64_note_gnu_abi_tag_t *note =
         (elf64_note_gnu_abi_tag_t *) (page + VDSO_OFF_NOTE);
@@ -1076,10 +1074,9 @@ uint64_t vdso_build(guest_t *g)
     phdr2->p_memsz = VDSO_NOTE_SIZE;
     phdr2->p_align = 4;
 
-    /* Text trampolines. rt_sigreturn keeps the 12-byte SVC pattern; the
-     * other four entries are fast paths (CNTVCT for clock_gettime /
-     * gettimeofday; arithmetic for clock_getres / getcpu) with their own
-     * svc_fallback tails.
+    /* Text trampolines. rt_sigreturn keeps the 12-byte SVC pattern; the other
+     * four entries are fast paths (CNTVCT for clock_gettime / gettimeofday;
+     * arithmetic for clock_getres / getcpu) with their own svc_fallback tails.
      */
     emit_svc_trampoline((uint32_t *) (page + TEXT_OFF_SIGRET), 139);
     emit_clock_getres_trampoline((uint32_t *) (page + TEXT_OFF_GETRES),
@@ -1091,8 +1088,8 @@ uint64_t vdso_build(guest_t *g)
     emit_getcpu_trampoline((uint32_t *) (page + TEXT_OFF_GETCPU),
                            TEXT_OFF_GETCPU, VDSO_OFF_VVAR);
 
-    /* vvar starts zero (initialized==0). The first __kernel_clock_gettime
-     * SVC fallback will let the host populate the anchor.
+    /* vvar starts zero (initialized==0). The first __kernel_clock_gettime SVC
+     * fallback will let the host populate the anchor.
      */
 
     /* Dynamic string table. */
@@ -1237,11 +1234,11 @@ void vdso_seed_anchor(guest_t *g,
                       int64_t real_sec,
                       int64_t real_nsec)
 {
-    /* Match vdso_attention_or: host-owned vvar writes go through the
-     * direct host_base + VDSO_BASE accessor, not the guest permission
-     * walker. The vDSO is RX to EL0 so guest_ptr_w would silently bail
-     * here; guest_ptr happens to work because it only requires read
-     * perm, but that inconsistency is brittle.
+    /* Match vdso_attention_or: host-owned vvar writes go through the direct
+     * host_base + VDSO_BASE accessor, not the guest permission walker. The vDSO
+     * is RX to EL0 so guest_ptr_w would silently bail here; guest_ptr happens
+     * to work because it only requires read perm, but that inconsistency is
+     * brittle.
      */
     uint8_t *page = vdso_host_page(g);
     if (!page)
@@ -1263,9 +1260,8 @@ void vdso_seed_anchor(guest_t *g,
      *      Pairs with the trampoline's recheck LDAR and vdso_anchor_*'s
      *      acquire loads.
      *
-     * MONO and REAL anchor pairs are written together under the same
-     * generation so a fast-path caller for either clockid sees a
-     * consistent pair.
+     * MONO and REAL anchor pairs are written together under the same generation
+     * so a fast-path caller for either clockid sees a consistent pair.
      */
     uint32_t cur = __atomic_load_n(initialized, __ATOMIC_ACQUIRE);
     if (cur & 1u)
@@ -1277,23 +1273,22 @@ void vdso_seed_anchor(guest_t *g,
                                      __ATOMIC_RELAXED))
         return; /* lost the race against another publisher */
 
-    /* Store-store barrier between the CAS-bump (odd publish) and the
-     * RELAXED field stores. ARMv8 is not multi-copy atomic without
-     * barriers: another CPU could otherwise observe a field store before
-     * the odd seq becomes visible, allowing a reader whose snapshot LDAR
-     * still sees the old even to read mid-write fields and then recheck
-     * with the same old even (snapshot == recheck, race undetected).
-     * __atomic_thread_fence(__ATOMIC_RELEASE) lowers to DMB ISH on
-     * AArch64 and orders the CAS odd-publish ahead of every subsequent
-     * field store from every observer's perspective.
+    /* Store-store barrier between the CAS-bump (odd publish) and the RELAXED
+     * field stores. ARMv8 is not multi-copy atomic without barriers: another
+     * CPU could otherwise observe a field store before the odd seq becomes
+     * visible, allowing a reader whose snapshot LDAR still sees the old even to
+     * read mid-write fields and then recheck with the same old even (snapshot
+     * == recheck, race undetected). __atomic_thread_fence(__ATOMIC_RELEASE)
+     * lowers to DMB ISH on AArch64 and orders the CAS odd-publish ahead of
+     * every subsequent field store from every observer's perspective.
      */
     __atomic_thread_fence(__ATOMIC_RELEASE);
 
-    /* RELAXED atomic stores: the trailing release-store on seq orders all
-     * these field stores before any reader's acquire-load of the next even
-     * seq. Using __atomic_store_n (rather than plain assignment) keeps the
-     * accesses well-defined under the C abstract machine even though the
-     * compiler will lower them to ordinary aligned 64-bit stores.
+    /* RELAXED atomic stores: the trailing release-store on seq orders all these
+     * field stores before any reader's acquire-load of the next even seq. Using
+     * __atomic_store_n (rather than plain assignment) keeps the accesses
+     * well-defined under the C abstract machine even though the compiler will
+     * lower them to ordinary aligned 64-bit stores.
      */
     uint64_t *vvar64 = (uint64_t *) vvar;
     __atomic_store_n(vvar64 + VVAR_OFF_ANCHOR_CNTVCT / 8, guest_cntvct,
@@ -1323,8 +1318,8 @@ uint64_t vdso_gettimeofday_svc_pc(void)
     return VDSO_BASE + VDSO_GETTIMEOFDAY_SVC_PC;
 }
 
-/* Acquire-load the seqlock counter. Pairs with the release store at the
- * tail of vdso_seed_anchor.
+/* Acquire-load the seqlock counter. Pairs with the release store at the tail of
+ * vdso_seed_anchor.
  */
 static uint32_t vvar_seq_acquire(const uint8_t *page)
 {
@@ -1337,9 +1332,9 @@ bool vdso_anchor_is_seeded(guest_t *g)
     uint8_t *page = vdso_host_page(g);
     if (!page)
         return false;
-    /* A seeded-and-stable anchor has seq != 0 && (seq & 1) == 0 (see the
-     * vvar layout block for the state machine). Acquire pairs with the
-     * release store at the tail of vdso_seed_anchor.
+    /* A seeded-and-stable anchor has seq != 0 && (seq & 1) == 0 (see the vvar
+     * layout block for the state machine). Acquire pairs with the release store
+     * at the tail of vdso_seed_anchor.
      */
     uint32_t seq = vvar_seq_acquire(page);
     return seq != 0 && (seq & 1u) == 0;
@@ -1352,10 +1347,10 @@ void vdso_attention_or(guest_t *g, uint32_t bits)
         return;
     uint32_t *attention =
         (uint32_t *) (page + VDSO_OFF_VVAR + VVAR_OFF_ATTENTION);
-    /* SEQ_CST mirrors shim_globals_attn_or: the EL0 fast paths read this
-     * word without going through HVC, so a reader that LDARs attn=0 must
-     * not observe later publish_creds stores. Release-acquire alone only
-     * orders the forward direction.
+    /* SEQ_CST mirrors shim_globals_attn_or: the EL0 fast paths read this word
+     * without going through HVC, so a reader that LDARs attn=0 must not observe
+     * later publish_creds stores. Release-acquire alone only orders the forward
+     * direction.
      */
     __atomic_fetch_or(attention, bits, __ATOMIC_SEQ_CST);
 }
@@ -1377,18 +1372,21 @@ typedef struct {
     int64_t real_sec, real_nsec;
 } vvar_anchor_t;
 
-/* Snapshot the anchor fields under the seqlock. Returns false when the
- * read window straddles a host refresh (seq mismatch, odd, or zero),
- * leaving *out untouched; callers must treat false as "no useful data,
- * skip the staleness check". Returns true with the fields filled when
- * the read landed entirely within one stable generation.
+/* Snapshot the anchor fields under the seqlock.
+ *
+ * Returns false when the read window straddles a host refresh (seq mismatch,
+ * odd, or zero), leaving *out untouched; callers must treat false as "no useful
+ * data, skip the staleness check".
+ *
+ * Returns true with the fields filled when the read landed entirely within one
+ * stable generation.
  *
  * Ordering mirrors the trampoline: acquire-load of seq snapshots the
- * generation, RELAXED atomic loads of fields, then a
- * thread-fence(ACQUIRE) before the recheck so the field loads cannot be
- * reordered past the recheck LDAR. Without the fence an acquire load
- * only orders subsequent ops after itself, not prior ops before itself
- * (the same memory-model corner the trampoline's DMB ISHLD addresses).
+ * generation, RELAXED atomic loads of fields, then a thread-fence(ACQUIRE)
+ * before the recheck so the field loads cannot be reordered past the recheck
+ * LDAR. Without the fence an acquire load only orders subsequent ops after
+ * itself, not prior ops before itself (the same memory-model corner the
+ * trampoline's DMB ISHLD addresses).
  */
 static bool vvar_snapshot_anchor(const uint8_t *page, vvar_anchor_t *out)
 {
@@ -1431,9 +1429,9 @@ bool vdso_anchor_age_exceeded(guest_t *g, uint64_t current_cntvct)
 }
 
 /* Drift threshold for REALTIME anchor invalidation. macOS NTP steps are
- * typically O(ms) to a few seconds. 100 ms is large enough to absorb the
- * noise from sampling host MONO/REAL back-to-back yet small enough that a
- * stepped wall clock is caught on the first SVC after the step.
+ * typically O(ms) to a few seconds. 100 ms is large enough to absorb the noise
+ * from sampling host MONO/REAL back-to-back yet small enough that a stepped
+ * wall clock is caught on the first SVC after the step.
  */
 #define VDSO_ANCHOR_MAX_DRIFT_NS 100000000LL
 
@@ -1451,9 +1449,9 @@ bool vdso_realtime_drift_exceeded(guest_t *g,
     if (current_cntvct < a.cntvct)
         return true;
 
-    /* An anchor past the age cap also needs a refresh, so declare drift
-     * up front. Short-circuiting here also keeps the mult below uint64
-     * even if a caller invokes this helper with a multi-decade delta.
+    /* An anchor past the age cap also needs a refresh, so declare drift up
+     * front. Short-circuiting here also keeps the mult below uint64 even if a
+     * caller invokes this helper with a multi-decade delta.
      */
     uint64_t delta_cycles = current_cntvct - a.cntvct;
     if (delta_cycles >> VDSO_ANCHOR_AGE_SHIFT)
@@ -1467,9 +1465,9 @@ bool vdso_realtime_drift_exceeded(guest_t *g,
     int64_t delta_sec = (int64_t) (delta_ns / 1000000000ULL);
     int64_t delta_nsec = (int64_t) (delta_ns % 1000000000ULL);
 
-    /* anchor_sec is read from the vvar and could in principle be
-     * adversarial. Catch signed overflow on every add/subtract that
-     * mixes it with the freshly-sampled real_sec.
+    /* anchor_sec is read from the vvar and could in principle be adversarial.
+     * Catch signed overflow on every add/subtract that mixes it with the
+     * freshly-sampled real_sec.
      */
     int64_t pred_sec;
     if (__builtin_add_overflow(a.real_sec, delta_sec, &pred_sec))
@@ -1487,8 +1485,8 @@ bool vdso_realtime_drift_exceeded(guest_t *g,
         return true;
     int64_t sec_diff = real_sec - pred_sec;
 
-    /* Saturate against the drift threshold before multiplying by 1e9 so
-     * the final diff_ns multiply cannot overflow int64.
+    /* Saturate against the drift threshold before multiplying by 1e9 so the
+     * final diff_ns multiply cannot overflow int64.
      */
     const int64_t sat_sec = (VDSO_ANCHOR_MAX_DRIFT_NS / 1000000000LL) + 2;
     if (sec_diff > sat_sec || sec_diff < -sat_sec)

--- a/src/core/vdso.h
+++ b/src/core/vdso.h
@@ -20,38 +20,37 @@
 /* Guest address where the vDSO is placed (one 4KiB page, below PT pool) */
 #define VDSO_BASE 0x0000F000ULL
 #define VDSO_SIZE 0x00001000ULL /* 4KiB */
-/* Offset of __kernel_rt_sigreturn (the signal trampoline glibc/musl jumps
- * to via X30/LR after the handler returns). Must match TEXT_OFF_SIGRET in
- * src/core/vdso.c; kept here so signal.c can target it without including
- * the vDSO internals.
+/* Offset of __kernel_rt_sigreturn (the signal trampoline glibc/musl jumps to
+ * via X30/LR after the handler returns). Must match TEXT_OFF_SIGRET in
+ * src/core/vdso.c; kept here so signal.c can target it without including the
+ * vDSO internals.
  */
 #define VDSO_OFF_SIGRET 0x0E0
 
-/* Build a minimal vDSO ELF image at VDSO_BASE in guest memory.
- * The image contains a valid ELF header, one LOAD program header, SHT_DYNSYM
- * and SHT_STRTAB sections, and a __kernel_rt_sigreturn symbol pointing to a
- * small trampoline (mov x8, #139; svc #0).
+/* Build a minimal vDSO ELF image at VDSO_BASE in guest memory. The image
+ * contains a valid ELF header, one LOAD program header, SHT_DYNSYM and
+ * SHT_STRTAB sections, and a __kernel_rt_sigreturn symbol pointing to a small
+ * trampoline (mov x8, #139; svc #0).
  * Returns the GVA of the ELF header (== VDSO_BASE), or 0 on failure.
  */
 uint64_t vdso_build(guest_t *g);
 
-/* Publish a new vvar anchor under the seqlock. Handles both the initial
- * seed (seq 0 -> 1 -> 2) and refresh (seq 2K -> 2K+1 -> 2K+2) atomically
- * through one CAS-then-release-store sequence. Concurrent publishers
- * either lose the CAS or observe an odd seq and bail without blocking;
- * trampoline readers detect mid-write tearing via their own LDAR
- * snapshot/recheck. Callers (sys_clock_gettime / sys_gettimeofday) only
- * need to invoke this when an SVC trap from the vDSO trampoline carries a
- * trustworthy guest CNTVCT in X9.
+/* Publish a new vvar anchor under the seqlock. Handles both the initial seed
+ * (seq 0 -> 1 -> 2) and refresh (seq 2K -> 2K+1 -> 2K+2) atomically through one
+ * CAS-then-release-store sequence. Concurrent publishers either lose the CAS or
+ * observe an odd seq and bail without blocking; trampoline readers detect
+ * mid-write tearing via their own LDAR snapshot/recheck. Callers
+ * (sys_clock_gettime / sys_gettimeofday) only need to invoke this when an SVC
+ * trap from the vDSO trampoline carries a trustworthy guest CNTVCT in X9.
  *
  * Overflow invariant: this function, the trampoline math, and
  * vdso_realtime_drift_exceeded all depend on VDSO_ANCHOR_AGE_SHIFT == 22
- * capping the per-call CNTVCT delta below 2^22. That bound keeps
- * (delta * 699050666) below 2^52 (no uint64 overflow) and keeps
- * anchor_nsec + delta_ns below 2e9 (so the trampoline's sub-1e9 carry
- * collapses to a single SUBS + CSEL + CINC instead of a UDIV). The
- * host-side drift check must apply the same formula and the same cap;
- * any divergence lets the trampoline interpolate from a stale anchor.
+ * capping the per-call CNTVCT delta below 2^22. That bound keeps (delta *
+ * 699050666) below 2^52 (no uint64 overflow) and keeps anchor_nsec + delta_ns
+ * below 2e9 (so the trampoline's sub-1e9 carry collapses to a single SUBS +
+ * CSEL + CINC instead of a UDIV). The host-side drift check must apply the same
+ * formula and the same cap; any divergence lets the trampoline interpolate from
+ * a stale anchor.
  */
 void vdso_seed_anchor(guest_t *g,
                       uint64_t guest_cntvct,
@@ -70,32 +69,32 @@ uint64_t vdso_clock_gettime_svc_pc(void);
 uint64_t vdso_gettimeofday_svc_pc(void);
 
 /* Returns true when the seqlock counter is at a stable (nonzero, even)
- * generation, i.e. the anchor is currently publishable. Uses acquire
- * ordering paired with vdso_seed_anchor's release store of the next
- * even generation. Callers use this to gate the age / drift checks
- * that decide whether to publish a refresh.
+ * generation, i.e. the anchor is currently publishable. Uses acquire ordering
+ * paired with vdso_seed_anchor's release store of the next even generation.
+ * Callers use this to gate the age / drift checks that decide whether to
+ * publish a refresh.
  */
 bool vdso_anchor_is_seeded(guest_t *g);
 
-/* Mirror the shim attention bitmask into the vvar page. The vDSO
- * clock_gettime fast path reads this word and falls back to SVC whenever
- * it is nonzero, preserving the normal post-HVC timer/signal epilogue while
- * guest attention is pending.
+/* Mirror the shim attention bitmask into the vvar page. The vDSO clock_gettime
+ * fast path reads this word and falls back to SVC whenever it is nonzero,
+ * preserving the normal post-HVC timer/signal epilogue while guest attention is
+ * pending.
  */
 void vdso_attention_or(guest_t *g, uint32_t bits);
 void vdso_attention_and(guest_t *g, uint32_t mask);
 
-/* True iff the anchor is currently stable AND (current_cntvct -
- * anchor_cntvct) has exceeded the trampoline's age cap. The host uses
- * this with a freshly-sampled CNTVCT to decide whether to publish a
- * refresh through vdso_seed_anchor.
+/* True iff the anchor is currently stable AND (current_cntvct - anchor_cntvct)
+ * has exceeded the trampoline's age cap. The host uses this with a
+ * freshly-sampled CNTVCT to decide whether to publish a refresh through
+ * vdso_seed_anchor.
  */
 bool vdso_anchor_age_exceeded(guest_t *g, uint64_t current_cntvct);
 
-/* True iff the anchor is seeded AND the wall-clock value predicted from
- * the anchor + CNTVCT delta differs from the supplied freshly-sampled
- * REALTIME (real_sec, real_nsec) by more than VDSO_ANCHOR_MAX_DRIFT_NS.
- * Catches macOS NTP steps that shift wall time without bumping CNTVCT.
+/* True iff the anchor is seeded AND the wall-clock value predicted from the
+ * anchor + CNTVCT delta differs from the supplied freshly-sampled REALTIME
+ * (real_sec, real_nsec) by more than VDSO_ANCHOR_MAX_DRIFT_NS. Catches macOS
+ * NTP steps that shift wall time without bumping CNTVCT.
  */
 bool vdso_realtime_drift_exceeded(guest_t *g,
                                   uint64_t current_cntvct,

--- a/src/debug/crashreport.c
+++ b/src/debug/crashreport.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Prints a structured diagnostic to stderr when elfuse encounters a fatal
- * error. Sections: environment, crash type, binary info, registers,
- * memory layout, and instructions for filing a GitHub issue.
+ * error. Sections: environment, crash type, binary info, registers, memory
+ * layout, and instructions for filing a GitHub issue.
  */
 
 #include <stdio.h>
@@ -66,8 +66,8 @@ static const char *crash_type_name(crash_type_t type)
     return "UNKNOWN";
 }
 
-/* Decode ESR_EL1 exception class (bits [31:26]) to a short label.
- * Values per ARM DDI 0487 (ARMv8-A Architecture Reference Manual).
+/* Decode ESR_EL1 exception class (bits [31:26]) to a short label. Values per
+ * ARM DDI 0487 (ARMv8-A Architecture Reference Manual).
  */
 static const char *esr_ec_name(uint64_t esr)
 {
@@ -130,14 +130,14 @@ static bool esr_is_data_abort(uint64_t esr)
     return ec == 0x24 || ec == 0x25;
 }
 
-/* Walk the guest stage-1 page tables for `va` and print L0/L1/L2/L3 entries
- * in raw form so the crash report localises an "unmapped" claim either to the
- * guest PT (entry is 0 or PT_VALID clear) or to a downstream stage-2 hole.
- * The walker mirrors gva_translate_perm in src/core/guest.c but accepts any
- * PT_VALID descriptor instead of enforcing requested permissions, so a
+/* Walk the guest stage-1 page tables for the supplied VA and print L0/L1/L2/L3
+ * entries in raw form so the crash report localises an "unmapped" claim either
+ * to the guest PT (entry is 0 or PT_VALID clear) or to a downstream stage-2
+ * hole. The walker mirrors gva_translate_perm in src/core/guest.c but accepts
+ * any PT_VALID descriptor instead of enforcing requested permissions, so a
  * non-executable or EL1-only page still prints with its actual contents.
- * Silently skips when g, host_base, or ttbr0 are missing -- the data needed
- * for the dump is gone before the walker can stage anything useful.
+ * Silently skips when g, host_base, or ttbr0 are missing -- the data needed for
+ * the dump is gone before the walker can stage anything useful.
  */
 static bool dump_pt_walk_for_va(const guest_t *g,
                                 uint64_t va,
@@ -237,11 +237,11 @@ static bool dump_pt_walk_for_va(const guest_t *g,
     return true;
 }
 
-/* Print the HVF stage-2 backing range covering `ipa` plus the region-tracker
- * entry whose VA range includes the same address. A missing stage-2 backing is
- * the downstream analogue of an INVALID L3 entry above; a missing region
- * tracker is normal for non-tracked ranges (vDSO, shim) but useful for "is
- * this VA in a known ELF segment" reasoning.
+/* Print the HVF stage-2 backing range covering the supplied IPA plus the
+ * region-tracker entry whose VA range includes the same address. A missing
+ * stage-2 backing is the downstream analogue of an INVALID L3 entry above; a
+ * missing region tracker is normal for non-tracked ranges (vDSO, shim) but
+ * useful for "is this VA in a known ELF segment" reasoning.
  */
 static void dump_segment_and_region_for(const guest_t *g,
                                         uint64_t va,
@@ -363,8 +363,8 @@ void crash_report(hv_vcpu_t vcpu,
     if (sysroot)
         fprintf(stderr, "- sysroot: %s\n", sysroot);
 
-    /* proc_get_cmdline() stores the guest argv vector as a NUL-separated
-     * blob. Re-expand it into shell-like spacing for the human report.
+    /* proc_get_cmdline() stores the guest argv vector as a NUL-separated blob.
+     * Re-expand it into shell-like spacing for the human report.
      */
     if (cmdline && cmdline_len > 0) {
         fprintf(stderr, "- cmdline:");
@@ -392,10 +392,10 @@ void crash_report(hv_vcpu_t vcpu,
         hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_SP_EL0, &sp_el0);
         hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, &tpidr);
 
-        /* The Rosetta breadcrumb has its own section header so
-         * downstream parsers can keep treating "## Registers" as the
-         * first line of the register section. Emitting the banner
-         * inline above that header used to break that assumption.
+        /* The Rosetta breadcrumb has its own section header so downstream
+         * parsers can keep treating "## Registers" as the first line of the
+         * register section. Emitting the banner inline above that header used
+         * to break that assumption.
          */
         if ((g && g->is_rosetta) || proc_rosetta_active()) {
             fprintf(stderr, "## Rosetta\n");
@@ -460,12 +460,12 @@ void crash_report(hv_vcpu_t vcpu,
         fprintf(stderr, "ttbr0       = 0x%llx\n\n",
                 (unsigned long long) g->ttbr0);
 
-        /* Translation diagnostics for the faulting PC. Helps decide whether
-         * an inst-abort or data-abort came from a stage-1 PT entry that went
-         * away (L3 INVALID after an unrelated mprotect / munmap) or from a
-         * stage-2 backing hole (for example, an hvf_segment_split that left no
-         * covering entry). Data aborts also dump FAR when it differs from PC
-         * because FAR is the actual load/store fault address.
+        /* Translation diagnostics for the faulting PC. Helps decide whether an
+         * inst-abort or data-abort came from a stage-1 PT entry that went away
+         * (L3 INVALID after an unrelated mprotect / munmap) or from a stage-2
+         * backing hole (for example, an hvf_segment_split that left no covering
+         * entry). Data aborts also dump FAR when it differs from PC because FAR
+         * is the actual load/store fault address.
          */
         if (vcpu) {
             uint64_t pc = 0, esr = 0, far_reg = 0;

--- a/src/debug/crashreport.h
+++ b/src/debug/crashreport.h
@@ -4,10 +4,10 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * When elfuse encounters a fatal error (timeout, bad exception, unexpected
- * HVC, etc.), crash_report() prints a structured diagnostic to stderr
- * formatted as a GitHub issue template. This gives users all the info
- * they need to file a useful bug report.
+ * When elfuse encounters a fatal error (timeout, bad exception, unexpected HVC,
+ * etc.), crash_report() prints a structured diagnostic to stderr formatted as a
+ * GitHub issue template. This gives users all the info they need to file a
+ * useful bug report.
  */
 
 #pragma once
@@ -28,10 +28,9 @@ typedef enum {
 
 /* Print a structured crash report to stderr.
  *
- * vcpu: vCPU handle for register dump (0 if unavailable).
- * g: guest state for memory layout dump (NULL if unavailable).
- * type: crash classification.
- * detail: human-readable context string (e.g., "HVC #99", "EC=0x20").
+ * vcpu: vCPU handle for register dump (0 if unavailable). g: guest state for
+ * memory layout dump (NULL if unavailable). type: crash classification. detail:
+ * human-readable context string (e.g., "HVC #99", "EC=0x20").
  */
 void crash_report(hv_vcpu_t vcpu,
                   const guest_t *g,

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Implements a minimal GDB RSP server over TCP. When the guest hits a
- * hardware breakpoint/watchpoint or receives Ctrl+C from GDB, all vCPUs stop
- * (all-stop mode) and the stub services register/memory queries.
+ * Implements a minimal GDB RSP server over TCP. When the guest hits a hardware
+ * breakpoint/watchpoint or receives Ctrl+C from GDB, all vCPUs stop (all-stop
+ * mode) and the stub services register/memory queries.
  *
  * Architecture:
  *   - A listener thread accepts one GDB connection at a time
@@ -75,8 +75,8 @@
 #define DBGWCR_LSC_LOAD (0x1 << 3)  /* Read watchpoint */
 #define DBGWCR_LSC_BOTH (0x3 << 3)  /* Access watchpoint */
 
-/* HVF debug register ID lookup tables.
- * The HVF enum values use stride 8 per index:
+/* HVF debug register ID lookup tables. The HVF enum values use stride 8 per
+ * index:
  *   BVR0=0x8004, BCR0=0x8005, BVR1=0x800c, BCR1=0x800d, etc.
  *   WVR0=0x8006, WCR0=0x8007, WVR1=0x800e, WCR1=0x800f, etc.
  */
@@ -193,23 +193,23 @@ static int rsp_reply_error(int errnum)
     return rsp_reply(buf);
 }
 
-/* Read one RSP packet from the client. Strips $...# framing and
- * verifies checksum. Sends + acknowledgment on success.
- * Returns packet length, 0 on EOF, -1 on error.
- * Also handles bare 0x03 (Ctrl+C) by returning "\x03" as a 1-byte packet.
+/* Read one RSP packet from the client. Strips $...# framing and verifies
+ * checksum. Sends + acknowledgment on success.
+ * Returns packet length, 0 on EOF, -1 on error. Also handles bare 0x03 (Ctrl+C)
+ * by returning "\x03" as a 1-byte packet.
  *
- * Uses a static read buffer to batch socket reads instead of reading
- * one byte at a time. Packets exceeding bufsz are rejected with E00.
+ * Uses a static read buffer to batch socket reads instead of reading one byte
+ * at a time. Packets exceeding bufsz are rejected with E00.
  */
 /* Breakpoint / watchpoint management. */
 
-/* BAS (Byte Address Select) for a watchpoint of given length aligned
- * to the watch address modulo 8.
+/* BAS (Byte Address Select) for a watchpoint of given length aligned to the
+ * watch address modulo 8.
  */
 static uint32_t wp_bas_for_len(uint64_t addr, uint64_t len)
 {
-    /* Watchpoint address must be doubleword-aligned in DBGWVR;
-     * BAS selects which bytes within the doubleword to watch.
+    /* Watchpoint address must be doubleword-aligned in DBGWVR; BAS selects
+     * which bytes within the doubleword to watch.
      */
     unsigned offset = (unsigned) (addr & 7);
     uint32_t mask = 0;
@@ -287,9 +287,8 @@ void gdb_stub_sync_debug_regs(hv_vcpu_t vcpu)
     /* Enable debug exceptions to trap to EL2 (host) */
     HV_CHECK(hv_vcpu_set_trap_debug_exceptions(vcpu, true));
 
-    /* MDSCR_EL1: enable monitor debug (MDE, bit 15).
-     * MDE is required for hardware breakpoint/watchpoint exceptions
-     * to fire at EL0.
+    /* MDSCR_EL1: enable monitor debug (MDE, bit 15). MDE is required for
+     * hardware breakpoint/watchpoint exceptions to fire at EL0.
      */
     uint64_t mdscr;
     HV_CHECK(hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_MDSCR_EL1, &mdscr));
@@ -308,8 +307,8 @@ void gdb_stub_sync_debug_regs(hv_vcpu_t vcpu)
                 gdb.breakpoints[i].used = false;
             }
         } else {
-            /* Disable this breakpoint slot (ignore errors for
-             * unsupported hardware indices)
+            /* Disable this breakpoint slot (ignore errors for unsupported
+             * hardware indices)
              */
             (void) hv_vcpu_set_sys_reg(vcpu, dbgbcr_regs[i], 0);
         }
@@ -352,9 +351,11 @@ void gdb_stub_sync_debug_regs(hv_vcpu_t vcpu)
 
 /* Thread helpers. */
 
-/* Find the thread entry for a given guest TID. Returns NULL if not found.
- * This returns thread_entry_t * rather than hv_vcpu_t because a valid HVF
- * vCPU handle can be 0 for the first created vCPU.
+/* Find the thread entry for a given guest TID.
+ *
+ * Returns NULL if not found. This returns thread_entry_t * rather than
+ * hv_vcpu_t because a valid HVF vCPU handle can be 0 for the first created
+ * vCPU.
  */
 static thread_entry_t *find_thread_for_tid(int64_t tid)
 {
@@ -650,8 +651,8 @@ static void handle_thread_alive(const char *pkt)
         rsp_reply_error(1);
 }
 
-/* Handle 'Z'/'z': insert/remove breakpoint or watchpoint.
- * Format: Z/z TYPE,ADDR,KIND
+/* Handle 'Z'/'z': insert/remove breakpoint or watchpoint. Format: Z/z
+ * TYPE,ADDR,KIND
  */
 static void handle_breakpoint(const char *pkt, int insert)
 {
@@ -667,8 +668,8 @@ static void handle_breakpoint(const char *pkt, int insert)
     int rc;
     switch (type) {
     case 0:
-        /* Software breakpoint: for MVP, treat as hardware breakpoint
-         * since hardware support is available and this avoids I-cache issues
+        /* Software breakpoint: for MVP, treat as hardware breakpoint since
+         * hardware support is available and this avoids I-cache issues
          */
         /* fallthrough */
     case 1:
@@ -756,8 +757,8 @@ static void handle_thread_info(int first)
         return;
     }
 
-    /* Build comma-separated hex thread ID list.
-     * Worst case: MAX_THREADS(64) x 17 chars (16 hex + comma) + 1 prefix + NUL.
+    /* Build comma-separated hex thread ID list. Worst case: MAX_THREADS(64) x
+     * 17 chars (16 hex + comma) + 1 prefix + NUL.
      */
     char reply[2048];
     int pos = 0;
@@ -821,8 +822,8 @@ static void handle_vcont(const char *pkt)
 
     /* Set up single-step by placing a temporary hardware breakpoint at PC+4.
      * This covers straight-line instructions; branch-accurate stepping would
-     * require an instruction decoder. GDB can still set explicit breakpoints
-     * at branch targets when it needs that precision.
+     * require an instruction decoder. GDB can still set explicit breakpoints at
+     * branch targets when it needs that precision.
      */
     if (do_step && step_tid > 0) {
         const thread_entry_t *step_t = find_thread_for_tid(step_tid);
@@ -1086,9 +1087,10 @@ static void handle_packet(const char *pkt, int pkt_len)
 
 /* GDB client session. */
 
-/* Main loop for servicing a connected GDB client. Runs on the listener
- * thread. Reads packets and dispatches them. Returns when the client
- * disconnects.
+/* Main loop for servicing a connected GDB client. Runs on the listener thread.
+ * Reads packets and dispatches them.
+ *
+ * Returns when the client disconnects.
  */
 static void gdb_client_session(void)
 {
@@ -1103,8 +1105,8 @@ static void gdb_client_session(void)
     gdb.rsp_ctx = &rsp_ctx;
 
     while (gdb.client_fd >= 0) {
-        /* Wait for either a packet from GDB or a stop event from a vCPU.
-         * Use poll() so the GDB stub can wake up when a thread stops.
+        /* Wait for either a packet from GDB or a stop event from a vCPU. Use
+         * poll() so the GDB stub can wake up when a thread stops.
          */
         struct pollfd pfd = {
             .fd = gdb.client_fd,
@@ -1171,8 +1173,8 @@ static void *listener_thread_fn(void *arg)
         gdb.client_fd = fd;
 
         /* If the GDB stub is in stop-on-entry mode, the main thread is already
-         * blocked in gdb_stub_wait_for_attach(). Wake it up now that
-         * the GDB stub has a client.
+         * blocked in gdb_stub_wait_for_attach(). Wake it up now that the GDB
+         * stub has a client.
          */
         pthread_mutex_lock(&gdb.lock);
         pthread_cond_broadcast(&gdb.stop_cond);
@@ -1282,8 +1284,8 @@ void gdb_stub_wait_for_attach(void)
 
     log_info("Waiting for GDB to attach...");
 
-    /* Snapshot registers before blocking. Runs on the vCPU owner thread
-     * This lets GDB inspect initial register state at entry.
+    /* Snapshot registers before blocking. Runs on the vCPU owner thread This
+     * lets GDB inspect initial register state at entry.
      */
     if (current_thread)
         gdb_snap_vcpu(current_thread);
@@ -1308,15 +1310,15 @@ void gdb_stub_wait_for_attach(void)
 
     pthread_mutex_unlock(&gdb.lock);
 
-    /* Apply any register changes GDB made.
-     * Stop-on-entry is shim-mediated (not TDE), so tde_stop=0.
+    /* Apply any register changes GDB made. Stop-on-entry is shim-mediated (not
+     * TDE), so tde_stop=0.
      */
     if (current_thread && current_thread->gdb_regs_dirty)
         gdb_restore_vcpu(current_thread, 0);
 
-    /* Re-sync debug registers because breakpoints/watchpoints may have been
-     * set by GDB during the initial attach (e.g., step sets a temp bp).
-     * The initial sync in main.c ran before any breakpoints existed.
+    /* Re-sync debug registers because breakpoints/watchpoints may have been set
+     * by GDB during the initial attach (e.g., step sets a temp bp). The initial
+     * sync in main.c ran before any breakpoints existed.
      */
     if (current_thread)
         gdb_stub_sync_debug_regs(current_thread->vcpu);
@@ -1336,23 +1338,23 @@ int gdb_stub_handle_stop(int stop_reason, uint64_t stop_addr)
 
     int64_t my_tid = current_thread ? current_thread->guest_tid : 1;
 
-    /* Snapshot vCPU registers into thread entry. Must happen on the
-     * vCPU's owning thread (HVF requirement). The GDB handler thread
-     * reads/writes this snapshot while the vCPU thread is blocked.
+    /* Snapshot vCPU registers into thread entry. Must happen on the vCPU's
+     * owning thread (HVF requirement). The GDB handler thread reads/writes this
+     * snapshot while the vCPU thread is blocked.
      */
     if (current_thread)
         gdb_snap_vcpu(current_thread);
 
     pthread_mutex_lock(&gdb.lock);
 
-    /* In all-stop mode, only the first stopped thread reports to GDB.
-     * Other stopped threads wait here until GDB resumes the inferior.
+    /* In all-stop mode, only the first stopped thread reports to GDB. Other
+     * stopped threads wait here until GDB resumes the inferior.
      */
     int first_to_stop = !gdb.all_stopped;
 
     if (first_to_stop) {
-        /* Remove temporary breakpoints (must be under lock to avoid
-         * concurrent modification of the breakpoint table).
+        /* Remove temporary breakpoints (must be under lock to avoid concurrent
+         * modification of the breakpoint table).
          */
         bp_remove_temps();
 
@@ -1390,10 +1392,10 @@ int gdb_stub_handle_stop(int stop_reason, uint64_t stop_addr)
     int do_step = gdb.resume_action;
     pthread_mutex_unlock(&gdb.lock);
 
-    /* Apply any register changes GDB made to the snapshot.
-     * TDE debug stops (breakpoint, step, watchpoint) bypassed EL1,
-     * so HV_REG_PC must also be written for the resume to work.
-     * Shim-mediated stops (signals, Ctrl+C) only need ELR_EL1.
+    /* Apply any register changes GDB made to the snapshot. TDE debug stops
+     * (breakpoint, step, watchpoint) bypassed EL1, so HV_REG_PC must also be
+     * written for the resume to work. Shim-mediated stops (signals, Ctrl+C)
+     * only need ELR_EL1.
      */
     int tde =
         (stop_reason == GDB_STOP_BREAKPOINT || stop_reason == GDB_STOP_STEP ||

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -4,10 +4,10 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Implements a GDB RSP stub over TCP so that aarch64-linux-gnu-gdb or
- * LLDB can connect and debug the guest ELF binary running inside elfuse.
- * Uses hardware breakpoints (DBGBVR/DBGBCR) and watchpoints (DBGWVR/
- * DBGWCR) via hv_vcpu_set_trap_debug_exceptions(). All-stop mode.
+ * Implements a GDB RSP stub over TCP so that aarch64-linux-gnu-gdb or LLDB can
+ * connect and debug the guest ELF binary running inside elfuse. Uses hardware
+ * breakpoints (DBGBVR/DBGBCR) and watchpoints (DBGWVR/ DBGWCR) via
+ * hv_vcpu_set_trap_debug_exceptions(). All-stop mode.
  *
  * Supported:
  *   - aarch64 guests only
@@ -34,39 +34,39 @@
 #define GDB_STOP_ENTRY 5 /* stop-on-entry before first instruction */
 
 /* Initialize the GDB stub. Starts a TCP listener on the given port.
- * Returns 0 on success, -1 on failure. Must be called before the
- * vCPU run loop. The stub thread runs in the background and processes
- * GDB packets asynchronously.
+ * Returns 0 on success, -1 on failure. Must be called before the vCPU run loop.
+ * The stub thread runs in the background and processes GDB packets
+ * asynchronously.
  */
 int gdb_stub_init(int port, guest_t *g);
 
-/* Block until a GDB client connects and sends its initial packet.
- * Call this after gdb_stub_init() when --gdb-stop-on-entry is set
- * to halt the guest before the first instruction executes.
+/* Block until a GDB client connects and sends its initial packet. Call this
+ * after gdb_stub_init() when --gdb-stop-on-entry is set to halt the guest
+ * before the first instruction executes.
  */
 void gdb_stub_wait_for_attach(void);
 
 /* Check if the GDB stub is active (initialized and client connected). */
 int gdb_stub_is_active(void);
 
-/* Notify the GDB stub that a debug exception occurred on the current
- * thread's vCPU. The vCPU is already stopped (hv_vcpu_run returned).
- * This blocks the calling thread until GDB resumes it.
+/* Notify the GDB stub that a debug exception occurred on the current thread's
+ * vCPU. The vCPU is already stopped (hv_vcpu_run returned). This blocks the
+ * calling thread until GDB resumes it.
  *
  * ec: exception class from syndrome (0x30=hw bp, 0x32=step, 0x34=wp)
  * Returns: 0 to continue, 1 to single-step next instruction.
  */
 int gdb_stub_handle_stop(int stop_reason, uint64_t stop_addr);
 
-/* Check if GDB has requested all vCPUs to stop (Ctrl+C or breakpoint
- * on another thread). Called from the vCPU loop after HV_EXIT_REASON_CANCELED.
+/* Check if GDB has requested all vCPUs to stop (Ctrl+C or breakpoint on another
+ * thread). Called from the vCPU loop after HV_EXIT_REASON_CANCELED.
  * Returns non-zero if this thread should enter gdb_stub_handle_stop.
  */
 int gdb_stub_stop_requested(void);
 
-/* Program hardware debug registers for a specific vCPU.
- * Called when a thread is about to resume execution. This writes
- * the current breakpoint/watchpoint state to the vCPU's debug regs.
+/* Program hardware debug registers for a specific vCPU. Called when a thread is
+ * about to resume execution. This writes the current breakpoint/watchpoint
+ * state to the vCPU's debug regs.
  */
 void gdb_stub_sync_debug_regs(hv_vcpu_t vcpu);
 

--- a/src/debug/log.h
+++ b/src/debug/log.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Provides leveled logging (TRACE through FATAL) with timestamps, source
- * file:line, optional ANSI color, and thread-safe output.
- * All output goes to stderr.
+ * file:line, optional ANSI color, and thread-safe output. All output goes to
+ * stderr.
  */
 
 #pragma once
@@ -30,14 +30,14 @@ enum log_level {
 #define log_error(...) log_impl(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 #define log_fatal(...) log_impl(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
 
-/* Initialize the logging subsystem. Installs a default pthread-based
- * lock and detects ANSI color support via isatty(STDERR_FILENO).
- * Call once at program startup before any log output.
+/* Initialize the logging subsystem. Installs a default pthread-based lock and
+ * detects ANSI color support via isatty(STDERR_FILENO). Call once at program
+ * startup before any log output.
  */
 void log_init(void);
 
-/* Set the minimum log level. Messages below this level are suppressed.
- * Default after log_init() is LOG_WARN.
+/* Set the minimum log level. Messages below this level are suppressed. Default
+ * after log_init() is LOG_WARN.
  */
 void log_set_level(int level);
 

--- a/src/debug/syscall-hist.c
+++ b/src/debug/syscall-hist.c
@@ -28,9 +28,9 @@
 
 /* Tri-state lifecycle. OFF is the default; RECORD is set by the env-var
  * resolver once it sees "syscalls" or "all"; FROZEN is set when the first
- * execve commits so steady-state traffic does not pollute startup data.
- * Stored as atomic because syscall_hist_enabled is on every dispatch path
- * and syscall_hist_freeze runs on a single vCPU while others may still be
+ * execve commits so steady-state traffic does not pollute startup data. Stored
+ * as atomic because syscall_hist_enabled is on every dispatch path and
+ * syscall_hist_freeze runs on a single vCPU while others may still be
  * recording.
  */
 enum {
@@ -52,30 +52,30 @@ static pthread_once_t hist_init_once = PTHREAD_ONCE_INIT;
  */
 static const char *_Atomic hist_freeze_reason = NULL;
 
-/* Captured at the first record so the dump can report elapsed wall time
- * even when no execve fires. Set atomically; readers only consult after
- * mode transitions to FROZEN or the process is winding down.
+/* Captured at the first record so the dump can report elapsed wall time even
+ * when no execve fires. Set atomically; readers only consult after mode
+ * transitions to FROZEN or the process is winding down.
  */
 static _Atomic uint64_t hist_first_ns = 0;
 
-/* Count of recorders currently inside the update window. Bumped at entry
- * to syscall_hist_record before the mode probe and decremented after the
- * slot updates retire. syscall_hist_dump waits for this to drain to zero
- * after flipping mode to OFF, so a sibling vCPU that already passed the
- * mode probe cannot land its atomic_fetch_add on count / total_ns / max_ns
- * after the dump has read those slots. Without this barrier the dump and
- * a mid-flight recorder race and the dump's totals can silently lose
- * updates or read torn intermediate values.
+/* Count of recorders currently inside the update window. Bumped at entry to
+ * syscall_hist_record before the mode probe and decremented after the slot
+ * updates retire. syscall_hist_dump waits for this to drain to zero after
+ * flipping mode to OFF, so a sibling vCPU that already passed the mode probe
+ * cannot land its atomic_fetch_add on count / total_ns / max_ns after the dump
+ * has read those slots. Without this barrier the dump and a mid-flight recorder
+ * race and the dump's totals can silently lose updates or read torn
+ * intermediate values.
  */
 static _Atomic int hist_active_recorders = 0;
 
 /* Per-syscall counters. Each slot is touched by every vCPU thread, but the
- * atomic-fetch-add pattern keeps updates lock-free and the relaxed memory
- * order is fine because the dump consumes them only after all vCPUs have
- * stopped recording. No false sharing concern at HIST_TABLE_SIZE=512: the
- * working set during dynamic-linker bring-up is dominated by a handful of
- * syscall numbers (openat / mmap / mprotect / fstat / read), so contention
- * already sits on the same cache lines whether we pad or not.
+ * atomic-fetch-add pattern keeps updates lock-free and the relaxed memory order
+ * is fine because the dump consumes them only after all vCPUs have stopped
+ * recording. No false sharing concern at HIST_TABLE_SIZE=512: the working set
+ * during dynamic-linker bring-up is dominated by a handful of syscall numbers
+ * (openat / mmap / mprotect / fstat / read), so contention already sits on the
+ * same cache lines whether we pad or not.
  */
 typedef struct {
     _Atomic uint64_t count;
@@ -85,10 +85,10 @@ typedef struct {
 
 static hist_slot_t hist_table[HIST_TABLE_SIZE];
 
-/* Name table generated from dispatch.tbl: reuse the SYSCALL_TABLE_ENTRIES
- * macro so a new dispatch entry automatically gains a name without touching
- * this file. Entries without a name (unreachable indexes) stay NULL and the
- * dump prints the raw number.
+/* Name table generated from dispatch.tbl: reuse the SYSCALL_TABLE_ENTRIES macro
+ * so a new dispatch entry automatically gains a name without touching this
+ * file. Entries without a name (unreachable indexes) stay NULL and the dump
+ * prints the raw number.
  */
 static const char *const hist_names[HIST_TABLE_SIZE] = {
 #define _(sys_name, sc_handler, extra) [sys_name] = #sys_name,
@@ -98,8 +98,8 @@ static const char *const hist_names[HIST_TABLE_SIZE] = {
 
 /* Parse ELFUSE_STARTUP_TRACE. Accepts comma-separated tokens. "syscalls" or
  * "all" turns the histogram on. The legacy "1" value (steps trace) and the
- * "steps" token leave the histogram off so existing scripts keep working.
- * Token matching is whole-word against a fixed allow-list to avoid matching
+ * "steps" token leave the histogram off so existing scripts keep working. Token
+ * matching is whole-word against a fixed allow-list to avoid matching
  * "syscalls_disabled" or similar.
  */
 static bool env_contains_token(const char *env, const char *tok)
@@ -151,10 +151,10 @@ uint64_t syscall_hist_now_ns(void)
 
 void syscall_hist_record(int nr, uint64_t ns)
 {
-    /* Enter the recording window before the mode probe. The matching
-     * decrement runs on every exit path. syscall_hist_dump waits for the
-     * counter to drain to zero after flipping mode to OFF; that wait is
-     * what guarantees the dump's reads see no further updates.
+    /* Enter the recording window before the mode probe. The matching decrement
+     * runs on every exit path. syscall_hist_dump waits for the counter to drain
+     * to zero after flipping mode to OFF; that wait is what guarantees the
+     * dump's reads see no further updates.
      */
     atomic_fetch_add_explicit(&hist_active_recorders, 1, memory_order_acquire);
     if (atomic_load_explicit(&hist_mode, memory_order_acquire) != HIST_RECORD)
@@ -162,11 +162,10 @@ void syscall_hist_record(int nr, uint64_t ns)
     if (nr < 0 || nr >= HIST_TABLE_SIZE)
         goto leave;
 
-    /* Cheap-load probe before the clock_gettime: hist_first_ns is set
-     * exactly once at the first record, so subsequent records skip the
-     * syscall entirely. Without this gate, every record paid for a
-     * CLOCK_MONOTONIC read whose result was thrown away by the failing
-     * CAS.
+    /* Cheap-load probe before the clock_gettime: hist_first_ns is set exactly
+     * once at the first record, so subsequent records skip the syscall
+     * entirely. Without this gate, every record paid for a CLOCK_MONOTONIC read
+     * whose result was thrown away by the failing CAS.
      */
     if (atomic_load_explicit(&hist_first_ns, memory_order_relaxed) == 0) {
         uint64_t expected = 0;
@@ -179,10 +178,9 @@ void syscall_hist_record(int nr, uint64_t ns)
     atomic_fetch_add_explicit(&slot->count, 1, memory_order_relaxed);
     atomic_fetch_add_explicit(&slot->total_ns, ns, memory_order_relaxed);
 
-    /* CAS-loop max keeps the slot lock-free under contention from sibling
-     * vCPUs racing on the same syscall number. Reads use relaxed order
-     * because the dump only consumes them after the active-recorder count
-     * drains.
+    /* CAS-loop max keeps the slot lock-free under contention from sibling vCPUs
+     * racing on the same syscall number. Reads use relaxed order because the
+     * dump only consumes them after the active-recorder count drains.
      */
     uint64_t prev = atomic_load_explicit(&slot->max_ns, memory_order_relaxed);
     while (ns > prev) {
@@ -197,12 +195,12 @@ leave:
 
 void syscall_hist_freeze(const char *reason)
 {
-    /* Publish the reason BEFORE the state transition so a concurrent dump
-     * that wins the FROZEN -> OFF exchange cannot observe HIST_FROZEN with
-     * a NULL reason and print the wrong dump header. The store on
-     * hist_freeze_reason uses release ordering; the freeze CAS below pairs
-     * with the dump path's acquire load on hist_mode, so any thread that
-     * sees the CAS result also sees the reason that preceded it.
+    /* Publish the reason BEFORE the state transition so a concurrent dump that
+     * wins the FROZEN -> OFF exchange cannot observe HIST_FROZEN with a NULL
+     * reason and print the wrong dump header. The store on hist_freeze_reason
+     * uses release ordering; the freeze CAS below pairs with the dump path's
+     * acquire load on hist_mode, so any thread that sees the CAS result also
+     * sees the reason that preceded it.
      */
     int probe = atomic_load_explicit(&hist_mode, memory_order_acquire);
     if (probe != HIST_RECORD)
@@ -224,8 +222,8 @@ void syscall_hist_disable(void)
     atomic_store_explicit(&hist_mode, HIST_OFF, memory_order_release);
 }
 
-/* Sort key for the dump. Keys carry the slot index so the qsort comparator
- * can resolve names without consulting hist_table again.
+/* Sort key for the dump. Keys carry the slot index so the qsort comparator can
+ * resolve names without consulting hist_table again.
  */
 typedef struct {
     int nr;
@@ -255,8 +253,8 @@ void syscall_hist_dump(void)
     if (mode == HIST_OFF)
         return;
 
-    /* One-shot: flip to OFF so a second call (cleanup from forked child
-     * after the parent already dumped, etc) is a clean no-op.
+    /* One-shot: flip to OFF so a second call (cleanup from forked child after
+     * the parent already dumped, etc) is a clean no-op.
      */
     if (mode == HIST_RECORD) {
         int expected = HIST_RECORD;
@@ -269,20 +267,19 @@ void syscall_hist_dump(void)
     if (prev == HIST_OFF)
         return;
 
-    /* Wait for any in-flight recorders to retire. A sibling vCPU that
-     * already incremented hist_active_recorders and observed the prior
-     * RECORD mode must finish its atomic_fetch_add on the slot before we
-     * read it; otherwise the dump can lose an update or read torn
-     * intermediate values. The spin is bounded by the slowest recorder
-     * (a few hundred ns) and only runs during the one-shot dump.
+    /* Wait for any in-flight recorders to retire. A sibling vCPU that already
+     * incremented hist_active_recorders and observed the prior RECORD mode must
+     * finish its atomic_fetch_add on the slot before we read it; otherwise the
+     * dump can lose an update or read torn intermediate values. The spin is
+     * bounded by the slowest recorder (a few hundred ns) and only runs during
+     * the one-shot dump.
      */
     while (atomic_load_explicit(&hist_active_recorders, memory_order_acquire) >
            0) {
-        /* sched_yield is not portable to relaxed memory models the same
-         * way pause is on x86; on aarch64 macOS the loop iteration cost
-         * is dominated by the atomic load anyway. No need for an explicit
-         * yield -- the spin terminates as soon as the in-flight recorders
-         * retire.
+        /* sched_yield is not portable to relaxed memory models the same way
+         * pause is on x86; on aarch64 macOS the loop iteration cost is
+         * dominated by the atomic load anyway. No need for an explicit yield --
+         * the spin terminates as soon as the in-flight recorders retire.
          */
     }
 
@@ -336,11 +333,11 @@ void syscall_hist_dump(void)
     fprintf(stderr, "total: %llu syscalls, %.3f ms\n",
             (unsigned long long) total_count, (double) total_ns / 1000000.0);
 
-    /* Wall-clock span from the first record to dump time. Lets the
-     * reader compare syscall total against guest wall time and see
-     * what fraction of execution was spent inside syscalls. Only
-     * meaningful when at least one record landed; first_ns is set
-     * exactly once by the first successful record CAS.
+    /* Wall-clock span from the first record to dump time. Lets the reader
+     * compare syscall total against guest wall time and see what fraction of
+     * execution was spent inside syscalls. Only meaningful when at least one
+     * record landed; first_ns is set exactly once by the first successful
+     * record CAS.
      */
     uint64_t first_ns =
         atomic_load_explicit(&hist_first_ns, memory_order_relaxed);

--- a/src/debug/syscall-hist.h
+++ b/src/debug/syscall-hist.h
@@ -6,13 +6,13 @@
  * Per-syscall count + total + max latency, captured during the EL0 syscall
  * storm that dominates dynamic-linker bring-up. Opt-in via
  * ELFUSE_STARTUP_TRACE=syscalls (or =all alongside the existing per-step VM
- * bring-up tracer). Recording stops at the first successful execve so the
- * dump reflects pre-execve startup; without execve it dumps on guest exit.
+ * bring-up tracer). Recording stops at the first successful execve so the dump
+ * reflects pre-execve startup; without execve it dumps on guest exit.
  *
  * Disabled cost is one branch + one global load per syscall_dispatch entry
- * because syscall_hist_enabled() resolves the env once and caches the
- * result. Enabled cost is two CLOCK_MONOTONIC reads per syscall plus three
- * relaxed atomic adds.
+ * because syscall_hist_enabled() resolves the env once and caches the result.
+ * Enabled cost is two CLOCK_MONOTONIC reads per syscall plus three relaxed
+ * atomic adds.
  */
 
 #ifndef ELFUSE_SYSCALL_HIST_H

--- a/src/hvutil.h
+++ b/src/hvutil.h
@@ -13,9 +13,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/* HV_CHECK macro.
- * Abort on HVF API failure. Used for calls that should never fail
- * during normal operation (vCPU register access, VM mapping).
+/* HV_CHECK macro. Abort on HVF API failure. Used for calls that should never
+ * fail during normal operation (vCPU register access, VM mapping).
  */
 #define HV_CHECK(call)                                                   \
     do {                                                                 \
@@ -26,8 +25,8 @@
         }                                                                \
     } while (0)
 
-/* HV_CHECK variant that emits a structured crash report before exit.
- * Use in the vCPU run loop where vcpu and guest_t are available.
+/* HV_CHECK variant that emits a structured crash report before exit. Use in the
+ * vCPU run loop where vcpu and guest_t are available.
  */
 #define HV_CHECK_CTX(call, vcpu, g)                                      \
     do {                                                                 \
@@ -39,9 +38,8 @@
         }                                                                \
     } while (0)
 
-/* SCTLR_EL1 bits.
- * These are needed by main.c (initial setup), runtime/forkipc.c (child MMU
- * enable), and syscall/exec.c (exec MMU re-enable).
+/* SCTLR_EL1 bits. These are needed by main.c (initial setup), runtime/forkipc.c
+ * (child MMU enable), and syscall/exec.c (exec MMU re-enable).
  */
 #define SCTLR_M (1ULL << 0)    /* MMU enable */
 #define SCTLR_C (1ULL << 2)    /* Data cache enable */
@@ -50,10 +48,10 @@
 #define SCTLR_UCT (1ULL << 15) /* EL0 access to CTR_EL0 (cache type) */
 #define SCTLR_UCI (1ULL << 26) /* EL0 cache maintenance (IC IVAU, DC CVA*) */
 
-/* RES1 bits in SCTLR_EL1: these MUST be 1 for correct behavior.
- * Apple Hypervisor.framework returns default SCTLR=0x0, so the setup code must
- * set them explicitly. The hardware eventually auto-updates them, but the
- * initial instruction fetches execute with whatever the setup code wrote.
+/* RES1 bits in SCTLR_EL1: these MUST be 1 for correct behavior. Apple
+ * Hypervisor.framework returns default SCTLR=0x0, so the setup code must set
+ * them explicitly. The hardware eventually auto-updates them, but the initial
+ * instruction fetches execute with whatever the setup code wrote.
  */
 #define SCTLR_RES1                                                   \
     ((1ULL << 29) /* LSMAOE */ | (1ULL << 28) /* nTLSMD */ |         \
@@ -62,9 +60,8 @@
      (1ULL << 11) /* EOS    */ | (1ULL << 8) /* SED    */ |          \
      (1ULL << 7) /* ITD    */)
 
-/* TCR_EL1.
- * 4KiB granule, 48-bit VA, EPD1=1 (TTBR1 walks disabled).
- * Used by main.c (initial setup) and syscall/exec.c (exec re-init).
+/* TCR_EL1. 4KiB granule, 48-bit VA, EPD1=1 (TTBR1 walks disabled). Used by
+ * main.c (initial setup) and syscall/exec.c (exec re-init).
  *
  * The KBUF variant clears EPD1 (TTBR1 walks enabled) and sets TBI1=1 so
  * rosetta's TaggedPointer masking still resolves the kbuf window at the
@@ -75,9 +72,9 @@
 
 /* vCPU register helpers.
  *
- * Thin wrappers around hv_vcpu_{get,set}_reg/sys_reg with internal
- * HV_CHECK. Reduces boilerplate and centralizes error handling.
- * Use these for new code; existing call sites can migrate gradually.
+ * Thin wrappers around hv_vcpu_{get,set}_reg/sys_reg with internal HV_CHECK.
+ * Reduces boilerplate and centralizes error handling. Use these for new code;
+ * existing call sites can migrate gradually.
  */
 
 static inline uint64_t vcpu_get_gpr(hv_vcpu_t vcpu, unsigned n)
@@ -118,8 +115,8 @@ static inline void vcpu_set_sysreg(hv_vcpu_t vcpu,
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, reg, val));
 }
 
-/* Snapshot all 31 GPRs (X0..X30) into out[31].
- * Must be called on the owning thread.
+/* Snapshot all 31 GPRs (X0..X30) into out[31]. Must be called on the owning
+ * thread.
  */
 static inline void vcpu_snapshot_gprs(hv_vcpu_t vcpu, uint64_t out[31])
 {
@@ -127,8 +124,8 @@ static inline void vcpu_snapshot_gprs(hv_vcpu_t vcpu, uint64_t out[31])
         out[i] = vcpu_get_gpr(vcpu, i);
 }
 
-/* Restore all 31 GPRs (X0..X30) from in[31].
- * Must be called on the owning thread.
+/* Restore all 31 GPRs (X0..X30) from in[31]. Must be called on the owning
+ * thread.
  */
 static inline void vcpu_restore_gprs(hv_vcpu_t vcpu, const uint64_t in[31])
 {
@@ -159,8 +156,8 @@ static inline void vcpu_set_simd(hv_vcpu_t vcpu,
 
 /* SIMD/FP state snapshot.
  *
- * Bundles V0-V31 + FPSR + FPCR into a single struct for capture/restore.
- * Used by clone(CLONE_THREAD), clone(CLONE_VM), and IPC fork paths.
+ * Bundles V0-V31 + FPSR + FPCR into a single struct for capture/restore. Used
+ * by clone(CLONE_THREAD), clone(CLONE_VM), and IPC fork paths.
  */
 
 typedef struct {
@@ -168,8 +165,7 @@ typedef struct {
     uint64_t fpsr, fpcr;
 } vcpu_simd_state_t;
 
-/* Snapshot all SIMD/FP state from a vCPU. Must be called on the owning
- * thread.
+/* Snapshot all SIMD/FP state from a vCPU. Must be called on the owning thread.
  */
 static inline void vcpu_snapshot_simd(hv_vcpu_t vcpu, vcpu_simd_state_t *s)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -127,14 +127,16 @@ static void cleanup_main_resources(guest_t *g,
  * few x the current blob) so the rest of the reserve goes to the page-table
  * pool. If the shim ever outgrows the slot it would overlap the shim-data
  * block; fail the build loudly rather than corrupt memory at boot. Enlarge
- * INFRA_SHIM_SLOT (and shrink the pool to match) if this fires. */
+ * INFRA_SHIM_SLOT (and shrink the pool to match) if this fires.
+ */
 _Static_assert(sizeof(shim_bin) <= INFRA_SHIM_SLOT,
                "shim blob exceeds its infra slot; bump INFRA_SHIM_SLOT");
 
 /* The infra-reserve layout invariants documented in guest.h are derived from
  * raw offset constants, so a future edit that grows the pool by shifting one
- * offset without the others would silently overlap two regions. Enforce them
- * at build time rather than trusting the comment. */
+ * offset without the others would silently overlap two regions. Enforce them at
+ * build time rather than trusting the comment.
+ */
 _Static_assert(INFRA_PT_POOL_END_OFF == INFRA_SHIM_OFF,
                "PT pool must end exactly where the shim slot begins");
 _Static_assert(INFRA_SHIM_DATA_OFF + BLOCK_2MIB == INFRA_RESERVE,
@@ -151,12 +153,12 @@ _Static_assert((INFRA_PT_POOL_OFF & 0xFFF) == 0 &&
 /* Verify the host CPU's DC ZVA granule matches the shim's hardcoded value.
  *
  * DCZID_EL0 is readable from EL0 without trapping, so guest libc reads the
- * host's value directly and uses it as the stride for memset(0) loops. The
- * shim emulates each trapped DC ZVA by zeroing exactly 64 bytes
- * (src/core/shim.S). Apple Silicon M1..M4 report DCZID_EL0.BS=4 (64 bytes);
- * any future host that advertises a different granule would cause silent
- * partial-zero corruption of guest memory. Abort here so the mismatch
- * surfaces at startup instead of as data corruption later.
+ * host's value directly and uses it as the stride for memset(0) loops. The shim
+ * emulates each trapped DC ZVA by zeroing exactly 64 bytes (src/core/shim.S).
+ * Apple Silicon M1..M4 report DCZID_EL0.BS=4 (64 bytes); any future host that
+ * advertises a different granule would cause silent partial-zero corruption of
+ * guest memory. Abort here so the mismatch surfaces at startup instead of as
+ * data corruption later.
  */
 static int host_dc_zva_assert(void)
 {
@@ -188,10 +190,10 @@ int main(int argc, char **argv)
     syscall_hist_init();
 
     bool verbose = false;
-    /* x86_64-via-Rosetta is on by default; --no-rosetta or
-     * ELFUSE_NO_ROSETTA=1 disables it. Architecture is auto-detected from
-     * the ELF header in guest_bootstrap_prepare; the access() probe in
-     * rosetta_prepare surfaces an install hint if Rosetta is not present.
+    /* x86_64-via-Rosetta is on by default; --no-rosetta or ELFUSE_NO_ROSETTA=1
+     * disables it. Architecture is auto-detected from the ELF header in
+     * guest_bootstrap_prepare; the access() probe in rosetta_prepare surfaces
+     * an install hint if Rosetta is not present.
      */
     bool rosetta_enabled = true;
     int timeout_sec = 10, fork_child_fd = -1, vfork_notify_fd = -1;
@@ -330,11 +332,11 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* ELFUSE_NO_ROSETTA=1 mirrors --no-rosetta for environments where
-     * passing flags is awkward (test harnesses, wrapper scripts). Unset or
-     * any other value leaves the default on. Commit the result before the
-     * --fork-child early-return so helper processes inherit the parent's
-     * opt-out semantics exactly.
+    /* ELFUSE_NO_ROSETTA=1 mirrors --no-rosetta for environments where passing
+     * flags is awkward (test harnesses, wrapper scripts). Unset or any other
+     * value leaves the default on. Commit the result before the --fork-child
+     * early-return so helper processes inherit the parent's opt-out semantics
+     * exactly.
      */
     if (rosetta_enabled) {
         const char *no_rosetta_env = getenv("ELFUSE_NO_ROSETTA");
@@ -536,16 +538,16 @@ int main(int argc, char **argv)
     gdb_stub_shutdown();
 
     /* Diagnostic counter dump runs before guest_destroy so the shim_data
-     * mapping is still valid. ELFUSE_SHIM_STATS is the gate; an unset
-     * variable produces no output.
+     * mapping is still valid. ELFUSE_SHIM_STATS is the gate; an unset variable
+     * produces no output.
      */
     if (shim_globals_stats_enabled())
         shim_globals_counters_dump(&g);
 
     /* Dump the startup histogram before guest_destroy so any cleanup-path
      * syscalls (closing host fds, unmapping the slab) do not appear in the
-     * captured set. The dump is a no-op when ELFUSE_STARTUP_TRACE=syscalls
-     * was not requested.
+     * captured set. The dump is a no-op when ELFUSE_STARTUP_TRACE=syscalls was
+     * not requested.
      */
     syscall_hist_dump();
     cleanup_main_resources(&g, guest_initialized, &sysroot_mount,

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -37,10 +37,10 @@ int fork_ipc_write_all(int fd, const void *buf, size_t len)
             return -1;
         }
         if (n == 0) {
-            /* Defensive: an unexpected zero return on a blocking socket
-             * would otherwise spin forever, since p and len stay at the
-             * same offset. Treat it as an IO failure so the parent and
-             * child both bail rather than wedge.
+            /* Defensive: an unexpected zero return on a blocking socket would
+             * otherwise spin forever, since p and len stay at the same offset.
+             * Treat it as an IO failure so the parent and child both bail
+             * rather than wedge.
              */
             errno = EIO;
             return -1;
@@ -260,11 +260,11 @@ int fork_ipc_send_fd_table(int ipc_sock)
         if (fd_table[i].type == FD_CLOSED)
             continue;
 
-        /* Synthetic-fd types are filtered here; see fd_type_is_synthetic
-         * in syscall/internal.h for the rationale (kqueue cannot cross
-         * SCM_RIGHTS on macOS, per-class side tables are not serialized).
-         * The child sees these slots as FD_CLOSED and recreates them via
-         * the appropriate syscall.
+        /* Synthetic-fd types are filtered here; see fd_type_is_synthetic in
+         * syscall/internal.h for the rationale (kqueue cannot cross SCM_RIGHTS
+         * on macOS, per-class side tables are not serialized). The child sees
+         * these slots as FD_CLOSED and recreates them via the appropriate
+         * syscall.
          */
         int t = fd_table[i].type;
         if (fd_type_is_synthetic(t))
@@ -400,12 +400,12 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
                    sizeof(fd_table[gfd].proc_path));
             fd_table[gfd].seals = fd_entries[i].seals;
         } else if (fd_type_is_synthetic(fd_entries[i].type)) {
-            /* Defense in depth: the parent's fork_ipc_send_fd_table
-             * already filters synthetic types out of the SCM_RIGHTS
-             * payload (see fd_type_is_synthetic in syscall/internal.h).
-             * If anything still arrives here, drop the inherited host
-             * fd and leave the slot FD_CLOSED so the child must
-             * recreate the fd via the appropriate syscall.
+            /* Defense in depth: the parent's fork_ipc_send_fd_table already
+             * filters synthetic types out of the SCM_RIGHTS payload (see
+             * fd_type_is_synthetic in syscall/internal.h). If anything still
+             * arrives here, drop the inherited host fd and leave the slot
+             * FD_CLOSED so the child must recreate the fd via the appropriate
+             * syscall.
              */
             log_debug(
                 "fork-child: dropping unexpected synthetic-type fd %d (type "

--- a/src/runtime/fork-state.h
+++ b/src/runtime/fork-state.h
@@ -18,12 +18,12 @@
 /* Magic values for IPC frame delimiters */
 #define IPC_MAGIC_HEADER 0x454C464BU   /* "ELFK" */
 #define IPC_MAGIC_SENTINEL 0x454C4F4BU /* "ELOK" */
-/* Bumped to 11 when regions_tracker_stale was added to process state so
- * forked children preserve mprotect fast-path correctness.
+/* Bumped to 11 when regions_tracker_stale was added to process state so forked
+ * children preserve mprotect fast-path correctness.
  *
- * Bumped to 10 when the rosetta placement / kbuf / ttbr1 tuple was added so
- * a rosetta-aware child rejects an older parent's header instead of trying
- * to interpret unknown trailing fields.
+ * Bumped to 10 when the rosetta placement / kbuf / ttbr1 tuple was added so a
+ * rosetta-aware child rejects an older parent's header instead of trying to
+ * interpret unknown trailing fields.
  */
 #define IPC_VERSION 11
 
@@ -46,9 +46,9 @@ typedef struct {
     uint32_t _pad;
     uint64_t absock_namespace_id;
     int64_t sid, pgid;
-    /* Rosetta placement fields. All zero for aarch64 guests; populated when
-     * the parent is_rosetta. The child rebuilds the TTBR1 kbuf tree from the
-     * PT pool that came across in the memory transfer; rosetta_guest_base /
+    /* Rosetta placement fields. All zero for aarch64 guests; populated when the
+     * parent is_rosetta. The child rebuilds the TTBR1 kbuf tree from the PT
+     * pool that came across in the memory transfer; rosetta_guest_base /
      * va_base / size pin the segments at the same primary-buffer location so
      * the non-identity page-table mapping remains coherent across the fork.
      */
@@ -68,10 +68,10 @@ typedef struct {
     uint64_t ttbr0_el1;
     /* TTBR1_EL1 is zero for aarch64 guests and carries the rosetta kbuf
      * page-table root for is_rosetta guests. The parent captures the live
-     * sysreg so a forked child resumes with the same TTBR1 the parent had
-     * after bootstrap_create_vcpu set it; without this the child comes up
-     * with TTBR1=0 even though TCR_EL1.EPD1 is cleared, and the first
-     * kernel-VA access faults.
+     * sysreg so a forked child resumes with the same TTBR1 the parent had after
+     * bootstrap_create_vcpu set it; without this the child comes up with
+     * TTBR1=0 even though TCR_EL1.EPD1 is cleared, and the first kernel-VA
+     * access faults.
      */
     uint64_t ttbr1_el1;
     uint64_t sctlr_el1, tcr_el1, mair_el1, cpacr_el1, tpidr_el0, sp_el1;
@@ -100,12 +100,11 @@ int fork_ipc_send_fd_table(int ipc_sock);
 int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g);
 
 /* Carry the /dev/ptmx keepalive slave fds across the fork boundary. The fd
- * table batch sends master fds without their hidden keepalive companions, so
- * a child that inherits a master would otherwise hit the macOS ENOTTY /
- * winsize-reset cliff that proc_pty_close_keepalive papers over in the
- * parent. send/recv must run AFTER fork_ipc_send_fd_table / _recv_fd_table
- * so the child can look up its new master host fd from the just-installed
- * fd_table entry.
+ * table batch sends master fds without their hidden keepalive companions, so a
+ * child that inherits a master would otherwise hit the macOS ENOTTY /
+ * winsize-reset cliff that proc_pty_close_keepalive papers over in the parent.
+ * send/recv must run AFTER fork_ipc_send_fd_table / _recv_fd_table so the child
+ * can look up its new master host fd from the just-installed fd_table entry.
  */
 int fork_ipc_send_pty_keepalives(int ipc_sock);
 int fork_ipc_recv_pty_keepalives(int ipc_fd);

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -78,8 +78,8 @@ int fork_child_main(int ipc_fd,
 
     /* The startup syscall histogram captures dynamic-linker bring-up of the
      * top-level guest only; the child resumes from the parent's snapshot, so
-     * its first syscalls would be steady-state traffic that confuses the
-     * dump. Disable before any guest syscall is dispatched.
+     * its first syscalls would be steady-state traffic that confuses the dump.
+     * Disable before any guest syscall is dispatched.
      */
     syscall_hist_disable();
 
@@ -122,20 +122,19 @@ int fork_child_main(int ipc_fd,
     proc_set_session(hdr.sid, hdr.pgid);
 
     /* Validate header layout fields before any size-derived arithmetic.
-     * guest_init / guest_init_from_shm derive interp_base, mmap_limit, and
-     * the high-IPA infra reserve from these inputs; underflow on tiny or
-     * malformed values would place pt_pool_base and friends near UINT64_MAX,
-     * which then feeds unchecked host-buffer offsets in pt_alloc_page and
-     * pt_at. Reject impossible layouts up front.
+     * guest_init / guest_init_from_shm derive interp_base, mmap_limit, and the
+     * high-IPA infra reserve from these inputs; underflow on tiny or malformed
+     * values would place pt_pool_base and friends near UINT64_MAX, which then
+     * feeds unchecked host-buffer offsets in pt_alloc_page and pt_at. Reject
+     * impossible layouts up front.
      *
-     * Lower bound: guest_size must leave room for both mmap_limit
-     * (size - 8 GiB) and interp_base (size - 4 GiB) plus the 16 MiB infra
-     * reserve below it. 8 GiB satisfies all three with margin.
-     * Upper bound: guest_size must fit in the negotiated IPA width.
-     * IPA bits: 36 (M1/M2) and 40 (M3+) for native aarch64; 48 for
-     * Rosetta guests, which need the wider Stage-2 width for high VAs
-     * (image at 128 TiB) even though their primary slab stays under
-     * 40-bit. Reject anything outside [36, 48].
+     * Lower bound: guest_size must leave room for both mmap_limit (size - 8
+     * GiB) and interp_base (size - 4 GiB) plus the 16 MiB infra reserve below
+     * it. 8 GiB satisfies all three with margin. Upper bound: guest_size must
+     * fit in the negotiated IPA width. IPA bits: 36 (M1/M2) and 40 (M3+) for
+     * native aarch64; 48 for Rosetta guests, which need the wider Stage-2 width
+     * for high VAs (image at 128 TiB) even though their primary slab stays
+     * under 40-bit. Reject anything outside [36, 48].
      */
     if (hdr.ipa_bits < 36 || hdr.ipa_bits > 48) {
         log_error("fork-child: invalid ipa_bits %u", (unsigned) hdr.ipa_bits);
@@ -156,10 +155,9 @@ int fork_child_main(int ipc_fd,
     guest_t g;
 
     if (hdr.has_shm) {
-        /* CoW fork: receive shm fd via SCM_RIGHTS, then map MAP_PRIVATE.
-         * This gives the child an instant copy-on-write snapshot of the
-         * parent's entire guest memory, with no region enumeration or byte
-         * copying.
+        /* CoW fork: receive shm fd via SCM_RIGHTS, then map MAP_PRIVATE. This
+         * gives the child an instant copy-on-write snapshot of the parent's
+         * entire guest memory, with no region enumeration or byte copying.
          */
         int shm_fd = -1, shm_count = 0;
         if (fork_ipc_recv_fds(ipc_fd, &shm_fd, 1, &shm_count) < 0 ||
@@ -184,14 +182,14 @@ int fork_child_main(int ipc_fd,
     }
 
     /* Restore allocator/page-table cursors before mmap/brk can run in child.
-     * Validate pt_pool_next and ttbr0 against the child's own page-table
-     * pool, which the child just computed from hdr.guest_size +
-     * hdr.ipa_bits via compute_infra_layout.
+     * Validate pt_pool_next and ttbr0 against the child's own page-table pool,
+     * which the child just computed from hdr.guest_size + hdr.ipa_bits via
+     * compute_infra_layout.
      *
      * Range alone is not enough: pt_alloc_page advances pt_pool_next in
-     * GUEST_PAGE_SIZE quanta, and pt_at converts page-table GPAs straight
-     * into host-buffer pointers. An unaligned value passes the [base, end)
-     * gate but then misaligns the walker. Require:
+     * GUEST_PAGE_SIZE quanta, and pt_at converts page-table GPAs straight into
+     * host-buffer pointers. An unaligned value passes the [base, end) gate but
+     * then misaligns the walker. Require:
      *   - pt_pool_next page-aligned relative to pt_pool_base
      *   - ttbr0 strictly inside the in-use pool [pt_pool_base, pt_pool_next)
      *     (parent must have allocated the L0 page) and page-aligned.
@@ -225,10 +223,10 @@ int fork_child_main(int ipc_fd,
     g.mmap_rx_next = hdr.mmap_rx_next;
     g.mmap_rx_end = hdr.mmap_rx_end;
     /* Restore rosetta placement so the non-identity page-table entries that
-     * came across in the memory transfer continue to resolve. ttbr1 points
-     * at the L0 page the parent's PT pool emitted; that page sits inside
-     * the primary buffer and is copied by the region transfer below, so the
-     * child can reuse it without rebuilding the tree.
+     * came across in the memory transfer continue to resolve. ttbr1 points at
+     * the L0 page the parent's PT pool emitted; that page sits inside the
+     * primary buffer and is copied by the region transfer below, so the child
+     * can reuse it without rebuilding the tree.
      */
     g.is_rosetta = (hdr.is_rosetta != 0);
     proc_set_rosetta_active(g.is_rosetta);
@@ -279,9 +277,9 @@ int fork_child_main(int ipc_fd,
 
     /* POSIX: "Signals pending to the parent shall not be pending to the child."
      * Clear pending bitmask and RT queue before applying state.
-     * signal_set_state() is deferred until after thread_register_main()
-     * so that current_thread is non-NULL and per-thread state (blocked mask,
-     * altstack) is properly restored.
+     * signal_set_state() is deferred until after thread_register_main() so that
+     * current_thread is non-NULL and per-thread state (blocked mask, altstack)
+     * is properly restored.
      */
     sig.pending = 0;
     memset(sig.rt_queue, 0, sizeof(sig.rt_queue));
@@ -319,23 +317,22 @@ int fork_child_main(int ipc_fd,
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL1, regs.sp_el1));
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, regs.tpidr_el0));
 
-    /* TPIDR_EL1 is set by the host (never inherited from the parent's
-     * register snapshot) because it must point at the child's own
-     * shim_globals base in the child's IPA; shim_data_base happens to
-     * be the same value in both processes (layout derives from
-     * guest_size + ipa_bits which match across fork), but installing
-     * it explicitly keeps the child consistent with the bootstrap path.
-     * CONTEXTIDR_EL1 holds the per-vCPU tid (== child pid for the
-     * single-threaded child at this point).
+    /* TPIDR_EL1 is set by the host (never inherited from the parent's register
+     * snapshot) because it must point at the child's own shim_globals base in
+     * the child's IPA; shim_data_base happens to be the same value in both
+     * processes (layout derives from guest_size + ipa_bits which match across
+     * fork), but installing it explicitly keeps the child consistent with the
+     * bootstrap path. CONTEXTIDR_EL1 holds the per-vCPU tid (== child pid for
+     * the single-threaded child at this point).
      */
     if (shim_globals_install_per_vcpu(vcpu, &g, hdr.child_pid) < 0) {
         guest_destroy(&g);
         return 1;
     }
 
-    /* Enable MMU directly (page tables already in guest memory from IPC).
-     * SCTLR must include MMU-enable (M), caches (C, I), RES1 bits, and EL0
-     * cache maintenance access (UCI, UCT) for JIT translators.
+    /* Enable MMU directly (page tables already in guest memory from IPC). SCTLR
+     * must include MMU-enable (M), caches (C, I), RES1 bits, and EL0 cache
+     * maintenance access (UCI, UCT) for JIT translators.
      */
     uint64_t sctlr_with_mmu = SCTLR_RES1 | SCTLR_M | SCTLR_C | SCTLR_I |
                               SCTLR_DZE | SCTLR_UCT | SCTLR_UCI;
@@ -351,55 +348,53 @@ int fork_child_main(int ipc_fd,
 
     vcpu_restore_simd(vcpu, &regs.simd_state);
 
-    /* Start at the clone return point in EL0 (not the shim entry).
-     * ELR_EL1 points to the guest's clone return site. SPSR_EL1 has the saved
-     * EL0 state. The child sets PC/CPSR for EL0t execution.
+    /* Start at the clone return point in EL0 (not the shim entry). ELR_EL1
+     * points to the guest's clone return site. SPSR_EL1 has the saved EL0
+     * state. The child sets PC/CPSR for EL0t execution.
      */
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, regs.elr_el1));
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1, regs.spsr_el1));
     HV_CHECK(hv_vcpu_set_reg(vcpu, HV_REG_PC, regs.elr_el1));
     HV_CHECK(hv_vcpu_set_reg(vcpu, HV_REG_CPSR, 0)); /* EL0t */
 
-    /* Register the fork child's main thread in the thread table.
-     * Without this, current_thread is NULL and any syscall handler that
-     * accesses per-thread state (signal masks, ptrace, CLONE_THREAD) will
-     * dereference NULL.
+    /* Register the fork child's main thread in the thread table. Without this,
+     * current_thread is NULL and any syscall handler that accesses per-thread
+     * state (signal masks, ptrace, CLONE_THREAD) will dereference NULL.
      */
     thread_register_main(vcpu, vexit, hdr.child_pid, regs.sp_el1);
 
-    /* Re-publish identity into the child's shim-globals cache: the
-     * CoW / region copy inherits the parent's pid/uid values, and the
-     * shim's identity fast path would otherwise return the parent's
-     * pid to the child. Identity is now committed via the same path
-     * the bootstrap uses.
+    /* Re-publish identity into the child's shim-globals cache: the CoW / region
+     * copy inherits the parent's pid/uid values, and the shim's identity fast
+     * path would otherwise return the parent's pid to the child. Identity is
+     * now committed via the same path the bootstrap uses.
      */
     shim_globals_init(&g);
     shim_globals_publish_stats_gate(&g);
     shim_globals_set_trace_enabled(&g, verbose);
     shim_globals_publish_pid(&g, hdr.child_pid, hdr.parent_pid);
     shim_globals_publish_creds(&g, hdr.uid, hdr.euid, hdr.gid, hdr.egid);
-    /* proc_set_session above committed hdr.pgid/sid into proc-identity;
-     * mirror into the shim cache so the child's getpgid(0)/getsid(0)
-     * fast paths see the inherited session state from the first syscall.
-     * Publish via proc-identity to keep parity with the syscall-time
-     * session_lock ordering even though no sibling vCPU exists at this point.
+    /* proc_set_session above committed hdr.pgid/sid into proc-identity; mirror
+     * into the shim cache so the child's getpgid(0)/getsid(0) fast paths see
+     * the inherited session state from the first syscall. Publish via
+     * proc-identity to keep parity with the syscall-time session_lock ordering
+     * even though no sibling vCPU exists at this point.
      */
     proc_publish_pgsid_snapshot(&g);
-    /* Fresh entropy for the child. Linux's vDSO getrandom epoch-bumps
-     * across fork; here we just re-fill the ring from arc4random_buf
-     * which seeds from the host kernel's RNG, so parent and child do
-     * not share future urandom output.
+    /* Fresh entropy for the child. Linux's vDSO getrandom epoch-bumps across
+     * fork; this path re-fills the ring from arc4random_buf which seeds from
+     * the host kernel's RNG, so parent and child do not share future urandom
+     * output.
      */
     shim_globals_refill_urandom_ring(&g);
-    /* Register the singleton for the child's signal.c so its
-     * attention setters know which guest to update.
+    /* Register the singleton for the child's signal.c so its attention setters
+     * know which guest to update.
      */
     signal_set_shim_globals_guest(&g);
-    /* Same for the fd-table hooks. Must precede any fd_alloc the
-     * child performs (the fd-table-restore step has already run
-     * above, but those slots are populated via direct memcpy of the
-     * parent's entries; subsequent open/dup/close in the child rely
-     * on this registration to keep the bitmap in sync).
+    /* Same for the fd-table hooks. Must precede any fd_alloc the child performs
+     * (the fd-table-restore step has already run above, but those slots are
+     * populated via direct memcpy of the parent's entries; subsequent
+     * open/dup/close in the child rely on this registration to keep the bitmap
+     * in sync).
      */
     shim_globals_set_singleton(&g);
     /* shim_globals_init above zeroed the urandom bitmap. Walk the inherited fd
@@ -435,8 +430,8 @@ int fork_child_main(int ipc_fd,
 #define LINUX_CLONE_CHILD_SETTID 0x01000000
 /* LINUX_SIGCHLD defined in syscall_signal.h (included above) */
 
-/* Namespace flags. elfuse implements no namespace isolation. Both
- * sys_clone and sys_clone3 reject them.
+/* Namespace flags. elfuse implements no namespace isolation. Both sys_clone and
+ * sys_clone3 reject them.
  */
 #define LINUX_CLONE_NEWTIME 0x00000080
 #define LINUX_CLONE_NEWNS 0x00020000
@@ -548,9 +543,9 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_ENOMEM;
     }
 
-    /* Capture parent register state before spawning worker.
-     * HVF binds vCPU to the creating thread, so the worker must call
-     * hv_vcpu_create itself. The parent passes all parent state via the args.
+    /* Capture parent register state before spawning worker. HVF binds vCPU to
+     * the creating thread, so the worker must call hv_vcpu_create itself. The
+     * parent passes all parent state via the args.
      */
     uint64_t parent_elr, parent_spsr, parent_vbar, parent_ttbr0;
     uint64_t parent_sctlr, parent_tcr, parent_mair, parent_cpacr;
@@ -613,8 +608,8 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         t->clear_child_tid = ctid_gva;
     }
 
-    /* CLONE_CHILD_SETTID: write child TID to the child's ctid address.
-     * This writes into shared guest memory (visible to child thread).
+    /* CLONE_CHILD_SETTID: write child TID to the child's ctid address. This
+     * writes into shared guest memory (visible to child thread).
      */
     if (flags & LINUX_CLONE_CHILD_SETTID) {
         int32_t tid32 = (int32_t) child_tid;
@@ -645,8 +640,8 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         pthread_cond_destroy(&startup.cond);
         pthread_mutex_destroy(&startup.lock);
         /* Roll back any SETTID writes done before pthread_create. Same
-         * rationale as the post-handshake failure path: clone(2) does not
-         * leave live-looking TIDs behind for a thread that never started.
+         * rationale as the post-handshake failure path: clone(2) does not leave
+         * live-looking TIDs behind for a thread that never started.
          */
         if (flags & LINUX_CLONE_PARENT_SETTID) {
             int32_t zero = 0;
@@ -668,10 +663,10 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
     pthread_cond_destroy(&startup.cond);
     pthread_mutex_destroy(&startup.lock);
     if (startup.startup_rc < 0) {
-        /* Worker failed during HVF bring-up after the SETTID writes had
-         * already populated the guest TID slots. Linux clone(2) does not
-         * leave a live-looking TID behind for a thread that never started,
-         * so zero the slots before the parent sees the error.
+        /* Worker failed during HVF bring-up after the SETTID writes had already
+         * populated the guest TID slots. Linux clone(2) does not leave a
+         * live-looking TID behind for a thread that never started, so zero the
+         * slots before the parent sees the error.
          */
         pthread_join(host_thread, NULL);
         if (flags & LINUX_CLONE_PARENT_SETTID) {
@@ -744,10 +739,10 @@ static void *thread_create_and_run(void *arg)
     WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TTBR0_EL1, tca->ttbr0));
     WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_CPACR_EL1, tca->cpacr));
 
-    /* All worker vCPUs in the process share the same shim_globals base
-     * (one VM per process); a fresh TPIDR_EL1 set is still required
-     * because HVF created this vCPU empty. CONTEXTIDR_EL1 holds the
-     * per-thread tid that the gettid shim fast path returns.
+    /* All worker vCPUs in the process share the same shim_globals base (one VM
+     * per process); a fresh TPIDR_EL1 set is still required because HVF created
+     * this vCPU empty. CONTEXTIDR_EL1 holds the per-thread tid that the gettid
+     * shim fast path returns.
      */
     if (shim_globals_install_per_vcpu(vcpu, tca->guest, t->guest_tid) < 0)
         goto startup_failed;
@@ -772,11 +767,11 @@ static void *thread_create_and_run(void *arg)
     WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, tca->elr));
     WORKER_HV(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1, tca->spsr));
 
-    /* Copy all 31 GPRs from parent, then set X0=0 (child clone return).
-     * The vcpu_restore_gprs / vcpu_restore_simd helpers in hvutil.h abort
-     * the whole process on failure via HV_CHECK, which would defeat the
-     * handshake rollback. Open-code the restore here so transient HVF
-     * failures fall into the same startup_failed path as the sysreg writes.
+    /* Copy all 31 GPRs from parent, then set X0=0 (child clone return). The
+     * vcpu_restore_gprs / vcpu_restore_simd helpers in hvutil.h abort the whole
+     * process on failure via HV_CHECK, which would defeat the handshake
+     * rollback. Open-code the restore here so transient HVF failures fall into
+     * the same startup_failed path as the sysreg writes.
      */
     for (unsigned i = 0; i < 31; i++)
         WORKER_HV(hv_vcpu_set_reg(vcpu, HV_REG_X0 + i, tca->gprs[i]));
@@ -809,13 +804,13 @@ static void *thread_create_and_run(void *arg)
 
 startup_failed:
     /* HVF sysreg/GPR setup failed after vCPU creation. Drop the thread slot
-     * before tearing the vCPU down: thread_interrupt_all() scans the active
-     * set and calls hv_vcpus_exit() on each t->vcpu without a null check, so
+     * before tearing the vCPU down: thread_interrupt_all() scans the active set
+     * and calls hv_vcpus_exit() on each t->vcpu without a null check, so
      * clearing t->vcpu while the slot is still active would let a concurrent
-     * exit_group hand a zero handle to HVF. Deactivating first removes the
-     * slot from iteration. Then destroy the vCPU on its owning thread (the
-     * only thread allowed to do so), free args, and finally signal the
-     * parent so it observes a fully torn-down state.
+     * exit_group hand a zero handle to HVF. Deactivating first removes the slot
+     * from iteration. Then destroy the vCPU on its owning thread (the only
+     * thread allowed to do so), free args, and finally signal the parent so it
+     * observes a fully torn-down state.
      */
     thread_deactivate(t);
     hv_vcpu_destroy(vcpu);
@@ -840,9 +835,9 @@ startup_ok:;
     if (t->robust_list_head != 0)
         robust_list_walk(g, t);
 
-    /* CLONE_CHILD_CLEARTID: write 0 to the address and wake one waiter.
-     * This is how pthread_join works in musl: the joining thread does
-     * FUTEX_WAIT on this address until it becomes 0.
+    /* CLONE_CHILD_CLEARTID: write 0 to the address and wake one waiter. This is
+     * how pthread_join works in musl: the joining thread does FUTEX_WAIT on
+     * this address until it becomes 0.
      *
      * Drain any deferred munmap of this thread's stack before waking the
      * joiner: the parent may reuse the freed VA as soon as it returns from
@@ -873,8 +868,8 @@ startup_ok:;
 
     /* When all CLONE_THREAD workers have exited and only the main thread
      * remains, interrupt its futex_wait. In real Linux, child exit delivers
-     * SIGCHLD which interrupts futex_wait with -EINTR.
-     * elfuse simulates this through the futex interrupt API.
+     * SIGCHLD which interrupts futex_wait with -EINTR. elfuse simulates this
+     * through the futex interrupt API.
      */
     if (thread_active_count() == 1) {
         log_debug(
@@ -1101,8 +1096,8 @@ static void *vm_clone_thread_run(void *arg)
     int exit_code = vcpu_run_loop(vcpu, vexit, g, verbose, 0);
 
     /* CLONE_CHILD_CLEARTID cleanup. Same ordering as thread_entry: drain
-     * deferred stack munmaps before waking the joiner so the parent does
-     * not reuse the VA before it is released.
+     * deferred stack munmaps before waking the joiner so the parent does not
+     * reuse the VA before it is released.
      */
     bool wake_ctid = false;
     if (t->clear_child_tid != 0) {
@@ -1122,8 +1117,8 @@ static void *vm_clone_thread_run(void *arg)
     if (wake_ctid)
         futex_wake_one(g, t->clear_child_tid);
 
-    /* Mark exit status for parent's wait4 to collect.
-     * vm_exit_status uses wait-format: (exit_code << 8) for normal exit.
+    /* Mark exit status for parent's wait4 to collect. vm_exit_status uses
+     * wait-format: (exit_code << 8) for normal exit.
      */
     pthread_mutex_t *lock = thread_get_lock();
     pthread_mutex_lock(lock);
@@ -1156,31 +1151,32 @@ static void *vm_clone_thread_run(void *arg)
     }
 
     hv_vcpu_destroy(vcpu);
-    /* Keep the slot active until the parent collects status with wait4.
-     * The slot is freed when thread_ptrace_wait reads vm_exited.
+    /* Keep the slot active until the parent collects status with wait4. The
+     * slot is freed when thread_ptrace_wait reads vm_exited.
      */
 
     return NULL;
 }
 
 /* Create an APFS block-level CoW clone of src_fd via fclonefileat (O(metadata),
- * independent of the source once either side writes). Returns the clone fd on
- * success, -1 with errno set on failure (non-APFS /tmp, ENOSYS, ENOSPC, ...).
- * Callers that issue this snapshot are documented at the call site; the helper
- * itself only owns the clone-path lifecycle.
+ * independent of the source once either side writes).
+ *
+ * Returns the clone fd on success, -1 with errno set on failure (non-APFS /tmp,
+ * ENOSYS, ENOSPC, ...). Callers that issue this snapshot are documented at the
+ * call site; the helper itself only owns the clone-path lifecycle.
  */
 static int fork_snapshot_shm_via_clonefile(int src_fd)
 {
     /* fclonefileat needs a destination path on the same APFS volume as the
      * source. /tmp is APFS on every shipped macOS Apple Silicon configuration;
-     * if a user has remapped /tmp to a different filesystem the call fails
-     * and the caller drops back to the legacy path.
+     * if a user has remapped /tmp to a different filesystem the call fails and
+     * the caller drops back to the legacy path.
      *
-     * The destination lives inside a fresh mkdtemp directory (mode 0700) so
-     * no other local user can race to claim the destination basename between
-     * path selection and fclonefileat: an earlier mkstemp + unlink +
-     * fclonefileat sequence left a window where /tmp was world-writable for
-     * that name and a concurrent process could DoS the fast path via EEXIST.
+     * The destination lives inside a fresh mkdtemp directory (mode 0700) so no
+     * other local user can race to claim the destination basename between path
+     * selection and fclonefileat: an earlier mkstemp + unlink + fclonefileat
+     * sequence left a window where /tmp was world-writable for that name and a
+     * concurrent process could DoS the fast path via EEXIST.
      */
     char tmpdir[] = "/tmp/elfuse-fork-XXXXXX";
     if (mkdtemp(tmpdir) == NULL)
@@ -1196,8 +1192,8 @@ static int fork_snapshot_shm_via_clonefile(int src_fd)
     int clone_fd = open(clone_path, O_RDWR | O_CLOEXEC);
     int saved_errno = errno;
     /* Best-effort cleanup: the clone fd alone keeps the inode alive, so any
-     * unlink/rmdir failure here is a directory-leak nuisance, not a
-     * correctness issue. Caller still gets the open fd.
+     * unlink/rmdir failure here is a directory-leak nuisance, not a correctness
+     * issue. Caller still gets the open fd.
      */
     (void) unlink(clone_path);
     (void) rmdir(tmpdir);
@@ -1249,10 +1245,10 @@ int64_t sys_clone(hv_vcpu_t vcpu,
     bool is_vfork = (flags & LINUX_CLONE_VFORK) != 0;
 
     /* CLONE_VM without CLONE_THREAD usually creates an in-process VM-clone
-     * child that shares guest memory and is waitable via wait4/ptrace.
-     * However CLONE_VFORK must go through the helper-process path below so the
-     * child's later execve replaces only the child image rather than resetting
-     * the parent's shared guest_t.
+     * child that shares guest memory and is waitable via wait4/ptrace. However
+     * CLONE_VFORK must go through the helper-process path below so the child's
+     * later execve replaces only the child image rather than resetting the
+     * parent's shared guest_t.
      */
     if ((flags & LINUX_CLONE_VM) && !(flags & LINUX_CLONE_THREAD) &&
         !is_vfork) {
@@ -1291,8 +1287,8 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         return -LINUX_ENOMEM;
     }
 
-    /* The child starts in --fork-child mode and receives the inherited state
-     * on the socket fd.
+    /* The child starts in --fork-child mode and receives the inherited state on
+     * the socket fd.
      */
     char fd_str[32];
     snprintf(fd_str, sizeof(fd_str), "%d", sock_fds[1]);
@@ -1304,10 +1300,10 @@ int64_t sys_clone(hv_vcpu_t vcpu,
     child_argv[ci++] = self_path;
     if (verbose)
         child_argv[ci++] = "--verbose";
-    /* Rosetta is on by default; only propagate the opt-out flag when the
-     * parent explicitly disabled it. The child re-reads ELFUSE_NO_ROSETTA
-     * from the environment too, so an env-based opt-out is preserved
-     * across fork without an explicit argv entry.
+    /* Rosetta is on by default; only propagate the opt-out flag when the parent
+     * explicitly disabled it. The child re-reads ELFUSE_NO_ROSETTA from the
+     * environment too, so an env-based opt-out is preserved across fork without
+     * an explicit argv entry.
      */
     if (!proc_rosetta_enabled())
         child_argv[ci++] = "--no-rosetta";
@@ -1331,8 +1327,8 @@ int64_t sys_clone(hv_vcpu_t vcpu,
     posix_spawnattr_init(&spawn_attr);
     posix_spawnattr_setflags(&spawn_attr, POSIX_SPAWN_CLOEXEC_DEFAULT);
 
-    /* Set up file actions: explicitly inherit only needed FDs.
-     * With CLOEXEC_DEFAULT, everything is closed unless elfuse opts in.
+    /* Set up file actions: explicitly inherit only needed FDs. With
+     * CLOEXEC_DEFAULT, everything is closed unless elfuse opts in.
      */
     posix_spawn_file_actions_t file_actions;
     posix_spawn_file_actions_init(&file_actions);
@@ -1365,8 +1361,8 @@ int64_t sys_clone(hv_vcpu_t vcpu,
     /* The parent keeps only its end of the control channel. Reset the closed
      * write end to -1 so the fail_snapshot guarded close at the bottom of the
      * function cannot double-close it. In a multithreaded guest, another vCPU
-     * could open a new fd between the two closes and get the same number,
-     * which the second close would then steal.
+     * could open a new fd between the two closes and get the same number, which
+     * the second close would then steal.
      */
     close(sock_fds[1]);
     if (vfork_notify_fds[1] >= 0) {
@@ -1380,12 +1376,12 @@ int64_t sys_clone(hv_vcpu_t vcpu,
      */
     int64_t child_guest_pid = proc_alloc_pid();
 
-    /* Quiesce sibling vCPUs for snapshot consistency.
-     * In multithreaded guests, sibling vCPUs may be actively mutating guest
-     * memory during the fork snapshot (CoW or legacy IPC copy).
-     * Without quiescing them, the child process can receive a torn snapshot
-     * with partially-updated data structures. This matches POSIX fork semantics
-     * where only the calling thread survives.
+    /* Quiesce sibling vCPUs for snapshot consistency. In multithreaded guests,
+     * sibling vCPUs may be actively mutating guest memory during the fork
+     * snapshot (CoW or legacy IPC copy). Without quiescing them, the child
+     * process can receive a torn snapshot with partially-updated data
+     * structures. This matches POSIX fork semantics where only the calling
+     * thread survives.
      */
     thread_quiesce_siblings();
 
@@ -1397,14 +1393,13 @@ int64_t sys_clone(hv_vcpu_t vcpu,
      */
     int snapshot_shm_fd = -1;
 
-    /* Convert MAP_SHARED|MAP_ANONYMOUS regions that have no backing fd
-     * into memfd-backed overlay regions. The conversion seeds a private
-     * temp file with the current bytes and installs a host
-     * MAP_SHARED|MAP_FIXED overlay on the parent. The child receives the
-     * fd via SCM_RIGHTS and re-installs its own overlay so subsequent
-     * writes from either side flow through the kernel page cache and
-     * reach the other. File-backed MAP_SHARED regions already carry a
-     * backing fd and are unaffected. Misaligned shared regions
+    /* Convert MAP_SHARED|MAP_ANONYMOUS regions that have no backing fd into
+     * memfd-backed overlay regions. The conversion seeds a private temp file
+     * with the current bytes and installs a host MAP_SHARED|MAP_FIXED overlay
+     * on the parent. The child receives the fd via SCM_RIGHTS and re-installs
+     * its own overlay so subsequent writes from either side flow through the
+     * kernel page cache and reach the other. File-backed MAP_SHARED regions
+     * already carry a backing fd and are unaffected. Misaligned shared regions
      * (snapshot-style) remain incoherent across fork by design.
      */
     if (mmap_fork_prepare_anon_shared(g, &anon_shared_txn) < 0)
@@ -1415,9 +1410,9 @@ int64_t sys_clone(hv_vcpu_t vcpu,
      * MAP_PRIVATE; subsequent writes on either side are private.
      *
      * The parent's own mapping cannot be flipped to MAP_PRIVATE here: hv_vm_map
-     * caches the host VA->PA mapping, and a MAP_FIXED remap invalidates it
-     * (the parent then reads stale memory and writev returns EFAULT). So the
-     * parent stays on MAP_SHARED and the snapshot is what isolates the child.
+     * caches the host VA->PA mapping, and a MAP_FIXED remap invalidates it (the
+     * parent then reads stale memory and writev returns EFAULT). So the parent
+     * stays on MAP_SHARED and the snapshot is what isolates the child.
      *
      * Two snapshot sources, in preference order (selected just below):
      *   1. fclonefileat of g->shm_fd to an independent APFS clone. The clone
@@ -1580,11 +1575,11 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         goto fail_snapshot;
     }
 
-    /* Snapshot the semantic region array before resuming siblings.
-     * Siblings may mmap/munmap/mprotect after resume, so the code needs a
-     * stable copy for the IPC send. Heap-allocated because
-     * GUEST_MAX_REGIONS * sizeof(guest_region_t) exceeds safe
-     * stack limits on worker threads (512KiB default).
+    /* Snapshot the semantic region array before resuming siblings. Siblings may
+     * mmap/munmap/mprotect after resume, so the code needs a stable copy for
+     * the IPC send. Heap-allocated because GUEST_MAX_REGIONS *
+     * sizeof(guest_region_t) exceeds safe stack limits on worker threads
+     * (512KiB default).
      */
     int nregions_snapshot = g->nregions;
     bool regions_tracker_stale_snapshot = g->regions_tracker_stale;
@@ -1607,9 +1602,9 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         goto fail_snapshot;
     }
 
-    /* Must follow fork_ipc_send_fd_table because the keepalive payload
-     * carries a guest_fd that the child resolves through its just-installed
-     * fd_table to recover the child-side master host fd.
+    /* Must follow fork_ipc_send_fd_table because the keepalive payload carries
+     * a guest_fd that the child resolves through its just-installed fd_table to
+     * recover the child-side master host fd.
      */
     if (fork_ipc_send_pty_keepalives(ipc_sock) < 0) {
         log_error("clone: failed to send pty keepalives");
@@ -1635,9 +1630,9 @@ int64_t sys_clone(hv_vcpu_t vcpu,
 
     close(ipc_sock);
 
-    /* After CoW fork, parent stays on MAP_SHARED because no remap was done.
-     * The shm fd is kept open so subsequent forks can also use CoW.
-     * The child has its own MAP_PRIVATE view of the same file.
+    /* After CoW fork, parent stays on MAP_SHARED because no remap was done. The
+     * shm fd is kept open so subsequent forks can also use CoW. The child has
+     * its own MAP_PRIVATE view of the same file.
      */
 
     /* Register after successful IPC so wait4/waitid can observe the child. */
@@ -1679,12 +1674,12 @@ fail_snapshot:
     free(regions_snapshot);
     if (snapshot_shm_fd >= 0)
         close(snapshot_shm_fd);
-    /* Roll back the in-place anon-shared overlay conversion while
-     * siblings are still parked. A partial rollback failure (e.g.,
-     * region drift past the quiesce timeout) leaves the parent in a
-     * mixed state: the originating fork-IPC error is the user-visible
-     * one, but log abort failures so post-mortem can spot the
-     * lingering overlay without grepping for behavioral symptoms.
+    /* Roll back the in-place anon-shared overlay conversion while siblings are
+     * still parked. A partial rollback failure (e.g., region drift past the
+     * quiesce timeout) leaves the parent in a mixed state: the originating
+     * fork-IPC error is the user-visible one, but log abort failures so
+     * post-mortem can spot the lingering overlay without grepping for
+     * behavioral symptoms.
      */
     int abort_rc = mmap_fork_abort_anon_shared(g, &anon_shared_txn);
     if (abort_rc < 0)
@@ -1699,14 +1694,13 @@ fail_snapshot:
     if (vfork_notify_fds[1] >= 0)
         close(vfork_notify_fds[1]);
     /* posix_spawn at the top of sys_clone always succeeds before any goto
-     * fail_snapshot fires, so child_host_pid is a live process here. The
-     * IPC socket just closed; the child reads EOF on fork_ipc_read_all and
-     * returns nonzero from fork_child_main. Without an explicit waitpid the
-     * exited child becomes a zombie: proc_register_child only runs on the
-     * success path, so neither proc_reap_finished nor sys_wait4 will ever
-     * pick this PID up, and the guest's fork(2) already reported failure.
-     * Reap it here to keep host PIDs from accumulating across repeated
-     * failures.
+     * fail_snapshot fires, so child_host_pid is a live process here. The IPC
+     * socket just closed; the child reads EOF on fork_ipc_read_all and returns
+     * nonzero from fork_child_main. Without an explicit waitpid the exited
+     * child becomes a zombie: proc_register_child only runs on the success
+     * path, so neither proc_reap_finished nor sys_wait4 will ever pick this PID
+     * up, and the guest's fork(2) already reported failure. Reap it here to
+     * keep host PIDs from accumulating across repeated failures.
      */
     pid_t reaped;
     do {
@@ -1720,8 +1714,8 @@ fail_snapshot:
 
 /* clone3: extended clone with clone_args struct. */
 
-/* Linux clone_args layout (kernel v5.3+, extensible).
- * Fields beyond the caller-provided size are treated as zero.
+/* Linux clone_args layout (kernel v5.3+, extensible). Fields beyond the
+ * caller-provided size are treated as zero.
  */
 struct linux_clone_args {
     uint64_t flags, pidfd;
@@ -1786,8 +1780,8 @@ int64_t sys_clone3(hv_vcpu_t vcpu,
     if (ca.set_tid_size != 0)
         return -LINUX_EINVAL; /* set_tid not implemented */
 
-    /* Validate exit_signal range (0-64 on Linux).
-     * CLONE_THREAD requires exit_signal == 0 (threads do not signal on exit).
+    /* Validate exit_signal range (0-64 on Linux). CLONE_THREAD requires
+     * exit_signal == 0 (threads do not signal on exit).
      */
     if (ca.exit_signal > 64)
         return -LINUX_EINVAL;
@@ -1800,22 +1794,20 @@ int64_t sys_clone3(hv_vcpu_t vcpu,
     if ((ca.stack == 0) != (ca.stack_size == 0))
         return -LINUX_EINVAL;
 
-    /* Merge exit_signal into flags for sys_clone compatibility.
-     * clone3 moved exit_signal out of the flags field; sys_clone expects
-     * it in the low byte. Safe because validation confirmed ca.flags low byte
-     * is zero.
+    /* Merge exit_signal into flags for sys_clone compatibility. clone3 moved
+     * exit_signal out of the flags field; sys_clone expects it in the low byte.
+     * Safe because validation confirmed ca.flags low byte is zero.
      */
-    /* Strip CLONE_PIDFD before passing to sys_clone (which does not
-     * understand it). Pidfd creation happens after the clone returns.
+    /* Strip CLONE_PIDFD before passing to sys_clone (which does not understand
+     * it). Pidfd creation happens after the clone returns.
      */
     bool want_pidfd = (ca.flags & LINUX_CLONE_PIDFD) != 0;
     uint64_t flags =
         (ca.flags & ~(uint64_t) LINUX_CLONE_PIDFD) | ca.exit_signal;
 
-    /* Compute child stack pointer.
-     * clone: child_stack is the TOP of the stack (SP value).
-     * clone3: stack is the BOTTOM, stack_size is the length.
-     * SP = stack + stack_size (grows downward on aarch64).
+    /* Compute child stack pointer. clone: child_stack is the TOP of the stack
+     * (SP value). clone3: stack is the BOTTOM, stack_size is the length. SP =
+     * stack + stack_size (grows downward on aarch64).
      */
     uint64_t child_stack = 0;
     if (ca.stack != 0) {
@@ -1836,8 +1828,8 @@ int64_t sys_clone3(hv_vcpu_t vcpu,
                             ca.stack + ca.stack_size, ca.parent_tid, ca.tls,
                             ca.child_tid, verbose);
 
-    /* If clone succeeded and CLONE_PIDFD was requested, create a pidfd
-     * for the child and write the guest FD number to ca.pidfd.
+    /* If clone succeeded and CLONE_PIDFD was requested, create a pidfd for the
+     * child and write the guest FD number to ca.pidfd.
      */
     if (ret > 0 && want_pidfd && ca.pidfd != 0) {
         int pfd = pidfd_create(g, ret);

--- a/src/runtime/forkipc.h
+++ b/src/runtime/forkipc.h
@@ -42,8 +42,8 @@ int64_t sys_clone(hv_vcpu_t vcpu,
                   uint64_t ctid_gva,
                   bool verbose);
 
-/* clone3 syscall: extended clone with clone_args struct.
- * Translates clone_args to sys_clone parameters and delegates.
+/* clone3 syscall: extended clone with clone_args struct. Translates clone_args
+ * to sys_clone parameters and delegates.
  * Returns child guest PID to parent, or negative Linux errno.
  */
 int64_t sys_clone3(hv_vcpu_t vcpu,

--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -85,10 +85,9 @@ static _Atomic int futex_interrupt_requested = 0;
  *   0-30: TID of lock holder (0 = unlocked)
  *   31:   FUTEX_WAITERS (at least one thread is blocked)
  *
- * Linux kernel: FUTEX_WAITERS=0x80000000 (bit 31),
- * FUTEX_OWNER_DIED=0x40000000 (bit 30), FUTEX_TID_MASK=0x3FFFFFFF.
- * FUTEX_OWNER_DIED=0x40000000 (bit 30) is set by robust_list_walk
- * on thread exit. FUTEX_TID_MASK is 30 bits.
+ * Linux kernel: FUTEX_WAITERS=0x80000000 (bit 31), FUTEX_OWNER_DIED=0x40000000
+ * (bit 30), FUTEX_TID_MASK=0x3FFFFFFF. FUTEX_OWNER_DIED=0x40000000 (bit 30) is
+ * set by robust_list_walk on thread exit. FUTEX_TID_MASK is 30 bits.
  */
 #define FUTEX_TID_MASK 0x3FFFFFFFU
 #define FUTEX_OWNER_DIED 0x40000000U
@@ -97,21 +96,21 @@ static _Atomic int futex_interrupt_requested = 0;
 /* Address-wait helper state.
  *
  * os_sync_available is set in futex_init() when the runtime supports the
- * os_sync_wait_on_address family (macOS 14.4+). Plain FUTEX_WAIT remains on
- * the bucket path until Darwin can preserve Linux's -EAGAIN race semantics, so
+ * os_sync_wait_on_address family (macOS 14.4+). Plain FUTEX_WAIT remains on the
+ * bucket path until Darwin can preserve Linux's -EAGAIN race semantics, so
  * os_sync_wait_enabled stays false for now and the wake-side helper stays
  * dormant too.
  *
  * The wait quantum is capped at 100 ms so proc_exit_group_requested() and
  * futex_interrupt_pending() get noticed promptly without a process-wide
- * broadcast channel. EINTR is only returned when an actual deliverable
- * signal is queued for this thread (confirmed under sig_lock via
- * signal_pending(), not the atomic hint, so that rt_sigprocmask masking the
- * queued signal cannot leave a stale-true edge behind), or when a guest
- * itimer expires under the poll loop's signal_check_timer poke. Earlier
- * revisions returned -EINTR after one unconditional second of waiting to
- * unblock shutdown-stalled multi-threaded runtimes, but that broke POSIX
- * sem_wait callers that do not retry on EINTR (e.g. foot's render worker).
+ * broadcast channel. EINTR is only returned when an actual deliverable signal
+ * is queued for this thread (confirmed under sig_lock via signal_pending(), not
+ * the atomic hint, so that rt_sigprocmask masking the queued signal cannot
+ * leave a stale-true edge behind), or when a guest itimer expires under the
+ * poll loop's signal_check_timer poke. Earlier revisions returned -EINTR after
+ * one unconditional second of waiting to unblock shutdown-stalled
+ * multi-threaded runtimes, but that broke POSIX sem_wait callers that do not
+ * retry on EINTR (e.g. foot's render worker).
  */
 #if ELFUSE_HAVE_OS_SYNC_WAIT_ON_ADDRESS
 static bool os_sync_available;
@@ -154,8 +153,8 @@ static void futex_waiter_notify_group(futex_waiter_t *w)
     pthread_mutex_unlock(w->group_lock);
 }
 
-/* One bucket in the hash table. Protected by its own mutex.
- * Lock order: 7 (leaf locks, index-ordered when two acquired).
+/* One bucket in the hash table. Protected by its own mutex. Lock order: 7 (leaf
+ * locks, index-ordered when two acquired).
  */
 typedef struct {
     pthread_mutex_t lock;
@@ -179,8 +178,8 @@ static inline bool futex_uaddr_is_aligned(uint64_t uaddr)
 }
 
 /* Unlink a waiter from its bucket's singly-linked list. Caller must hold
- * b->lock. Silently returns if the waiter is not in the list (already
- * unlinked by a wake/requeue).
+ * b->lock. Silently returns if the waiter is not in the list (already unlinked
+ * by a wake/requeue).
  */
 static void bucket_unlink_locked(futex_bucket_t *b, const futex_waiter_t *w)
 {
@@ -227,8 +226,8 @@ int futex_interrupt_pending(void)
  * next blocking wait, mirroring how real Linux delivers SIGCHLD. Without the
  * clear, the flag stays set and every subsequent epoll_pwait, ppoll, futex
  * wait, etc. spins on EINTR until execve clears it -- in foot's case it never
- * does, and the spinning main thread eventually faults in a code path the
- * guest never expects to reach.
+ * does, and the spinning main thread eventually faults in a code path the guest
+ * never expects to reach.
  */
 int futex_interrupt_consume(void)
 {
@@ -242,10 +241,10 @@ int futex_interrupt_consume(void)
  * delta_sec = lts.tv_sec - mono.tv_sec) cannot overflow even for adversarial
  * inputs. INT64_MAX / 4 leaves four-way headroom for any pairwise sum or
  * difference and still allows absolute CLOCK_REALTIME deadlines billions of
- * years into the future, which comfortably covers the year-2038/2106
- * envelope. Linux saturates at KTIME_MAX (INT64_MAX ns ~ 292 years) on
- * conversion to ktime_t; this code stays in struct timespec so it does not
- * need that conversion, only the cap.
+ * years into the future, which comfortably covers the year-2038/2106 envelope.
+ * Linux saturates at KTIME_MAX (INT64_MAX ns ~ 292 years) on conversion to
+ * ktime_t; this code stays in struct timespec so it does not need that
+ * conversion, only the cap.
  */
 #define FUTEX_TIMESPEC_SEC_MAX (INT64_MAX / 4)
 
@@ -255,9 +254,9 @@ static int linux_timespec_is_valid(const linux_timespec_t *lts)
            lts->tv_nsec >= 0 && lts->tv_nsec < 1000000000L;
 }
 
-/* Convert a Linux guest timespec to an absolute struct timespec deadline.
- * For FUTEX_WAIT (relative timeout), adds the duration to the current time.
- * For FUTEX_WAIT_BITSET (absolute timeout), uses the value directly.
+/* Convert a Linux guest timespec to an absolute struct timespec deadline. For
+ * FUTEX_WAIT (relative timeout), adds the duration to the current time. For
+ * FUTEX_WAIT_BITSET (absolute timeout), uses the value directly.
  * Returns 0 on success, -1 if the guest pointer is invalid, -2 if the guest
  * timespec is malformed.
  */
@@ -324,8 +323,8 @@ static uint64_t futex_remaining_ns(const struct timespec *deadline,
         return 0;
     if (delta_sec >= 1)
         return cap_ns;
-    /* delta_sec == 0 and delta_nsec > 0; the borrow above guarantees
-     * delta_nsec < NSEC_PER_SEC.
+    /* delta_sec == 0 and delta_nsec > 0; the borrow above guarantees delta_nsec
+     * < NSEC_PER_SEC.
      */
     uint64_t rem = (uint64_t) delta_nsec;
     return rem < cap_ns ? rem : cap_ns;
@@ -516,8 +515,8 @@ static int64_t futex_wait(guest_t *g,
 
     pthread_mutex_lock(&b->lock);
 
-    /* Atomically read the futex word while holding the bucket lock.
-     * If it does not match, return EAGAIN immediately.
+    /* Atomically read the futex word while holding the bucket lock. If it does
+     * not match, return EAGAIN immediately.
      */
     uint32_t *word = (uint32_t *) guest_ptr(g, uaddr);
     if (!word) {
@@ -570,10 +569,10 @@ static int64_t futex_wait(guest_t *g,
         /* Lock-order: bucket lock(7) outranks sig_lock(4), so signal_pending()
          * and signal_check_timer() may only be called once the bucket lock has
          * been released. Drop it, poke the itimers, observe queued signals
-         * under sig_lock (the slow-path confirm avoids the stale-true edge
-         * that the atomic hint can carry after rt_sigprocmask masks the
-         * queued signal), then re-acquire and re-check waiter.woken in case
-         * a wake landed in the window.
+         * under sig_lock (the slow-path confirm avoids the stale-true edge that
+         * the atomic hint can carry after rt_sigprocmask masks the queued
+         * signal), then re-acquire and re-check waiter.woken in case a wake
+         * landed in the window.
          */
         pthread_mutex_unlock(&b->lock);
         signal_check_timer();
@@ -583,10 +582,10 @@ static int64_t futex_wait(guest_t *g,
         if (__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE))
             break;
 
-        /* Return EINTR only when a real deliverable signal is queued for
-         * this thread. POSIX callers (e.g. glibc sem_wait, foot's render
-         * worker) often do not retry on EINTR, so synthetic spurious
-         * wakeups cannot be issued here.
+        /* Return EINTR only when a real deliverable signal is queued for this
+         * thread. POSIX callers (e.g. glibc sem_wait, foot's render worker)
+         * often do not retry on EINTR, so synthetic spurious wakeups cannot be
+         * issued here.
          */
         if (sig_ready) {
             ret = -LINUX_EINTR;
@@ -638,9 +637,9 @@ static int64_t futex_wait(guest_t *g,
     return ret;
 }
 
-/* FUTEX_WAKE / FUTEX_WAKE_BITSET: wake up to val waiters at uaddr.
- * Woken waiters are unlinked from the bucket list so subsequent operations do
- * not count them as still-sleeping entries.
+/* FUTEX_WAKE / FUTEX_WAKE_BITSET: wake up to val waiters at uaddr. Woken
+ * waiters are unlinked from the bucket list so subsequent operations do not
+ * count them as still-sleeping entries.
  *
  * If the Darwin address-wait path is ever enabled again, drain any kernel-side
  * waiters at the same address up to the remaining budget so a wake site that
@@ -792,13 +791,13 @@ static int64_t futex_requeue(guest_t *g,
     /* If the Darwin address-wait path is enabled again, drain the remaining
      * wake + requeue budget against kernel-side waiters at uaddr. The kernel
      * API has no facility for migrating waiters between addresses, so the
-     * requeue portion degrades into a wake at uaddr: waiters return to
-     * userland and either re-acquire what they actually need (typically the
-     * mutex pthread_cond_broadcast wanted to requeue onto) or re-wait.
-     * Widen the cap to uint64_t before adding so INT_MAX + INT_MAX fits,
-     * then clamp to UINT32_MAX inside futex_os_sync_wake_n; this preserves
-     * the INT_MAX "wake all" sentinel without overflowing the syscall return
-     * contract (woken + requeued must not exceed wake_count + requeue_count).
+     * requeue portion degrades into a wake at uaddr: waiters return to userland
+     * and either re-acquire what they actually need (typically the mutex
+     * pthread_cond_broadcast wanted to requeue onto) or re-wait. Widen the cap
+     * to uint64_t before adding so INT_MAX + INT_MAX fits, then clamp to
+     * UINT32_MAX inside futex_os_sync_wake_n; this preserves the INT_MAX "wake
+     * all" sentinel without overflowing the syscall return contract (woken +
+     * requeued must not exceed wake_count + requeue_count).
      */
     uint64_t remaining_wake = (uint64_t) wake_count - (uint64_t) woken;
     uint64_t remaining_requeue = (uint64_t) requeue_count - (uint64_t) requeued;
@@ -811,9 +810,9 @@ static int64_t futex_requeue(guest_t *g,
 /* FUTEX_WAKE_OP: atomically modify *uaddr2, wake val waiters at uaddr, then
  * conditionally wake val2 waiters at uaddr2 based on the old value.
  *
- * The op argument encodes: operation on *uaddr2 and comparison predicate.
- * Used by glibc's pthread_cond_signal; musl does NOT use this, but futex
- * emulation implements it for compatibility with glibc-linked binaries.
+ * The op argument encodes: operation on *uaddr2 and comparison predicate. Used
+ * by glibc's pthread_cond_signal; musl does NOT use this, but futex emulation
+ * implements it for compatibility with glibc-linked binaries.
  *
  * val3 encodes both the operation and comparison:
  *   bits 28-31: op code (SET=0, ADD=1, OR=2, ANDN=3, XOR=4)
@@ -847,13 +846,12 @@ static int64_t futex_wake_op(guest_t *g,
         pthread_mutex_lock(&b1->lock);
     }
 
-    /* Decode operation and comparison from val3.
-     * Bits 31-28: operation (bit 31 = OPARG_SHIFT flag, bits 30-28 = op)
-     * Bits 27-24: comparison operator
-     * Bits 23-12: op_arg (operand for modify, 12-bit signed)
-     * Bits 11-0:  cmp_arg (operand for compare, 12-bit signed)
-     * Both op_arg and cmp_arg are sign-extended from 12 bits to match
-     * the Linux kernel's sign_extend32() in futex_atomic_op_inuser().
+    /* Decode operation and comparison from val3. Bits 31-28: operation (bit 31
+     * = OPARG_SHIFT flag, bits 30-28 = op) Bits 27-24: comparison operator Bits
+     * 23-12: op_arg (operand for modify, 12-bit signed) Bits 11-0: cmp_arg
+     * (operand for compare, 12-bit signed) Both op_arg and cmp_arg are
+     * sign-extended from 12 bits to match the Linux kernel's sign_extend32() in
+     * futex_atomic_op_inuser().
      */
     unsigned wake_op = (val3 >> 28) & 0xF;
     unsigned wake_cmp = (val3 >> 24) & 0xF;
@@ -877,9 +875,9 @@ static int64_t futex_wake_op(guest_t *g,
         return -LINUX_EFAULT;
     }
 
-    /* Atomic read-modify-write on *uaddr2 using CAS loop.
-     * Matches Linux kernel's futex_atomic_op_inuser() semantics:
-     * the modification must be atomic w.r.t. concurrent guest stores.
+    /* Atomic read-modify-write on *uaddr2 using CAS loop. Matches Linux
+     * kernel's futex_atomic_op_inuser() semantics: the modification must be
+     * atomic w.r.t. concurrent guest stores.
      */
     uint32_t old_val, new_val;
     do {
@@ -1152,8 +1150,8 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
                     return -LINUX_ETIMEDOUT;
                 }
             } else {
-                /* No timeout: poll every 100ms to check exit_group
-                 * and dead lock owners.
+                /* No timeout: poll every 100ms to check exit_group and dead
+                 * lock owners.
                  */
                 struct timespec poll_ts;
                 timespec_deadline_in_ms(&poll_ts, 100);
@@ -1168,9 +1166,9 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
                 }
 
                 /* Check if the owner thread has died while the waiter was
-                 * waiting. If so, clear the lock and retry.
-                 * Use thread_tid_alive (lock-free) instead of thread_find to
-                 * avoid lock order inversion: bucket lock(7) is held here, and
+                 * waiting. If so, clear the lock and retry. Use
+                 * thread_tid_alive (lock-free) instead of thread_find to avoid
+                 * lock order inversion: bucket lock(7) is held here, and
                  * thread_find acquires thread_lock(5).
                  */
                 uint32_t check = __atomic_load_n(word, __ATOMIC_SEQ_CST);
@@ -1211,8 +1209,8 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
     }
 }
 
-/* FUTEX_TRYLOCK_PI: Non-blocking version of LOCK_PI.
- * CAS 0 -> TID; if the lock is held, return -EAGAIN immediately.
+/* FUTEX_TRYLOCK_PI: Non-blocking version of LOCK_PI. CAS 0 -> TID; if the lock
+ * is held, return -EAGAIN immediately.
  */
 static int64_t futex_trylock_pi(guest_t *g, uint64_t uaddr)
 {
@@ -1239,8 +1237,8 @@ static int64_t futex_trylock_pi(guest_t *g, uint64_t uaddr)
 /* FUTEX_UNLOCK_PI: Release the PI lock at uaddr and wake one waiter.
  *
  * Called by the lock owner when FUTEX_WAITERS is set (slow unlock path).
- * Atomically clear the word to 0 (releasing the lock + clearing WAITERS),
- * then wake one blocked waiter so it can retry CAS(0->TID) acquisition.
+ * Atomically clear the word to 0 (releasing the lock + clearing WAITERS), then
+ * wake one blocked waiter so it can retry CAS(0->TID) acquisition.
  */
 static int64_t futex_unlock_pi(guest_t *g, uint64_t uaddr)
 {
@@ -1259,8 +1257,8 @@ static int64_t futex_unlock_pi(guest_t *g, uint64_t uaddr)
     if ((cur & FUTEX_TID_MASK) != tid)
         return -LINUX_EPERM;
 
-    /* Atomically release: set word to 0 (clear TID + WAITERS flag).
-     * Use CAS loop in case another thread is concurrently setting WAITERS.
+    /* Atomically release: set word to 0 (clear TID + WAITERS flag). Use CAS
+     * loop in case another thread is concurrently setting WAITERS.
      */
     for (;;) {
         uint32_t v = __atomic_load_n(word, __ATOMIC_SEQ_CST);
@@ -1361,18 +1359,17 @@ int futex_wake_one(guest_t *g, uint64_t uaddr)
 
 /* Unlink a waiter from whichever bucket it currently sits in, with retry on
  * concurrent requeue. The waiter's struct lives on the calling thread's stack;
- * leaving a dangling reference behind is a real host-safety bug because a
- * later wake at the new uaddr would dereference it. The regular futex_wait
+ * leaving a dangling reference behind is a real host-safety bug because a later
+ * wake at the new uaddr would dereference it. The regular futex_wait
  * self-dequeue path handles the same race the same way.
  *
  * Termination: on each iteration we either find w in the bucket (unlink and
- * return), or observe w->woken==1 under the bucket lock (the wake path
- * unlinks before storing woken with RELEASE under the bucket lock; once we
- * acquire that bucket lock we synchronize with it), or determine w was
- * requeued elsewhere (re-hash and retry). Forward progress is guaranteed
- * because every requeue and every wake also holds bucket locks, so once we
- * take the lock for the bucket that hashes w's current uaddr, no concurrent
- * mover can step around us.
+ * return), or observe w->woken==1 under the bucket lock (the wake path unlinks
+ * before storing woken with RELEASE under the bucket lock; once we acquire that
+ * bucket lock we synchronize with it), or determine w was requeued elsewhere
+ * (re-hash and retry). Forward progress is guaranteed because every requeue and
+ * every wake also holds bucket locks, so once we take the lock for the bucket
+ * that hashes w's current uaddr, no concurrent mover can step around us.
  */
 static void waitv_unlink(futex_waiter_t *w)
 {
@@ -1394,8 +1391,8 @@ static void waitv_unlink(futex_waiter_t *w)
         pthread_mutex_unlock(&b->lock);
         if (found || was_woken)
             return;
-        /* w must have been requeued to another bucket while we hashed.
-         * Re-read uaddr and try again.
+        /* w must have been requeued to another bucket while we hashed. Re-read
+         * uaddr and try again.
          */
     }
 }
@@ -1599,10 +1596,10 @@ int64_t sys_futex_waitv(guest_t *g,
     for (int i = nbuckets - 1; i >= 0; i--)
         pthread_mutex_unlock(&bucket_ptrs[i]->lock);
 
-    /* All enqueued. Block on shared.cond until any wake site signals it.
-     * The bounded sleep (capped at 500ms or the user deadline, whichever is
-     * sooner) gives proc_exit_group_requested() and timeout checks a chance to
-     * run if the cond_signal never arrives.
+    /* All enqueued. Block on shared.cond until any wake site signals it. The
+     * bounded sleep (capped at 500ms or the user deadline, whichever is sooner)
+     * gives proc_exit_group_requested() and timeout checks a chance to run if
+     * the cond_signal never arrives.
      */
     int result_idx = -1;
     pthread_mutex_lock(&shared.lock);
@@ -1720,28 +1717,28 @@ void robust_list_walk(guest_t *g, thread_entry_t *t)
     int64_t futex_offset = (int64_t) head[1];
     uint64_t pending = head[2]; /* list_op_pending */
 
-    /* The head of the list is at &head->list (which is head_gva itself).
-     * Walk entries until the walk loops back to the head pointer.
+    /* The head of the list is at &head->list (which is head_gva itself). Walk
+     * entries until the walk loops back to the head pointer.
      */
     uint64_t head_entry = head_gva; /* address of head->list field */
     int count = 0;
 
     while (list_ptr != head_entry && count < ROBUST_LIST_LIMIT) {
-        /* The futex word is at list_ptr + futex_offset.
-         * Use unsigned add to avoid signed overflow UB; skip entries where the
-         * result wraps past the guest address space.
+        /* The futex word is at list_ptr + futex_offset. Use unsigned add to
+         * avoid signed overflow UB; skip entries where the result wraps past
+         * the guest address space.
          */
         uint64_t futex_gva;
         if (futex_offset >= 0)
             futex_gva = list_ptr + (uint64_t) futex_offset;
         else
             futex_gva = list_ptr - (uint64_t) (-futex_offset);
-        /* Canonical user-VA range check (bits 47:0). Anything with bit 63
-         * set is kernel-VA territory and is never a valid futex address.
-         * The previous primary-buffer-only check (futex_gva < ipa_base +
+        /* Canonical user-VA range check (bits 47:0). Anything with bit 63 set
+         * is kernel-VA territory and is never a valid futex address. The
+         * previous primary-buffer-only check (futex_gva < ipa_base +
          * guest_size) silently dropped rosetta's high-VA futexes; the
-         * subsequent guest_read_small / guest_write_small calls do the
-         * actual mapping check via the page-table walker.
+         * subsequent guest_read_small / guest_write_small calls do the actual
+         * mapping check via the page-table walker.
          */
         if (futex_gva > 0x0000FFFFFFFFFFFFULL ||
             !futex_uaddr_is_aligned(futex_gva)) {
@@ -1796,8 +1793,8 @@ void robust_list_walk(guest_t *g, thread_entry_t *t)
         else
             futex_gva = pending - (uint64_t) (-futex_offset);
         /* Canonical user-VA + alignment only; guest_read_small below is the
-         * actual reachability test, so rosetta high-VA robust futexes are
-         * not silently skipped (was: futex_gva >= ipa_base + guest_size).
+         * actual reachability test, so rosetta high-VA robust futexes are not
+         * silently skipped (was: futex_gva >= ipa_base + guest_size).
          */
         if (futex_gva > 0x0000FFFFFFFFFFFFULL ||
             !futex_uaddr_is_aligned(futex_gva))

--- a/src/runtime/futex.h
+++ b/src/runtime/futex.h
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Hash table of wait queues keyed by guest virtual address. Supports
- * FUTEX_WAIT, FUTEX_WAKE, FUTEX_WAIT_BITSET, FUTEX_WAKE_BITSET,
- * FUTEX_REQUEUE, FUTEX_CMP_REQUEUE, FUTEX_WAKE_OP, and PI futexes
- * (FUTEX_LOCK_PI, FUTEX_UNLOCK_PI, FUTEX_TRYLOCK_PI).
- * Each waiter has its own condition variable for precise wakeup.
+ * FUTEX_WAIT, FUTEX_WAKE, FUTEX_WAIT_BITSET, FUTEX_WAKE_BITSET, FUTEX_REQUEUE,
+ * FUTEX_CMP_REQUEUE, FUTEX_WAKE_OP, and PI futexes (FUTEX_LOCK_PI,
+ * FUTEX_UNLOCK_PI, FUTEX_TRYLOCK_PI). Each waiter has its own condition
+ * variable for precise wakeup.
  */
 
 #pragma once
@@ -29,13 +29,11 @@ void futex_interrupt_clear(void);
 int futex_interrupt_pending(void);
 int futex_interrupt_consume(void);
 
-/* Main futex syscall entry point.
- * op:    futex operation (FUTEX_WAIT, FUTEX_WAKE, etc.)
- * uaddr: guest virtual address of the futex word
- * val:   expected value (WAIT) or max wakeups (WAKE)
- * timeout_gva: guest pointer to timespec (or 0 for no timeout)
- * uaddr2: second futex address (for REQUEUE/CMP_REQUEUE/WAKE_OP)
- * val3:  bitset (for WAIT_BITSET/WAKE_BITSET)
+/* Main futex syscall entry point. op: futex operation (FUTEX_WAIT, FUTEX_WAKE,
+ * etc.) uaddr: guest virtual address of the futex word val: expected value
+ * (WAIT) or max wakeups (WAKE) timeout_gva: guest pointer to timespec (or 0 for
+ * no timeout) uaddr2: second futex address (for REQUEUE/CMP_REQUEUE/WAKE_OP)
+ * val3: bitset (for WAIT_BITSET/WAKE_BITSET)
  * Returns 0 on success, negative Linux errno on failure.
  */
 int64_t sys_futex(guest_t *g,
@@ -46,14 +44,16 @@ int64_t sys_futex(guest_t *g,
                   uint64_t uaddr2,
                   uint32_t val3);
 
-/* Wake up to 1 waiter at uaddr. Used by thread exit for
- * CLONE_CHILD_CLEARTID cleanup. Returns number of waiters woken.
+/* Wake up to 1 waiter at uaddr. Used by thread exit for CLONE_CHILD_CLEARTID
+ * cleanup.
+ *
+ * Returns number of waiters woken.
  */
 int futex_wake_one(guest_t *g, uint64_t uaddr);
 
-/* futex_waitv (SYS 449): batch wait on multiple futex addresses.
- * clockid selects the timeout clock (Linux CLOCK_REALTIME=0 or
- * CLOCK_MONOTONIC=1); ignored when timeout_gva==0.
+/* futex_waitv (SYS 449): batch wait on multiple futex addresses. clockid
+ * selects the timeout clock (Linux CLOCK_REALTIME=0 or CLOCK_MONOTONIC=1);
+ * ignored when timeout_gva==0.
  * Returns the index of the woken futex, or negative errno.
  */
 int64_t sys_futex_waitv(guest_t *g,
@@ -63,8 +63,8 @@ int64_t sys_futex_waitv(guest_t *g,
                         uint64_t timeout_gva,
                         int clockid);
 
-/* Walk the robust futex list on thread exit and set FUTEX_OWNER_DIED
- * on each held lock. Wakes one waiter per lock so a new owner can
- * acquire it and see EOWNERDEAD.
+/* Walk the robust futex list on thread exit and set FUTEX_OWNER_DIED on each
+ * held lock. Wakes one waiter per lock so a new owner can acquire it and see
+ * EOWNERDEAD.
  */
 void robust_list_walk(guest_t *g, thread_entry_t *t);

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -14,8 +14,8 @@
  */
 #define MAPS_ENTRY_MAX 256
 
-/* Column at which the region name starts in /proc/self/maps output.
- * Matches observed Linux kernel formatting (verified via strace).
+/* Column at which the region name starts in /proc/self/maps output. Matches
+ * observed Linux kernel formatting (verified via strace).
  */
 #define MAPS_NAME_COLUMN 73
 
@@ -380,11 +380,13 @@ static void proc_scratch_register_atexit(void)
 }
 
 /* Open a per-call scratch directory populated with one empty file per live
- * guest fd. Returns a host dirfd on success, -1 on failure with errno set.
+ * guest fd.
  *
- * The dirfd is the standard backing for getdents on this synthetic listing.
- * Two concurrent openers get two independent dirs, so neither mutates the
- * other's enumeration.
+ * Returns a host dirfd on success, -1 on failure with errno set.
+ *
+ * The dirfd is the standard backing for getdents on this synthetic listing. Two
+ * concurrent openers get two independent dirs, so neither mutates the other's
+ * enumeration.
  */
 static int proc_open_fd_scratch(const char *prefix, int linux_flags)
 {
@@ -515,9 +517,11 @@ const char *proc_get_shm_dir(void)
     return shm_dir_path();
 }
 
-/* Create a synthetic file from a buffer. Returns a host fd positioned at the
- * start, or -1 on failure. Caller owns the returned fd.
- * Uses a temp file (unlinked immediately) so that pread/lseek work.
+/* Create a synthetic file from a buffer.
+ *
+ * Returns a host fd positioned at the start, or -1 on failure. Caller owns the
+ * returned fd. Uses a temp file (unlinked immediately) so that pread/lseek
+ * work.
  */
 static int proc_synthetic_fd(const void *data, size_t len)
 {
@@ -542,8 +546,10 @@ static int proc_synthetic_fd(const void *data, size_t len)
     return fd;
 }
 
-/* Lazy mkdtemp into a caller-provided buffer. Returns 0 on success (buf holds
- * the path), or -1 on failure (buf[0] reset to '\0').
+/* Lazy mkdtemp into a caller-provided buffer.
+ *
+ * Returns 0 on success (buf holds the path), or -1 on failure (buf[0] reset to
+ * '\0').
  *
  * Caller must hold the lock that protects buf, since the helper runs the "is
  * buf empty?" check and mkdtemp non-atomically. The created directory is reused
@@ -574,14 +580,14 @@ static int proc_synthetic_fd_str(const char *buf, int snprintf_ret, size_t cap)
     return proc_synthetic_fd(buf, (size_t) snprintf_ret);
 }
 
-/* Format a string into a stack buffer and return the synthetic fd in one
- * step. Collapses the recurring three-line pattern:
+/* Format a string into a stack buffer and return the synthetic fd in one step.
+ * Collapses the recurring three-line pattern:
  *     char buf[N];
  *     int len = snprintf(buf, sizeof(buf), fmt, ...);
  *     return proc_synthetic_fd_str(buf, len, sizeof(buf));
  * 4096-byte cap is the largest formatted /proc payload elfuse emits via this
- * helper (the few handlers that exceed it -- /proc/self/maps, /proc/net/tcp
- * -- build their output incrementally and call proc_synthetic_fd directly).
+ * helper (the few handlers that exceed it -- /proc/self/maps, /proc/net/tcp --
+ * build their output incrementally and call proc_synthetic_fd directly).
  */
 __attribute__((format(printf, 1, 2))) static int proc_emit_fmt(const char *fmt,
                                                                ...)
@@ -611,10 +617,9 @@ static int proc_emit_literal(const char *s)
  */
 static const char *proc_comm_name(void)
 {
-    /* Snapshot into a thread-local buffer so a concurrent execve cannot
-     * tear the shared elf_path under the basename scan. The TLS lifetime
-     * matches the calling thread, which is what callers (printf-style
-     * formatters) require.
+    /* Snapshot into a thread-local buffer so a concurrent execve cannot tear
+     * the shared elf_path under the basename scan. The TLS lifetime matches the
+     * calling thread, which is what callers (printf-style formatters) require.
      */
     static _Thread_local char exe_tls[LINUX_PATH_MAX];
     if (!proc_elf_path_snapshot(exe_tls, sizeof(exe_tls)))
@@ -623,10 +628,12 @@ static const char *proc_comm_name(void)
     return slash ? slash + 1 : exe_tls;
 }
 
-/* Parse the numeric tail of a /proc/.../<N> or /dev/fd/<N> path.
- * prefix_len is the length of the leading literal that the caller already
- * matched with strncmp. Returns the parsed fd on success, or -1 with errno set
- * to errno_on_invalid for any malformed input or out-of-range index.
+/* Parse the numeric tail of a /proc/.../<N> or /dev/fd/<N> path. prefix_len is
+ * the length of the leading literal that the caller already matched with
+ * strncmp.
+ *
+ * Returns the parsed fd on success, or -1 with errno set to errno_on_invalid
+ * for any malformed input or out-of-range index.
  */
 static int proc_parse_fd_index(const char *path,
                                size_t prefix_len,
@@ -712,8 +719,9 @@ static void stat_fill_proc_dir(struct stat *st,
 
 /* Resolve a /dev/fd/<N> or /proc/self/fd/<N> path to a fresh dup() of the
  * underlying host fd. prefix_len is the length of the matched literal (8 for
- * "/dev/fd/", 14 for "/proc/self/fd/"). Returns the dup or -1 with errno=EBADF
- * for malformed indices or closed slots.
+ * "/dev/fd/", 14 for "/proc/self/fd/").
+ *
+ * Returns the dup or -1 with errno=EBADF for malformed indices or closed slots.
  *
  * fd_to_host_dup duplicates the host fd atomically under fd_lock so a
  * concurrent close+reopen on another vCPU cannot redirect the dup to an
@@ -735,8 +743,8 @@ static int dev_fd_dup(const char *path, size_t prefix_len)
 /* If path matches /proc/<our_pid>[/...], rewrite into alias as /proc/self[...]
  * Used by both proc_intercept_open and proc_intercept_stat so the explicit-pid
  * form aliases through the same /proc/self handlers (Linux treats them
- * equivalent for the calling process). The trailing-character constraint
- * admits the bare /proc/<pid> directory and /proc/<pid>/X files alike.
+ * equivalent for the calling process). The trailing-character constraint admits
+ * the bare /proc/<pid> directory and /proc/<pid>/X files alike.
  *
  * Returns 1 when alias was rewritten (caller should recurse on alias), 0 when
  * path is not a self-alias (caller continues with other handlers), or -1 with
@@ -762,9 +770,9 @@ static int proc_alias_self(const char *path, char *alias, size_t alias_sz)
     return 1;
 }
 
-/* Populate *st for a synthetic /proc regular-file entry. Linux reports
- * st_size = 0 for proc nodes; mirroring that forces readers to drain to EOF
- * instead of pre-sizing buffers from a stale value.
+/* Populate *st for a synthetic /proc regular-file entry. Linux reports st_size
+ * = 0 for proc nodes; mirroring that forces readers to drain to EOF instead of
+ * pre-sizing buffers from a stale value.
  */
 static void stat_fill_proc_file(struct stat *st, mode_t mode, const char *path)
 {
@@ -829,9 +837,9 @@ static void proc_net_for_each_socket(proc_net_socket_visitor visit, void *ctx)
     }
 }
 
-/* Visitor context + callback for /proc/net/{tcp,udp,raw}{,6}.
- * sl counts only emitted rows so the "sl" column stays dense even when the
- * iterator visits other-family sockets that the visitor filters out.
+/* Visitor context + callback for /proc/net/{tcp,udp,raw}{,6}. sl counts only
+ * emitted rows so the "sl" column stays dense even when the iterator visits
+ * other-family sockets that the visitor filters out.
  */
 struct proc_net_inet_ctx {
     char *buf;
@@ -844,9 +852,9 @@ struct proc_net_inet_ctx {
     bool want_v6;
 };
 
-/* Map macOS TSI_S_* socket states (returned in tcp_connection_info.state)
- * to the 1-based hex values Linux /proc/net/tcp uses (ESTABLISHED=01,
- * LISTEN=0A, etc.). Indexed by macOS state ordinal.
+/* Map macOS TSI_S_* socket states (returned in tcp_connection_info.state) to
+ * the 1-based hex values Linux /proc/net/tcp uses (ESTABLISHED=01, LISTEN=0A,
+ * etc.). Indexed by macOS state ordinal.
  */
 static int proc_net_tcp_state_linux(int kstate)
 {
@@ -920,8 +928,9 @@ typedef struct {
     {.path = {0}, .lock = PTHREAD_MUTEX_INITIALIZER, .template = prefix}
 
 /* Acquire the persistent dir's lock and ensure the dir exists. Caller owns the
- * lock until proc_persistent_dir_release(). Returns the directory path or NULL
- * on failure (lock released, errno set).
+ * lock until proc_persistent_dir_release().
+ *
+ * Returns the directory path or NULL on failure (lock released, errno set).
  */
 static const char *proc_persistent_dir_acquire(proc_persistent_dir_t *d)
 {
@@ -945,11 +954,11 @@ static bool proc_net_unix_visit(const struct socket_fdinfo *sinfo,
 {
     (void) pid;
     struct proc_net_unix_ctx *c = ctx_v;
-    /* A unix row is up to 56 bytes of fixed format plus a sun_path of
-     * up to 108 bytes plus the trailing newline -- ~165 bytes worst
-     * case. The 128-byte margin previously inherited from the inline
-     * loop could leave a half-formatted row at the buffer tail; 256
-     * matches the inet visitor and covers the longest possible path.
+    /* A unix row is up to 56 bytes of fixed format plus a sun_path of up to 108
+     * bytes plus the trailing newline -- ~165 bytes worst case. The 128-byte
+     * margin previously inherited from the inline loop could leave a
+     * half-formatted row at the buffer tail; 256 matches the inet visitor and
+     * covers the longest possible path.
      */
     if (c->off >= (int) c->bufsz - 256)
         return false;
@@ -1131,9 +1140,10 @@ static void format_proc_net_addr(char out[33],
              words[3]);
 }
 
-/* Lazily create the synthetic /proc directory tree. Returns the path to the
- * temp dir, or NULL on failure. Thread-safe via proc_tmpdir_lock (multiple
- * vCPUs can hit proc_intercept_open concurrently).
+/* Lazily create the synthetic /proc directory tree.
+ *
+ * Returns the path to the temp dir, or NULL on failure. Thread-safe via
+ * proc_tmpdir_lock (multiple vCPUs can hit proc_intercept_open concurrently).
  */
 static const char *ensure_proc_tmpdir(const guest_t *g)
 {
@@ -1220,8 +1230,8 @@ static int syscpu_count(void)
 }
 
 /* Walk syscpu_dir and remove every entry plus the dir itself. Caller is
- * responsible for any owner/initialized checks; the partial-init recovery
- * path needs to call this even when syscpu_dir_ok is still false.
+ * responsible for any owner/initialized checks; the partial-init recovery path
+ * needs to call this even when syscpu_dir_ok is still false.
  */
 static void syscpu_dir_remove_tree(void)
 {
@@ -1242,8 +1252,8 @@ static void syscpu_dir_remove_tree(void)
             if (n <= 0 || (size_t) n >= sizeof(path))
                 continue;
             /* cpuN entries are directories, range files are regular files.
-             * rmdir succeeds for the dirs, fails with ENOTDIR for files;
-             * unlink covers the latter without an extra stat.
+             * rmdir succeeds for the dirs, fails with ENOTDIR for files; unlink
+             * covers the latter without an extra stat.
              */
             if (rmdir(path) < 0)
                 unlink(path);
@@ -1293,11 +1303,12 @@ static int syscpu_write_file(const char *dir,
     return rc;
 }
 
-/* Lazily build /tmp/elfuse-syscpu-XXXXXX/ with the cpumask files and one
- * empty cpuN directory per host CPU. Returns the temp dir path on success,
- * or NULL on failure with errno set. Any failure mid-population tears down
- * the partial tree so callers never observe a half-built directory.
- * Thread-safe via syscpu_dir_lock.
+/* Lazily build /tmp/elfuse-syscpu-XXXXXX/ with the cpumask files and one empty
+ * cpuN directory per host CPU.
+ *
+ * Returns the temp dir path on success, or NULL on failure with errno set. Any
+ * failure mid-population tears down the partial tree so callers never observe a
+ * half-built directory. Thread-safe via syscpu_dir_lock.
  */
 static const char *ensure_syscpu_dir(void)
 {
@@ -1343,8 +1354,8 @@ static const char *ensure_syscpu_dir(void)
         }
     }
 
-    /* Record the owner before flipping syscpu_dir_ok so the cleanup hook,
-     * if it ever observes the populated state, also sees the right pid.
+    /* Record the owner before flipping syscpu_dir_ok so the cleanup hook, if it
+     * ever observes the populated state, also sees the right pid.
      */
     syscpu_owner_pid = getpid();
     atexit(syscpu_dir_cleanup);
@@ -1354,8 +1365,8 @@ static const char *ensure_syscpu_dir(void)
 
 fail:
     /* Tear down the partial tree so a later call can mkdtemp a fresh slot.
-     * Bypass the syscpu_dir_ok guard since this path runs before the flag
-     * is flipped.
+     * Bypass the syscpu_dir_ok guard since this path runs before the flag is
+     * flipped.
      */
     syscpu_dir_remove_tree();
     syscpu_dir[0] = '\0';
@@ -1364,12 +1375,12 @@ fail:
     return NULL;
 }
 
-/* Reject any '..' component in suffix so the joined host path cannot escape
- * the scratch dir. The synthetic /sys/devices/system/cpu tree has no use
- * case for parent-directory traversal, and accepting it would let a guest
- * call like open("/sys/devices/system/cpu/../../etc/passwd") drive
- * lstat/open on an arbitrary host path. Empty components and '.' are
- * harmless and pass through unchanged.
+/* Reject any '..' component in suffix so the joined host path cannot escape the
+ * scratch dir. The synthetic /sys/devices/system/cpu tree has no use case for
+ * parent-directory traversal, and accepting it would let a guest call like
+ * open("/sys/devices/system/cpu/../../etc/passwd") drive lstat/open on an
+ * arbitrary host path. Empty components and '.' are harmless and pass through
+ * unchanged.
  */
 static bool syscpu_suffix_safe(const char *suffix)
 {
@@ -1388,10 +1399,12 @@ static bool syscpu_suffix_safe(const char *suffix)
 }
 
 /* Translate a /sys/devices/system/cpu[/...] path into the path inside the
- * scratch dir. Returns 0 on success (host_path filled), -1 with errno set
- * for malformed inputs (ENOENT for missing init, EACCES for traversal,
- * ENAMETOOLONG for overflow). When the suffix is empty (the root dir
- * itself), host_path receives just the scratch dir.
+ * scratch dir.
+ *
+ * Returns 0 on success (host_path filled), -1 with errno set for malformed
+ * inputs (ENOENT for missing init, EACCES for traversal, ENAMETOOLONG for
+ * overflow). When the suffix is empty (the root dir itself), host_path receives
+ * just the scratch dir.
  */
 static int syscpu_resolve_path(const char *suffix,
                                char *host_path,
@@ -1418,10 +1431,9 @@ static int syscpu_resolve_path(const char *suffix,
     return 0;
 }
 
-/* The synthetic sysfs CPU tree is read-only. Accept only descriptor flags
- * that make sense for a read-only open and reject mutating flags up front
- * so the guest cannot create, truncate, or request write access anywhere
- * in the stub.
+/* The synthetic sysfs CPU tree is read-only. Accept only descriptor flags that
+ * make sense for a read-only open and reject mutating flags up front so the
+ * guest cannot create, truncate, or request write access anywhere in the stub.
  */
 static bool syscpu_open_is_readonly(int linux_flags)
 {
@@ -1444,8 +1456,8 @@ static bool syscpu_open_is_readonly(int linux_flags)
 #define SYSFS_CPU "/sys/devices/system/cpu"
 #define SYSFS_CPU_LEN (sizeof(SYSFS_CPU) - 1)
 /* Host scratch-dir path buffer size: scratch dir is /tmp/elfuse-syscpu-<6>
- * (under 30 chars) plus a /sys/devices/system/cpu/<suffix> remainder bounded
- * by LINUX_PATH_MAX. 256 is comfortable for the realistic suffixes the stub
+ * (under 30 chars) plus a /sys/devices/system/cpu/<suffix> remainder bounded by
+ * LINUX_PATH_MAX. 256 is comfortable for the realistic suffixes the stub
  * exposes (cpuN, cpumask range files).
  */
 #define SYSCPU_HOST_PATH_MAX 256
@@ -1519,8 +1531,8 @@ static void proc_task_collect_cb(thread_entry_t *t, void *arg)
  */
 #define PTY_KEEPALIVE_MAX 256
 #define PTY_KEEPALIVE_FREE (-1)
-/* PTY_SLAVE_PATH_MAX lives in procemu.h so this table and the fork-IPC
- * payload (proc_pty_ipc_entry_t) cannot drift apart.
+/* PTY_SLAVE_PATH_MAX lives in procemu.h so this table and the fork-IPC payload
+ * (proc_pty_ipc_entry_t) cannot drift apart.
  */
 static struct {
     int master_host_fd;
@@ -1572,9 +1584,11 @@ static int pty_keepalive_clear_slot_locked(int slot)
 static uint32_t pty_extract_pts_num(const char *slave_path)
 {
     /* macOS canonical slave paths are /dev/ttysNNN with a decimal tail. Read
-     * the longest decimal suffix and return it as the Linux pts number used
-     * by guest /dev/pts/N. Returns UINT32_MAX on parse failure so callers
-     * can reject ambiguous names rather than silently aliasing.
+     * the longest decimal suffix and return it as the Linux pts number used by
+     * guest /dev/pts/N.
+     *
+     * Returns UINT32_MAX on parse failure so callers can reject ambiguous names
+     * rather than silently aliasing.
      */
     if (!slave_path)
         return UINT32_MAX;
@@ -1595,12 +1609,14 @@ static uint32_t pty_extract_pts_num(const char *slave_path)
 #define PTY_REG_EXISTS 1   /* a matching entry already existed */
 #define PTY_REG_FULL (-1)  /* table out of free slots */
 
-/* Caller-holds-lock variant. Returns one of PTY_REG_* and, on PTY_REG_EXISTS,
- * writes the existing entry's pts number to *existing_pts_num. The lock-held
- * variant exists so proc_pty_master_adopt can atomically pair fd-table slot
- * validation with keepalive insertion under fd_lock + pty_keepalive_lock,
- * eliminating the race window where a sibling close+recycle between validate
- * and register would attach the keepalive to the wrong file.
+/* Caller-holds-lock variant.
+ *
+ * Returns one of PTY_REG_* and, on PTY_REG_EXISTS, writes the existing entry's
+ * pts number to *existing_pts_num. The lock-held variant exists so
+ * proc_pty_master_adopt can atomically pair fd-table slot validation with
+ * keepalive insertion under fd_lock + pty_keepalive_lock, eliminating the race
+ * window where a sibling close+recycle between validate and register would
+ * attach the keepalive to the wrong file.
  */
 static int pty_keepalive_register_locked(int master_host_fd,
                                          int slave_host_fd,
@@ -1621,8 +1637,8 @@ static int pty_keepalive_register_locked(int master_host_fd,
             continue;
         /* Prefer a stale-path slot with the same pts number: the macOS minor
          * deterministically maps to the same slave_path string, so reusing
-         * keeps lookups path-correct and bounds the table at one slot per
-         * live minor instead of accumulating a new entry on every reopen.
+         * keeps lookups path-correct and bounds the table at one slot per live
+         * minor instead of accumulating a new entry on every reopen.
          */
         if (pty_keepalive_table[i].slave_path[0] != '\0' &&
             pty_keepalive_table[i].linux_pts_num == linux_pts_num) {
@@ -1672,9 +1688,11 @@ static int pty_keepalive_register_locked(int master_host_fd,
 }
 
 /* Lock-acquiring convenience wrapper used by the open-time and fork-restore
- * paths where atomicity with fd_table is not required. Returns 0 on success
- * (including PTY_REG_EXISTS, in which case the caller should close its own
- * redundant slave_host_fd), -1 with errno set on table-full (ENOSPC).
+ * paths where atomicity with fd_table is not required.
+ *
+ * Returns 0 on success (including PTY_REG_EXISTS, in which case the caller
+ * should close its own redundant slave_host_fd), -1 with errno set on
+ * table-full (ENOSPC).
  */
 static int pty_keepalive_register(int master_host_fd,
                                   int slave_host_fd,
@@ -1726,13 +1744,13 @@ static bool pty_fd_still_canonical(int guest_fd,
 
 uint32_t proc_pty_master_adopt(int guest_fd)
 {
-    /* Step 1: atomically snapshot (host_fd, generation) and dup the
-     * canonical fd in a single fd_lock window. fd_snapshot_and_dup pins
-     * the file object behind the canonical host fd, so even if a sibling
-     * closes the guest fd and the host fd number is recycled by an
-     * unrelated open, host syscalls against the probe still operate on
-     * the right tty. The generation captured here is the witness for the
-     * subsequent table lookup and register validations.
+    /* Step 1: atomically snapshot (host_fd, generation) and dup the canonical
+     * fd in a single fd_lock window. fd_snapshot_and_dup pins the file object
+     * behind the canonical host fd, so even if a sibling closes the guest fd
+     * and the host fd number is recycled by an unrelated open, host syscalls
+     * against the probe still operate on the right tty. The generation captured
+     * here is the witness for the subsequent table lookup and register
+     * validations.
      */
     fd_entry_t snap;
     int probe = fd_snapshot_and_dup(guest_fd, &snap);
@@ -1742,12 +1760,12 @@ uint32_t proc_pty_master_adopt(int guest_fd)
     uint64_t canonical_gen = snap.generation;
 
     /* Fast path: a keepalive was already registered for this canonical fd
-     * (typical case for /dev/ptmx opens that went through pty_open_master).
-     * The keepalive table is keyed by host fd number, so re-validate the
-     * slot identity before trusting the returned pts_num. If the fd has
-     * been recycled to a different file (generation mismatch), the
-     * existing entry belongs to that file, not ours, and the slow path
-     * below must register a fresh entry for our pinned probe.
+     * (typical case for /dev/ptmx opens that went through pty_open_master). The
+     * keepalive table is keyed by host fd number, so re-validate the slot
+     * identity before trusting the returned pts_num. If the fd has been
+     * recycled to a different file (generation mismatch), the existing entry
+     * belongs to that file, not the pinned probe, and the slow path below must
+     * register a fresh entry for the pinned probe.
      */
     uint32_t existing = proc_pty_master_pts_num(canonical_host_fd);
     if (existing != UINT32_MAX &&
@@ -1756,9 +1774,9 @@ uint32_t proc_pty_master_adopt(int guest_fd)
         return existing;
     }
 
-    /* Step 2: confirm the file really is a /dev/ptmx master. ptsname(3)
-     * returns NULL/ENOTTY on non-pty descriptors, so a stray TIOCGPTN
-     * against a regular file is rejected without any side effect.
+    /* Step 2: confirm the file really is a /dev/ptmx master. ptsname(3) returns
+     * NULL/ENOTTY on non-pty descriptors, so a stray TIOCGPTN against a regular
+     * file is rejected without any side effect.
      */
     char slave_path[PTY_SLAVE_PATH_MAX];
     uint32_t pts_num = UINT32_MAX;
@@ -1770,8 +1788,8 @@ uint32_t proc_pty_master_adopt(int guest_fd)
         goto out;
 
     /* unlockpt(3) is harmless if the sender already unlocked. EINVAL means
-     * already unlocked; anything else means the slave will not open and
-     * we give up cleanly.
+     * already unlocked; anything else means the slave will not open and we give
+     * up cleanly.
      */
     if (unlockpt(probe) < 0 && errno != EINVAL) {
         pts_num = UINT32_MAX;
@@ -1825,11 +1843,12 @@ out:
     return pts_num;
 }
 
-/* Look up the captured macOS slave path for a Linux pts number. Returns 0 and
- * writes the path on hit, -1 with errno=ENOENT on miss. Used by the /dev/pts/N
- * open and stat intercepts so they hit the exact path returned by ptsname(3)
- * rather than a guessed /dev/ttys%03lu reformat that breaks if macOS changes
- * its naming scheme or uses an unexpected minor encoding.
+/* Look up the captured macOS slave path for a Linux pts number.
+ *
+ * Returns 0 and writes the path on hit, -1 with errno=ENOENT on miss. Used by
+ * the /dev/pts/N open and stat intercepts so they hit the exact path returned
+ * by ptsname(3) rather than a guessed /dev/ttys%03lu reformat that breaks if
+ * macOS changes its naming scheme or uses an unexpected minor encoding.
  */
 static int pty_lookup_slave_path(uint32_t linux_pts_num,
                                  char *out,
@@ -1841,10 +1860,10 @@ static int pty_lookup_slave_path(uint32_t linux_pts_num,
     }
     int hit = -1;
     pty_keepalive_lock_acquire();
-    /* Prefer a live entry (master still open in this process) over a stale
-     * path entry. Both encode the same slave_path for a given minor on macOS,
-     * so the preference only matters if a future change ever lets the two
-     * diverge - live wins by breaking out of the scan on first match.
+    /* Prefer a live entry (master still open in this process) over a stale path
+     * entry. Both encode the same slave_path for a given minor on macOS, so the
+     * preference only matters if a future change ever lets the two diverge -
+     * live wins by breaking out of the scan on first match.
      */
     for (int i = 0; i < PTY_KEEPALIVE_MAX; i++) {
         if (pty_keepalive_table[i].linux_pts_num != linux_pts_num)
@@ -1917,8 +1936,8 @@ static int pty_open_slave(uint32_t linux_pts_num, int linux_flags)
 
     /* Stale fork-child entries are one-shot. The retained slave fd pins the
      * macOS tty while we translate the close-before-open sequence, preventing
-     * the cached path from resolving to a reused unrelated minor. Regardless
-     * of open success, consume the stale mapping before returning.
+     * the cached path from resolving to a reused unrelated minor. Regardless of
+     * open success, consume the stale mapping before returning.
      */
     size_t len = strlen(pty_keepalive_table[stale_hit].slave_path);
     if (len >= sizeof(host_path)) {
@@ -2040,8 +2059,8 @@ void proc_pty_dup_keepalive_locked(int src_master_host_fd,
     memcpy(src_slave_path, pty_keepalive_table[slot].slave_path,
            PTY_SLAVE_PATH_MAX);
 
-    /* dup(2) clears FD_CLOEXEC; the keepalive must not survive exec into
-     * a guest child that has no map back to it.
+    /* dup(2) clears FD_CLOEXEC; the keepalive must not survive exec into a
+     * guest child that has no map back to it.
      */
     int fdflags = fcntl(dst_slave, F_GETFD);
     if (fdflags < 0 || fcntl(dst_slave, F_SETFD, fdflags | FD_CLOEXEC) < 0) {
@@ -2053,9 +2072,9 @@ void proc_pty_dup_keepalive_locked(int src_master_host_fd,
                                       src_pts_num, src_slave_path, false, NULL);
     if (rc != PTY_REG_INSERTED) {
         /* Table full or duplicate entry for dst_master_host_fd; drop the
-         * redundant slave. Duplicate is unexpected: dst is a freshly-duped
-         * host fd that should not already be in the table unless a prior
-         * close skipped proc_pty_close_keepalive.
+         * redundant slave. Duplicate is unexpected: dst is a freshly-duped host
+         * fd that should not already be in the table unless a prior close
+         * skipped proc_pty_close_keepalive.
          */
         close(dst_slave);
     }
@@ -2212,8 +2231,8 @@ static int pty_open_master(int linux_flags)
     if (master < 0)
         return -1;
 
-    /* grantpt(3) is a no-op on a unix98 pty mount, but call it for clarity
-     * and to match what posix_openpt(3)'s callers expect to have happened.
+    /* grantpt(3) is a no-op on a unix98 pty mount, but call it for clarity and
+     * to match what posix_openpt(3)'s callers expect to have happened.
      */
     char slave_path[PTY_SLAVE_PATH_MAX];
     if (grantpt(master) < 0 || unlockpt(master) < 0 ||
@@ -2248,10 +2267,10 @@ static int pty_open_master(int linux_flags)
         errno = EMFILE;
         return -1;
     }
-    /* Defense-in-depth: the freshly-opened master fd should not already have
-     * a keepalive (would indicate a stale entry from a prior close that did
-     * not run proc_pty_close_keepalive). Drop the redundant slave so it does
-     * not leak.
+    /* Defense-in-depth: the freshly-opened master fd should not already have a
+     * keepalive (would indicate a stale entry from a prior close that did not
+     * run proc_pty_close_keepalive). Drop the redundant slave so it does not
+     * leak.
      */
     if (errno == EEXIST)
         close(slave);
@@ -2314,10 +2333,9 @@ int proc_intercept_open(const guest_t *g,
         return open(host_dev, oflags);
     }
 
-    /* /dev/shm -> tmpfs-backed host temp directory.
-     * Linux applications use /dev/shm for shm_open + mmap MAP_SHARED.
-     * Redirect to one shared host namespace so named shm works across elfuse
-     * processes and fork children.
+    /* /dev/shm -> tmpfs-backed host temp directory. Linux applications use
+     * /dev/shm for shm_open + mmap MAP_SHARED. Redirect to one shared host
+     * namespace so named shm works across elfuse processes and fork children.
      */
     if (!strcmp(path, "/dev/shm")) {
         const char *shm = shm_dir_path();
@@ -2374,9 +2392,9 @@ int proc_intercept_open(const guest_t *g,
             errno = ENOENT;
             return -1;
         }
-        /* /dev/pts/N is a character device; strip O_CREAT and friends so
-         * the two-argument open(2) never sees a creation-mode-required
-         * combination without a mode arg.
+        /* /dev/pts/N is a character device; strip O_CREAT and friends so the
+         * two-argument open(2) never sees a creation-mode-required combination
+         * without a mode arg.
          */
         return pty_open_slave((uint32_t) n, linux_flags);
     }
@@ -2448,14 +2466,15 @@ int proc_intercept_open(const guest_t *g,
         }
     }
 
-    /* /proc/self/exe -> open the actual ELF binary.
-     * Unlike readlinkat (which returns the path string), openat needs to
-     * return an actual file descriptor to the binary.
-     * Under rosetta, the binfmt_misc convention treats rosetta as the
-     * interpreter visible to the guest: rosetta opens /proc/self/fd/X
-     * via /proc/self/exe to identify itself and then issues the VZ ioctls on
-     * that descriptor. Return ROSETTA_PATH so the VZ ioctl gate
-     * (rosetta_ioctl_target_fd) recognises the fd.
+    /* /proc/self/exe -> open the actual ELF binary. Unlike readlinkat (which
+     * returns the path string), openat needs to return an actual file
+     * descriptor to the binary. Under rosetta, the binfmt_misc convention
+     * treats rosetta as the interpreter visible to the guest: rosetta opens
+     * /proc/self/fd/X via /proc/self/exe to identify itself and then issues the
+     * VZ ioctls on that descriptor.
+     *
+     * Return ROSETTA_PATH so the VZ ioctl gate (rosetta_ioctl_target_fd)
+     * recognises the fd.
      */
     if (!strcmp(path, "/proc/self/exe")) {
         if (g && g->is_rosetta)
@@ -2468,9 +2487,9 @@ int proc_intercept_open(const guest_t *g,
         return open(exe, O_RDONLY);
     }
 
-    /* /proc/cpuinfo -> synthetic file with CPU count.
-     * Buffer sized dynamically from ncpu (~200 bytes/entry) to avoid silent
-     * truncation on hosts with >16 CPUs.
+    /* /proc/cpuinfo -> synthetic file with CPU count. Buffer sized dynamically
+     * from ncpu (~200 bytes/entry) to avoid silent truncation on hosts with >16
+     * CPUs.
      */
     if (!strcmp(path, "/proc/cpuinfo")) {
         int ncpu = (int) sysconf(_SC_NPROCESSORS_ONLN);
@@ -2577,13 +2596,13 @@ int proc_intercept_open(const guest_t *g,
         return proc_synthetic_fd(data, len);
     }
 
-    /* /proc/self/task -> directory with per-thread TID entries.
-     * Debuggers and runtimes (GDB, LLDB, JVM, Go runtime) probe this at startup
-     * to discover thread count and per-thread state.
+    /* /proc/self/task -> directory with per-thread TID entries. Debuggers and
+     * runtimes (GDB, LLDB, JVM, Go runtime) probe this at startup to discover
+     * thread count and per-thread state.
      *
-     * Rebuilds a temp directory on each open (thread set is dynamic).
-     * Cannot rmdir before returning the fd because macOS getdents on unlinked
-     * dirs returns empty. Uses a static path cleaned up at exit.
+     * Rebuilds a temp directory on each open (thread set is dynamic). Cannot
+     * rmdir before returning the fd because macOS getdents on unlinked dirs
+     * returns empty. Uses a static path cleaned up at exit.
      */
     if (!strcmp(path, "/proc/self/task") || !strcmp(path, "/proc/self/task/")) {
         static proc_persistent_dir_t taskdir =
@@ -2671,12 +2690,12 @@ int proc_intercept_open(const guest_t *g,
         return -2; /* unknown /proc/self/task/<tid>/XXX */
     }
 
-    /* /proc/self/maps -> generated from guest region tracking.
-     * Addresses are page-aligned (rounded down/up) to match real Linux
-     * behavior. Output merges consecutive regions with the same prot, flags,
-     * and name into a single maps line, matching real Linux kernel behavior
-     * where a single mmap() call produces one maps entry even when the backing
-     * pages span multiple physical frames.
+    /* /proc/self/maps -> generated from guest region tracking. Addresses are
+     * page-aligned (rounded down/up) to match real Linux behavior. Output
+     * merges consecutive regions with the same prot, flags, and name into a
+     * single maps line, matching real Linux kernel behavior where a single
+     * mmap() call produces one maps entry even when the backing pages span
+     * multiple physical frames.
      */
     if (!strcmp(path, "/proc/self/maps")) {
         char buf[16384];
@@ -2766,8 +2785,8 @@ int proc_intercept_open(const guest_t *g,
                 line, sizeof(line), "%llx-%llx %s %08llx 00:00 0",
                 (unsigned long long) e->start, (unsigned long long) e->end,
                 perms, (unsigned long long) e->offset);
-            /* Cap lineoff to buffer size (snprintf may return more
-             * than available on truncation)
+            /* Cap lineoff to buffer size (snprintf may return more than
+             * available on truncation)
              */
             if (lineoff >= (int) sizeof(line))
                 lineoff = (int) sizeof(line) - 1;
@@ -2796,9 +2815,9 @@ int proc_intercept_open(const guest_t *g,
         return proc_synthetic_fd(buf, off);
     }
 
-    /* /proc/uptime -> synthetic uptime in seconds.
-     * Uses sysctl(KERN_BOOTTIME), same as sys_sysinfo() in syscall/sys.c.
-     * Idle time is 0 (no meaningful macOS equivalent).
+    /* /proc/uptime -> synthetic uptime in seconds. Uses sysctl(KERN_BOOTTIME),
+     * same as sys_sysinfo() in syscall/sys.c. Idle time is 0 (no meaningful
+     * macOS equivalent).
      */
     if (!strcmp(path, "/proc/uptime")) {
         struct timeval boottime;
@@ -2813,8 +2832,8 @@ int proc_intercept_open(const guest_t *g,
         return proc_emit_fmt("%.2f 0.00\n", uptime);
     }
 
-    /* /proc/loadavg -> synthetic load averages.
-     * Musl's getloadavg() reads /proc/loadavg, so GNU uptime needs this.
+    /* /proc/loadavg -> synthetic load averages. Musl's getloadavg() reads
+     * /proc/loadavg, so GNU uptime needs this.
      */
     if (!strcmp(path, "/proc/loadavg")) {
         double loadavg[3] = {0};
@@ -2824,8 +2843,8 @@ int proc_intercept_open(const guest_t *g,
                              (long long) proc_get_pid());
     }
 
-    /* /var/run/utmp, /run/utmp -> synthetic utmp with current user.
-     * Creates one USER_PROCESS record for who, users, pinky.
+    /* /var/run/utmp, /run/utmp -> synthetic utmp with current user. Creates one
+     * USER_PROCESS record for who, users, pinky.
      */
     if (!strcmp(path, "/var/run/utmp") || !strcmp(path, "/run/utmp")) {
         _Static_assert(sizeof(linux_utmpx_t) == 400,
@@ -2848,10 +2867,9 @@ int proc_intercept_open(const guest_t *g,
         return proc_synthetic_fd(&entry, sizeof(entry));
     }
 
-    /* /proc/net: live socket tables.
-     * Enumerates sockets from the local FD table AND from all active fork-child
-     * processes via macOS proc_pidfdinfo().  This gives system-wide visibility
-     * matching real Linux /proc/net semantics.
+    /* /proc/net: live socket tables. Enumerates sockets from the local FD table
+     * AND from all active fork-child processes via macOS proc_pidfdinfo(). This
+     * gives system-wide visibility matching real Linux /proc/net semantics.
      */
     if (!strcmp(path, "/proc/net/tcp") || !strcmp(path, "/proc/net/tcp6") ||
         !strcmp(path, "/proc/net/udp") || !strcmp(path, "/proc/net/udp6") ||
@@ -2988,9 +3006,9 @@ int proc_intercept_open(const guest_t *g,
 
         /* fd_to_host_dup atomically duplicates under fd_lock so a concurrent
          * close+reopen on another vCPU cannot redirect the lseek to an
-         * unrelated host fd that took the freed slot. The probe pollutes
-         * errno with ESPIPE on non-seekable fds (sockets, pipes), so save
-         * and restore around the call to keep the caller's view clean.
+         * unrelated host fd that took the freed slot. The probe pollutes errno
+         * with ESPIPE on non-seekable fds (sockets, pipes), so save and restore
+         * around the call to keep the caller's view clean.
          */
         off_t pos = 0;
         int dup_fd = fd_to_host_dup(n);
@@ -3007,9 +3025,10 @@ int proc_intercept_open(const guest_t *g,
         extra[0] = '\0';
         if (snap.type == FD_EVENTFD) {
             uint64_t count;
-            /* fs/eventfd.c uses a single space after the colon, matching
-             * the timerfd convention (and unlike pos:/flags:/mnt_id: in
-             * fs/proc/fd.c which use tabs). */
+            /* fs/eventfd.c uses a single space after the colon, matching the
+             * timerfd convention (and unlike pos:/flags:/mnt_id: in
+             * fs/proc/fd.c which use tabs).
+             */
             if (eventfd_fdinfo_snapshot(n, &count))
                 snprintf(extra, sizeof(extra), "eventfd-count: %16llx\n",
                          (unsigned long long) count);
@@ -3082,8 +3101,8 @@ int proc_intercept_open(const guest_t *g,
         sysctl(mib, 2, &physmem, &sz, NULL, 0);
         uint64_t total_kb = (uint64_t) physmem / 1024;
 
-        /* Query host vm_statistics for accurate free/active/inactive.
-         * Falls back to approximations if the mach call fails.
+        /* Query host vm_statistics for accurate free/active/inactive. Falls
+         * back to approximations if the mach call fails.
          */
         uint64_t free_kb, avail_kb, buffers_kb, cached_kb;
         vm_statistics64_data_t vm_stat = {0};
@@ -3147,10 +3166,9 @@ int proc_intercept_open(const guest_t *g,
             (unsigned long long) (total_kb / 2));
     }
 
-    /* /proc/self/io -> synthetic I/O counters.
-     * Some node-style observability runtimes read this for resource monitoring
-     * metrics. procfs emulation returns zeroed counters because it does not
-     * track per-guest I/O.
+    /* /proc/self/io -> synthetic I/O counters. Some node-style observability
+     * runtimes read this for resource monitoring metrics. procfs emulation
+     * returns zeroed counters because it does not track per-guest I/O.
      */
     if (!strcmp(path, "/proc/self/io")) {
         return proc_emit_literal(
@@ -3163,12 +3181,11 @@ int proc_intercept_open(const guest_t *g,
             "cancelled_write_bytes: 0\n");
     }
 
-    /* /proc/self/stat -> single-line process stat (man 5 proc).
-     * Managed runtimes read this for resource monitoring (utime, stime, rss,
-     * vsize).
-     * Format: pid (comm) state ppid pgrp session tty_nr tpgid flags ...
-     * Fields populated with meaningful values: pid, comm, state, ppid,
-     * utime(14), stime(15), vsize(23), rss(24). Rest are zero/defaults.
+    /* /proc/self/stat -> single-line process stat (man 5 proc). Managed
+     * runtimes read this for resource monitoring (utime, stime, rss, vsize).
+     * Format: pid (comm) state ppid pgrp session tty_nr tpgid flags ... Fields
+     * populated with meaningful values: pid, comm, state, ppid, utime(14),
+     * stime(15), vsize(23), rss(24). Rest are zero/defaults.
      */
     if (!strcmp(path, "/proc/self/stat")) {
         /* Get process CPU times for utime/stime fields */
@@ -3260,11 +3277,11 @@ int proc_intercept_open(const guest_t *g,
             "user:x:1000:\n");
     }
 
-    /* /sys/devices/system/cpu[/...] -> synthetic CPU topology stub.
-     * Backs the lazy scratch dir that holds the cpumask range files plus
-     * one empty cpuN directory per host CPU. The cache/topology subtrees
-     * stay empty so consumers that only need cpu count (Java GC, Go
-     * scheduler init, libnuma) succeed; deeper queries return ENOENT.
+    /* /sys/devices/system/cpu[/...] -> synthetic CPU topology stub. Backs the
+     * lazy scratch dir that holds the cpumask range files plus one empty cpuN
+     * directory per host CPU. The cache/topology subtrees stay empty so
+     * consumers that only need cpu count (Java GC, Go scheduler init, libnuma)
+     * succeed; deeper queries return ENOENT.
      */
     {
         const char *suffix;
@@ -3283,9 +3300,9 @@ int proc_intercept_open(const guest_t *g,
             char host_path[SYSCPU_HOST_PATH_MAX];
             if (syscpu_resolve_path(suffix, host_path, sizeof(host_path)) < 0)
                 return -1;
-            /* O_NOFOLLOW: the scratch dir contents are owned by elfuse, but
-             * a caller could still race a symlink into the tree before this
-             * open. Block any cross-tree escape attempt regardless.
+            /* O_NOFOLLOW: the scratch dir contents are owned by elfuse, but a
+             * caller could still race a symlink into the tree before this open.
+             * Block any cross-tree escape attempt regardless.
              */
             int oflags = translate_open_flags(linux_flags);
             return open(host_path, oflags | O_NOFOLLOW, mode);
@@ -3297,9 +3314,9 @@ int proc_intercept_open(const guest_t *g,
 
 int proc_intercept_stat(const char *path, struct stat *st)
 {
-    /* Intercept stat for /proc paths emulated via proc_intercept_open.
-     * Without this, runtime libraries that probe a file's existence via stat()
-     * before opening it would fail on synthetic /proc paths (e.g., a stat() of
+    /* Intercept stat for /proc paths emulated via proc_intercept_open. Without
+     * this, runtime libraries that probe a file's existence via stat() before
+     * opening it would fail on synthetic /proc paths (e.g., a stat() of
      * /proc/self/io would return ENOENT before the caller ever issues open()).
      *
      * procfs emulation returns a minimal regular file stat. Exact values are
@@ -3340,12 +3357,12 @@ int proc_intercept_stat(const char *path, struct stat *st)
         return stat(host_path, st);
     }
 
-    /* /dev/pts directory and /dev/pts/N slave entries. glibc ptsname(3)
-     * stats /dev/pts/N after TIOCGPTN and rejects with ENOENT if absent.
-     * Synthesize a minimal char-device stat whose st_rdev decodes to Linux's
-     * standard pts major (136) so glibc's major(rdev) == UNIX98_PTY_SLAVE_MAJOR
-     * check passes. The numeric tail must round-trip with /dev/ttysN via the
-     * open intercept (see proc_intercept_open).
+    /* /dev/pts directory and /dev/pts/N slave entries. glibc ptsname(3) stats
+     * /dev/pts/N after TIOCGPTN and rejects with ENOENT if absent. Synthesize a
+     * minimal char-device stat whose st_rdev decodes to Linux's standard pts
+     * major (136) so glibc's major(rdev) == UNIX98_PTY_SLAVE_MAJOR check
+     * passes. The numeric tail must round-trip with /dev/ttysN via the open
+     * intercept (see proc_intercept_open).
      */
     if (!strcmp(path, "/dev/pts") || !strcmp(path, "/dev/pts/")) {
         stat_fill_proc_dir(st, 0755, 2, path);
@@ -3364,9 +3381,9 @@ int proc_intercept_stat(const char *path, struct stat *st)
             return -1;
         }
         /* Resolve through the captured-path table: ENOENT unless the
-         * corresponding master is currently open. This avoids the host
-         * stat false-positive where /dev/ttysNNN happens to exist for an
-         * unrelated tty allocated outside elfuse.
+         * corresponding master is currently open. This avoids the host stat
+         * false-positive where /dev/ttysNNN happens to exist for an unrelated
+         * tty allocated outside elfuse.
          */
         char host_path[PTY_SLAVE_PATH_MAX];
         if (pty_lookup_slave_path((uint32_t) n, host_path, sizeof(host_path)) <
@@ -3534,9 +3551,9 @@ int proc_intercept_stat(const char *path, struct stat *st)
         return 0;
     }
 
-    /* /sys/devices/system/cpu[/...]: synthesize stat from the lazy scratch
-     * dir. Anything not present in the scratch dir (e.g. cpuN/topology,
-     * cpuN/cache) returns ENOENT, which matches the "stub-empty" contract.
+    /* /sys/devices/system/cpu[/...]: synthesize stat from the lazy scratch dir.
+     * Anything not present in the scratch dir (e.g. cpuN/topology, cpuN/cache)
+     * returns ENOENT, which matches the "stub-empty" contract.
      */
     {
         const char *suffix;
@@ -3582,15 +3599,15 @@ int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz)
             return proc_intercept_readlink(alias, buf, bufsiz);
     }
 
-    /* /proc/self/exe -> path of current ELF binary.
-     * Strip the sysroot prefix so a guest running under --sysroot=/opt/sr
-     * sees /bin/ls rather than /opt/sr/bin/ls, matching the chroot-like
-     * abstraction the rest of the path layer presents.
+    /* /proc/self/exe -> path of current ELF binary. Strip the sysroot prefix so
+     * a guest running under --sysroot=/opt/sr sees /bin/ls rather than
+     * /opt/sr/bin/ls, matching the chroot-like abstraction the rest of the path
+     * layer presents.
      */
     if (!strcmp(path, "/proc/self/exe")) {
         /* Under rosetta, readlink("/proc/self/exe") points at the rosetta
-         * translator (the binfmt_misc interpreter). Matches the behavior
-         * Linux exposes when binfmt_misc dispatch is active.
+         * translator (the binfmt_misc interpreter). Matches the behavior Linux
+         * exposes when binfmt_misc dispatch is active.
          */
         if (proc_rosetta_active()) {
             size_t len = strlen(ROSETTA_PATH);

--- a/src/runtime/procemu.h
+++ b/src/runtime/procemu.h
@@ -21,8 +21,8 @@
  */
 #define PROC_NOT_INTERCEPTED (-2)
 
-/* Intercept openat for /proc and /dev paths.
- * The guest_t pointer is needed to generate /proc/self/maps from region data.
+/* Intercept openat for /proc and /dev paths. The guest_t pointer is needed to
+ * generate /proc/self/maps from region data.
  * Returns a host fd on match (caller should fd_alloc it), -1 on error with
  * errno set, or PROC_NOT_INTERCEPTED if the path is not intercepted.
  */
@@ -44,8 +44,8 @@ int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz);
 int proc_intercept_stat(const char *path, struct stat *mac_st);
 
 /* Intercept writes to synthetic proc files that need stateful behavior.
- * Returns 1 if handled (with *written_out set), 0 if not intercepted, or -1
- * on error with errno set.
+ * Returns 1 if handled (with *written_out set), 0 if not intercepted, or -1 on
+ * error with errno set.
  */
 int proc_intercept_write(int guest_fd,
                          int host_fd,
@@ -73,16 +73,18 @@ int proc_intercept_readv(int guest_fd,
                          int64_t offset,
                          ssize_t *read_out);
 
-/* Get the /dev/shm emulation directory path (creating it on first call).
- * Used by sys_unlinkat to rewrite /dev/shm/<name> paths.
+/* Get the /dev/shm emulation directory path (creating it on first call). Used
+ * by sys_unlinkat to rewrite /dev/shm/<name> paths.
  */
 const char *proc_get_shm_dir(void);
 
 /* Resolve a /dev/shm/<suffix> guest-path suffix to a host path inside the
  * per-UID /dev/shm emulation directory. Rejects empty, ".."-bearing, or
- * compound suffixes with errno = EACCES. Returns 0 on success and writes the
- * full host path to host_path; returns -1 with errno set (EACCES on invalid
- * suffix, ENAMETOOLONG on overflow, or as set by shm_dir_path()).
+ * compound suffixes with errno = EACCES.
+ *
+ * Returns 0 on success and writes the full host path to host_path; returns -1
+ * with errno set (EACCES on invalid suffix, ENAMETOOLONG on overflow, or as set
+ * by shm_dir_path()).
  */
 int proc_dev_shm_resolve(const char *guest_suffix,
                          char *host_path,
@@ -97,44 +99,46 @@ void proc_pty_close_keepalive(int master_host_fd);
 
 /* Caller-locked variant of pty keepalive duplication. Brackets the host
  * fd_snapshot_and_dup and the keepalive mirror under one pty_keepalive_lock
- * window so a sibling close cannot run proc_pty_close_keepalive in the
- * gap and leave the alias without a keepalive entry. Caller must wrap the
- * sequence with proc_pty_lock_for_dup / proc_pty_unlock_for_dup.
+ * window so a sibling close cannot run proc_pty_close_keepalive in the gap and
+ * leave the alias without a keepalive entry. Caller must wrap the sequence with
+ * proc_pty_lock_for_dup / proc_pty_unlock_for_dup.
  */
 void proc_pty_lock_for_dup(void);
 void proc_pty_unlock_for_dup(void);
 void proc_pty_dup_keepalive_locked(int src_master_host_fd,
                                    int dst_master_host_fd);
 
-/* Return the captured Linux pts number for a host master fd, or UINT32_MAX
- * when no keepalive is registered. Lets sys_ioctl TIOCGPTN report the value
- * /dev/pts/N opens / stats round-trip through, instead of independently
- * parsing the macOS slave path and risking divergence with the open table.
+/* Return the captured Linux pts number for a host master fd, or UINT32_MAX when
+ * no keepalive is registered. Lets sys_ioctl TIOCGPTN report the value
+ * /dev/pts/N opens / stats round-trip through, instead of independently parsing
+ * the macOS slave path and risking divergence with the open table.
  */
 uint32_t proc_pty_master_pts_num(int master_host_fd);
 
-/* Best-effort lazy registration for a /dev/ptmx master that elfuse did not
- * open itself (e.g. one received from a peer via SCM_RIGHTS). Takes a guest
- * fd because the canonical host fd would race with sibling close+reuse if
- * passed in directly: this helper snapshots fd_table[guest_fd].host_fd and
- * its generation, performs the slave open against a private dup, and only
- * registers the keepalive after re-verifying the slot still holds the
- * original (host_fd, generation). Returns the pts number on success, or
- * UINT32_MAX if the fd is not a pty master, the slot got closed/recycled
- * mid-adoption, or the keepalive table is full. Idempotent: if the master
- * already has a keepalive entry, returns its stored linux_pts_num.
+/* Best-effort lazy registration for a /dev/ptmx master that elfuse did not open
+ * itself (e.g. one received from a peer via SCM_RIGHTS). Takes a guest fd
+ * because the canonical host fd would race with sibling close+reuse if passed
+ * in directly: this helper snapshots fd_table[guest_fd].host_fd and its
+ * generation, performs the slave open against a private dup, and only registers
+ * the keepalive after re-verifying the slot still holds the original (host_fd,
+ * generation).
+ *
+ * Returns the pts number on success, or UINT32_MAX if the fd is not a pty
+ * master, the slot got closed/recycled mid-adoption, or the keepalive table is
+ * full. Idempotent: if the master already has a keepalive entry, returns its
+ * stored linux_pts_num.
  */
 uint32_t proc_pty_master_adopt(int guest_fd);
 
-/* Max bytes for a captured macOS slave path (e.g. "/dev/ttys004"). Lives in
- * the header so proc_pty_ipc_entry_t below and the in-memory keepalive table
- * in procemu.c share one source of truth; a divergence would silently corrupt
- * the fork-IPC wire format.
+/* Max bytes for a captured macOS slave path (e.g. "/dev/ttys004"). Lives in the
+ * header so proc_pty_ipc_entry_t below and the in-memory keepalive table in
+ * procemu.c share one source of truth; a divergence would silently corrupt the
+ * fork-IPC wire format.
  */
 #define PTY_SLAVE_PATH_MAX 64
 
-/* Serialized form of a pty keepalive entry, used by fork-IPC. The slave host
- * fd travels separately via SCM_RIGHTS; this struct only carries the
+/* Serialized form of a pty keepalive entry, used by fork-IPC. The slave host fd
+ * travels separately via SCM_RIGHTS; this struct only carries the
  * lifetime-independent metadata that the child needs to re-register.
  */
 typedef struct {
@@ -145,10 +149,12 @@ typedef struct {
 
 /* Snapshot the current pty keepalive table into out_entries / out_slave_fds.
  * dup()s every slave fd under the keepalive lock so the snapshot stays valid
- * across the SCM_RIGHTS send even if the original master gets closed before
- * the IPC drains. Returns the number of live entries written (always
- * <= max_entries); on success the caller owns the duplicated slave fds and
- * must close them after the IPC send completes.
+ * across the SCM_RIGHTS send even if the original master gets closed before the
+ * IPC drains.
+ *
+ * Returns the number of live entries written (always <= max_entries); on
+ * success the caller owns the duplicated slave fds and must close them after
+ * the IPC send completes.
  */
 int proc_pty_snapshot_keepalive(proc_pty_ipc_entry_t *out_entries,
                                 int *out_slave_fds,

--- a/src/runtime/proctitle.c
+++ b/src/runtime/proctitle.c
@@ -63,9 +63,9 @@ void runtime_set_process_title(int argc, char **argv, const char *elf_path)
 
     /* Write the argv block with explicit byte stores through a volatile
      * destination. The libc memcpy/memset on Apple Silicon are free to use
-     * cache-line-aligned stp/DC ZVA stores; using single-byte STRB removes
-     * any chance of touching the byte past avail, which on a Linux-style
-     * initial stack is the first character of envp[0].
+     * cache-line-aligned stp/DC ZVA stores; using single-byte STRB removes any
+     * chance of touching the byte past avail, which on a Linux-style initial
+     * stack is the first character of envp[0].
      */
     size_t copy = title_len < avail ? title_len : avail - 1;
     volatile char *dst = (volatile char *) argv[0];

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Thread table with _Thread_local fast path for current thread access.
- * Protected by a mutex since thread creation/destruction is infrequent
- * relative to per-syscall access (which uses the lock-free TLS pointer).
+ * Protected by a mutex since thread creation/destruction is infrequent relative
+ * to per-syscall access (which uses the lock-free TLS pointer).
  */
 
 #include <errno.h>
@@ -24,9 +24,9 @@
 #include "core/guest.h" /* guest_t (shim_data_base/ipa_base), BLOCK_2MIB */
 #include "hvutil.h"     /* vcpu_get_gpr, vcpu_get_sysreg */
 
-/* From syscall/signal.h, included here directly to avoid pulling in
- * the full signal header (macOS defines sa_handler as a macro that
- * conflicts with the linux_sigaction_t field name).
+/* From syscall/signal.h, included here directly to avoid pulling in the full
+ * signal header (macOS defines sa_handler as a macro that conflicts with the
+ * linux_sigaction_t field name).
  */
 #define LINUX_SS_DISABLE 2
 
@@ -38,10 +38,10 @@ static int thread_can_add_deferred_unmap_locked(thread_entry_t *t,
                                                 uint64_t start,
                                                 uint64_t end);
 
-/* Top of the EL1 exception stack region (one 4KiB slot per thread).
- * The shim data block sits at high IPA, computed at guest_init time and
- * stored in g->shim_data_base; the top of the EL1 stacks is the next
- * 2MiB boundary above that. Caller must hold a guest_t reference.
+/* Top of the EL1 exception stack region (one 4KiB slot per thread). The shim
+ * data block sits at high IPA, computed at guest_init time and stored in
+ * g->shim_data_base; the top of the EL1 stacks is the next 2MiB boundary above
+ * that. Caller must hold a guest_t reference.
  */
 static inline uint64_t sp_el1_top(const guest_t *g)
 {
@@ -64,8 +64,8 @@ static _Atomic int active_thread_count = 0;
     THREAD_FOR_EACH (t)           \
         if (t->active)
 
-/* Iterate active slots without holding thread_lock. Uses an acquire load on
- * the active flag so the lock-free observers in thread_tid_alive() and
+/* Iterate active slots without holding thread_lock. Uses an acquire load on the
+ * active flag so the lock-free observers in thread_tid_alive() and
  * thread_signal_deliverable() see a consistent transition.
  */
 #define THREAD_FOR_EACH_ACTIVE_RELAXED(t) \
@@ -164,8 +164,8 @@ thread_entry_t *thread_alloc(int64_t tid,
     return result;
 }
 
-/* Free an SP_EL1 slot for reuse. Must be called with thread_lock held.
- * Reads the slot index recorded at allocation time and clears the bit.
+/* Free an SP_EL1 slot for reuse. Must be called with thread_lock held. Reads
+ * the slot index recorded at allocation time and clears the bit.
  */
 static void thread_free_sp_el1_locked(thread_entry_t *t)
 {
@@ -194,10 +194,9 @@ void thread_deactivate(thread_entry_t *t)
 
     pthread_mutex_lock(&thread_lock);
 
-    /* If this is a VM-clone child, mark it as exited and wake the
-     * tracer/parent so wait4 can collect the exit status.  Must happen BEFORE
-     * destroying the condvars, since broadcasting a destroyed condvar is
-     * undefined behavior.
+    /* If this is a VM-clone child, mark it as exited and wake the tracer/parent
+     * so wait4 can collect the exit status. Must happen BEFORE destroying the
+     * condvars, since broadcasting a destroyed condvar is undefined behavior.
      */
     /* Guard against double-deactivation: if already inactive, skip. */
     if (!t->active) {
@@ -290,8 +289,8 @@ uint64_t thread_alloc_sp_el1(const guest_t *g, thread_entry_t *t)
         log_error("thread: SP_EL1 slots exhausted");
     } else {
         int slot = bit_ctz64(free_mask);
-        /* Main thread's SP_EL1 sits at the top of the shim data block.
-         * Each subsequent thread is 4KiB below.
+        /* Main thread's SP_EL1 sits at the top of the shim data block. Each
+         * subsequent thread is 4KiB below.
          */
         uint64_t top = sp_el1_top(g);
         sp = top - (uint64_t) slot * 4096;
@@ -338,10 +337,10 @@ void thread_join_workers(void)
     /* Poll/join each worker OUTSIDE the lock. Workers that responded to
      * hv_vcpus_exit typically finish within microseconds. Threads stuck in
      * uninterruptible host calls (blocking read/poll) are given 100ms to
-     * finish. If still alive, detach and let process exit clean up. The vCPU
-     * is NOT destroyed here because HVF vCPUs are thread-affine, so
-     * cross-thread hv_vcpu_destroy while the owning thread may still be inside
-     * hv_vcpu_run is unsafe.
+     * finish. If still alive, detach and let process exit clean up. The vCPU is
+     * NOT destroyed here because HVF vCPUs are thread-affine, so cross-thread
+     * hv_vcpu_destroy while the owning thread may still be inside hv_vcpu_run
+     * is unsafe.
      */
     for (int w = 0; w < nworkers; w++) {
         for (int i = 0; i < 20; i++) {
@@ -378,8 +377,8 @@ void thread_destroy_all_vcpus(void)
 
 void thread_interrupt_all(void)
 {
-    /* Collect active vCPUs under the lock, then call hv_vcpus_exit outside
-     * the lock to avoid holding it during a framework call.
+    /* Collect active vCPUs under the lock, then call hv_vcpus_exit outside the
+     * lock to avoid holding it during a framework call.
      */
     hv_vcpu_t vcpus[MAX_THREADS];
     int count = 0;
@@ -449,12 +448,11 @@ void thread_quiesce_siblings(void)
     /* Force siblings out of hv_vcpu_run */
     hv_vcpus_exit(vcpus, (uint32_t) count);
 
-    /* Wait until all siblings have blocked on the barrier.
-     * Use a bounded wait: siblings in long-running host syscalls (poll, read,
-     * accept) may not reach the barrier check promptly since hv_vcpus_exit only
-     * affects threads inside hv_vcpu_run. After the timeout, proceed with the
-     * snapshot; the sibling is blocked in a host syscall and not mutating guest
-     * memory.
+    /* Wait until all siblings have blocked on the barrier. Use a bounded wait:
+     * siblings in long-running host syscalls (poll, read, accept) may not reach
+     * the barrier check promptly since hv_vcpus_exit only affects threads
+     * inside hv_vcpu_run. After the timeout, proceed with the snapshot; the
+     * sibling is blocked in a host syscall and not mutating guest memory.
      */
     pthread_mutex_lock(&thread_lock);
     if (fork_quiesced_count < fork_target_count) {
@@ -523,11 +521,11 @@ int thread_collect_and_defer_stack_ranges(
 retry:
     nranges = 0;
 
-    /* Pass 1: enumerate every thread whose live stack overlaps [start, end)
-     * and verify each one can record a new deferred-unmap entry. If the
+    /* Pass 1: enumerate every thread whose live stack overlaps [start, end) and
+     * verify each one can record a new deferred-unmap entry. If the
      * caller-provided buffer is too small or any thread is at its
-     * deferred-unmap cap, refuse the whole operation so pass 2 never has
-     * to handle a partial commit.
+     * deferred-unmap cap, refuse the whole operation so pass 2 never has to
+     * handle a partial commit.
      */
     THREAD_FOR_EACH_ACTIVE (t) {
         uint64_t rs = t->stack_map_start;
@@ -562,8 +560,8 @@ retry:
         }
         nranges++;
     }
-    /* Pass 2: commit. Both passes iterate the table in the same order
-     * under the same lock, so the active set seen here matches pass 1.
+    /* Pass 2: commit. Both passes iterate the table in the same order under the
+     * same lock, so the active set seen here matches pass 1.
      */
     for (int i = 0; i < nranges; i++) {
         (void) thread_add_deferred_unmap_locked(txns[i].thread, txns[i].start,
@@ -724,9 +722,9 @@ static int thread_add_deferred_unmap_locked(thread_entry_t *t,
     if (!t || start >= end)
         return 0;
 
-    /* Absorb every existing slot that overlaps or is adjacent to [start,
-     * end), expanding the candidate as needed. Compact the array in place
-     * by pulling the live tail into each absorbed slot.
+    /* Absorb every existing slot that overlaps or is adjacent to [start, end),
+     * expanding the candidate as needed. Compact the array in place by pulling
+     * the live tail into each absorbed slot.
      */
     int n = t->deferred_stack_unmap_count;
     int i = 0;

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -66,17 +66,16 @@ typedef struct {
      */
     uint64_t robust_list_head;
 
-    /* rseq (restartable sequences) per-thread registration state.
-     * When rseq_gva != 0, the thread has a registered struct rseq.
-     * Signal delivery and preemption must abort active critical sections.
+    /* rseq (restartable sequences) per-thread registration state. When rseq_gva
+     * != 0, the thread has a registered struct rseq. Signal delivery and
+     * preemption must abort active critical sections.
      */
     uint64_t rseq_gva;       /* Guest VA of struct rseq (0 = not registered) */
     uint32_t rseq_len;       /* Length from registration */
     uint32_t rseq_signature; /* Abort signature from registration */
 
-    /* ptrace state.
-     * Used by two-process JIT architectures: the tracer attaches via
-     * PTRACE_SEIZE, then uses BRK-triggered SIGTRAP + wait4 to discover
+    /* ptrace state. Used by two-process JIT architectures: the tracer attaches
+     * via PTRACE_SEIZE, then uses BRK-triggered SIGTRAP + wait4 to discover
      * untranslated code on-demand. The tracee snapshots its own vCPU registers
      * before stopping and applies any tracer-written changes on resume,
      * avoiding cross-thread HVF register access (which may not be supported).
@@ -94,10 +93,9 @@ typedef struct {
     linux_user_pt_regs_t ptrace_regs; /* snapshot for cross-thread access */
     bool ptrace_regs_dirty;           /* Tracer modified registers */
 
-    /* GDB stub state.
-     * Per-thread stop state for the GDB remote stub. When GDB requests a stop
-     * (breakpoint, Ctrl+C, step), the thread records its stop reason here so
-     * the stub can report it to GDB.
+    /* GDB stub state. Per-thread stop state for the GDB remote stub. When GDB
+     * requests a stop (breakpoint, Ctrl+C, step), the thread records its stop
+     * reason here so the stub can report it to GDB.
      *
      * Register access: HVF requires vCPU register reads/writes on the owning
      * thread. When stopped, the vCPU thread snapshots registers into
@@ -110,10 +108,9 @@ typedef struct {
                                     */
     bool gdb_regs_dirty;           /* GDB handler modified snapshot */
 
-    /* VM-clone child state.
-     * For clone(CLONE_VM) without CLONE_THREAD: shares guest memory but has a
-     * separate TID, is waitable via wait4, and can be ptraced.
-     * Used by clone(CLONE_VM) two-process architecture.
+    /* VM-clone child state. For clone(CLONE_VM) without CLONE_THREAD: shares
+     * guest memory but has a separate TID, is waitable via wait4, and can be
+     * ptraced. Used by clone(CLONE_VM) two-process architecture.
      */
     bool is_vm_clone;   /* Waitable via wait4 */
     int64_t parent_tid; /* Parent TID for wait4 matching */
@@ -121,10 +118,10 @@ typedef struct {
     bool vm_exited;     /* Child has exited */
     int vm_exit_status; /* Wait-format exit status */
 
-    /* Guest stack range supplied by clone3(stack, stack_size).
-     * elfuse uses this to avoid tearing down a still-active child stack when
-     * another thread munmaps the backing range before the child is done with
-     * its bootstrap stack.
+    /* Guest stack range supplied by clone3(stack, stack_size). elfuse uses this
+     * to avoid tearing down a still-active child stack when another thread
+     * munmaps the backing range before the child is done with its bootstrap
+     * stack.
      */
     uint64_t stack_map_start;
     uint64_t stack_map_end;
@@ -144,8 +141,8 @@ typedef struct {
     int deferred_count;
 } thread_deferred_stack_unmap_txn_t;
 
-/* Current thread pointer, set once per host pthread at thread start.
- * All syscall handlers can access per-thread state through this.
+/* Current thread pointer, set once per host pthread at thread start. All
+ * syscall handlers can access per-thread state through this.
  */
 extern _Thread_local thread_entry_t *current_thread;
 
@@ -161,8 +158,8 @@ void thread_register_main(hv_vcpu_t vcpu,
                           uint64_t sp_el1);
 
 /* Allocate a new thread table slot for the given TID.
- * Returns a pointer to the entry, or NULL if the table is full.
- * The caller must fill in vcpu, vexit, host_thread, sp_el1.
+ * Returns a pointer to the entry, or NULL if the table is full. The caller must
+ * fill in vcpu, vexit, host_thread, sp_el1.
  */
 thread_entry_t *thread_alloc(int64_t tid,
                              uint64_t stack_start,
@@ -177,8 +174,8 @@ thread_entry_t *thread_find(int64_t tid);
 /* Lock-free check: is there an active thread with this TID?
  * Returns 1 if found, 0 if not. Safe to call without holding any lock (used
  * from futex_lock_pi to avoid lock order inversion with bucket locks). May
- * return a stale true if the thread is being deactivated concurrently;
- * callers must tolerate this.
+ * return a stale true if the thread is being deactivated concurrently; callers
+ * must tolerate this.
  */
 int thread_tid_alive(int64_t tid);
 
@@ -188,70 +185,69 @@ int thread_active_count(void);
 /* Fast path: return non-zero when exactly one guest thread is active. */
 int thread_is_single_active(void);
 
-/* Allocate a per-thread SP_EL1 stack and record both the IPA and the slot
- * index into t. Thread N gets the Nth 4KiB slot counting down from the top
- * of the shim data block (g->shim_data_base + 2MiB). The shim block lives
- * at high IPA computed by guest_init, so callers must pass g; the slot
- * index is stored in t->sp_el1_slot so the free path (which is reached
- * from teardown contexts that lack g) can clear the bitmask directly.
+/* Allocate a per-thread SP_EL1 stack and record both the IPA and the slot index
+ * into t. Thread N gets the Nth 4KiB slot counting down from the top of the
+ * shim data block (g->shim_data_base + 2MiB). The shim block lives at high IPA
+ * computed by guest_init, so callers must pass g; the slot index is stored in
+ * t->sp_el1_slot so the free path (which is reached from teardown contexts that
+ * lack g) can clear the bitmask directly.
  * Returns the SP_EL1 IPA, or 0 on slot exhaustion.
  */
 uint64_t thread_alloc_sp_el1(const guest_t *g, thread_entry_t *t);
 
-/* Iterate over all active threads, calling fn(entry, ctx) for each.
- * Holds the thread table lock during iteration.
+/* Iterate over all active threads, calling fn(entry, ctx) for each. Holds the
+ * thread table lock during iteration.
  */
 void thread_for_each(void (*fn)(thread_entry_t *t, void *ctx), void *ctx);
 
-/* Count active VM-clone threads (is_vm_clone && !vm_exited).
- * Used to detect when the last VM-clone child exits.
+/* Count active VM-clone threads (is_vm_clone && !vm_exited). Used to detect
+ * when the last VM-clone child exits.
  */
 int thread_count_active_vm_clones(void);
 
-/* Join worker threads (all active threads except the caller).
- * Collects thread handles under the lock, then polls/joins OUTSIDE
- * the lock so workers can call thread_deactivate() to set active=0.
- * Threads still alive after ~50ms are detached (process is exiting).
+/* Join worker threads (all active threads except the caller). Collects thread
+ * handles under the lock, then polls/joins OUTSIDE the lock so workers can call
+ * thread_deactivate() to set active=0. Threads still alive after ~50ms are
+ * detached (process is exiting).
  */
 void thread_join_workers(void);
 
-/* Destroy all active worker vCPUs. Called during guest_destroy to
- * ensure no vCPUs remain active before hv_vm_destroy().
+/* Destroy all active worker vCPUs. Called during guest_destroy to ensure no
+ * vCPUs remain active before hv_vm_destroy().
  */
 void thread_destroy_all_vcpus(void);
 
-/* Interrupt all active vCPUs by calling hv_vcpus_exit().
- * Used for signal preemption: when a signal is queued while a vCPU
- * is running in a tight loop (no syscalls), this forces it to break
- * out of hv_vcpu_run so the signal can be delivered.
+/* Interrupt all active vCPUs by calling hv_vcpus_exit(). Used for signal
+ * preemption: when a signal is queued while a vCPU is running in a tight loop
+ * (no syscalls), this forces it to break out of hv_vcpu_run so the signal can
+ * be delivered.
  */
 void thread_interrupt_all(void);
 
-/* Check if any active thread has sigbit unblocked in its signal mask.
- * Uses relaxed reads on per-thread blocked fields; false positives
- * (stale blocked=0) cause a harmless spurious interrupt; false negatives
- * (stale blocked=1) are corrected by rt_sigprocmask re-checking pending
- * signals after unblock.  Does NOT acquire thread_lock.
+/* Check if any active thread has sigbit unblocked in its signal mask. Uses
+ * relaxed reads on per-thread blocked fields; false positives (stale blocked=0)
+ * cause a harmless spurious interrupt; false negatives (stale blocked=1) are
+ * corrected by rt_sigprocmask re-checking pending signals after unblock. Does
+ * NOT acquire thread_lock.
  */
 int thread_signal_deliverable(uint64_t sigbit);
 
 /* Fork quiesce helpers. */
 
-/* Quiesce all sibling vCPUs for fork snapshot consistency.
- * Calls hv_vcpus_exit on all active threads except the caller,
- * then waits until they are all blocked on the fork barrier.
- * Caller must NOT hold thread_lock.
+/* Quiesce all sibling vCPUs for fork snapshot consistency. Calls hv_vcpus_exit
+ * on all active threads except the caller, then waits until they are all
+ * blocked on the fork barrier. Caller must NOT hold thread_lock.
  */
 void thread_quiesce_siblings(void);
 
-/* Resume sibling vCPUs after fork snapshot is complete.
- * Clears the quiesce flag and broadcasts the fork condvar.
+/* Resume sibling vCPUs after fork snapshot is complete. Clears the quiesce flag
+ * and broadcasts the fork condvar.
  */
 void thread_resume_siblings(void);
 
-/* Check if a fork quiesce is in progress. Called from the vCPU run
- * loop's HV_EXIT_REASON_CANCELED handler. If active, increments the
- * quiesced counter, blocks until the fork completes, then returns 1.
+/* Check if a fork quiesce is in progress. Called from the vCPU run loop's
+ * HV_EXIT_REASON_CANCELED handler. If active, increments the quiesced counter,
+ * blocks until the fork completes, then returns 1.
  * Returns 0 if no quiesce is active.
  */
 int thread_fork_barrier_check(void);
@@ -267,8 +263,8 @@ int thread_ptrace_stop(thread_entry_t *t, int sig);
 void thread_ptrace_cont(thread_entry_t *t, int sig);
 
 /* Tracer: wait for a ptraced or vm-clone child to stop or exit.
- * Returns child TID on success, 0 on WNOHANG with none ready,
- * or negative Linux errno. Writes wait-format status to *out_status.
+ * Returns child TID on success, 0 on WNOHANG with none ready, or negative Linux
+ * errno. Writes wait-format status to *out_status.
  */
 int64_t thread_ptrace_wait(int64_t tracer_tid,
                            int pid,
@@ -278,14 +274,14 @@ int64_t thread_ptrace_wait(int64_t tracer_tid,
 /* Get the thread table mutex (needed for ptrace wait blocking). */
 pthread_mutex_t *thread_get_lock(void);
 
-/* Snapshot every active guest stack range overlapping [start, end), then
- * record a deferred-unmap entry on each one. While the transaction is live,
- * cleanup of the affected thread's deferred stack entries will block so a
- * later rollback cannot race with thread exit.
- * On success, txns[0..nranges) contains both the overlapping ranges and the
- * pre-update deferred-unmap state needed for rollback.
- * Returns the number of overlapping stack ranges, or -1 if the caller's
- * buffer is too small or any thread's deferred-unmap budget is exhausted.
+/* Snapshot every active guest stack range overlapping [start, end), then record
+ * a deferred-unmap entry on each one. While the transaction is live, cleanup of
+ * the affected thread's deferred stack entries will block so a later rollback
+ * cannot race with thread exit. On success, txns[0..nranges) contains both the
+ * overlapping ranges and the pre-update deferred-unmap state needed for
+ * rollback.
+ * Returns the number of overlapping stack ranges, or -1 if the caller's buffer
+ * is too small or any thread's deferred-unmap budget is exhausted.
  */
 int thread_collect_and_defer_stack_ranges(
     uint64_t start,
@@ -309,8 +305,9 @@ void thread_rollback_deferred_stack_ranges(
 
 /* For thread exit cleanup: wait for any in-flight deferred-stack munmap
  * transaction affecting this thread to finish, then clear the live stack map
- * and snapshot the current deferred unmaps. Returns the number of entries
- * copied (capped at max_ranges).
+ * and snapshot the current deferred unmaps.
+ *
+ * Returns the number of entries copied (capped at max_ranges).
  */
 int thread_prepare_deferred_stack_unmaps_for_cleanup(thread_entry_t *t,
                                                      uint64_t *starts,

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -14,8 +14,8 @@
 #include "core/elf.h"
 
 /* Linux aarch64 syscall numbers. */
-/* Sorted numerically for easy lookup.
- * Reference: include/uapi/asm-generic/unistd.h in Linux source.
+/* Sorted numerically for easy lookup. Reference:
+ * include/uapi/asm-generic/unistd.h in Linux source.
  */
 #define SYS_io_destroy 1
 #define SYS_getcwd 17
@@ -250,9 +250,9 @@
 #define LINUX_PTRACE_INTERRUPT 0x4207
 #define LINUX_NT_PRSTATUS 1
 
-/* Linux aarch64 user_pt_regs: matches the kernel's struct user_pt_regs.
- * Used by PTRACE_GETREGSET/SETREGSET with NT_PRSTATUS to exchange
- * GPR state between tracer and tracee threads.
+/* Linux aarch64 user_pt_regs: matches the kernel's struct user_pt_regs. Used by
+ * PTRACE_GETREGSET/SETREGSET with NT_PRSTATUS to exchange GPR state between
+ * tracer and tracee threads.
  */
 typedef struct {
     uint64_t regs[31]; /* X0-X30 */
@@ -340,11 +340,10 @@ typedef struct {
 /* Linux FD flags. */
 #define LINUX_FD_CLOEXEC 1
 
-/* Linux ioctl constants.
- * Linux and macOS use different ioctl numbers for the same operations.
- * Linux terminal ioctls use 0x54xx (from asm-generic/ioctls.h).
- * macOS equivalents are in <sys/ioctl.h> and <sys/ttycom.h>.
- * Translation is done in syscall_io.c:sys_ioctl().
+/* Linux ioctl constants. Linux and macOS use different ioctl numbers for the
+ * same operations. Linux terminal ioctls use 0x54xx (from
+ * asm-generic/ioctls.h). macOS equivalents are in <sys/ioctl.h> and
+ * <sys/ttycom.h>. Translation is done in syscall_io.c:sys_ioctl().
  */
 #define LINUX_TCGETS 0x5401     /* -> macOS TIOCGETA (tcgetattr) */
 #define LINUX_TCSETS 0x5402     /* -> macOS TIOCSETA (tcsetattr TCSANOW) */
@@ -378,9 +377,9 @@ typedef struct {
 #define LINUX_O_RDONLY 0x0000
 #define LINUX_O_WRONLY 0x0001
 #define LINUX_O_RDWR 0x0002
-/* O_ACCMODE is the mask covering O_RDONLY, O_WRONLY, O_RDWR. The urandom
- * read fast-path bitmap and the dup-alias metadata both need this mask to
- * isolate the access-mode bits from the other LINUX_O_* flags.
+/* O_ACCMODE is the mask covering O_RDONLY, O_WRONLY, O_RDWR. The urandom read
+ * fast-path bitmap and the dup-alias metadata both need this mask to isolate
+ * the access-mode bits from the other LINUX_O_* flags.
  */
 #define LINUX_O_ACCMODE 0x0003
 #define LINUX_O_CREAT 0x0040
@@ -391,8 +390,8 @@ typedef struct {
 #define LINUX_O_NONBLOCK 0x0800
 #define LINUX_O_DSYNC 0x1000
 #define LINUX_O_ASYNC 0x2000
-/* aarch64-linux open flag values (from asm-generic/fcntl.h).
- * These differ from x86_64-linux values.
+/* aarch64-linux open flag values (from asm-generic/fcntl.h). These differ from
+ * x86_64-linux values.
  */
 #define LINUX_O_DIRECTORY 0x4000  /* 040000 octal */
 #define LINUX_O_NOFOLLOW 0x8000   /* 0100000 octal */
@@ -405,9 +404,9 @@ typedef struct {
 #define LINUX___O_TMPFILE 0x400000
 #define LINUX_O_TMPFILE (LINUX___O_TMPFILE | LINUX_O_DIRECTORY)
 
-/* Linux fallocate(2) mode bits (linux/falloc.h). PUNCH_HOLE requires the
- * caller to also set KEEP_SIZE per the manpage; collapse/insert/zero/unshare
- * range modes are recognised numerically but elsewhere unsupported.
+/* Linux fallocate(2) mode bits (linux/falloc.h). PUNCH_HOLE requires the caller
+ * to also set KEEP_SIZE per the manpage; collapse/insert/zero/unshare range
+ * modes are recognised numerically but elsewhere unsupported.
  */
 #define LINUX_FALLOC_FL_KEEP_SIZE 0x01
 #define LINUX_FALLOC_FL_PUNCH_HOLE 0x02
@@ -426,8 +425,8 @@ typedef struct {
 #define LINUX_UTIME_NOW 0x3fffffff
 #define LINUX_UTIME_OMIT 0x3ffffffe
 
-/* statx() sync mode bits. AT_STATX_SYNC_AS_STAT == 0; the FORCE/DONT
- * variants are accepted and ignored (host fstatat is implicitly synchronous).
+/* statx() sync mode bits. AT_STATX_SYNC_AS_STAT == 0; the FORCE/DONT variants
+ * are accepted and ignored (host fstatat is implicitly synchronous).
  */
 #define LINUX_AT_STATX_FORCE_SYNC 0x2000
 #define LINUX_AT_STATX_DONT_SYNC 0x4000
@@ -448,10 +447,10 @@ typedef struct {
 #define LINUX_CAP_LAST_CAP 40
 #define LINUX_PR_SET_VMA 0x53564d41 /* "SVMA" */
 #define LINUX_PR_SET_VMA_ANON_NAME 0
-/* PR_SET_MEM_MODEL / PR_GET_MEM_MODEL: per-thread memory ordering control.
- * On Apple Silicon, setting model to TSO enables Total Store Ordering via
- * ACTLR_EL1.EnTSO, giving ARM64 loads/stores x86-style memory ordering.
- * From Asahi Linux: include/uapi/linux/prctl.h (not in mainline Linux).
+/* PR_SET_MEM_MODEL / PR_GET_MEM_MODEL: per-thread memory ordering control. On
+ * Apple Silicon, setting model to TSO enables Total Store Ordering via
+ * ACTLR_EL1.EnTSO, giving ARM64 loads/stores x86-style memory ordering. From
+ * Asahi Linux: include/uapi/linux/prctl.h (not in mainline Linux).
  */
 #define LINUX_PR_SET_MEM_MODEL 0x4d4d444c /* "MMDL" in ASCII */
 #define LINUX_PR_GET_MEM_MODEL 0x6d4d444c /* "mMDL" in ASCII */
@@ -557,7 +556,7 @@ typedef struct {
 /* Linux struct sysinfo. */
 typedef struct {
     int64_t uptime;
-    uint64_t loads[3]; /* 1, 5, 15 minute load averages × 65536 */
+    uint64_t loads[3]; /* 1, 5, 15 minute load averages * 65536 */
     uint64_t totalram, freeram, sharedram, bufferram, totalswap, freeswap;
     uint16_t procs, pad;
     uint32_t pad2;
@@ -582,8 +581,8 @@ typedef struct {
 } linux_rlimit64_t;
 
 /* Linux struct utmpx (aarch64 LP64). */
-/* Matches musl's struct utmpx layout. Used for /var/run/utmp synthesis.
- * On LP64: short=2, int=4, long=8, sizeof(struct timeval)=16.
+/* Matches musl's struct utmpx layout. Used for /var/run/utmp synthesis. On
+ * LP64: short=2, int=4, long=8, sizeof(struct timeval)=16.
  * sizeof(linux_utmpx_t) == 400 (396 data + 4 trailing padding).
  */
 #define LINUX_UT_LINESIZE 32
@@ -715,10 +714,10 @@ enum {
     SOCK_OPT_IP_PKTINFO,
     SOCK_OPT_IP_RECVTTL,
     SOCK_OPT_IP_RECVTOS,
-    /* IP_MTU_DISCOVER value stored verbatim so getsockopt round-trips the
-     * Linux PMTUD mode the guest set. The host accepts the value but does
-     * not honour every Linux mode; see sys_setsockopt for the IP_DONTFRAG
-     * translation for the modes macOS supports.
+    /* IP_MTU_DISCOVER value stored verbatim so getsockopt round-trips the Linux
+     * PMTUD mode the guest set. The host accepts the value but does not honour
+     * every Linux mode; see sys_setsockopt for the IP_DONTFRAG translation for
+     * the modes macOS supports.
      */
     SOCK_OPT_IP_MTU_DISCOVER,
     SOCK_OPT_COUNT

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Implements execve: reads path/argv/envp from guest memory, closes
- * CLOEXEC fds, resets the guest VM, reloads the shim and new ELF,
- * rebuilds page tables, and restarts at the new entry point.
+ * Implements execve: reads path/argv/envp from guest memory, closes CLOEXEC
+ * fds, resets the guest VM, reloads the shim and new ELF, rebuilds page tables,
+ * and restarts at the new entry point.
  */
 
 #include <stdbool.h>
@@ -44,12 +44,12 @@
  * entry has been removed from the shared fd table.
  */
 
-/* Force HVF to commit the sysreg/GPR writes that sys_execve performs after
- * a guest_reset before vcpu_run resumes. HVF defers writes until the next
- * register-touch on the owning thread, and a stale read here is harmless.
- * Use the HV_CHECK-wrapped accessors so a real HVF error (HV_BUSY,
- * HV_ERROR) past the point of no return aborts cleanly with a diagnostic
- * instead of silently resuming with undefined register state.
+/* Force HVF to commit the sysreg/GPR writes that sys_execve performs after a
+ * guest_reset before vcpu_run resumes. HVF defers writes until the next
+ * register-touch on the owning thread, and a stale read here is harmless. Use
+ * the HV_CHECK-wrapped accessors so a real HVF error (HV_BUSY, HV_ERROR) past
+ * the point of no return aborts cleanly with a diagnostic instead of silently
+ * resuming with undefined register state.
  */
 static void exec_sync_vcpu_regs(hv_vcpu_t vcpu)
 {
@@ -66,18 +66,18 @@ static void exec_republish_shim_globals_or_die(hv_vcpu_t vcpu,
                                                guest_t *g,
                                                bool verbose)
 {
-    /* guest_reset zeros shim_data. Reinitialize the host-owned fast-path
-     * state before returning to either native aarch64 code or the Rosetta
-     * runtime, otherwise identity and urandom fast paths observe all-zero
-     * cache state after exec.
+    /* guest_reset zeros shim_data. Reinitialize the host-owned fast-path state
+     * before returning to either native aarch64 code or the Rosetta runtime,
+     * otherwise identity and urandom fast paths observe all-zero cache state
+     * after exec.
      */
     shim_globals_init(g);
     shim_globals_publish_stats_gate(g);
     shim_globals_set_trace_enabled(g, verbose);
 
     /* TPIDR_EL1 carries the shim_globals base. Past PNR, failure leaves the
-     * replacement image unable to use the EL1 shim safely, so abort in the
-     * same shape as other post-reset fatal errors.
+     * replacement image unable to use the EL1 shim safely, so abort in the same
+     * shape as other post-reset fatal errors.
      */
     if (shim_globals_install_tpidr(vcpu, g) < 0) {
         log_fatal(
@@ -171,10 +171,10 @@ static int exec_resolve_interp_host_path(const char *sysroot,
                                         interp_host_path_sz, interp_host_temp);
 }
 
-/* Read a NULL-terminated pointer array from guest memory.
- * Each pointer in the array is a 64-bit GVA pointing to a string.
- * Returns the count of entries (excluding the NULL terminator),
- * or -1 on error. Strings are copied into the provided buffer.
+/* Read a NULL-terminated pointer array from guest memory. Each pointer in the
+ * array is a 64-bit GVA pointing to a string.
+ * Returns the count of entries (excluding the NULL terminator), or -1 on error.
+ * Strings are copied into the provided buffer.
  */
 static int read_string_array(guest_t *g,
                              uint64_t array_gva,
@@ -207,9 +207,10 @@ static int read_string_array(guest_t *g,
         count++;
     }
 
-    /* If all max_count slots are consumed, check whether the array
-     * continues (non-NULL next entry). Return -2 to signal E2BIG
-     * rather than silently truncating.
+    /* If all max_count slots are consumed, check whether the array continues
+     * (non-NULL next entry).
+     *
+     * Return -2 to signal E2BIG rather than silently truncating.
      */
     if (count == max_count) {
         uint64_t next;
@@ -230,10 +231,10 @@ int64_t sys_execve(hv_vcpu_t vcpu,
                    bool verbose,
                    const char *host_path)
 {
-    /* Copy guest execve inputs before any state-reset point of no return.
-     * If host_path is provided (from execveat resolution), use it directly
-     * instead of reading from guest memory. This avoids writing host-resolved
-     * paths into guest address space.
+    /* Copy guest execve inputs before any state-reset point of no return. If
+     * host_path is provided (from execveat resolution), use it directly instead
+     * of reading from guest memory. This avoids writing host-resolved paths
+     * into guest address space.
      */
     char path[LINUX_PATH_MAX];
     if (host_path) {
@@ -286,9 +287,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     }
     envp[envc] = NULL;
 
-    /* Resolve /proc/self/exe to the actual binary path.  Busybox sh
-     * execs applets via execve("/proc/self/exe", ["applet", ...]) and
-     * macOS has no /proc filesystem.
+    /* Resolve /proc/self/exe to the actual binary path. Busybox sh execs
+     * applets via execve("/proc/self/exe", ["applet", ...]) and macOS has no
+     * /proc filesystem.
      */
     if (!strcmp(path, "/proc/self/exe")) {
         const char *exe = proc_get_elf_path();
@@ -323,13 +324,13 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     }
 
     /* Try loading as ELF; if that fails, emulate Linux binfmt_script for
-     * shebang files.
-     * Linux kernel handles shebangs transparently in binfmt_script.
+     * shebang files. Linux kernel handles shebangs transparently in
+     * binfmt_script.
      */
     elf_info_t elf_info;
     if (elf_load(path_host, &elf_info) < 0) {
-        /* Not a valid ELF. Check if it's a script with a shebang line.
-         * Read the first 256 bytes and look for "#!" at the start.
+        /* Not a valid ELF. Check if it's a script with a shebang line. Read the
+         * first 256 bytes and look for "#!" at the start.
          */
         int script_fd = open(path_host, O_RDONLY);
         if (script_fd < 0) {
@@ -353,8 +354,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         if (eol)
             *eol = '\0';
 
-        /* Parse interpreter path and optional argument.
-         * Format: "#! /path/to/interpreter [optional-arg]"
+        /* Parse interpreter path and optional argument. Format: "#!
+         * /path/to/interpreter [optional-arg]"
          */
         char *interp_start = shebang_buf + 2;
         while (*interp_start == ' ' || *interp_start == '\t')
@@ -470,17 +471,17 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         }
     }
 
-    /* Pre-PNR validation.
-     * All checks that can fail gracefully MUST happen before guest_reset().
-     * After guest_reset(), the old process image is gone. Failures are
-     * unrecoverable, matching the Linux kernel's behavior (SIGKILL).
+    /* Pre-PNR validation. All checks that can fail gracefully MUST happen
+     * before guest_reset(). After guest_reset(), the old process image is gone.
+     * Failures are unrecoverable, matching the Linux kernel's behavior
+     * (SIGKILL).
      */
 
-    /* x86_64 targets dispatch through guest_bootstrap_rosetta_post_reset
-     * once the point-of-no-return work below clears guest state. Reject
-     * here only when Rosetta is disabled via --no-rosetta or
-     * ELFUSE_NO_ROSETTA=1; otherwise mark the transition and skip the
-     * aarch64-specific ELF/interp setup below.
+    /* x86_64 targets dispatch through guest_bootstrap_rosetta_post_reset once
+     * the point-of-no-return work below clears guest state. Reject here only
+     * when Rosetta is disabled via --no-rosetta or ELFUSE_NO_ROSETTA=1;
+     * otherwise mark the transition and skip the aarch64-specific ELF/interp
+     * setup below.
      */
     bool target_is_rosetta = false;
     if (elf_info.e_machine == EM_X86_64) {
@@ -495,9 +496,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         target_is_rosetta = true;
     }
 
-    /* Compute load base once (used for size check and later mapping).
-     * PIE (ET_DYN) binaries start near address 0 and would overlap with the
-     * shim; load them at PIE_LOAD_BASE instead.
+    /* Compute load base once (used for size check and later mapping). PIE
+     * (ET_DYN) binaries start near address 0 and would overlap with the shim;
+     * load them at PIE_LOAD_BASE instead.
      */
     uint64_t elf_load_base = (elf_info.e_type == ET_DYN) ? PIE_LOAD_BASE : 0;
 
@@ -513,9 +514,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         goto fail;
     }
 
-    /* Pre-load interpreter (headers only) for dynamic binaries.
-     * This validates the interpreter exists and is a valid ELF before exec
-     * crosses the point of no return. elf_map_segments() happens post-PNR.
+    /* Pre-load interpreter (headers only) for dynamic binaries. This validates
+     * the interpreter exists and is a valid ELF before exec crosses the point
+     * of no return. elf_map_segments() happens post-PNR.
      */
     elf_info_t interp_info;
     memset(&interp_info, 0, sizeof(interp_info));
@@ -564,8 +565,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         }
     }
 
-    /* Past pre-PNR validation. Fall through to point of no return.
-     * The fail label below handles all pre-PNR error paths.
+    /* Past pre-PNR validation. Fall through to point of no return. The fail
+     * label below handles all pre-PNR error paths.
      */
     if (0) {
     fail:
@@ -574,11 +575,10 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         return err;
     }
 
-    /* Point of no return.
-     * guest_reset() zeroes all guest memory. The old process image is gone.
-     * All validation that can fail gracefully MUST happen above this line.
-     * Failures below are unrecoverable; elfuse exits fatally, matching the
-     * Linux kernel's behavior (SIGKILL after exec PNR).
+    /* Point of no return. guest_reset() zeroes all guest memory. The old
+     * process image is gone. All validation that can fail gracefully MUST
+     * happen above this line. Failures below are unrecoverable; elfuse exits
+     * fatally, matching the Linux kernel's behavior (SIGKILL after exec PNR).
      */
 
     /* Close CLOEXEC fds by first removing them from the shared table under
@@ -586,8 +586,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
      * Cleanup acquires sfd_lock or inotify_lock, which must NOT be held under
      * fd_lock (lock ordering: fd_lock(3) < sfd_lock(5a) < inotify_lock(7)).
      *
-     * Two passes: count first, then heap-allocate. Avoids placing a ~100KiB
-     * VLA on the stack (FD_TABLE_SIZE * sizeof(fd_entry_t+int)).
+     * Two passes: count first, then heap-allocate. Avoids placing a ~100KiB VLA
+     * on the stack (FD_TABLE_SIZE * sizeof(fd_entry_t+int)).
      */
     int cloexec_count = 0;
     pthread_mutex_lock(&fd_lock);
@@ -665,20 +665,21 @@ int64_t sys_execve(hv_vcpu_t vcpu,
      */
     fork_notify_vfork_exec();
     /* Only clear rosetta state when leaving rosetta. For rosetta-to-rosetta
-     * exec the placement (rosetta_guest_base, rosetta_va_base, kbuf_gpa,
-     * ttbr1) must survive guest_reset so guest_bootstrap_rosetta_post_reset
-     * hits rosetta_prepare's re-entry branch and reuses the existing GPA
-     * instead of picking a fresh one. Keep proc_rosetta_active in sync so
-     * /proc/self/exe readlink reports the right path.
+     * exec the placement (rosetta_guest_base, rosetta_va_base, kbuf_gpa, ttbr1)
+     * must survive guest_reset so guest_bootstrap_rosetta_post_reset hits
+     * rosetta_prepare's re-entry branch and reuses the existing GPA instead of
+     * picking a fresh one. Keep proc_rosetta_active in sync so /proc/self/exe
+     * readlink reports the right path.
      */
     if (g->is_rosetta && !target_is_rosetta) {
         rosettad_clear_binary_path();
         guest_clear_rosetta_state(g);
         proc_set_rosetta_active(false);
     } else if (!g->is_rosetta && target_is_rosetta) {
-        /* aarch64 -> rosetta: enter rosetta mode fresh. guest_clear was
-         * already a no-op in this branch since the parent had no rosetta
-         * state to clear. */
+        /* aarch64 -> rosetta: enter rosetta mode fresh. guest_clear was already
+         * a no-op in this branch since the parent had no rosetta state to
+         * clear.
+         */
         g->is_rosetta = true;
         proc_set_rosetta_active(true);
     }
@@ -690,9 +691,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     proc_clear_exit_group();
     futex_interrupt_clear();
 
-    /* POSIX exec signal semantics:
-     * Handlers set to SIG_DFL (except SIG_IGN stays SIG_IGN), pending signals
-     * preserved, and signal mask preserved.
+    /* POSIX exec signal semantics: Handlers set to SIG_DFL (except SIG_IGN
+     * stays SIG_IGN), pending signals preserved, and signal mask preserved.
      */
     signal_reset_for_exec();
 
@@ -706,17 +706,17 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     }
 
     /* x86_64 re-bootstrap branch: hand off the post-reset work to the
-     * Rosetta-aware helper, then write vCPU sysregs for kernel-VA execution
-     * and return without touching the aarch64-specific block below.
+     * Rosetta-aware helper, then write vCPU sysregs for kernel-VA execution and
+     * return without touching the aarch64-specific block below.
      */
     if (target_is_rosetta) {
-        /* Drain the previous rosettad bridge before rosetta_finalize wires
-         * a fresh one. The detached handler thread only clears its global
-         * client-fd marker on its own EOF/exit. 1 s is enough headroom
-         * for a loaded host; a hung handler past that point will lose
-         * the start_handler CAS later, and the warning here marks the
-         * cause. Soft cap; the install may still succeed on timeout if
-         * the handler's CAS races us favourably.
+        /* Drain the previous rosettad bridge before rosetta_finalize wires a
+         * fresh one. The detached handler thread only clears its global
+         * client-fd marker on its own EOF/exit. 1 s is enough headroom for a
+         * loaded host; a hung handler past that point will lose the
+         * start_handler CAS later, and the warning here marks the cause. Soft
+         * cap; the install may still succeed on timeout if the handler's CAS
+         * races us favourably.
          */
         if (!rosettad_wait_for_idle(1000)) {
             log_warn(
@@ -725,14 +725,13 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         }
 
         /* path_host may point at path_host_buf (normal path) or at
-         * interp_host_buf (shebang resolution landed on a FUSE-backed
-         * x86_64 binary). Ownership of any materialized temp transfers
-         * to rosettad regardless of which buffer holds the path, so
-         * capture that temp path in one place and clear the matching
-         * temp flag here. exec_cleanup_inputs becomes a no-op for the
-         * transferred slot, and the post-PNR rollback below can unlink
-         * via owned_rosetta_temp without re-discriminating which buffer
-         * was selected.
+         * interp_host_buf (shebang resolution landed on a FUSE-backed x86_64
+         * binary). Ownership of any materialized temp transfers to rosettad
+         * regardless of which buffer holds the path, so capture that temp path
+         * in one place and clear the matching temp flag here.
+         * exec_cleanup_inputs becomes a no-op for the transferred slot, and the
+         * post-PNR rollback below can unlink via owned_rosetta_temp without
+         * re-discriminating which buffer was selected.
          */
         const char *owned_rosetta_temp = NULL;
         if (path_host == path_host_buf && path_host_temp) {
@@ -748,11 +747,11 @@ int64_t sys_execve(hv_vcpu_t vcpu,
                 g, path_host, owned_rosetta_temp != NULL, path, argc,
                 (const char **) argv, envp, shim_size, false, &r_entry, &r_sp,
                 &r_ttbr0) < 0) {
-            /* Post-PNR fatal failure. The temp flag was cleared up front
-             * so exec_cleanup_inputs would be a no-op, and rosettad never
-             * reached its ownership-commit point on this failure path.
-             * Best-effort unlink so the materialized temp does not orphan
-             * in /tmp on a path the kernel parallels with SIGKILL.
+            /* Post-PNR fatal failure. The temp flag was cleared up front so
+             * exec_cleanup_inputs would be a no-op, and rosettad never reached
+             * its ownership-commit point on this failure path. Best-effort
+             * unlink so the materialized temp does not orphan in /tmp on a path
+             * the kernel parallels with SIGKILL.
              */
             if (owned_rosetta_temp)
                 unlink(owned_rosetta_temp);
@@ -806,8 +805,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         exit(128);
     }
 
-    /* Track lowest loaded ELF address for the legacy fork IPC path
-     * after exec replaces the previous image (see guest_get_used_regions).
+    /* Track lowest loaded ELF address for the legacy fork IPC path after exec
+     * replaces the previous image (see guest_get_used_regions).
      */
     g->elf_load_min = elf_info.load_min + elf_load_base;
 
@@ -891,9 +890,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
 
     /* EL1 exception handlers use this block for stack and scratch state.
      * EL1-only so EL0 cannot read or store directly to the identity cache,
-     * urandom ring, or attention word that the shim fast paths consult.
-     * Matches bootstrap.c; if this regresses to plain RW, execve quietly
-     * defeats the protection on every new image.
+     * urandom ring, or attention word that the shim fast paths consult. Matches
+     * bootstrap.c; if this regresses to plain RW, execve quietly defeats the
+     * protection on every new image.
      */
     if (nregions >= MAX_REGIONS)
         goto too_many_regions;
@@ -904,8 +903,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
 
     /* The vDSO sits in the same 2MiB block as the shim. The page-table builder
      * splits the block into 4KiB L3 pages when its regions don't fully cover
-     * it, so the vDSO must appear here to keep the trampoline page valid and
-     * RX after rebuild.
+     * it, so the vDSO must appear here to keep the trampoline page valid and RX
+     * after rebuild.
      */
     if (nregions >= MAX_REGIONS)
         goto too_many_regions;
@@ -914,8 +913,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
                                           .perms = MEM_PERM_RX};
 
     /* Translate ELF p_flags into guest page permissions. Silent drops would
-     * leave the loaded segment unmapped, so treat overflow as fatal (we are
-     * already past the point of no return).
+     * leave the loaded segment unmapped, so treat overflow as fatal (the caller
+     * is already past the point of no return).
      */
     for (int i = 0; i < elf_info.num_segments; i++) {
         if (nregions >= MAX_REGIONS)
@@ -1072,11 +1071,11 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     /* SPSR_EL1: EL0t, AArch64 */
     hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1, 0x0);
 
-    /* Reset TPIDR_EL0 (thread-local storage base). The previous program's
-     * TLS pointer must not leak into the new program because glibc's ld-linux
-     * uses TLS very early (GL() macro accesses static TLS), and a stale
-     * TPIDR_EL0 causes it to read garbage for its internal state (link_map
-     * l_relocated flags, scope lists, etc.), breaking relocation.
+    /* Reset TPIDR_EL0 (thread-local storage base). The previous program's TLS
+     * pointer must not leak into the new program because glibc's ld-linux uses
+     * TLS very early (GL() macro accesses static TLS), and a stale TPIDR_EL0
+     * causes it to read garbage for its internal state (link_map l_relocated
+     * flags, scope lists, etc.), breaking relocation.
      */
     hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, 0);
 
@@ -1085,8 +1084,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
      */
     vcpu_zero_gprs(vcpu);
 
-    /* Tell the shim that execve replaced the full guest register state.
-     * X8=2 means: flush TLB, discard the old syscall frame, and return without
+    /* Tell the shim that execve replaced the full guest register state. X8=2
+     * means: flush TLB, discard the old syscall frame, and return without
      * restoring pre-exec registers. This bypasses the normal syscall epilogue,
      * which would otherwise overwrite X8 from cpu_tlbi_req.
      */

--- a/src/syscall/exec.h
+++ b/src/syscall/exec.h
@@ -15,8 +15,8 @@
 #include <stdint.h>
 #include "core/guest.h"
 
-/* Execute a new binary, replacing current process image.
- * Reads path, argv[], envp[] from guest memory, reloads ELF, resets state.
+/* Execute a new binary, replacing current process image. Reads path, argv[],
+ * envp[] from guest memory, reloads ELF, resets state.
  * Returns SYSCALL_EXEC_HAPPENED on success (caller skips X0 write), or negative
  * Linux errno on failure.
  */

--- a/src/syscall/fd.c
+++ b/src/syscall/fd.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Emulates Linux eventfd (pipe+counter), signalfd (synthetic signal reads),
- * and timerfd (kqueue EVFILT_TIMER). Each provides special read/write/close
+ * Emulates Linux eventfd (pipe+counter), signalfd (synthetic signal reads), and
+ * timerfd (kqueue EVFILT_TIMER). Each provides special read/write/close
  * semantics dispatched from sys_read/sys_write/sys_close.
  */
 
@@ -71,8 +71,8 @@ static int sfd_alloc_slot(const void *state, size_t count, size_t stride)
 
 /* timerfd emulation via kqueue EVFILT_TIMER
  *
- * Each timerfd_create() creates a kqueue + timer registration.
- * Reads from the timerfd return an 8-byte counter of expirations.
+ * Each timerfd_create() creates a kqueue + timer registration. Reads from the
+ * timerfd return an 8-byte counter of expirations.
  */
 
 /* Linux itimerspec for timerfd_settime/gettime */
@@ -127,8 +127,8 @@ static int timerfd_alloc(void)
 /* Called with sfd_lock held. Drain any kevent expirations sitting on the
  * timer's kqueue and fold them into the slot's accumulator. Used by
  * timerfd_read before consuming the counter and by timerfd_fdinfo_snapshot
- * before reporting it; without this drain, fdinfo would lag the actual
- * fire count by however many ticks were pending in the kqueue.
+ * before reporting it; without this drain, fdinfo would lag the actual fire
+ * count by however many ticks were pending in the kqueue.
  */
 static void timerfd_drain_pending_locked(int slot)
 {
@@ -144,8 +144,10 @@ static void timerfd_drain_pending_locked(int slot)
     }
 }
 
-/* Called with sfd_lock held. Returns nanoseconds until the next expiration,
- * or 0 when the timer is disarmed or a one-shot timer has already expired.
+/* Called with sfd_lock held.
+ *
+ * Returns nanoseconds until the next expiration, or 0 when the timer is
+ * disarmed or a one-shot timer has already expired.
  */
 static int64_t timerfd_remaining_ns_locked(int slot, int64_t now_ns)
 {
@@ -183,10 +185,10 @@ int64_t sys_timerfd_create(int clockid, int flags)
     if (kq < 0)
         return linux_errno();
 
-    /* macOS kqueue fds reject fcntl(F_SETFL, O_NONBLOCK) with ENOTTY, so
-     * track the non-blocking mode in fd_table[gfd].linux_flags below and
-     * let timerfd_read consult that field directly. F_SETFD CLOEXEC still
-     * works on a kqueue fd.
+    /* macOS kqueue fds reject fcntl(F_SETFL, O_NONBLOCK) with ENOTTY, so track
+     * the non-blocking mode in fd_table[gfd].linux_flags below and let
+     * timerfd_read consult that field directly. F_SETFD CLOEXEC still works on
+     * a kqueue fd.
      */
     if ((flags & LINUX_TFD_CLOEXEC) && fd_set_cloexec(kq) < 0) {
         close(kq);
@@ -214,9 +216,9 @@ int64_t sys_timerfd_create(int clockid, int flags)
     timerfd_state[slot].clockid = clockid;
     pthread_mutex_unlock(&sfd_lock);
 
-    /* Linux opens the timerfd inode O_RDWR (anon_inode_getfd in
-     * fs/timerfd.c). Stamp O_RDWR into linux_flags so the F_GETFL branch
-     * below can surface the access mode without re-deriving it.
+    /* Linux opens the timerfd inode O_RDWR (anon_inode_getfd in fs/timerfd.c).
+     * Stamp O_RDWR into linux_flags so the F_GETFL branch below can surface the
+     * access mode without re-deriving it.
      */
     fd_publish_linux_flags(
         gfd, LINUX_O_RDWR |
@@ -300,9 +302,8 @@ int64_t sys_timerfd_settime(guest_t *g,
         its.it_value_nsec = relative_ns % NS_PER_SEC;
     }
 
-    /* Clamp large seconds values to prevent signed integer overflow.
-     * INT64_MAX / 1e6 is about 9.2e12 seconds; INT64_MAX / 1e9 is about 9.2e9
-     * seconds.
+    /* Clamp large seconds values to prevent signed integer overflow. INT64_MAX
+     * / 1e6 is about 9.2e12 seconds; INT64_MAX / 1e9 is about 9.2e9 seconds.
      */
     int64_t val_sec = its.it_value_sec, int_sec = its.it_interval_sec;
     if (val_sec > INT64_MAX / US_PER_SEC)
@@ -335,7 +336,7 @@ int64_t sys_timerfd_settime(guest_t *g,
         timerfd_state[slot].armed = false;
         timerfd_state[slot].expirations = 0;
     } else {
-        /* Arm timer.  Always use EV_ONESHOT: for repeating timers where initial
+        /* Arm timer. Always use EV_ONESHOT: for repeating timers where initial
          * value != interval, kqueue would repeat at the wrong period (initial
          * instead of interval). timerfd_read re-arms with the interval after
          * the first read.
@@ -441,17 +442,18 @@ int64_t timerfd_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
         }
 
         /* If the timer was never armed, there's no kevent registered --
-         * kevent(NULL timeout) would block forever. Return EAGAIN.
+         * kevent(NULL timeout) would block forever.
+         *
+         * Return EAGAIN.
          */
         if (!timerfd_state[slot].armed) {
             pthread_mutex_unlock(&sfd_lock);
             return -LINUX_EAGAIN;
         }
 
-        /* Blocking: release lock, wait for the timer, re-lock.
-         * Another thread may close the fd while the timerfd wait is active --
-         * kevent() returns EBADF in that case, and the code re-validates the
-         * slot.
+        /* Blocking: release lock, wait for the timer, re-lock. Another thread
+         * may close the fd while the timerfd wait is active -- kevent() returns
+         * EBADF in that case, and the code re-validates the slot.
          */
         struct kevent kev;
         pthread_mutex_unlock(&sfd_lock);
@@ -480,7 +482,7 @@ int64_t timerfd_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
     int64_t intv = timerfd_state[slot].interval_ns;
     int rearm_kq = timerfd_state[slot].kq_fd;
 
-    /* Re-arm repeating timers with the interval period.  The initial fire used
+    /* Re-arm repeating timers with the interval period. The initial fire used
      * EV_ONESHOT (see timerfd_settime), so the code re-arms here to get correct
      * interval timing even when initial != interval.
      */
@@ -545,9 +547,8 @@ static void timerfd_close(int guest_fd)
  * multiple guest_fds can map to the same slot. The slot owns its own read end
  * for readiness/drain/blocking operations so it does not depend on any one
  * guest fd remaining open. The slot is freed when refcount drops to zero. The
- * slot's guest_fd field is retained for sfd_alloc_slot's
- * "free if guest_fd == -1" convention and tracks the most recently allocated
- * primary owner.
+ * slot's guest_fd field is retained for sfd_alloc_slot's "free if guest_fd ==
+ * -1" convention and tracks the most recently allocated primary owner.
  */
 #define EVENTFD_MAX 32
 static struct {
@@ -606,8 +607,8 @@ int64_t sys_eventfd2(unsigned int initval, int flags)
     if (pipe(pipefd) < 0)
         return linux_errno();
 
-    /* Both ends must be non-blocking to avoid blocking on pipe I/O. CLOEXEC
-     * is opt-in via EFD_CLOEXEC.
+    /* Both ends must be non-blocking to avoid blocking on pipe I/O. CLOEXEC is
+     * opt-in via EFD_CLOEXEC.
      */
     bool want_cloexec = (flags & LINUX_EFD_CLOEXEC) != 0;
     if (fd_set_nonblock(pipefd[0]) < 0 || fd_set_nonblock(pipefd[1]) < 0 ||
@@ -686,8 +687,8 @@ static void eventfd_close(int guest_fd)
     pthread_mutex_unlock(&sfd_lock);
 }
 
-/* Bind an additional guest_fd to the same slot as src_fd, sharing the
- * counter and pipe state. Two races to defeat:
+/* Bind an additional guest_fd to the same slot as src_fd, sharing the counter
+ * and pipe state. Two races to defeat:
  *
  *   - Source identity. duplicate_guest_fd() snapshots src_fd under
  *     fd_lock, releases it, then calls us. Between those points src_fd
@@ -713,9 +714,9 @@ int eventfd_dup_fd(int src_fd,
                    bool fixed_slot,
                    int linux_flags)
 {
-    /* Pin the source under fd_lock + sfd_lock and dup the slot-owned
-     * readiness fd. The slot fd is independent of any guest alias, so closing
-     * the source later cannot invalidate eventfd_state[slot].pipe_rd.
+    /* Pin the source under fd_lock + sfd_lock and dup the slot-owned readiness
+     * fd. The slot fd is independent of any guest alias, so closing the source
+     * later cannot invalidate eventfd_state[slot].pipe_rd.
      */
     pthread_mutex_lock(&fd_lock);
     pthread_mutex_lock(&sfd_lock);
@@ -739,8 +740,8 @@ int eventfd_dup_fd(int src_fd,
         return -1;
 
     /* Publish the destination fd with eventfd_close as cleanup. The
-     * eventfd_owner mapping is still -1, so a racing close here observes
-     * owner == -1 and does nothing; we detect that below.
+     * eventfd_owner mapping is still -1, so a racing close here observes owner
+     * == -1 and does nothing; we detect that below.
      */
     int new_guest_fd = fixed_slot
                            ? fd_alloc_at_relaxed(fixed_guest_fd, FD_EVENTFD,
@@ -757,11 +758,11 @@ int eventfd_dup_fd(int src_fd,
         return -1;
     }
 
-    /* Commit the bind under both locks in the documented order
-     * (fd_lock then sfd_lock). If a close already ran, fd_table[new].type
-     * is FD_CLOSED and we just bail with -EBADF; the host_fd is already
-     * gone via sys_close. Otherwise verify the source slot is still
-     * alive and unchanged, then install owner for the reserved ref.
+    /* Commit the bind under both locks in the documented order (fd_lock then
+     * sfd_lock). If a close already ran, fd_table[new].type is FD_CLOSED and we
+     * just bail with -EBADF; the host_fd is already gone via sys_close.
+     * Otherwise verify the source slot is still alive and unchanged, then
+     * install owner for the reserved ref.
      */
     pthread_mutex_lock(&fd_lock);
     pthread_mutex_lock(&sfd_lock);
@@ -771,9 +772,9 @@ int eventfd_dup_fd(int src_fd,
         eventfd_state[slot].pipe_rd != original_pipe_rd) {
         pthread_mutex_unlock(&sfd_lock);
         pthread_mutex_unlock(&fd_lock);
-        /* If the destination is still open but the source went away,
-         * tear it down. (If the destination already closed itself, the
-         * snapshot below sees FD_CLOSED and is a no-op.)
+        /* If the destination is still open but the source went away, tear it
+         * down. (If the destination already closed itself, the snapshot below
+         * sees FD_CLOSED and is a no-op.)
          */
         fd_entry_t snap;
         if (fd_snapshot_and_close(new_guest_fd, &snap))
@@ -791,8 +792,8 @@ int eventfd_dup_fd(int src_fd,
     return new_guest_fd;
 }
 
-/* Read from eventfd: return 8-byte counter value, then reset to 0.
- * In EFD_SEMAPHORE mode, return 1 and decrement counter by 1.
+/* Read from eventfd: return 8-byte counter value, then reset to 0. In
+ * EFD_SEMAPHORE mode, return 1 and decrement counter by 1.
  */
 int64_t eventfd_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
 {
@@ -812,11 +813,11 @@ int64_t eventfd_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
             return -LINUX_EAGAIN;
         }
 
-        /* Blocking mode: release lock, block on pipe, re-lock.
-         * The pipe is O_NONBLOCK, so temporarily make it blocking so read()
-         * actually waits for the writer. Matches signalfd_read. Another thread
-         * may close the fd while the eventfd wait is active; read() returns
-         * EBADF in that case, and the code re-validates the slot.
+        /* Blocking mode: release lock, block on pipe, re-lock. The pipe is
+         * O_NONBLOCK, so temporarily make it blocking so read() actually waits
+         * for the writer. Matches signalfd_read. Another thread may close the
+         * fd while the eventfd wait is active; read() returns EBADF in that
+         * case, and the code re-validates the slot.
          */
         int rd_fd = eventfd_state[slot].pipe_rd;
         pthread_mutex_unlock(&sfd_lock);
@@ -875,8 +876,8 @@ int64_t eventfd_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
     return 8;
 }
 
-/* Write to eventfd: add value to counter. Value must be uint64_t.
- * Maximum counter value is UINT64_MAX - 1.
+/* Write to eventfd: add value to counter. Value must be uint64_t. Maximum
+ * counter value is UINT64_MAX - 1.
  */
 int64_t eventfd_write(int guest_fd,
                       guest_t *g,
@@ -913,9 +914,9 @@ int64_t eventfd_write(int guest_fd,
     bool was_zero = (eventfd_state[slot].counter == 0);
     eventfd_state[slot].counter += val;
 
-    /* Signal readability via pipe if counter transitioned from 0.
-     * The pipe is non-blocking; retry on EINTR and warn on other errors since
-     * a missed wakeup here can deadlock ppoll/epoll waiters.
+    /* Signal readability via pipe if counter transitioned from 0. The pipe is
+     * non-blocking; retry on EINTR and warn on other errors since a missed
+     * wakeup here can deadlock ppoll/epoll waiters.
      */
     if (was_zero && eventfd_state[slot].counter > 0) {
         uint8_t byte = 1;
@@ -1001,8 +1002,8 @@ static int signalfd_slot_alloc(void)
                           sizeof(signalfd_state[0]));
 }
 
-/* Clean up signalfd state when guest closes the fd. Must hold sfd_lock
- * to prevent racing with concurrent signalfd_notify.
+/* Clean up signalfd state when guest closes the fd. Must hold sfd_lock to
+ * prevent racing with concurrent signalfd_notify.
  */
 static void signalfd_close(int guest_fd)
 {
@@ -1092,9 +1093,9 @@ int64_t sys_signalfd4(guest_t *g,
 
 /* Read from signalfd: consume pending signals matching the signalfd's mask.
  *
- * Each signal produces one signalfd_siginfo (128 bytes). RT signals (32-64)
- * are queued: each sigqueue/rt_tgsigqueueinfo enqueues a distinct instance with
- * its own si_int/si_ptr payload, and signalfd_read returns them in FIFO order
+ * Each signal produces one signalfd_siginfo (128 bytes). RT signals (32-64) are
+ * queued: each sigqueue/rt_tgsigqueueinfo enqueues a distinct instance with its
+ * own si_int/si_ptr payload, and signalfd_read returns them in FIFO order
  * without coalescing (Linux behavior).
  *
  * Per-thread signal mask is intentionally not consulted: signalfd is the
@@ -1102,9 +1103,9 @@ int64_t sys_signalfd4(guest_t *g,
  * delivery via sigprocmask(). The signalfd's own mask (set at create time or
  * via signalfd(fd, &mask, ...)) is the only filter applied.
  *
- * ssi_int/ssi_ptr are populated from queued metadata when present.
- * Standard signals (1-31) still coalesce to one pending instance, but Linux
- * preserves one siginfo payload for that instance.
+ * ssi_int/ssi_ptr are populated from queued metadata when present. Standard
+ * signals (1-31) still coalesce to one pending instance, but Linux preserves
+ * one siginfo payload for that instance.
  *
  * Returns the number of bytes read (multiple of sizeof(signalfd_siginfo)), or
  * -EAGAIN if nothing pending and the fd is non-blocking.
@@ -1116,8 +1117,8 @@ int64_t signalfd_read(int guest_fd,
 {
 retry:
     /* Capture slot state under sfd_lock, then release BEFORE calling
-     * signal_get_state() which acquires sig_lock(4). Holding sfd_lock(5a)
-     * while taking sig_lock(4) would violate lock ordering.
+     * signal_get_state() which acquires sig_lock(4). Holding sfd_lock(5a) while
+     * taking sig_lock(4) would violate lock ordering.
      */
     pthread_mutex_lock(&sfd_lock);
     int slot = signalfd_find(guest_fd);
@@ -1280,9 +1281,9 @@ void signalfd_notify(int signum)
 }
 
 /* /proc/self/fdinfo type-specific snapshots. Each takes sfd_lock to prevent
- * tearing across concurrent read/write/settime; lock order is fd_lock(3)
- * -> sfd_lock(5a), and these accessors take only sfd_lock so the procemu
- * caller is free to drop fd_lock between fd_snapshot and the lookup here.
+ * tearing across concurrent read/write/settime; lock order is fd_lock(3) ->
+ * sfd_lock(5a), and these accessors take only sfd_lock so the procemu caller is
+ * free to drop fd_lock between fd_snapshot and the lookup here.
  */
 
 bool eventfd_fdinfo_snapshot(int guest_fd, uint64_t *count_out)
@@ -1323,9 +1324,9 @@ bool timerfd_fdinfo_snapshot(int guest_fd,
         pthread_mutex_unlock(&sfd_lock);
         return false;
     }
-    /* Fold any pending kqueue fires into expirations before exporting,
-     * matching what timerfd_read does. Without this, fdinfo lags by
-     * however many ticks were sitting on the kqueue.
+    /* Fold any pending kqueue fires into expirations before exporting, matching
+     * what timerfd_read does. Without this, fdinfo lags by however many ticks
+     * were sitting on the kqueue.
      */
     timerfd_drain_pending_locked(slot);
     *clockid_out = timerfd_state[slot].clockid;

--- a/src/syscall/fd.h
+++ b/src/syscall/fd.h
@@ -14,8 +14,8 @@
 #include <stdint.h>
 #include "core/guest.h"
 
-/* Initialize all special FD subsystem state arrays. Must be called
- * once from syscall_init() before any guest code runs.
+/* Initialize all special FD subsystem state arrays. Must be called once from
+ * syscall_init() before any guest code runs.
  */
 void timerfd_init(void);
 void eventfd_init(void);
@@ -33,13 +33,14 @@ int64_t sys_timerfd_gettime(guest_t *g, int fd, uint64_t curr_value_gva);
 /* eventfd (emulated via pipe + counter) */
 int64_t sys_eventfd2(unsigned int initval, int flags);
 
-/* Duplicate an eventfd into a new guest_fd slot, sharing the counter and
- * pipe state with src_fd. Mirrors the Linux contract that dup'd eventfds
- * share the same underlying kernel object. src_host_fd must be the host
- * fd snapshotted from fd_table[src_fd].host_fd by the caller; the
- * implementation uses it to verify under fd_lock + sfd_lock that the source
- * fd still refers to the same live eventfd between the caller's snapshot and
- * the dup commit. Returns the new guest_fd or -1 with errno set.
+/* Duplicate an eventfd into a new guest_fd slot, sharing the counter and pipe
+ * state with src_fd. Mirrors the Linux contract that dup'd eventfds share the
+ * same underlying kernel object. src_host_fd must be the host fd snapshotted
+ * from fd_table[src_fd].host_fd by the caller; the implementation uses it to
+ * verify under fd_lock + sfd_lock that the source fd still refers to the same
+ * live eventfd between the caller's snapshot and the dup commit.
+ *
+ * Returns the new guest_fd or -1 with errno set.
  */
 int eventfd_dup_fd(int src_fd,
                    int src_host_fd,
@@ -57,8 +58,8 @@ int64_t sys_signalfd4(guest_t *g,
 
 /* Special read/write handlers for eventfd, signalfd, and timerfd FD types.
  * Called from sys_read/sys_write when the fd type requires special semantics
- * (8-byte counter for eventfd, signalfd_siginfo for signalfd, 8-byte
- * expiration count for timerfd).
+ * (8-byte counter for eventfd, signalfd_siginfo for signalfd, 8-byte expiration
+ * count for timerfd).
  */
 int64_t eventfd_read(int guest_fd,
                      guest_t *g,

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -25,8 +25,8 @@
 #include "syscall/abi.h"
 #include "syscall/internal.h"
 
-/* Protects the FD table (fd_alloc, fd_alloc_at, fd_alloc_from, sys_close).
- * File descriptor operations from concurrent threads must be serialized.
+/* Protects the FD table (fd_alloc, fd_alloc_at, fd_alloc_from, sys_close). File
+ * descriptor operations from concurrent threads must be serialized.
  */
 pthread_mutex_t fd_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 3 */
 
@@ -35,8 +35,8 @@ fd_entry_t fd_table[FD_TABLE_SIZE];
 static uint64_t fd_next_generation = 1;
 
 /* RLIMIT_NOFILE tracking. */
-/* Guest-side soft limit for RLIMIT_NOFILE. fd_alloc checks this.
- * Default matches typical Linux default (1024). Updated by prlimit64.
+/* Guest-side soft limit for RLIMIT_NOFILE. fd_alloc checks this. Default
+ * matches typical Linux default (1024). Updated by prlimit64.
  */
 static _Atomic int rlimit_nofile_cur = FD_TABLE_SIZE;
 
@@ -98,13 +98,12 @@ void fd_refresh_urandom_bitmap(int fd)
         return;
 
     /* Hold fd_lock across both the read of (type, linux_flags) AND the
-     * shim_globals bitmap publish. Dropping the lock before the publish
-     * would let a concurrent sys_close flip the slot to FD_CLOSED in
-     * the gap; the subsequent mark would then stomp a stale 'readable
-     * urandom' bit onto a freed slot, and the EL1 fast path honors that
-     * bitmap. shim_globals_mark_urandom_fd is itself atomic on the
-     * bitmap word, but atomicity is meaningless without an in-lock
-     * source-to-publish window.
+     * shim_globals bitmap publish. Dropping the lock before the publish would
+     * let a concurrent sys_close flip the slot to FD_CLOSED in the gap; the
+     * subsequent mark would then stomp a stale 'readable urandom' bit onto a
+     * freed slot, and the EL1 fast path honors that bitmap.
+     * shim_globals_mark_urandom_fd is itself atomic on the bitmap word, but
+     * atomicity is meaningless without an in-lock source-to-publish window.
      */
     pthread_mutex_lock(&fd_lock);
     int type = fd_table[fd].type;
@@ -116,8 +115,7 @@ void fd_refresh_urandom_bitmap(int fd)
 }
 
 /* Find the lowest free FD >= minfd using the bitmap.
- * Returns -1 if no free FD exists at or above minfd.
- * Caller must hold fd_lock.
+ * Returns -1 if no free FD exists at or above minfd. Caller must hold fd_lock.
  */
 static int fd_bitmap_find_free(int minfd)
 {
@@ -146,8 +144,8 @@ static int fd_bitmap_find_free(int minfd)
 
 /* fdtable_init. */
 
-/* Initialize the FD table and bitmap, pre-open stdin/stdout/stderr.
- * Extracted from syscall_init(); call before any guest code runs.
+/* Initialize the FD table and bitmap, pre-open stdin/stdout/stderr. Extracted
+ * from syscall_init(); call before any guest code runs.
  */
 void fdtable_init(void)
 {
@@ -174,8 +172,10 @@ void fdtable_init(void)
 
 /* FD helpers. */
 
-/* Find and populate the lowest free FD >= minfd. Returns -1 with errno=EMFILE
- * if no slot is available within RLIMIT_NOFILE. Caller must hold fd_lock.
+/* Find and populate the lowest free FD >= minfd.
+ *
+ * Returns -1 with errno=EMFILE if no slot is available within RLIMIT_NOFILE.
+ * Caller must hold fd_lock.
  */
 static int fd_alloc_locked(int minfd,
                            int type,
@@ -193,8 +193,10 @@ static int fd_alloc_locked(int minfd,
     return fd;
 }
 
-/* Allocate the lowest available FD. Returns -1 if table is full
- * or RLIMIT_NOFILE would be exceeded (sets errno to EMFILE).
+/* Allocate the lowest available FD.
+ *
+ * Returns -1 if table is full or RLIMIT_NOFILE would be exceeded (sets errno to
+ * EMFILE).
  */
 int fd_alloc(int type, int host_fd, void (*cleanup)(int))
 {
@@ -204,8 +206,9 @@ int fd_alloc(int type, int host_fd, void (*cleanup)(int))
     return fd;
 }
 
-/* Allocate the lowest available FD >= minfd. Returns -1 if none available
- * or RLIMIT_NOFILE would be exceeded.
+/* Allocate the lowest available FD >= minfd.
+ *
+ * Returns -1 if none available or RLIMIT_NOFILE would be exceeded.
  */
 int fd_alloc_from(int minfd, int type, int host_fd, void (*cleanup)(int))
 {
@@ -226,8 +229,9 @@ int fd_alloc_from_relaxed(int minfd,
 }
 
 /* Allocate a specific FD slot. Enforces RLIMIT_NOFILE. Properly cleans up any
- * existing entry (including DIR* for directory FDs) before overwriting. Returns
- * -1 if out of range.
+ * existing entry (including DIR* for directory FDs) before overwriting.
+ *
+ * Returns -1 if out of range.
  */
 int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int))
 {
@@ -236,9 +240,9 @@ int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int))
     if (fd >= rlimit_nofile_cur)
         return -1;
 
-    /* Snapshot old slot state under fd_lock, then replace atomically.
-     * Cleanup happens AFTER releasing fd_lock to avoid lock ordering
-     * violation: cleanup functions acquire sfd_lock/inotify_lock.
+    /* Snapshot old slot state under fd_lock, then replace atomically. Cleanup
+     * happens AFTER releasing fd_lock to avoid lock ordering violation: cleanup
+     * functions acquire sfd_lock/inotify_lock.
      */
     fd_entry_t old = {.type = FD_CLOSED};
 
@@ -271,17 +275,16 @@ int fd_alloc_at_relaxed(int fd, int type, int host_fd, void (*cleanup)(int))
     return fd;
 }
 
-/* Internal: mark fd closed with fd_lock already held.
- * Clear host_fd and dir BEFORE marking the slot free in the bitmap.
- * Otherwise another thread could fd_alloc() this slot, populate it
- * with a new host_fd/dir, and then the current stale writes would corrupt
- * the new entry.
+/* Internal: mark fd closed with fd_lock already held. Clear host_fd and dir
+ * BEFORE marking the slot free in the bitmap. Otherwise another thread could
+ * fd_alloc() this slot, populate it with a new host_fd/dir, and then the
+ * current stale writes would corrupt the new entry.
  */
 void fd_mark_closed_unlocked(int fd)
 {
     /* Clear before publishing FD_CLOSED/free. The EL1 urandom read fast path
-     * intentionally avoids fd_lock, so it must not observe a stale urandom
-     * bit after this slot has become invalid or reusable.
+     * intentionally avoids fd_lock, so it must not observe a stale urandom bit
+     * after this slot has become invalid or reusable.
      */
     shim_globals_mark_urandom_fd(fd, false);
     fd_table[fd].type = FD_CLOSED;
@@ -300,8 +303,10 @@ void fd_mark_closed(int fd)
     pthread_mutex_unlock(&fd_lock);
 }
 
-/* Snapshot fd_table[fd] into *out and optionally close it. Caller must
- * hold fd_lock. Returns true if the slot was open, false if closed.
+/* Snapshot fd_table[fd] into *out and optionally close it. Caller must hold
+ * fd_lock.
+ *
+ * Returns true if the slot was open, false if closed.
  */
 static bool fd_snapshot_locked(int fd, fd_entry_t *out, bool close_it)
 {
@@ -313,10 +318,12 @@ static bool fd_snapshot_locked(int fd, fd_entry_t *out, bool close_it)
     return true;
 }
 
-/* Atomically snapshot an fd entry and mark it closed. Returns true if the
- * slot was open (snapshot written to *out), false if already closed. This
- * eliminates the TOCTOU race where two concurrent sys_close() calls
- * both snapshot the same open entry and double-close the host fd.
+/* Atomically snapshot an fd entry and mark it closed.
+ *
+ * Returns true if the slot was open (snapshot written to *out), false if
+ * already closed. This eliminates the TOCTOU race where two concurrent
+ * sys_close() calls both snapshot the same open entry and double-close the host
+ * fd.
  */
 bool fd_snapshot_and_close(int fd, fd_entry_t *out)
 {
@@ -353,10 +360,11 @@ bool fd_close_regular_relaxed(int fd, int *host_fd_out)
     return true;
 }
 
-/* Look up a guest FD. Returns host FD or -1 if invalid.
- * WARNING: unsafe for concurrent use; a concurrent close() can
- * invalidate the returned host fd between this call and use.
- * For race-prone paths, use fd_snapshot() or fd_to_host_dup().
+/* Look up a guest FD.
+ *
+ * Returns host FD or -1 if invalid. WARNING: unsafe for concurrent use; a
+ * concurrent close() can invalidate the returned host fd between this call and
+ * use. For race-prone paths, use fd_snapshot() or fd_to_host_dup().
  */
 int fd_to_host(int guest_fd)
 {
@@ -367,8 +375,10 @@ int fd_to_host(int guest_fd)
     return fd_table[guest_fd].host_fd;
 }
 
-/* Snapshot an fd entry under fd_lock. Returns true if the slot was open
- * (entry copied to *out), false if closed or out of range.
+/* Snapshot an fd entry under fd_lock.
+ *
+ * Returns true if the slot was open (entry copied to *out), false if closed or
+ * out of range.
  */
 bool fd_snapshot(int guest_fd, fd_entry_t *out)
 {
@@ -414,10 +424,10 @@ void fd_publish_linux_flags(int guest_fd, int linux_flags)
     pthread_mutex_unlock(&fd_lock);
 }
 
-/* Sized to cover all FD_* constants in abi.h plus a small headroom. Indexed
- * by type. Each slot defaults to NULL (no per-type cleanup). Modules that
- * own a type call fd_register_cleanup() at init time; dup and fork-restore
- * paths read back the binding via fd_cleanup_for_type().
+/* Sized to cover all FD_* constants in abi.h plus a small headroom. Indexed by
+ * type. Each slot defaults to NULL (no per-type cleanup). Modules that own a
+ * type call fd_register_cleanup() at init time; dup and fork-restore paths read
+ * back the binding via fd_cleanup_for_type().
  */
 #define FD_TYPE_REGISTRY_SIZE 32
 static void (*fd_type_cleanup[FD_TYPE_REGISTRY_SIZE])(int);
@@ -436,10 +446,12 @@ void (*fd_cleanup_for_type(int type))(int)
     return fd_type_cleanup[type];
 }
 
-/* Look up a guest FD and return a dup'd host fd that the caller owns.
- * The dup is performed under fd_lock so that close() on another thread
- * cannot invalidate the host fd between lookup and dup. Caller must
- * close the returned fd when done. Returns -1 on failure.
+/* Look up a guest FD and return a dup'd host fd that the caller owns. The dup
+ * is performed under fd_lock so that close() on another thread cannot
+ * invalidate the host fd between lookup and dup. Caller must close the returned
+ * fd when done.
+ *
+ * Returns -1 on failure.
  */
 int fd_to_host_dup(int guest_fd)
 {
@@ -457,12 +469,12 @@ int fd_to_host_dup(int guest_fd)
 
 /* FD cleanup. */
 
-/* Release all type-specific resources for a closed FD entry.
- * Caller must have already removed the entry from fd_table (via
- * fd_snapshot_and_close or fd_mark_closed). Does NOT hold fd_lock.
+/* Release all type-specific resources for a closed FD entry. Caller must have
+ * already removed the entry from fd_table (via fd_snapshot_and_close or
+ * fd_mark_closed). Does NOT hold fd_lock.
  *
- * This consolidates the cleanup logic that was previously duplicated
- * in sys_close, close_guest_fd_snapshot, and the execve CLOEXEC loop.
+ * This consolidates the cleanup logic that was previously duplicated in
+ * sys_close, close_guest_fd_snapshot, and the execve CLOEXEC loop.
  */
 void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
 {
@@ -479,8 +491,8 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
         snap->cleanup(guest_fd);
 
     /* Drop any /dev/ptmx keepalive slave fd paired with this host fd. Must
-     * happen before close(snap->host_fd) because the side table is keyed by
-     * the still-live host master fd. No-op for non-pty fds.
+     * happen before close(snap->host_fd) because the side table is keyed by the
+     * still-live host master fd. No-op for non-pty fds.
      */
     proc_pty_close_keepalive(snap->host_fd);
 

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -215,8 +215,8 @@ static int64_t stat_at_path(guest_t *g,
     int64_t rc = 0;
     host_fd_ref_t dir_ref = {.fd = -1, .owned = false};
     if ((flags & LINUX_AT_EMPTY_PATH) && pathp[0] == '\0') {
-        /* Linux: AT_EMPTY_PATH with dirfd == AT_FDCWD operates on the
-         * current working directory.
+        /* Linux: AT_EMPTY_PATH with dirfd == AT_FDCWD operates on the current
+         * working directory.
          */
         if (dirfd == LINUX_AT_FDCWD) {
             dir_ref.fd = AT_FDCWD;

--- a/src/syscall/fs-xattr.c
+++ b/src/syscall/fs-xattr.c
@@ -16,11 +16,10 @@
 #include "syscall/internal.h"
 #include "syscall/path.h"
 
-/* macOS xattr API has extra position and options parameters vs Linux.
- * Linux: getxattr(path, name, value, size)
- * macOS: getxattr(path, name, value, size, position, options)
- * The xattr shim passes position=0, options=0 for normal operation, and
- * options=XATTR_NOFOLLOW for lgetxattr/lsetxattr/etc.
+/* macOS xattr API has extra position and options parameters vs Linux. Linux:
+ * getxattr(path, name, value, size) macOS: getxattr(path, name, value, size,
+ * position, options) The xattr shim passes position=0, options=0 for normal
+ * operation, and options=XATTR_NOFOLLOW for lgetxattr/lsetxattr/etc.
  */
 
 #define LINUX_XATTR_NAME_MAX 255

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -4,9 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Stat, open, close, directory, permissions, and other filesystem
- * operations. All functions are called from syscall_dispatch() in
- * syscall/syscall.c.
+ * Stat, open, close, directory, permissions, and other filesystem operations.
+ * All functions are called from syscall_dispatch() in syscall/syscall.c.
  */
 
 #include <stdbool.h>
@@ -239,12 +238,12 @@ static int fd_alloc_opened_host(int host_fd,
      * atomically with respect to the slot's identity. fd_alloc_*_relaxed drops
      * fd_lock before returning, so a sibling vCPU's pathological
      * close(guest_fd) + open() could reuse the slot between alloc and the
-     * metadata install below. Re-acquire fd_lock and verify the
-     * (type, host_fd) tuple still matches what just got allocated; if it does
-     * not, the slot belongs to a different file now and any install would
-     * clobber the sibling's entry. The sibling's close path already cleaned up
-     * the host_fd of this side via fd_cleanup_entry, so this side only owns
-     * dir, which gets closed below.
+     * metadata install below. Re-acquire fd_lock and verify the (type, host_fd)
+     * tuple still matches what just got allocated; if it does not, the slot
+     * belongs to a different file now and any install would clobber the
+     * sibling's entry. The sibling's close path already cleaned up the host_fd
+     * of this side via fd_cleanup_entry, so this side only owns dir, which gets
+     * closed below.
      */
     bool installed = false;
     pthread_mutex_lock(&fd_lock);
@@ -361,8 +360,8 @@ int64_t sys_openat_path(guest_t *g,
             /* Got a host fd from the intercept. Device nodes (/dev/...) use
              * fd_alloc() for POSIX lowest-fd semantics because busybox sh
              * relies on close(0)+open("/dev/null") returning fd 0. Synthetic
-             * /proc files use fd_alloc_from(128) to avoid races with
-             * concurrent GC finalizers that may close stale low-numbered fds.
+             * /proc files use fd_alloc_from(128) to avoid races with concurrent
+             * GC finalizers that may close stale low-numbered fds.
              */
             int type = intercepted_fd_type(tx.intercept_path, intercepted,
                                            linux_flags);
@@ -462,11 +461,11 @@ int64_t sys_close(int fd)
 
     int host_fd = -1;
     if (fd_close_regular_relaxed(fd, &host_fd)) {
-        /* The fast path bypasses fd_cleanup_entry, so any side tables
-         * keyed by host_fd that the slow path drops must be drained here
-         * too. proc_pty_close_keepalive is a cheap no-op for non-pty fds
-         * and prevents the keepalive slave from leaking past a /dev/ptmx
-         * close when no per-type cleanup is registered.
+        /* The fast path bypasses fd_cleanup_entry, so any side tables keyed by
+         * host_fd that the slow path drops must be drained here too.
+         * proc_pty_close_keepalive is a cheap no-op for non-pty fds and
+         * prevents the keepalive slave from leaking past a /dev/ptmx close when
+         * no per-type cleanup is registered.
          */
         proc_pty_close_keepalive(host_fd);
         if (close(host_fd) < 0)
@@ -474,9 +473,9 @@ int64_t sys_close(int fd)
         return 0;
     }
 
-    /* Atomically snapshot and mark closed under fd_lock.  This prevents
-     * a TOCTOU race where two concurrent sys_close() calls both read
-     * the same open entry and double-close the host fd.
+    /* Atomically snapshot and mark closed under fd_lock. This prevents a TOCTOU
+     * race where two concurrent sys_close() calls both read the same open entry
+     * and double-close the host fd.
      */
     fd_entry_t snap;
     if (!fd_snapshot_and_close_relaxed(fd, &snap))
@@ -495,11 +494,12 @@ static void discard_allocated_fd(int guest_fd)
         fd_cleanup_entry(guest_fd, &snap);
 }
 
-/* Open a DIR stream over a dup of dst_host_fd if the source was an
- * FD_DIR. Returns NULL on success-but-no-stream-needed (non-dir source)
- * or on dup/fdopendir failure with errno preserved. Pulled out of the
- * critical section in install_fd_alias_metadata_atomic because dup and
- * fdopendir are slow syscalls that must not hold fd_lock.
+/* Open a DIR stream over a dup of dst_host_fd if the source was an FD_DIR.
+ *
+ * Returns NULL on success-but-no-stream-needed (non-dir source) or on
+ * dup/fdopendir failure with errno preserved. Pulled out of the critical
+ * section in install_fd_alias_metadata_atomic because dup and fdopendir are
+ * slow syscalls that must not hold fd_lock.
  */
 static DIR *clone_dir_stream(const fd_entry_t *src_snap,
                              int dst_host_fd,
@@ -525,13 +525,13 @@ static DIR *clone_dir_stream(const fd_entry_t *src_snap,
     return dir;
 }
 
-/* Install dup-alias metadata atomically with the slot identity. Uses
- * the (type, host_fd) tuple as proof that the slot still belongs to
- * the in-flight duplicate_guest_fd call; a sibling vCPU's pathological
- * close + open between the relaxed allocator's lock release and this
- * call could otherwise clobber the sibling's freshly-installed entry.
- * Returns true on successful install, false if the slot was
- * reallocated (caller must closedir any cloned dir to avoid a leak).
+/* Install dup-alias metadata atomically with the slot identity. Uses the (type,
+ * host_fd) tuple as proof that the slot still belongs to the in-flight
+ * duplicate_guest_fd call; a sibling vCPU's pathological close + open between
+ * the relaxed allocator's lock release and this call could otherwise clobber
+ * the sibling's freshly-installed entry.
+ * Returns true on successful install, false if the slot was reallocated (caller
+ * must closedir any cloned dir to avoid a leak).
  */
 static bool install_fd_alias_metadata_atomic(int dst_fd,
                                              int expected_type,
@@ -572,8 +572,8 @@ static bool install_fd_alias_metadata_atomic(int dst_fd,
 }
 
 /* Duplicate a guest fd into either the next free slot >= min_guest_fd or a
- * fixed slot. The helper keeps fd metadata copying and directory-stream
- * cloning in one place so dup(), dup3(), and fcntl(F_DUPFD*) stay consistent.
+ * fixed slot. The helper keeps fd metadata copying and directory-stream cloning
+ * in one place so dup(), dup3(), and fcntl(F_DUPFD*) stay consistent.
  */
 static int duplicate_guest_fd(int src_fd,
                               int min_guest_fd,
@@ -582,14 +582,14 @@ static int duplicate_guest_fd(int src_fd,
                               int linux_flags)
 {
     /* Hold pty_keepalive_lock across the source snapshot, host dup, and
-     * keepalive mirror so a concurrent sys_close on src_fd cannot remove
-     * the source's keepalive entry between fd_snapshot_and_dup and
-     * proc_pty_dup_keepalive_locked. Without this bracket the alias would
-     * land in fd_table with no keepalive of its own.
+     * keepalive mirror so a concurrent sys_close on src_fd cannot remove the
+     * source's keepalive entry between fd_snapshot_and_dup and
+     * proc_pty_dup_keepalive_locked. Without this bracket the alias would land
+     * in fd_table with no keepalive of its own.
      *
-     * Lock order is pty_keepalive_lock -> fd_lock (fd_snapshot_and_dup
-     * takes fd_lock internally); proc_pty_master_adopt's joint-locked
-     * publish uses the same order so the two paths do not deadlock.
+     * Lock order is pty_keepalive_lock -> fd_lock (fd_snapshot_and_dup takes
+     * fd_lock internally); proc_pty_master_adopt's joint-locked publish uses
+     * the same order so the two paths do not deadlock.
      */
     proc_pty_lock_for_dup();
     fd_entry_t src_snap;
@@ -607,11 +607,10 @@ static int duplicate_guest_fd(int src_fd,
         return fuse_dup_fd(src_fd, min_guest_fd, fixed_guest_fd, fixed_slot,
                            linux_flags);
     }
-    /* eventfd dup must share the underlying counter and pipe state across
-     * the source and destination fds (Linux contract). Pass src_snap's
-     * host_fd through so eventfd_dup_fd can verify the source fd still
-     * refers to the same live eventfd between the snapshot here and the
-     * bind there.
+    /* eventfd dup must share the underlying counter and pipe state across the
+     * source and destination fds (Linux contract). Pass src_snap's host_fd
+     * through so eventfd_dup_fd can verify the source fd still refers to the
+     * same live eventfd between the snapshot here and the bind there.
      */
     if (src_snap.type == FD_EVENTFD) {
         proc_pty_unlock_for_dup();
@@ -625,13 +624,12 @@ static int duplicate_guest_fd(int src_fd,
         return -1;
     }
 
-    /* Mirror any /dev/ptmx keepalive BEFORE fd_alloc publishes guest_fd.
-     * Once the guest fd exists, a sibling thread can close it; that runs
-     * fd_cleanup_entry which calls proc_pty_close_keepalive(new_host_fd).
-     * For that cleanup to drop the freshly-duped keepalive, the keepalive
-     * entry must already be in the table; registering after fd_alloc would
-     * lose the race and leak the slave fd. No-op when the source has no
-     * keepalive.
+    /* Mirror any /dev/ptmx keepalive BEFORE fd_alloc publishes guest_fd. Once
+     * the guest fd exists, a sibling thread can close it; that runs
+     * fd_cleanup_entry which calls proc_pty_close_keepalive(new_host_fd). For
+     * that cleanup to drop the freshly-duped keepalive, the keepalive entry
+     * must already be in the table; registering after fd_alloc would lose the
+     * race and leak the slave fd. No-op when the source has no keepalive.
      */
     proc_pty_dup_keepalive_locked(src_snap.host_fd, new_host_fd);
     proc_pty_unlock_for_dup();
@@ -653,10 +651,10 @@ static int duplicate_guest_fd(int src_fd,
         return -1;
     }
 
-    /* Clone the DIR stream outside fd_lock (dup + fdopendir would block
-     * other fd ops), then install everything atomically under fd_lock
-     * with a tuple verification so a sibling close + reopen on the same
-     * guest_fd cannot make this install land on an unrelated slot.
+    /* Clone the DIR stream outside fd_lock (dup + fdopendir would block other
+     * fd ops), then install everything atomically under fd_lock with a tuple
+     * verification so a sibling close + reopen on the same guest_fd cannot make
+     * this install land on an unrelated slot.
      */
     bool dir_clone_failed = false;
     DIR *dir = clone_dir_stream(&src_snap, new_host_fd, &dir_clone_failed);
@@ -669,10 +667,10 @@ static int duplicate_guest_fd(int src_fd,
 
     if (!install_fd_alias_metadata_atomic(guest_fd, new_type, new_host_fd,
                                           &src_snap, linux_flags, dir)) {
-        /* Slot was reallocated by a sibling while metadata install was
-         * pending; the sibling's close path already cleaned up new_host_fd
-         * via fd_cleanup_entry, so the only resource this side still
-         * owns is the cloned DIR stream.
+        /* Slot was reallocated by a sibling while metadata install was pending;
+         * the sibling's close path already cleaned up new_host_fd via
+         * fd_cleanup_entry, so the only resource this side still owns is the
+         * cloned DIR stream.
          */
         if (dir)
             closedir(dir);
@@ -735,9 +733,9 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         return -LINUX_EBADF;
 
     /* Snapshot the slot under fd_lock once; readers use fd_snap below, and
-     * writers reacquire fd_lock and revalidate against fd_snap.generation
-     * so a close+reopen between the snapshot and the RMW returns EBADF
-     * instead of mutating an unrelated fd.
+     * writers reacquire fd_lock and revalidate against fd_snap.generation so a
+     * close+reopen between the snapshot and the RMW returns EBADF instead of
+     * mutating an unrelated fd.
      */
     fd_entry_t fd_snap;
     if (!fd_snapshot(fd, &fd_snap))
@@ -774,8 +772,8 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
     case 2: /* F_SETFD */
         /* Hold fd_lock across the read-modify-write so the CLOEXEC flip is
          * atomic against a concurrent F_SETFL on the same shadow word and
-         * against any fd_lock-protected reader. Revalidate against the
-         * snapshot generation so a close+reopen returns EBADF.
+         * against any fd_lock-protected reader. Revalidate against the snapshot
+         * generation so a close+reopen returns EBADF.
          */
         pthread_mutex_lock(&fd_lock);
         if (fd_table[fd].type == FD_CLOSED ||
@@ -794,9 +792,9 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
             return fd_snap.linux_flags;
         /* Linux timerfd F_GETFL reports O_RDWR plus the writable status bits
          * the kernel honors. Surface only those bits from the shadow rather
-         * than echoing arbitrary linux_flags bits so stray F_SETFL args
-         * cannot leak through here. O_ASYNC stays off because timerfd_fops
-         * lacks ->fasync, so generic_setfl drops it.
+         * than echoing arbitrary linux_flags bits so stray F_SETFL args cannot
+         * leak through here. O_ASYNC stays off because timerfd_fops lacks
+         * ->fasync, so generic_setfl drops it.
          */
         if (fd_type == FD_TIMERFD)
             return LINUX_O_RDWR |
@@ -822,14 +820,14 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
     {
         if (fuse_fd) {
             /* Preserve LINUX_O_ACCMODE: F_SETFL is not allowed to change the
-             * access mode in the Linux kernel, and without preserving it
-             * here a stray F_SETFL(0) would silently flip an O_RDWR FUSE
-             * shadow to O_RDONLY, surfacing the wrong mode through F_GETFL.
+             * access mode in the Linux kernel, and without preserving it here a
+             * stray F_SETFL(0) would silently flip an O_RDWR FUSE shadow to
+             * O_RDONLY, surfacing the wrong mode through F_GETFL.
              *
-             * Hold fd_lock across the read-modify-write so the update is
-             * atomic against a concurrent F_SETFD and any fd_lock-protected
-             * reader. Revalidate against the snapshot generation so a
-             * close+reopen returns EBADF.
+             * Hold fd_lock across the read-modify-write so the update is atomic
+             * against a concurrent F_SETFD and any fd_lock-protected reader.
+             * Revalidate against the snapshot generation so a close+reopen
+             * returns EBADF.
              */
             pthread_mutex_lock(&fd_lock);
             if (fd_table[fd].type != fd_type ||
@@ -851,13 +849,13 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         }
         /* Timerfd: kqueue host fd rejects fcntl(F_SETFL), so mirror Linux's
          * file-status word in the linux_flags shadow. Of Linux's writable
-         * status flags (O_APPEND, O_ASYNC, O_DIRECT, O_NOATIME, O_NONBLOCK)
-         * the timerfd kernel object honors O_APPEND, O_NONBLOCK, and
-         * O_NOATIME. O_ASYNC is silently dropped (timerfd_fops lacks
-         * ->fasync). O_DIRECT returns -EINVAL because the inode lacks
-         * FMODE_CAN_ODIRECT. Bits outside the writable set (access mode,
-         * CLOEXEC, O_PATH/DIRECTORY/NOFOLLOW/etc.) are silently ignored,
-         * matching how Linux F_SETFL drops them.
+         * status flags (O_APPEND, O_ASYNC, O_DIRECT, O_NOATIME, O_NONBLOCK) the
+         * timerfd kernel object honors O_APPEND, O_NONBLOCK, and O_NOATIME.
+         * O_ASYNC is silently dropped (timerfd_fops lacks ->fasync). O_DIRECT
+         * returns -EINVAL because the inode lacks FMODE_CAN_ODIRECT. Bits
+         * outside the writable set (access mode, CLOEXEC,
+         * O_PATH/DIRECTORY/NOFOLLOW/etc.) are silently ignored, matching how
+         * Linux F_SETFL drops them.
          */
         if (fd_type == FD_TIMERFD) {
             const int setfl_mask =
@@ -892,13 +890,13 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         host_fd_ref_t host_ref;
         if (host_fd_ref_open(fd, &host_ref) < 0)
             return -LINUX_EBADF;
-        /* Translate Linux struct flock (aarch64) to macOS struct flock.
-         * Linux aarch64 layout: {short l_type, short l_whence,
+        /* Translate Linux struct flock (aarch64) to macOS struct flock. Linux
+         * aarch64 layout: {short l_type, short l_whence,
          *   long l_start, long l_len, int l_pid, pad[4]}
          * macOS layout: {off_t l_start, off_t l_len, pid_t l_pid,
          *   short l_type, short l_whence}
-         * Use guest_read/guest_write (not guest_ptr) to safely handle
-         * structs that span 2MiB page table block boundaries.
+         * Use guest_read/guest_write (not guest_ptr) to safely handle structs
+         * that span 2MiB page table block boundaries.
          */
         uint8_t lflock[32]; /* Linux struct flock is 32 bytes on aarch64 */
         if (guest_read_small(g, arg, lflock, sizeof(lflock)) < 0)
@@ -915,9 +913,10 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         /* l_type constants differ between Linux and macOS/BSD:
          *   Linux: F_RDLCK=0, F_WRLCK=1, F_UNLCK=2
          *   macOS: F_RDLCK=1, F_UNLCK=2, F_WRLCK=3
-         * Passing the Linux value straight through makes a Linux F_RDLCK (0)
-         * an invalid type on macOS, which fcntl() rejects with EINVAL. This is
-         * the lock POSIX databases (e.g. SQLite) take first, so it must map. */
+         * Passing the Linux value straight through makes a Linux F_RDLCK (0) an
+         * invalid type on macOS, which fcntl() rejects with EINVAL. This is the
+         * lock POSIX databases (e.g. SQLite) take first, so it must map.
+         */
         short mac_type;
         switch (l_type) {
         case 0: /* LINUX_F_RDLCK */
@@ -1031,8 +1030,8 @@ int64_t sys_close_range(unsigned int first,
     if (last >= (unsigned) FD_TABLE_SIZE)
         last = FD_TABLE_SIZE - 1;
 
-    /* CLOSE_RANGE_CLOEXEC: mark FDs as CLOEXEC without closing them.
-     * Hold fd_lock to prevent races with concurrent fd_alloc/close.
+    /* CLOSE_RANGE_CLOEXEC: mark FDs as CLOEXEC without closing them. Hold
+     * fd_lock to prevent races with concurrent fd_alloc/close.
      */
     if (flags & LINUX_CLOSE_RANGE_CLOEXEC) {
         pthread_mutex_lock(&fd_lock);
@@ -1058,8 +1057,8 @@ int64_t sys_close_range(unsigned int first,
 
 /* directory operations. */
 
-/* getdents64: read directory entries from a guest directory fd.
- * Uses the persistent DIR* stored in fd_table (created by openat).
+/* getdents64: read directory entries from a guest directory fd. Uses the
+ * persistent DIR* stored in fd_table (created by openat).
  */
 int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
 {
@@ -1086,16 +1085,16 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
     size_t guest_pos = 0;
     struct dirent *de;
 
-    /* Temp buffer for dirent serialization. Max dirent64 is 280 bytes
-     * (19-byte header + NAME_MAX=255 + null + padding to 8). Using a
-     * stack buffer avoids guest_ptr boundary issues: guest_write() handles
-     * 2MiB block crossings that raw memcpy into guest_ptr() cannot.
+    /* Temp buffer for dirent serialization. Max dirent64 is 280 bytes (19-byte
+     * header + NAME_MAX=255 + null + padding to 8). Using a stack buffer avoids
+     * guest_ptr boundary issues: guest_write() handles 2MiB block crossings
+     * that raw memcpy into guest_ptr() cannot.
      */
     uint8_t entry_buf[280];
 
     while (1) {
         /* Save position BEFORE readdir so getdents emulation can rewind if the
-         * entry does not fit.  macOS telldir returns an opaque cookie --
+         * entry does not fit. macOS telldir returns an opaque cookie --
          * arithmetic on it (e.g. telldir()-1) is undefined.
          */
         long saved_pos = telldir(dir);
@@ -1227,13 +1226,13 @@ int64_t sys_chroot(guest_t *g, uint64_t path_gva)
     char path[LINUX_PATH_MAX];
     if (guest_read_str(g, path_gva, path, sizeof(path)) < 0)
         return -LINUX_EFAULT;
-    /* Only accept chroot("/") as a no-op. The original motivation was
-     * coreutils stdbuf (fork -> chroot("/") -> exec) which never changes
-     * roots in practice. Accepting an arbitrary path was a containment
-     * escape: a guest already running under --sysroot=/opt/sr could call
-     * chroot("/etc") and pivot to the host's /etc with no boundary check.
-     * Real chroot() requires CAP_SYS_CHROOT, which the guest does not have
-     * in elfuse's single-process VM model.
+    /* Only accept chroot("/") as a no-op. The original motivation was coreutils
+     * stdbuf (fork -> chroot("/") -> exec) which never changes roots in
+     * practice. Accepting an arbitrary path was a containment escape: a guest
+     * already running under --sysroot=/opt/sr could call chroot("/etc") and
+     * pivot to the host's /etc with no boundary check. Real chroot() requires
+     * CAP_SYS_CHROOT, which the guest does not have in elfuse's single-process
+     * VM model.
      */
     if (strcmp(path, "/") == 0)
         return 0;
@@ -1496,9 +1495,9 @@ int64_t sys_renameat2(guest_t *g,
     }
 
     /* Apply sysroot resolution for absolute paths */
-    /* RENAME_NOREPLACE: fail if destination exists. macOS renamex_np
-     * supports RENAME_EXCL for the same semantics. Only supported for
-     * AT_FDCWD paths (renamex_np does not take dirfd arguments).
+    /* RENAME_NOREPLACE: fail if destination exists. macOS renamex_np supports
+     * RENAME_EXCL for the same semantics. Only supported for AT_FDCWD paths
+     * (renamex_np does not take dirfd arguments).
      */
     if (flags & LINUX_RENAME_NOREPLACE) {
         if (olddirfd == LINUX_AT_FDCWD && newdirfd == LINUX_AT_FDCWD) {
@@ -1509,8 +1508,8 @@ int64_t sys_renameat2(guest_t *g,
             }
             return close_dir_refs_result(&olddir_ref, &newdir_ref, 0);
         }
-        /* For non-CWD dirfds, emulate with link+unlink. This is not atomic,
-         * but linkat() still preserves the "destination must not exist"
+        /* For non-CWD dirfds, emulate with link+unlink. This is not atomic, but
+         * linkat() still preserves the "destination must not exist"
          * requirement. This path still cannot handle directories because
          * hardlinking directories is not allowed.
          */
@@ -1989,14 +1988,13 @@ int64_t sys_utimensat(guest_t *g,
     if (flags & LINUX_AT_SYMLINK_NOFOLLOW)
         mac_flags |= AT_SYMLINK_NOFOLLOW;
 
-    /* macOS utimensat() does not support NULL path (Linux extension).
-     * When path is NULL, the caller wants to operate on dirfd itself,
-     * so use futimens() instead. Linux's do_utimes_fd rejects any flags
-     * with EINVAL, and utimensat(AT_FDCWD, NULL, ...) returns EFAULT
-     * because there is no real fd to apply timestamps to; mirror both
-     * here rather than letting futimens(AT_FDCWD, ...) be invoked with
-     * macOS's AT_FDCWD sentinel (-2), which returns EBADF and would not
-     * match Linux semantics.
+    /* macOS utimensat() does not support NULL path (Linux extension). When path
+     * is NULL, the caller wants to operate on dirfd itself, so use futimens()
+     * instead. Linux's do_utimes_fd rejects any flags with EINVAL, and
+     * utimensat(AT_FDCWD, NULL, ...) returns EFAULT because there is no real fd
+     * to apply timestamps to; mirror both here rather than letting
+     * futimens(AT_FDCWD, ...) be invoked with macOS's AT_FDCWD sentinel (-2),
+     * which returns EBADF and would not match Linux semantics.
      */
     if (!path_arg) {
         if (flags) {

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -206,11 +206,11 @@ typedef struct {
 #define FUSE_FAKE_DEV 0xF00D
 
 /* Implementation ceiling for a single FUSE frame (header + payload). The kernel
- * FUSE protocol caps a READ or WRITE payload at FUSE_MAX_PAGES * page_size =
- * ~1 MiB by default and up to 4 MiB under recent kernels. The 8 MiB hard cap
- * below leaves headroom for the FUSE header, in-band sub-headers, and any
- * future readahead growth while still bounding the largest single malloc the
- * daemon can force. Daemon-negotiated max_write is clamped to (FUSE_FRAME_CAP
+ * FUSE protocol caps a READ or WRITE payload at FUSE_MAX_PAGES * page_size = ~1
+ * MiB by default and up to 4 MiB under recent kernels. The 8 MiB hard cap below
+ * leaves headroom for the FUSE header, in-band sub-headers, and any future
+ * readahead growth while still bounding the largest single malloc the daemon
+ * can force. Daemon-negotiated max_write is clamped to (FUSE_FRAME_CAP
  * - sizeof(fuse_in_header_t) - sizeof(fuse_write_in)) at FUSE_INIT time so the
  * read-reply path cannot negotiate a size larger than fuse_dev_write will
  * accept.
@@ -266,8 +266,8 @@ typedef struct {
     /* session is the live transport for this mount; NULL once the owning
      * /dev/fuse fd is closed (the slot is tombstoned, keeping path/source/
      * fstype/mount_id intact so consumers stuck on this mount path can be
-     * routed to a deterministic -LINUX_ENOTCONN instead of leaking through
-     * to host-filesystem resolution). Re-binding the slot requires
+     * routed to a deterministic -LINUX_ENOTCONN instead of leaking through to
+     * host-filesystem resolution). Re-binding the slot requires
      * fuse_alloc_mount_locked or sys_mount replacing a tombstoned entry.
      */
     fuse_session_t *session;
@@ -289,17 +289,17 @@ typedef struct {
     uint64_t offset;
     int linux_flags;
     bool path_only;
-    /* session is pinned by the file's own session ref taken at open time.
-     * The mount slot the file came from may be reassigned independently;
-     * mount_id is the stable identifier used to detect that case without
-     * dereferencing a possibly-recycled fuse_mount_t.
+    /* session is pinned by the file's own session ref taken at open time. The
+     * mount slot the file came from may be reassigned independently; mount_id
+     * is the stable identifier used to detect that case without dereferencing a
+     * possibly-recycled fuse_mount_t.
      */
     fuse_session_t *session;
     int mount_id;
     char path[LINUX_PATH_MAX];
     fuse_attr_t attr;
-    /* Serialize stream read() / readdir() against the offset field. lseek
-     * also waits on io_in_progress to avoid clobbering an in-flight read's
+    /* Serialize stream read() / readdir() against the offset field. lseek also
+     * waits on io_in_progress to avoid clobbering an in-flight read's
      * post-update.
      */
     bool io_in_progress;
@@ -360,9 +360,9 @@ static int fuse_join_virtual_path(const char *base,
 
     size_t depth = 0;
     /* marks[i] stores the output index at which the i-th surviving component
-     * begins. Each value is bounded by outsz (capped at LINUX_PATH_MAX =
-     * 4096), so uint16_t is sufficient and shrinks the host-stack footprint
-     * from 16 KiB to 4 KiB per call.
+     * begins. Each value is bounded by outsz (capped at LINUX_PATH_MAX = 4096),
+     * so uint16_t is sufficient and shrinks the host-stack footprint from 16
+     * KiB to 4 KiB per call.
      */
     uint16_t marks[LINUX_PATH_MAX / 2];
     out[0] = '/';
@@ -422,12 +422,13 @@ static int fuse_join_virtual_path(const char *base,
 }
 
 /* Canonicalize an absolute guest path, collapsing "." and ".." against the
- * filesystem root. Returns 0 on success with the canonical form written to
- * out, or -1 (errno set) on overflow. Always overwrites out on success.
- * Callers use this before mount-prefix matching so paths like
- * "/mnt/fuse/./foo" and "/mnt/fuse/sub/../foo" route consistently with
- * "/mnt/fuse/foo" and paths like "/mnt/fuse/../etc" escape FUSE land
- * deterministically.
+ * filesystem root.
+ *
+ * Returns 0 on success with the canonical form written to out, or -1 (errno
+ * set) on overflow. Always overwrites out on success. Callers use this before
+ * mount-prefix matching so paths like "/mnt/fuse/./foo" and
+ * "/mnt/fuse/sub/../foo" route consistently with "/mnt/fuse/foo" and paths like
+ * "/mnt/fuse/../etc" escape FUSE land deterministically.
  */
 static int fuse_canonical_abs(const char *in, char *out, size_t outsz)
 {
@@ -484,30 +485,29 @@ static int fuse_dev_alias_count_locked(fuse_session_t *session)
 
 /* Bump session reference under fuse_lock. Each live mount, each FUSE-backed
  * file fd, and the /dev/fuse fd itself hold one ref. Destruction is deferred
- * until refcount drops to zero so a slow read/write on a mount-backed fd
- * cannot race with the daemon closing /dev/fuse and tearing down the lock.
+ * until refcount drops to zero so a slow read/write on a mount-backed fd cannot
+ * race with the daemon closing /dev/fuse and tearing down the lock.
  */
 static void fuse_session_get_locked(fuse_session_t *session)
 {
     session->refcount++;
 }
 
-/* Drop a session reference under fuse_lock. When the last reference is
- * dropped and the session has been closed, destroy the synchronization
- * primitives and clear the slot. Callers must not hold session->lock.
+/* Drop a session reference under fuse_lock. When the last reference is dropped
+ * and the session has been closed, destroy the synchronization primitives and
+ * clear the slot. Callers must not hold session->lock.
  *
- * The /dev/fuse fd is itself one of the session's refs (taken when the
- * fd is allocated, dropped in fuse_fd_cleanup), so the only path that
- * can drive refcount to zero runs through fuse_fd_cleanup setting
- * session->closed = true and session->daemon_dead = true before its
- * matching put. Any residual node_refs entries at this point therefore
- * cannot reach the daemon -- fuse_emit_forget_multi_locked short-
- * circuits on daemon_dead -- so no terminal FUSE_FORGET sweep is
- * emitted here. The compensating FORGET paths elsewhere in this file
- * (fuse_lookup_locked overflow, fuse_walk_path_locked mid-walk drop
- * failure, fuse_open_path error exits) keep the daemon's nlookup view
- * balanced while the daemon is still alive; teardown after the
- * daemon's exit needs no further reconciliation.
+ * The /dev/fuse fd is itself one of the session's refs (taken when the fd is
+ * allocated, dropped in fuse_fd_cleanup), so the only path that can drive
+ * refcount to zero runs through fuse_fd_cleanup setting session->closed = true
+ * and session->daemon_dead = true before its matching put. Any residual
+ * node_refs entries at this point therefore cannot reach the daemon --
+ * fuse_emit_forget_multi_locked short- circuits on daemon_dead -- so no
+ * terminal FUSE_FORGET sweep is emitted here. The compensating FORGET paths
+ * elsewhere in this file (fuse_lookup_locked overflow, fuse_walk_path_locked
+ * mid-walk drop failure, fuse_open_path error exits) keep the daemon's nlookup
+ * view balanced while the daemon is still alive; teardown after the daemon's
+ * exit needs no further reconciliation.
  */
 static void fuse_session_put_locked(fuse_session_t *session)
 {
@@ -543,10 +543,10 @@ static fuse_mount_t *fuse_mount_for_path_locked(const char *path,
     return best;
 }
 
-/* Fully free a mount slot. Drops any live session ref (tombstoned slots
- * have NULL session and have already dropped their ref via fuse_fd_cleanup).
- * Used by sys_mount error paths and by fuse_alloc_mount_locked when
- * reclaiming a tombstoned slot.
+/* Fully free a mount slot. Drops any live session ref (tombstoned slots have
+ * NULL session and have already dropped their ref via fuse_fd_cleanup). Used by
+ * sys_mount error paths and by fuse_alloc_mount_locked when reclaiming a
+ * tombstoned slot.
  */
 static void fuse_uninstall_mount_locked(fuse_mount_t *mount)
 {
@@ -788,14 +788,16 @@ static int fuse_send_init_locked(fuse_session_t *session)
                                sizeof(init), NULL, NULL);
 }
 
-/* Issue one FUSE request and wait for the reply. Returns 0 on success, or a
- * negative Linux errno on failure. The caller must hold session->lock.
+/* Issue one FUSE request and wait for the reply.
+ *
+ * Returns 0 on success, or a negative Linux errno on failure. The caller must
+ * hold session->lock.
  *
  * Known limitation: the wait uses a plain pthread_cond_wait, so a signal
- * delivered to a blocked consumer does not return -EINTR and does not emit
- * a FUSE_INTERRUPT frame to the daemon. Honoring SA_RESTART and emitting
- * FUSE_INTERRUPT requires integrating with the per-thread signal eventfd
- * and remains a deferred Tier B item. Until then, daemon death or session
+ * delivered to a blocked consumer does not return -EINTR and does not emit a
+ * FUSE_INTERRUPT frame to the daemon. Honoring SA_RESTART and emitting
+ * FUSE_INTERRUPT requires integrating with the per-thread signal eventfd and
+ * remains a deferred compatibility item. Until then, daemon death or session
  * close are the only paths that wake a blocked consumer.
  */
 static int fuse_request_locked(fuse_session_t *session,
@@ -891,8 +893,8 @@ static int fuse_lookup_locked(fuse_session_t *session,
     int hold_rc = fuse_node_ref_hold_locked(session, out->nodeid, 1);
     if (hold_rc < 0) {
         /* Daemon already accepted the lookup and bumped its nlookup. The
-         * per-session ref table is full, so emit a compensating FORGET to
-         * keep the daemon's view balanced rather than leaking a reference.
+         * per-session ref table is full, so emit a compensating FORGET to keep
+         * the daemon's view balanced rather than leaking a reference.
          */
         fuse_forget_one_t one = {.nodeid = out->nodeid, .nlookup = 1};
         (void) fuse_emit_forget_multi_locked(session, &one, 1);
@@ -950,13 +952,13 @@ static int fuse_walk_path_locked(fuse_session_t *session,
             return -LINUX_ENOENT;
         memcpy(name, p, len);
         name[len] = '\0';
-        /* The path is canonicalized before reaching the walk, so "." and
-         * ".." should never appear as a real component. Defend against
-         * accidental forwarding to the daemon (which has no notion of the
-         * mount root's containment) just in case a future caller skips
-         * canonicalization. The advance-then-continue order matters: a
-         * bare "continue" without advancing p would spin on the same
-         * component forever if a non-canonical path ever reached here.
+        /* The path is canonicalized before reaching the walk, so "." and ".."
+         * should never appear as a real component. Defend against accidental
+         * forwarding to the daemon (which has no notion of the mount root's
+         * containment) just in case a future caller skips canonicalization. The
+         * advance-then-continue order matters: a bare "continue" without
+         * advancing p would spin on the same component forever if a
+         * non-canonical path ever reached here.
          */
         if (len == 1 && name[0] == '.') {
             if (!slash)
@@ -972,8 +974,8 @@ static int fuse_walk_path_locked(fuse_session_t *session,
         if (rc < 0) {
             /* Release the lookup hold from the previous component before
              * propagating the error: every successful lookup along the way
-             * incremented nlookup on the daemon side, and bailing out without
-             * a matching FORGET would leak that reference.
+             * incremented nlookup on the daemon side, and bailing out without a
+             * matching FORGET would leak that reference.
              */
             if (held_lookup != 0)
                 (void) fuse_node_ref_drop_locked(session, held_lookup, 1, true);
@@ -982,15 +984,14 @@ static int fuse_walk_path_locked(fuse_session_t *session,
         if (held_lookup != 0) {
             rc = fuse_node_ref_drop_locked(session, held_lookup, 1, true);
             if (rc < 0) {
-                /* The previous component's drop already updated the local
-                 * ref table but failed to queue its FUSE_FORGET. The
-                 * just-acquired entry.nodeid hold would otherwise be
-                 * stranded in the local table on this error path and the
-                 * daemon would never see a matching FORGET for it. Drop
-                 * the new hold best-effort before propagating; if this
-                 * second drop also fails to emit, the caller still gets
-                 * the original error and the session teardown FORGET
-                 * sweep will reconcile any residual daemon-side count.
+                /* The previous component's drop already updated the local ref
+                 * table but failed to queue its FUSE_FORGET. The just-acquired
+                 * entry.nodeid hold would otherwise be stranded in the local
+                 * table on this error path and the daemon would never see a
+                 * matching FORGET for it. Drop the new hold best-effort before
+                 * propagating; if this second drop also fails to emit, the
+                 * caller still gets the original error and the session teardown
+                 * FORGET sweep will reconcile any residual daemon-side count.
                  */
                 (void) fuse_node_ref_drop_locked(session, entry.nodeid, 1,
                                                  true);
@@ -1070,10 +1071,9 @@ static void fuse_file_get_locked(fuse_file_t *file)
     file->refcount++;
 }
 
-/* Drop a file slot refcount under fuse_lock. The slot is destroyed and
- * cleared only when no one else holds a reference, so a concurrent close
- * cannot tear down io_cond out from under a thread that has already
- * snapshotted this slot.
+/* Drop a file slot refcount under fuse_lock. The slot is destroyed and cleared
+ * only when no one else holds a reference, so a concurrent close cannot tear
+ * down io_cond out from under a thread that has already snapshotted this slot.
  */
 static void fuse_file_put_locked(fuse_file_t *file)
 {
@@ -1088,10 +1088,9 @@ static void fuse_file_put_locked(fuse_file_t *file)
 static fuse_file_t *fuse_alloc_file_locked(void)
 {
     for (int i = 0; i < FUSE_MAX_OPEN_FILES; i++) {
-        /* A slot with refcount > 0 is still owned by an in-flight op even
-         * if its underlying fd has been closed; skip it until that op
-         * releases. used==false && refcount==0 is the only fully-free
-         * state.
+        /* A slot with refcount > 0 is still owned by an in-flight op even if
+         * its underlying fd has been closed; skip it until that op releases.
+         * used==false && refcount==0 is the only fully-free state.
          */
         if (!fuse_files[i].used && fuse_files[i].refcount == 0) {
             memset(&fuse_files[i], 0, sizeof(fuse_files[i]));
@@ -1138,9 +1137,9 @@ static int fuse_release_common_locked(fuse_session_t *session,
 {
     if (!session || session->daemon_dead || session->closed)
         return 0;
-    /* O_PATH opens skip FUSE_OPEN, so there is no fh to release. The path
-     * walk still incremented the daemon's nlookup, so emit FORGET to balance
-     * it. Without this, every successful O_PATH close leaks one reference.
+    /* O_PATH opens skip FUSE_OPEN, so there is no fh to release. The path walk
+     * still incremented the daemon's nlookup, so emit FORGET to balance it.
+     * Without this, every successful O_PATH close leaks one reference.
      */
     if (linux_flags & LINUX_O_PATH)
         return fuse_node_ref_drop_locked(session, nodeid, 1, true);
@@ -1159,10 +1158,10 @@ static int fuse_release_common_locked(fuse_session_t *session,
 
 static void fuse_fd_cleanup(int guest_fd)
 {
-    /* Step 1: snapshot the file slot's release-relevant fields and detach
-     * the slot from the fd. The slot itself stays alive (refcount > 0)
-     * until any in-flight op releases its ref; only then is io_cond
-     * destroyed and the slot zeroed.
+    /* Step 1: snapshot the file slot's release-relevant fields and detach the
+     * slot from the fd. The slot itself stays alive (refcount > 0) until any
+     * in-flight op releases its ref; only then is io_cond destroyed and the
+     * slot zeroed.
      */
     fuse_session_t *file_session = NULL;
     bool have_file = false;
@@ -1219,8 +1218,8 @@ static void fuse_fd_cleanup(int guest_fd)
     }
 
     /* Mark dead and wake every blocked waiter under the session lock so they
-     * see daemon_dead=true and exit with -LINUX_ENOTCONN before the lock
-     * itself goes away.
+     * see daemon_dead=true and exit with -LINUX_ENOTCONN before the lock itself
+     * goes away.
      */
     pthread_mutex_lock(&session->lock);
     session->closed = true;
@@ -1241,21 +1240,21 @@ static void fuse_fd_cleanup(int guest_fd)
     }
     pthread_mutex_unlock(&session->lock);
 
-    /* Wake any file slots blocked on io_in_progress; their owners will see
-     * the session's daemon_dead flag and exit with -LINUX_ENOTCONN.
+    /* Wake any file slots blocked on io_in_progress; their owners will see the
+     * session's daemon_dead flag and exit with -LINUX_ENOTCONN.
      */
     for (int i = 0; i < FUSE_MAX_OPEN_FILES; i++) {
         if (fuse_files[i].used && fuse_files[i].session == session)
             pthread_cond_broadcast(&fuse_files[i].io_cond);
     }
 
-    /* Tombstone each mount whose transport has just died: drop the
-     * per-mount session ref but keep the slot's path/source/fstype/
-     * mount_id intact so a process whose virtual cwd is on this mount
-     * still routes to a deterministic -LINUX_ENOTCONN instead of falling
-     * through to host-filesystem resolution. session is cleared to NULL
-     * as the tombstone marker; the slot is reclaimed by a later
-     * sys_mount at the same path or by fuse_alloc_mount_locked.
+    /* Tombstone each mount whose transport has just died: drop the per-mount
+     * session ref but keep the slot's path/source/fstype/ mount_id intact so a
+     * process whose virtual cwd is on this mount still routes to a
+     * deterministic -LINUX_ENOTCONN instead of falling through to
+     * host-filesystem resolution. session is cleared to NULL as the tombstone
+     * marker; the slot is reclaimed by a later sys_mount at the same path or by
+     * fuse_alloc_mount_locked.
      */
     for (int i = 0; i < FUSE_MAX_MOUNTS; i++) {
         if (fuse_mounts[i].used && fuse_mounts[i].session == session) {
@@ -1427,8 +1426,8 @@ int64_t sys_mount(guest_t *g,
     for (int i = 0; i < FUSE_MAX_MOUNTS; i++) {
         if (fuse_mounts[i].used && fuse_mounts[i].session != NULL &&
             !strcmp(fuse_mounts[i].path, target_canon)) {
-            /* Live mount at this path already; reject as EBUSY. A
-             * tombstoned slot at the same path is reclaimed below.
+            /* Live mount at this path already; reject as EBUSY. A tombstoned
+             * slot at the same path is reclaimed below.
              */
             pthread_mutex_unlock(&fuse_lock);
             return -LINUX_EBUSY;
@@ -1482,9 +1481,9 @@ bool fuse_path_matches_mount(const char *path)
     if (fuse_canonical_abs(path, canon, sizeof(canon)) < 0)
         return false;
     pthread_mutex_lock(&fuse_lock);
-    /* Matches both live and tombstoned mounts so post-daemon-death
-     * operations get routed to a deterministic -LINUX_ENOTCONN instead of
-     * silently falling through to host-filesystem resolution.
+    /* Matches both live and tombstoned mounts so post-daemon-death operations
+     * get routed to a deterministic -LINUX_ENOTCONN instead of silently falling
+     * through to host-filesystem resolution.
      */
     bool matched = fuse_mount_for_path_locked(canon, NULL) != NULL;
     pthread_mutex_unlock(&fuse_lock);
@@ -1511,8 +1510,8 @@ int fuse_path_mount_id(const char *path)
  * stat-like callers.
  *
  * Returns 0 on success, or a negative Linux errno. The session refcount is
- * bumped on success; callers must drop it via fuse_session_put_locked when
- * done with the resolution.
+ * bumped on success; callers must drop it via fuse_session_put_locked when done
+ * with the resolution.
  */
 static int fuse_path_lookup(const char *path,
                             bool retain_final_lookup,
@@ -1566,9 +1565,11 @@ static int fuse_path_lookup(const char *path,
     return 0;
 }
 
-/* Stat a FUSE-mounted path. Returns 0 on success, or a negative Linux errno
- * (LINUX_E*). Errno-via-globals is intentionally avoided: callers in
- * src/syscall/fs-stat.c return this value directly to the guest.
+/* Stat a FUSE-mounted path.
+ *
+ * Returns 0 on success, or a negative Linux errno (LINUX_E*). Errno-via-globals
+ * is intentionally avoided: callers in src/syscall/fs-stat.c return this value
+ * directly to the guest.
  *
  * at_flags is the LINUX_AT_* mask from the caller. Today only
  * LINUX_AT_SYMLINK_NOFOLLOW is honored: when the daemon's final LOOKUP returns
@@ -1719,9 +1720,12 @@ int fuse_materialize_path(const char *path, char *out_path, size_t outsz)
     return rc;
 }
 
-/* fstat against a FUSE-backed fd. Returns 0 on success, negative Linux errno
- * otherwise. Returns -LINUX_EBADF when the fd does not refer to a live FUSE
- * file so callers can distinguish "not ours" from "ours but failed".
+/* fstat against a FUSE-backed fd.
+ *
+ * Returns 0 on success, negative Linux errno otherwise.
+ *
+ * Returns -LINUX_EBADF when the fd does not refer to a live FUSE file so
+ * callers can distinguish "not ours" from "ours but failed".
  */
 int fuse_fstat_fd(int fd, struct stat *st)
 {
@@ -1813,11 +1817,10 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
         pthread_mutex_unlock(&fuse_lock);
         return -LINUX_ENOTDIR;
     }
-    /* Linux open(2): when O_PATH is set, access-mode bits (O_RDONLY /
-     * O_WRONLY / O_RDWR) are ignored. The descriptor is opaque to
-     * read/write but usable for fstat, fchdir, *at() dirfd, etc. Reject
-     * non-RDONLY only for ordinary file opens until FUSE write support
-     * exists for FD_FUSE_FILE.
+    /* Linux open(2): when O_PATH is set, access-mode bits (O_RDONLY / O_WRONLY
+     * / O_RDWR) are ignored. The descriptor is opaque to read/write but usable
+     * for fstat, fchdir, *at() dirfd, etc. Reject non-RDONLY only for ordinary
+     * file opens until FUSE write support exists for FD_FUSE_FILE.
      */
     if (!want_dir && !path_only && (linux_flags & 3) != LINUX_O_RDONLY) {
         (void) fuse_node_ref_drop_locked(session, nodeid, 1, true);
@@ -1877,10 +1880,9 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
     file->fh = out.fh;
     file->linux_flags = linux_flags;
     file->path_only = path_only;
-    /* Donate the session ref taken above to the file's own ref slot. The
-     * mount pointer itself is not cached; mount_id is enough to detect
-     * stale mount-slot reassignment without dereferencing a recycled
-     * fuse_mount_t.
+    /* Donate the session ref taken above to the file's own ref slot. The mount
+     * pointer itself is not cached; mount_id is enough to detect stale
+     * mount-slot reassignment without dereferencing a recycled fuse_mount_t.
      */
     file->session = session;
     file->mount_id = mount_id;
@@ -1901,18 +1903,18 @@ int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode)
         return -LINUX_EMFILE;
     }
     pthread_mutex_unlock(&fuse_lock);
-    /* Publish under fd_lock so the open's flags land on the same lock
-     * domain that sys_fcntl(F_SETFL/F_SETFD) uses.
+    /* Publish under fd_lock so the open's flags land on the same lock domain
+     * that sys_fcntl(F_SETFL/F_SETFD) uses.
      */
     fd_publish_linux_flags(guest_fd, linux_flags);
     return guest_fd;
 }
 
-/* Snapshot of fuse_file_t fields needed for a single read/readdir request.
- * The snapshot pins both the session (via session_get_locked) and the file
- * slot (via file_get_locked) for the duration of the operation. file is the
- * actual fuse_file_t pointer so io_in_progress / io_cond can be touched on
- * release without re-looking-up by guest_fd.
+/* Snapshot of fuse_file_t fields needed for a single read/readdir request. The
+ * snapshot pins both the session (via session_get_locked) and the file slot
+ * (via file_get_locked) for the duration of the operation. file is the actual
+ * fuse_file_t pointer so io_in_progress / io_cond can be touched on release
+ * without re-looking-up by guest_fd.
  */
 typedef struct {
     fuse_file_t *file;
@@ -1926,13 +1928,14 @@ typedef struct {
     bool serialize; /* true for stream reads/readdir; false for pread */
 } fuse_file_snap_t;
 
-/* Acquire exclusive offset-affecting access to a FUSE file, bump the file
- * and session refcounts, and snapshot the identity into snap. Stream reads
- * (and readdir) pass serialize=true so concurrent read() calls on the same
- * fd are serialized via io_in_progress, matching Linux f_pos_lock
- * semantics. pread/getattr-style operations that do not touch the stream
- * offset pass serialize=false. Returns 0 on success or a negative Linux
- * errno.
+/* Acquire exclusive offset-affecting access to a FUSE file, bump the file and
+ * session refcounts, and snapshot the identity into snap. Stream reads (and
+ * readdir) pass serialize=true so concurrent read() calls on the same fd are
+ * serialized via io_in_progress, matching Linux f_pos_lock semantics.
+ * pread/getattr-style operations that do not touch the stream offset pass
+ * serialize=false.
+ *
+ * Returns 0 on success or a negative Linux errno.
  */
 static int fuse_file_acquire(int guest_fd,
                              bool want_dir,
@@ -1980,9 +1983,9 @@ static void fuse_file_release(fuse_file_snap_t *snap)
 {
     pthread_mutex_lock(&fuse_lock);
     if (snap->serialize) {
-        /* Clearing io_in_progress on the pinned slot is safe even if the
-         * slot has been logically closed; in that case the broadcast goes
-         * to no live waiter and the slot will be zeroed on the final put.
+        /* Clearing io_in_progress on the pinned slot is safe even if the slot
+         * has been logically closed; in that case the broadcast goes to no live
+         * waiter and the slot will be zeroed on the final put.
          */
         snap->file->io_in_progress = false;
         pthread_cond_broadcast(&snap->file->io_cond);
@@ -2014,11 +2017,11 @@ int fuse_materialize_fd(int fd, char *out_path, size_t outsz)
     return rc;
 }
 
-/* Read up to count bytes from a FUSE-backed file or directory at offset.
- * Writes the daemon's reply into the guest buffer at buf_gva. Updates the
- * stream offset on success when advance_offset is true and the fd still
- * references the same (session, mount_id, nodeid) identity (post-close
- * races leave offsets untouched).
+/* Read up to count bytes from a FUSE-backed file or directory at offset. Writes
+ * the daemon's reply into the guest buffer at buf_gva. Updates the stream
+ * offset on success when advance_offset is true and the fd still references the
+ * same (session, mount_id, nodeid) identity (post-close races leave offsets
+ * untouched).
  */
 static int64_t fuse_read_common(guest_t *g,
                                 int guest_fd,
@@ -2128,9 +2131,9 @@ int64_t fuse_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
     while (src + FUSE_NAME_OFFSET <= (size_t) raw) {
         fuse_dirent_t *fde = (fuse_dirent_t *) (tmp + src);
         /* The daemon supplies fde->namelen; bound it to Linux NAME_MAX before
-         * any further arithmetic so a malicious daemon cannot make
-         * lreclen overflow the fixed entry[] buffer below or exceed the
-         * remaining frame body.
+         * any further arithmetic so a malicious daemon cannot make lreclen
+         * overflow the fixed entry[] buffer below or exceed the remaining frame
+         * body.
          */
         if (fde->namelen > 255) {
             free(tmp);
@@ -2144,9 +2147,9 @@ int64_t fuse_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
             break;
 
         size_t lreclen = (19 + fde->namelen + 1 + 7) & ~7ULL;
-        /* d_ino(8) + d_off(8) + d_reclen(2) + d_type(1) + name(<=255) +
-         * NUL(1) + padding(<=7) <= 280. Defense in depth against an
-         * arithmetic error -- never trust the daemon's record length.
+        /* d_ino(8) + d_off(8) + d_reclen(2) + d_type(1) + name(<=255) + NUL(1)
+         * + padding(<=7) <= 280. Defense in depth against an arithmetic error
+         * -- never trust the daemon's record length.
          */
         uint8_t entry[280];
         if (lreclen > sizeof(entry))
@@ -2265,10 +2268,10 @@ int64_t fuse_dev_write(guest_t *g,
 {
     if (count < sizeof(fuse_out_header_t))
         return -LINUX_EINVAL;
-    /* Reject any daemon write that exceeds the implementation hard ceiling.
-     * The same ceiling is applied at FUSE_INIT negotiation, so a daemon
-     * cannot advertise max_write larger than this and then have its reply
-     * payload silently rejected here.
+    /* Reject any daemon write that exceeds the implementation hard ceiling. The
+     * same ceiling is applied at FUSE_INIT negotiation, so a daemon cannot
+     * advertise max_write larger than this and then have its reply payload
+     * silently rejected here.
      */
     if (count > FUSE_FRAME_CAP)
         return -LINUX_EINVAL;
@@ -2334,9 +2337,9 @@ int64_t fuse_dev_write(guest_t *g,
     if (req->frame && ((fuse_in_header_t *) req->frame)->opcode == FUSE_INIT) {
         /* fuse(4): the daemon may return a fuse_init_out_t shorter than the
          * current struct size (older libfuse), and may negotiate a minor
-         * version different from ours. Accept any reply whose major matches
-         * and that is large enough to carry max_write. Reject only on an
-         * actual major-version mismatch or daemon-reported error.
+         * version different from ours. Accept any reply whose major matches and
+         * that is large enough to carry max_write. Reject only on an actual
+         * major-version mismatch or daemon-reported error.
          */
         const size_t init_min_len = offsetof(fuse_init_out_t, max_write) +
                                     sizeof(((fuse_init_out_t *) 0)->max_write);
@@ -2440,8 +2443,8 @@ int64_t fuse_lseek_fd(int fd, int64_t offset, int whence)
     if (snap.type != FD_FUSE_FILE && snap.type != FD_FUSE_DIR)
         return INT64_MIN;
 
-    /* Fast-reject O_PATH fds before the wait loop, then re-lookup under
-     * the lock for the seek itself.
+    /* Fast-reject O_PATH fds before the wait loop, then re-lookup under the
+     * lock for the seek itself.
      */
     pthread_mutex_lock(&fuse_lock);
     fuse_file_t *probe = fuse_file_by_fd_locked(fd);
@@ -2563,10 +2566,10 @@ int fuse_dup_fd(int src_fd,
         return -1;
     }
 
-    /* Install cleanup atomically with the type. Without this, a racing
-     * close between fd_alloc_*_relaxed publishing the slot and the later
-     * fd_table[guest_fd].cleanup assignment would skip fuse_fd_cleanup
-     * and leak the session or file ref.
+    /* Install cleanup atomically with the type. Without this, a racing close
+     * between fd_alloc_*_relaxed publishing the slot and the later
+     * fd_table[guest_fd].cleanup assignment would skip fuse_fd_cleanup and leak
+     * the session or file ref.
      */
     int guest_fd = fixed_slot ? fd_alloc_at_relaxed(fixed_guest_fd, snap.type,
                                                     -1, fuse_fd_cleanup)
@@ -2615,14 +2618,14 @@ int fuse_dup_fd(int src_fd,
 
     pthread_mutex_unlock(&fuse_lock);
 
-    /* O_NONBLOCK is a file-status flag preserved by dup(2)/dup2(2); without
-     * it a duplicated non-blocking FUSE fd would silently become blocking
-     * because nothing else carries the flag forward.
+    /* O_NONBLOCK is a file-status flag preserved by dup(2)/dup2(2); without it
+     * a duplicated non-blocking FUSE fd would silently become blocking because
+     * nothing else carries the flag forward.
      *
-     * Take fd_lock once for both the source read and the destination write
-     * so the dup snapshot is consistent with any concurrent F_SETFL on the
-     * source and so the destination publish cannot be overwritten by an
-     * early racing F_SETFL on the new slot.
+     * Take fd_lock once for both the source read and the destination write so
+     * the dup snapshot is consistent with any concurrent F_SETFL on the source
+     * and so the destination publish cannot be overwritten by an early racing
+     * F_SETFL on the new slot.
      */
     pthread_mutex_lock(&fd_lock);
     int preserved_flags =

--- a/src/syscall/fuse.h
+++ b/src/syscall/fuse.h
@@ -20,17 +20,17 @@ int fuse_proc_stat(struct stat *st);
 
 int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode);
 bool fuse_path_matches_mount(const char *path);
-/* Returns the mount_id of the FUSE mount containing path, or -1 if path is
- * not inside any live or tombstoned FUSE mount. Distinct FUSE mounts have
- * distinct mount_ids; used by RESOLVE_NO_XDEV to detect cross-mount paths.
+/* Returns the mount_id of the FUSE mount containing path, or -1 if path is not
+ * inside any live or tombstoned FUSE mount. Distinct FUSE mounts have distinct
+ * mount_ids; used by RESOLVE_NO_XDEV to detect cross-mount paths.
  */
 int fuse_path_mount_id(const char *path);
 /* Stat a FUSE-mounted path. at_flags carries the Linux AT_* mask from the
- * caller; only LINUX_AT_SYMLINK_NOFOLLOW is consulted today. When the
- * daemon returns S_IFLNK for the final component and the caller did not
- * request NOFOLLOW, the call surfaces -LINUX_ENOSYS because symlink
- * target resolution is not implemented yet. With NOFOLLOW the symlink's
- * own attrs are returned unchanged.
+ * caller; only LINUX_AT_SYMLINK_NOFOLLOW is consulted today. When the daemon
+ * returns S_IFLNK for the final component and the caller did not request
+ * NOFOLLOW, the call surfaces -LINUX_ENOSYS because symlink target resolution
+ * is not implemented yet. With NOFOLLOW the symlink's own attrs are returned
+ * unchanged.
  */
 int fuse_stat_path(const char *path, struct stat *st, int at_flags);
 int fuse_access_path(const char *path, int mode, int flags);
@@ -58,10 +58,11 @@ bool fuse_is_file_fd(int fd);
 bool fuse_is_dir_fd(int fd);
 bool fuse_fd_refuse_mmap(int fd);
 
-/* Move the per-fd offset for a FUSE-backed regular file. Returns the new offset
- * on success or a negative Linux errno. /dev/fuse and FUSE-backed directories
- * return -ESPIPE/-EINVAL to match Linux semantics for fds that do not support
- * absolute seeking.
+/* Move the per-fd offset for a FUSE-backed regular file.
+ *
+ * Returns the new offset on success or a negative Linux errno. /dev/fuse and
+ * FUSE-backed directories return -ESPIPE/-EINVAL to match Linux semantics for
+ * fds that do not support absolute seeking.
  */
 int64_t fuse_lseek_fd(int fd, int64_t offset, int whence);
 int64_t fuse_fchdir(int fd);

--- a/src/syscall/inotify.c
+++ b/src/syscall/inotify.c
@@ -1,5 +1,4 @@
-/* Linux inotify emulation via kqueue EVFILT_VNODE for
- * elfuse
+/* Linux inotify emulation via kqueue EVFILT_VNODE for elfuse
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -44,8 +43,8 @@ static void inotify_close(int guest_fd);
 
 /* Linux inotify constants (from linux/inotify.h). Only the bits emulation
  * actually emits or recognizes are listed; the remaining inotify events
- * (IN_ACCESS, IN_OPEN, IN_CLOSE_NOWRITE, IN_MOVED_FROM, IN_MOVED_TO) cannot
- * be derived from EVFILT_VNODE notifications, so emulation never sets them.
+ * (IN_ACCESS, IN_OPEN, IN_CLOSE_NOWRITE, IN_MOVED_FROM, IN_MOVED_TO) cannot be
+ * derived from EVFILT_VNODE notifications, so emulation never sets them.
  */
 #define IN_MODIFY 0x00000002
 #define IN_ATTRIB 0x00000004
@@ -99,9 +98,9 @@ typedef struct {
 
 static inotify_instance_t inotify_state[INOTIFY_MAX];
 
-/* Mutex protecting inotify_state[] for concurrent access.
- * Two guest threads may create/close/add-watch on different inotify
- * instances simultaneously.  Lock order: 7 (after pid_lock).
+/* Mutex protecting inotify_state[] for concurrent access. Two guest threads may
+ * create/close/add-watch on different inotify instances simultaneously. Lock
+ * order: 7 (after pid_lock).
  */
 static pthread_mutex_t inotify_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -169,8 +168,8 @@ static int watch_slot_alloc(inotify_instance_t *inst)
 
 /* Event translation. */
 
-/* Convert Linux IN_* mask to kqueue NOTE_* flags for EVFILT_VNODE.
- * Not all IN_* events have kqueue equivalents.
+/* Convert Linux IN_* mask to kqueue NOTE_* flags for EVFILT_VNODE. Not all IN_*
+ * events have kqueue equivalents.
  */
 static uint32_t in_mask_to_notes(uint32_t mask)
 {
@@ -192,8 +191,8 @@ static uint32_t in_mask_to_notes(uint32_t mask)
     return notes;
 }
 
-/* Convert kqueue NOTE_* fflags to Linux IN_* mask.
- * The watch's subscribed mask filters which events are actually reported.
+/* Convert kqueue NOTE_* fflags to Linux IN_* mask. The watch's subscribed mask
+ * filters which events are actually reported.
  */
 static uint32_t notes_to_in_mask(uint32_t fflags,
                                  uint32_t subscribed,
@@ -203,9 +202,8 @@ static uint32_t notes_to_in_mask(uint32_t fflags,
 
     if (fflags & NOTE_WRITE) {
         if (is_dir) {
-            /* Directory write = something was created/deleted inside.
-             * Report as IN_CREATE|IN_DELETE since inotify emulation cannot
-             * distinguish.
+            /* Directory write = something was created/deleted inside. Report as
+             * IN_CREATE|IN_DELETE since inotify emulation cannot distinguish.
              */
             if (subscribed & IN_CREATE)
                 mask |= IN_CREATE;
@@ -236,8 +234,10 @@ static uint32_t notes_to_in_mask(uint32_t fflags,
     return mask & subscribed;
 }
 
-/* Queue a single inotify event into the instance's buffer.
- * name may be NULL (no filename). Returns 0 on success, -1 if full.
+/* Queue a single inotify event into the instance's buffer. name may be NULL (no
+ * filename).
+ *
+ * Returns 0 on success, -1 if full.
  */
 static int queue_event(inotify_instance_t *inst,
                        int wd,
@@ -282,11 +282,10 @@ static void pipe_signal(inotify_instance_t *inst)
     write(inst->pipe_wr, &byte, 1);
 }
 
-/* Drain the self-pipe to reset readability. The pipe is O_NONBLOCK so
- * the loop terminates on EAGAIN. readv is used in place of read to
- * bypass clang's unix.BlockInCriticalSection checker, which flags
- * read() while a pthread mutex is held even though a non-blocking pipe
- * drain cannot stall.
+/* Drain the self-pipe to reset readability. The pipe is O_NONBLOCK so the loop
+ * terminates on EAGAIN. readv is used in place of read to bypass clang's
+ * unix.BlockInCriticalSection checker, which flags read() while a pthread mutex
+ * is held even though a non-blocking pipe drain cannot stall.
  */
 static void pipe_drain(inotify_instance_t *inst)
 {
@@ -298,9 +297,10 @@ static void pipe_drain(inotify_instance_t *inst)
 
 /* Collect events from kqueue. */
 
-/* Poll the kqueue for pending vnode events and translate them into
- * inotify events in the instance buffer. Returns the number of
- * events collected.
+/* Poll the kqueue for pending vnode events and translate them into inotify
+ * events in the instance buffer.
+ *
+ * Returns the number of events collected.
  */
 static int collect_events(inotify_instance_t *inst)
 {
@@ -412,16 +412,16 @@ int64_t sys_inotify_add_watch(guest_t *g,
                               uint64_t path_gva,
                               uint32_t mask)
 {
-    /* Read path from guest memory (no lock needed since guest_read_str
-     * only touches per-guest state, not inotify_state).
+    /* Read path from guest memory (no lock needed since guest_read_str only
+     * touches per-guest state, not inotify_state).
      */
     char path[LINUX_PATH_MAX];
     if (guest_read_str(g, path_gva, path, sizeof(path)) < 0)
         return -LINUX_EFAULT;
 
-    /* Open the path for event monitoring. O_EVTONLY is macOS-specific:
-     * opens for event notification only, does not prevent unmount or
-     * require read access to the file contents.
+    /* Open the path for event monitoring. O_EVTONLY is macOS-specific: opens
+     * for event notification only, does not prevent unmount or require read
+     * access to the file contents.
      */
     int host_fd = open(path, O_EVTONLY);
     if (host_fd < 0)
@@ -449,10 +449,11 @@ int64_t sys_inotify_add_watch(guest_t *g,
 
     inotify_instance_t *inst = &inotify_state[slot];
 
-    /* Linux inotify re-add semantics: if the same file (by dev/ino) is
-     * already watched, update the existing watch's mask instead of
-     * creating a new one.  IN_MASK_ADD ORs new bits; without it, the
-     * mask is replaced entirely.  Returns the existing wd.
+    /* Linux inotify re-add semantics: if the same file (by dev/ino) is already
+     * watched, update the existing watch's mask instead of creating a new one.
+     * IN_MASK_ADD ORs new bits; without it, the mask is replaced entirely.
+     *
+     * Returns the existing wd.
      */
     int existing = watch_find_by_devino(inst, st.st_dev, st.st_ino);
     if (existing >= 0) {
@@ -469,8 +470,8 @@ int64_t sys_inotify_add_watch(guest_t *g,
         /* Close the duplicate fd; inotify emulation keeps the original */
         close(host_fd);
 
-        /* Update kevent filter with the new mask (use snapshot --
-         * w->mask may be modified by another thread after unlock)
+        /* Update kevent filter with the new mask (use snapshot -- w->mask may
+         * be modified by another thread after unlock)
          */
         uint32_t notes = in_mask_to_notes(snapshot_mask);
         struct kevent kev;
@@ -506,10 +507,10 @@ int64_t sys_inotify_add_watch(guest_t *g,
     int kq_fd = inst->kq_fd;
     pthread_mutex_unlock(&inotify_lock);
 
-    /* Register kevent with EVFILT_VNODE. EV_CLEAR makes it re-arm
-     * automatically after each kevent() retrieval, matching inotify's
-     * continuous monitoring behavior.
-     * kevent() is thread-safe; run outside the lock to avoid blocking.
+    /* Register kevent with EVFILT_VNODE. EV_CLEAR makes it re-arm automatically
+     * after each kevent() retrieval, matching inotify's continuous monitoring
+     * behavior. kevent() is thread-safe; run outside the lock to avoid
+     * blocking.
      */
     uint32_t notes = in_mask_to_notes(event_mask);
     struct kevent kev;
@@ -587,11 +588,10 @@ int64_t inotify_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
                 return -LINUX_EAGAIN;
             }
 
-            /* Blocking read: release lock, wait on the kqueue for events.
-             * The self-pipe makes poll/select/epoll work, but for direct
-             * read() calls inotify emulation polls the kqueue with a moderate
-             * timeout and retry to avoid hanging indefinitely (allows signal
-             * delivery).
+            /* Blocking read: release lock, wait on the kqueue for events. The
+             * self-pipe makes poll/select/epoll work, but for direct read()
+             * calls inotify emulation polls the kqueue with a moderate timeout
+             * and retry to avoid hanging indefinitely (allows signal delivery).
              */
             int kq_fd = inst->kq_fd;
             pthread_mutex_unlock(&inotify_lock);
@@ -639,8 +639,8 @@ int64_t inotify_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
         return -LINUX_EAGAIN;
     }
 
-    /* Copy buffered events to a local buffer under lock, then write to
-     * guest after releasing the lock (guest_write does not need lock).
+    /* Copy buffered events to a local buffer under lock, then write to guest
+     * after releasing the lock (guest_write does not need lock).
      */
     size_t copied = 0, pos = 0;
 
@@ -698,8 +698,8 @@ static void inotify_close(int guest_fd)
 
     inotify_instance_t *inst = &inotify_state[slot];
 
-    /* Snapshot state that needs cleanup, then mark slot free.
-     * This prevents other threads from finding this instance.
+    /* Snapshot state that needs cleanup, then mark slot free. This prevents
+     * other threads from finding this instance.
      */
     int kq_fd = inst->kq_fd, pipe_wr = inst->pipe_wr;
 
@@ -726,8 +726,8 @@ static void inotify_close(int guest_fd)
         close(watch_fds[i]);
     }
 
-    /* Close kqueue and pipe write end.
-     * pipe_rd is closed by sys_close() as the host_fd.
+    /* Close kqueue and pipe write end. pipe_rd is closed by sys_close() as the
+     * host_fd.
      */
     close(kq_fd);
     close(pipe_wr);

--- a/src/syscall/inotify.h
+++ b/src/syscall/inotify.h
@@ -1,15 +1,14 @@
-/* Linux inotify emulation via kqueue EVFILT_VNODE for
- * elfuse
+/* Linux inotify emulation via kqueue EVFILT_VNODE for elfuse
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Emulates Linux inotify using macOS kqueue EVFILT_VNODE as the backend.
- * Each inotify_add_watch opens the target path and registers a kevent.
- * Events are translated from kqueue NOTE_* flags to Linux IN_* flags and
- * queued internally. A self-pipe provides poll/epoll readability notification
- * (same pattern as eventfd/signalfd).
+ * Emulates Linux inotify using macOS kqueue EVFILT_VNODE as the backend. Each
+ * inotify_add_watch opens the target path and registers a kevent. Events are
+ * translated from kqueue NOTE_* flags to Linux IN_* flags and queued
+ * internally. A self-pipe provides poll/epoll readability notification (same
+ * pattern as eventfd/signalfd).
  */
 
 #pragma once
@@ -17,13 +16,15 @@
 #include <stdint.h>
 #include "core/guest.h"
 
-/* Initialize inotify state arrays. Must be called once from
- * syscall_init() before any guest code runs.
+/* Initialize inotify state arrays. Must be called once from syscall_init()
+ * before any guest code runs.
  */
 void inotify_init(void);
 
 /* Create an inotify instance. flags may include IN_NONBLOCK (0x800) and
- * IN_CLOEXEC (0x80000). Returns a guest fd or negative Linux errno.
+ * IN_CLOEXEC (0x80000).
+ *
+ * Returns a guest fd or negative Linux errno.
  */
 int64_t sys_inotify_init1(int flags);
 
@@ -38,9 +39,10 @@ int64_t sys_inotify_add_watch(guest_t *g,
 /* Remove an existing watch. Returns 0 or negative Linux errno. */
 int64_t sys_inotify_rm_watch(int inotify_fd, int wd);
 
-/* Read pending inotify events into the guest buffer. Called from
- * sys_read() when the FD type is FD_INOTIFY. Returns bytes read,
- * or negative Linux errno.
+/* Read pending inotify events into the guest buffer. Called from sys_read()
+ * when the FD type is FD_INOTIFY.
+ *
+ * Returns bytes read, or negative Linux errno.
  */
 int64_t inotify_read(int guest_fd,
                      guest_t *g,

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -55,13 +55,17 @@ void fdtable_init(void);
 
 /* FD helpers. */
 
-/* Allocate the lowest available FD. Returns -1 if table is full.
- * cleanup is set atomically under fd_lock (pass NULL for plain fds).
+/* Allocate the lowest available FD.
+ *
+ * Returns -1 if table is full. cleanup is set atomically under fd_lock (pass
+ * NULL for plain fds).
  */
 int fd_alloc(int type, int host_fd, void (*cleanup)(int));
 
-/* Allocate the lowest available FD >= minfd. Returns -1 if none available.
- * cleanup is set atomically under fd_lock (pass NULL for plain fds).
+/* Allocate the lowest available FD >= minfd.
+ *
+ * Returns -1 if none available. cleanup is set atomically under fd_lock (pass
+ * NULL for plain fds).
  */
 int fd_alloc_from(int minfd, int type, int host_fd, void (*cleanup)(int));
 
@@ -74,18 +78,20 @@ int fd_alloc_from_relaxed(int minfd,
                           void (*cleanup)(int));
 
 /* Allocate a specific FD slot.
- * Returns -1 if out of range.
- * cleanup is set atomically under fd_lock (pass NULL for plain fds).
+ * Returns -1 if out of range. cleanup is set atomically under fd_lock (pass
+ * NULL for plain fds).
  */
 int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int));
 
-/* Allocate a specific FD slot with a single-thread fast path.
- * Falls back to fd_alloc_at() when replacement/cleanup must stay serialized.
+/* Allocate a specific FD slot with a single-thread fast path. Falls back to
+ * fd_alloc_at() when replacement/cleanup must stay serialized.
  */
 int fd_alloc_at_relaxed(int fd, int type, int host_fd, void (*cleanup)(int));
 
-/* Look up a guest FD. Returns host FD or -1 if invalid.
- * Unsafe for concurrent use; see fd_snapshot/fd_to_host_dup.
+/* Look up a guest FD.
+ *
+ * Returns host FD or -1 if invalid. Unsafe for concurrent use; see
+ * fd_snapshot/fd_to_host_dup.
  */
 int fd_to_host(int guest_fd);
 
@@ -96,25 +102,28 @@ int fd_to_host(int guest_fd);
 bool fd_snapshot(int guest_fd, fd_entry_t *out);
 
 /* Snapshot an fd entry AND dup its host fd in a single fd_lock critical
- * section. Eliminates the TOCTOU window between reading the type/metadata
- * and duplicating the host fd in the dup(2) path. Returns the dup'd host
- * fd (owned by the caller) on success, -1 on failure. On success the
- * snapshot in *out is consistent with the dup'd host fd.
+ * section. Eliminates the TOCTOU window between reading the type/metadata and
+ * duplicating the host fd in the dup(2) path.
+ *
+ * Returns the dup'd host fd (owned by the caller) on success, -1 on failure. On
+ * success the snapshot in *out is consistent with the dup'd host fd.
  */
 int fd_snapshot_and_dup(int guest_fd, fd_entry_t *out);
 
-/* Read just the fd type under fd_lock. Returns FD_CLOSED for out-of-range or
- * closed slots. Cheaper than fd_snapshot when only the type is needed for
- * dispatch (sys_read/sys_readv/sys_writev fast paths).
+/* Read just the fd type under fd_lock.
+ *
+ * Returns FD_CLOSED for out-of-range or closed slots. Cheaper than fd_snapshot
+ * when only the type is needed for dispatch (sys_read/sys_readv/sys_writev fast
+ * paths).
  */
 int fd_get_type(int guest_fd);
 
-/* Publish linux_flags for a guest fd under fd_lock. Use after fd_alloc when
- * the creating syscall needs to set linux_flags atomically with respect to a
+/* Publish linux_flags for a guest fd under fd_lock. Use after fd_alloc when the
+ * creating syscall needs to set linux_flags atomically with respect to a
  * concurrent fcntl(F_SETFL/F_SETFD) on the same slot. The fd_alloc-then-
  * publish window is small (the new gfd is not communicated to other threads
- * until the syscall returns) but the lock removes the structural race and
- * keeps every linux_flags writer on one lock domain.
+ * until the syscall returns) but the lock removes the structural race and keeps
+ * every linux_flags writer on one lock domain.
  */
 void fd_publish_linux_flags(int guest_fd, int linux_flags);
 
@@ -124,21 +133,21 @@ void fd_publish_linux_flags(int guest_fd, int linux_flags);
  */
 void fd_refresh_urandom_bitmap(int fd);
 
-/* Type -> cleanup registry. Modules that own a synthetic fd type register
- * their cleanup at init time; dup and fork-restore paths look up the
- * cleanup from the type so the binding stays consistent without each path
- * re-deriving the dispatch table.
+/* Type -> cleanup registry. Modules that own a synthetic fd type register their
+ * cleanup at init time; dup and fork-restore paths look up the cleanup from the
+ * type so the binding stays consistent without each path re-deriving the
+ * dispatch table.
  */
 void fd_register_cleanup(int type, void (*cleanup)(int));
 void (*fd_cleanup_for_type(int type))(int);
 
-/* True for fd types whose host backing (kqueue for timerfd/inotify, pipe
- * halves for eventfd/signalfd/netlink/pidfd, epoll instance) cannot be
- * meaningfully inherited across fork IPC: macOS SCM_RIGHTS rejects kqueue
- * fds, and the per-class side-table state (eventfd counter, signalfd mask,
- * pidfd target, epoll set, ...) is not serialized. The child must recreate
- * such fds via the appropriate syscall, so the parent filters them from the
- * SCM_RIGHTS payload and the receiver drops any that still arrive.
+/* True for fd types whose host backing (kqueue for timerfd/inotify, pipe halves
+ * for eventfd/signalfd/netlink/pidfd, epoll instance) cannot be meaningfully
+ * inherited across fork IPC: macOS SCM_RIGHTS rejects kqueue fds, and the
+ * per-class side-table state (eventfd counter, signalfd mask, pidfd target,
+ * epoll set, ...) is not serialized. The child must recreate such fds via the
+ * appropriate syscall, so the parent filters them from the SCM_RIGHTS payload
+ * and the receiver drops any that still arrive.
  */
 static inline bool fd_type_is_synthetic(int type)
 {
@@ -148,32 +157,34 @@ static inline bool fd_type_is_synthetic(int type)
 }
 
 /* Look up a guest FD and return a dup'd host fd owned by the caller.
- * Thread-safe: dup is performed under fd_lock. Returns -1 on failure.
- * Caller MUST close() the returned fd when done.
+ * Thread-safe: dup is performed under fd_lock.
+ *
+ * Returns -1 on failure. Caller MUST close() the returned fd when done.
  */
 int fd_to_host_dup(int guest_fd);
 
-/* Mark an FD slot as closed (set type = FD_CLOSED and update bitmap).
- * Does NOT close the host FD or free type-specific resources (DIR*,
- * epoll instance); caller must do that first.
+/* Mark an FD slot as closed (set type = FD_CLOSED and update bitmap). Does NOT
+ * close the host FD or free type-specific resources (DIR*, epoll instance);
+ * caller must do that first.
  */
 void fd_mark_closed(int fd);
 
-/* Same as fd_mark_closed but requires fd_lock to be already held.
- * Used by sys_execve CLOEXEC loop which holds fd_lock for the entire scan.
+/* Same as fd_mark_closed but requires fd_lock to be already held. Used by
+ * sys_execve CLOEXEC loop which holds fd_lock for the entire scan.
  */
 void fd_mark_closed_unlocked(int fd);
 
-/* Atomically snapshot an fd entry and mark it closed. Returns true if the
- * slot was open (snapshot written to *out), false if already closed. Prevents
- * the TOCTOU race where two concurrent close() calls both snapshot the
- * same open entry and double-close the host fd.
+/* Atomically snapshot an fd entry and mark it closed.
+ *
+ * Returns true if the slot was open (snapshot written to *out), false if
+ * already closed. Prevents the TOCTOU race where two concurrent close() calls
+ * both snapshot the same open entry and double-close the host fd.
  */
 bool fd_snapshot_and_close(int fd, fd_entry_t *out);
 
-/* Snapshot and close with a single-thread fast path.
- * Uses the unlocked table update when exactly one guest thread is active,
- * otherwise falls back to fd_snapshot_and_close().
+/* Snapshot and close with a single-thread fast path. Uses the unlocked table
+ * update when exactly one guest thread is active, otherwise falls back to
+ * fd_snapshot_and_close().
  */
 bool fd_snapshot_and_close_relaxed(int fd, fd_entry_t *out);
 
@@ -184,9 +195,9 @@ bool fd_snapshot_and_close_relaxed(int fd, fd_entry_t *out);
  */
 bool fd_close_regular_relaxed(int fd, int *host_fd_out);
 
-/* Release all type-specific resources for a closed FD entry (DIR*,
- * epoll instance, emulated subsystem state) and close the host fd.
- * Caller must have already removed the entry from fd_table.
+/* Release all type-specific resources for a closed FD entry (DIR*, epoll
+ * instance, emulated subsystem state) and close the host fd. Caller must have
+ * already removed the entry from fd_table.
  */
 void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap);
 
@@ -195,23 +206,22 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap);
 /* Convert macOS errno to negative Linux errno. */
 int64_t linux_errno(void);
 
-/* Translate Linux AT_* flags to macOS equivalents.
- * For unlinkat, fstatat, linkat, fchmodat, fchownat, utimensat.
+/* Translate Linux AT_* flags to macOS equivalents. For unlinkat, fstatat,
+ * linkat, fchmodat, fchownat, utimensat.
  */
 int translate_at_flags(int linux_flags);
 
-/* Reject any flag bits outside the allowed mask. Caller returns
- * -LINUX_EINVAL on failure. Shared by every *at() handler that validates
- * its flags argument.
+/* Reject any flag bits outside the allowed mask. Caller returns -LINUX_EINVAL
+ * on failure. Shared by every *at() handler that validates its flags argument.
  */
 static inline int validate_at_flags(int flags, int allowed)
 {
     return (flags & ~allowed) == 0;
 }
 
-/* Translate Linux faccessat flags to macOS equivalents.
- * Separate from translate_at_flags because Linux AT_EACCESS (0x200) shares
- * the same numeric value as AT_REMOVEDIR; the meaning is context-dependent.
+/* Translate Linux faccessat flags to macOS equivalents. Separate from
+ * translate_at_flags because Linux AT_EACCESS (0x200) shares the same numeric
+ * value as AT_REMOVEDIR; the meaning is context-dependent.
  */
 int translate_faccessat_flags(int linux_flags);
 
@@ -233,8 +243,8 @@ int64_t sys_mmap_anon(guest_t *g, uint64_t addr, uint64_t length, int prot);
 
 /* RLIMIT_NOFILE tracking. */
 
-/* Update the guest RLIMIT_NOFILE soft limit. Called from prlimit64
- * when resource == RLIMIT_NOFILE. fd_alloc checks this.
+/* Update the guest RLIMIT_NOFILE soft limit. Called from prlimit64 when
+ * resource == RLIMIT_NOFILE. fd_alloc checks this.
  */
 void fd_set_rlimit_nofile(int cur);
 
@@ -276,8 +286,8 @@ static inline int host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
 static inline void host_fd_ref_close(host_fd_ref_t *ref)
 {
     /* Preserve errno across close(2). Callers commonly invoke this on the
-     * cleanup path after a syscall failed and then read errno to translate
-     * the failure; a non-zero close error must not clobber that value.
+     * cleanup path after a syscall failed and then read errno to translate the
+     * failure; a non-zero close error must not clobber that value.
      */
     int saved_errno = errno;
     if (ref->owned && ref->fd >= 0)
@@ -298,11 +308,11 @@ static inline int host_dirfd_ref_open(guest_fd_t dirfd, host_fd_ref_t *ref)
     return host_fd_ref_open(dirfd, ref);
 }
 
-/* Open a host fd reference, rejecting O_PATH (FD_PATH) entries with -EBADF.
- * Use this for syscalls that operate on the underlying file -- read/write,
- * lseek, ftruncate, fsync/fdatasync, flock, fsetxattr/fremovexattr, ioctl, etc.
- * Linux returns EBADF on those calls when the fd was opened O_PATH; the host fd
- * here is a plain O_RDONLY descriptor, so without this gate the host call would
+/* Open a host fd reference, rejecting O_PATH (FD_PATH) entries with -EBADF. Use
+ * this for syscalls that operate on the underlying file -- read/write, lseek,
+ * ftruncate, fsync/fdatasync, flock, fsetxattr/fremovexattr, ioctl, etc. Linux
+ * returns EBADF on those calls when the fd was opened O_PATH; the host fd here
+ * is a plain O_RDONLY descriptor, so without this gate the host call would
  * silently succeed and diverge from Linux semantics.
  *
  * Calls that are explicitly allowed on O_PATH (fstat, fstatfs, fchdir, close,
@@ -323,8 +333,8 @@ static inline int64_t host_fd_ref_open_io(guest_fd_t guest_fd,
 }
 
 /* iov limits shared between readv/writev/preadv/pwritev and sendmsg/recvmsg.
- * SYSCALL_IOV_MAX matches the Linux UIO_MAXIOV cap; SYSCALL_IOV_STACK_MAX
- * keeps the typical case on the call-site stack.
+ * SYSCALL_IOV_MAX matches the Linux UIO_MAXIOV cap; SYSCALL_IOV_STACK_MAX keeps
+ * the typical case on the call-site stack.
  */
 #define SYSCALL_IOV_MAX 1024
 #define SYSCALL_IOV_STACK_MAX 64
@@ -337,13 +347,13 @@ typedef struct {
     struct iovec *iov;
 } host_iov_buf_t;
 
-/* Translate a guest iovec array at iov_gva (iovcnt entries) into the host
- * iovec layout in buf->iov, resolving each guest_base to a contiguous host
- * pointer with the requested permissions. On a non-contiguous iov entry the
- * helper truncates that entry to the contiguous prefix and zeros every
- * subsequent entry; the host readv/writev/sendmsg/recvmsg then returns a
- * POSIX-compliant short I/O instead of silently packing bytes from the next
- * guest buffer into the truncated tail.
+/* Translate a guest iovec array at iov_gva (iovcnt entries) into the host iovec
+ * layout in buf->iov, resolving each guest_base to a contiguous host pointer
+ * with the requested permissions. On a non-contiguous iov entry the helper
+ * truncates that entry to the contiguous prefix and zeros every subsequent
+ * entry; the host readv/writev/sendmsg/recvmsg then returns a POSIX-compliant
+ * short I/O instead of silently packing bytes from the next guest buffer into
+ * the truncated tail.
  *
  * iovcnt <= 0 or > SYSCALL_IOV_MAX returns -LINUX_EINVAL.
  *
@@ -369,10 +379,11 @@ void host_iov_free(host_iov_buf_t *buf);
 
 /* Read a guest path string with small-buffer optimization.
  *
- * Tries the stack-allocated short_buf first; falls back to long_buf for
- * paths > short_sz bytes.  On success, *out points to whichever buffer
- * contains the path (caller must not free).  Returns 0 on success, or
- * -LINUX_EFAULT on failure.
+ * Tries the stack-allocated short_buf first; falls back to long_buf for paths >
+ * short_sz bytes. On success, *out points to whichever buffer contains the path
+ * (caller must not free).
+ *
+ * Returns 0 on success, or -LINUX_EFAULT on failure.
  */
 static inline int guest_read_path(guest_t *g,
                                   uint64_t gva,

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -4,11 +4,11 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Read/write, ioctl, splice, sendfile, and copy_file_range operations.
- * All functions are called from syscall_dispatch() in syscall/syscall.c.
+ * Read/write, ioctl, splice, sendfile, and copy_file_range operations. All
+ * functions are called from syscall_dispatch() in syscall/syscall.c.
  *
- * Poll/select/epoll handlers are in syscall/poll.c.
- * Special FD types (eventfd, signalfd, timerfd) are in syscall/fd.c.
+ * Poll/select/epoll handlers are in syscall/poll.c. Special FD types (eventfd,
+ * signalfd, timerfd) are in syscall/fd.c.
  */
 
 #include <stdio.h>
@@ -53,8 +53,8 @@ typedef struct {
     uint16_t ws_row, ws_col, ws_xpixel, ws_ypixel;
 } linux_winsize_t;
 
-/* Linux struct termios used by TCGETS/TCSETS on aarch64.  Speed fields live
- * in Linux termios2, not in this ioctl ABI.
+/* Linux struct termios used by TCGETS/TCSETS on aarch64. Speed fields live in
+ * Linux termios2, not in this ioctl ABI.
  */
 typedef struct {
     uint32_t c_iflag, c_oflag, c_cflag, c_lflag;
@@ -63,10 +63,10 @@ typedef struct {
 } linux_termios_t;
 
 /* Per-fd lock embedded in the cache so a urandom read on fd A does not
- * serialize behind a concurrent urandom read on fd B. The previous design
- * used a single global mutex covering the whole cache array, which made
- * the per-fd cache pointless under any sibling-vCPU urandom traffic.
- * The lock array is initialized at startup by io_init().
+ * serialize behind a concurrent urandom read on fd B. The previous design used
+ * a single global mutex covering the whole cache array, which made the per-fd
+ * cache pointless under any sibling-vCPU urandom traffic. The lock array is
+ * initialized at startup by io_init().
  */
 typedef struct {
     pthread_mutex_t lock;
@@ -86,8 +86,8 @@ void io_init(void)
 _Static_assert(sizeof(linux_termios_t) == 36,
                "aarch64 Linux TCGETS struct termios must be 36 bytes");
 
-/* Linux struct termios2 used by TCGETS2/TCSETS2 on aarch64.
- * Same layout as termios but adds c_ispeed and c_ospeed at the end.
+/* Linux struct termios2 used by TCGETS2/TCSETS2 on aarch64. Same layout as
+ * termios but adds c_ispeed and c_ospeed at the end.
  */
 typedef struct {
     uint32_t c_iflag, c_oflag, c_cflag, c_lflag;
@@ -99,8 +99,8 @@ typedef struct {
 _Static_assert(sizeof(linux_termios2_t) == 44,
                "aarch64 Linux TCGETS2 struct termios2 must be 44 bytes");
 
-/* Linux <-> macOS c_cc index mapping: linux_mac_cc[linux_idx] = mac_idx.
- * Shared by TCGETS/TCSETS and their termios2 variants.
+/* Linux <-> macOS c_cc index mapping: linux_mac_cc[linux_idx] = mac_idx. Shared
+ * by TCGETS/TCSETS and their termios2 variants.
  *
  * Linux: VINTR=0 VQUIT=1 VERASE=2 VKILL=3 VEOF=4 VTIME=5
  *        VMIN=6 VSWTC=7 VSTART=8 VSTOP=9 VSUSP=10 VEOL=11
@@ -117,8 +117,8 @@ static void termios_copy_cc_to_linux(uint8_t linux_cc[19], const cc_t mac_cc[])
 {
     for (int i = 0; i < 19; i++) {
         int mac_idx = linux_mac_cc[i];
-        /* cppcheck-suppress negativeIndex
-         * RANGE_CHECK guards mac_idx >= 0 before the array access.
+        /* cppcheck-suppress negativeIndex RANGE_CHECK guards mac_idx >= 0
+         * before the array access.
          */
         linux_cc[i] = RANGE_CHECK(mac_idx, 0, NCCS) ? mac_cc[mac_idx] : 0;
     }
@@ -151,8 +151,8 @@ void urandom_fd_reset_cache(int guest_fd)
     if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))
         return;
 
-    /* Preserve the embedded lock; reset only the entropy fields. memset of
-     * the whole struct would clobber the mutex state.
+    /* Preserve the embedded lock; reset only the entropy fields. memset of the
+     * whole struct would clobber the mutex state.
      */
     urandom_cache_t *c = &urandom_cache[guest_fd];
     pthread_mutex_lock(&c->lock);
@@ -265,12 +265,11 @@ static int64_t urandom_read(guest_t *g,
     struct iovec iov = {.iov_base = dst, .iov_len = (size_t) count};
     int64_t rc = urandom_fill_iov(guest_fd, &iov, 1);
 
-    /* This slow path runs when the shim's identity-class fast path
-     * could not serve the read: either the request was larger than
-     * the shim's inline limit, or the ring was empty. Refill the
-     * shim's entropy ring before returning so a subsequent
-     * read(/dev/urandom) from the same vCPU sees a populated ring
-     * and stays on the fast path.
+    /* This slow path runs when the shim's identity-class fast path could not
+     * serve the read: either the request was larger than the shim's inline
+     * limit, or the ring was empty. Refill the shim's entropy ring before
+     * returning so a subsequent read(/dev/urandom) from the same vCPU sees a
+     * populated ring and stays on the fast path.
      */
     shim_globals_refill_urandom_ring(g);
     return rc;
@@ -281,10 +280,10 @@ static bool rosetta_ioctl_target_fd(guest_t *g, int host_fd)
     if (!g->is_rosetta)
         return false;
 
-    /* Rosetta opens /proc/self/exe (which under rosetta resolves to the
-     * rosetta translator, not elfuse) and issues the VZ probe ioctls on
-     * that descriptor. Match against ROSETTA_PATH so the gate triggers
-     * regardless of where elfuse itself lives on disk.
+    /* Rosetta opens /proc/self/exe (which under rosetta resolves to the rosetta
+     * translator, not elfuse) and issues the VZ probe ioctls on that
+     * descriptor. Match against ROSETTA_PATH so the gate triggers regardless of
+     * where elfuse itself lives on disk.
      */
     char resolved[PATH_MAX];
     if (fcntl(host_fd, F_GETPATH, resolved) < 0)
@@ -294,15 +293,15 @@ static bool rosetta_ioctl_target_fd(guest_t *g, int host_fd)
 
     /* Defense in depth: require the syscall to originate from inside the
      * rosetta translator image. The /proc/self/exe redirection makes the
-     * launcher fd reachable to any code running under a rosetta-enabled
-     * VM, so without this check a guest-launched helper that opened
-     * /proc/self/exe could exercise the synthetic VZ probe path. Today
-     * the responses are public constants, but the gate guards against
-     * future synthetic responses that leak host state. ELR_EL1 carries
-     * the EL0 return PC captured at SVC entry on aarch64.
+     * launcher fd reachable to any code running under a rosetta-enabled VM, so
+     * without this check a guest-launched helper that opened /proc/self/exe
+     * could exercise the synthetic VZ probe path. Today the responses are
+     * public constants, but the gate guards against future synthetic responses
+     * that leak host state. ELR_EL1 carries the EL0 return PC captured at SVC
+     * entry on aarch64.
      *
-     * Skip if the rosetta image bounds are not yet known (pre-finalize);
-     * the F_GETPATH match above is the only gate in that window, and
+     * Skip if the rosetta image bounds are not yet known (pre-finalize); the
+     * F_GETPATH match above is the only gate in that window, and
      * rosetta_finalize publishes the bounds before issuing any ioctl.
      */
     if (g->rosetta_va_base && g->rosetta_size) {
@@ -349,9 +348,9 @@ static int64_t rosetta_vz_ioctl(guest_t *g, uint64_t request, uint64_t arg)
         memcpy(&caps[ROSETTA_CAPS_SOCKET_PATH], fake_sock_path,
                sizeof(fake_sock_path));
         /* Snapshot the caps binary path under the rosetta path lock so a
-         * concurrent execve cannot tear the string between length probe
-         * and copy. Inline buffer matches the cap exactly; the snapshot
-         * helper bounds the write itself.
+         * concurrent execve cannot tear the string between length probe and
+         * copy. Inline buffer matches the cap exactly; the snapshot helper
+         * bounds the write itself.
          */
         char bin[ROSETTA_CAPS_BINARY_PATH_LEN];
         size_t bin_n = rosettad_snapshot_caps_binary_path(bin, sizeof(bin));
@@ -370,10 +369,10 @@ static int64_t rosetta_vz_ioctl(guest_t *g, uint64_t request, uint64_t arg)
 
 /* termios flag translation helpers. */
 
-/* Linux aarch64 c_iflag bits (from asm-generic/termbits-common.h).
- * Low 9 bits (IGNBRK..ICRNL) match macOS exactly.
- * Bits from 0x200 onward differ: Linux IUCLC=0x200 has no macOS equivalent;
- * Linux IXON=0x400/IXOFF=0x1000 vs macOS IXON=0x200/IXOFF=0x400.
+/* Linux aarch64 c_iflag bits (from asm-generic/termbits-common.h). Low 9 bits
+ * (IGNBRK..ICRNL) match macOS exactly. Bits from 0x200 onward differ: Linux
+ * IUCLC=0x200 has no macOS equivalent; Linux IXON=0x400/IXOFF=0x1000 vs macOS
+ * IXON=0x200/IXOFF=0x400.
  */
 #define LINUX_IFLAG_LOW_MASK 0x1ff /* bits 0-8: same on Linux and macOS */
 #define LINUX_IXON 0x0400
@@ -417,13 +416,13 @@ static uint32_t mac_iflag_to_linux(tcflag_t mf)
     return lf;
 }
 
-/* Linux aarch64 c_oflag bits (asm-generic/termbits-common.h + termbits.h).
- * Only OPOST (0x01) has the same value on both platforms.
- * macOS 0x02 = ONLCR; Linux 0x02 = OLCUC (output lowercase->uppercase, rare).
- * macOS 0x04 = OXTABS; Linux 0x04 = ONLCR. All other bits shift by one.
+/* Linux aarch64 c_oflag bits (asm-generic/termbits-common.h + termbits.h). Only
+ * OPOST (0x01) has the same value on both platforms. macOS 0x02 = ONLCR; Linux
+ * 0x02 = OLCUC (output lowercase->uppercase, rare). macOS 0x04 = OXTABS; Linux
+ * 0x04 = ONLCR. All other bits shift by one.
  */
-/* OLCUC (Linux 0x002, output lowercase->uppercase) has no macOS equivalent
- * and is silently dropped. macOS uses 0x002 for ONLCR.
+/* OLCUC (Linux 0x002, output lowercase->uppercase) has no macOS equivalent and
+ * is silently dropped. macOS uses 0x002 for ONLCR.
  */
 #define LINUX_OPOST 0x001
 #define LINUX_ONLCR 0x004  /* macOS ONLCR=0x002 */
@@ -478,12 +477,12 @@ static uint32_t mac_oflag_to_linux(tcflag_t mf)
     return lf;
 }
 
-/* Linux aarch64 c_cflag bits (asm-generic/termbits.h).
- * All standard flags differ from macOS: macOS shifts everything left by 4
- * bits (e.g., Linux CS8=0x30, macOS CS8=0x300; Linux CSTOPB=0x40, macOS=0x400).
- * The CBAUD field (Linux 0x0000100f) encodes baud rate symbolically; macOS
- * uses raw numeric speeds via cfgetispeed/cfsetispeed, so termios translation
- * drops CBAUD from c_cflag and always uses the speed accessors.
+/* Linux aarch64 c_cflag bits (asm-generic/termbits.h). All standard flags
+ * differ from macOS: macOS shifts everything left by 4 bits (e.g., Linux
+ * CS8=0x30, macOS CS8=0x300; Linux CSTOPB=0x40, macOS=0x400). The CBAUD field
+ * (Linux 0x0000100f) encodes baud rate symbolically; macOS uses raw numeric
+ * speeds via cfgetispeed/cfsetispeed, so termios translation drops CBAUD from
+ * c_cflag and always uses the speed accessors.
  */
 #define LINUX_CSIZE 0x0030
 #define LINUX_CS5 0x0000
@@ -504,9 +503,9 @@ static uint32_t mac_oflag_to_linux(tcflag_t mf)
 #define LINUX_BOTHER 0x1000
 
 /* Decode a Linux CBAUD field value to a numeric baud rate.
- * Returns the numeric rate, or 0 for B0 / unknown.
- * Standard rates B0-B38400 are in the low nibble (0-15);
- * extended rates B57600-B4000000 use CBAUDEX (0x1000) + low nibble.
+ * Returns the numeric rate, or 0 for B0 / unknown. Standard rates B0-B38400 are
+ * in the low nibble (0-15); extended rates B57600-B4000000 use CBAUDEX (0x1000)
+ * + low nibble.
  */
 static speed_t linux_cbaud_to_speed(uint32_t cbaud)
 {
@@ -603,12 +602,12 @@ static uint32_t mac_cflag_to_linux(tcflag_t mf)
     return lf;
 }
 
-/* Linux aarch64 c_lflag bits (asm-generic/termbits.h).
- * Virtually every flag has a different value from macOS.
- * Only ECHO (0x0008) is the same on both platforms.
+/* Linux aarch64 c_lflag bits (asm-generic/termbits.h). Virtually every flag has
+ * a different value from macOS. Only ECHO (0x0008) is the same on both
+ * platforms.
  */
-/* XCASE (Linux 0x004, rarely used, no macOS equivalent) is dropped; macOS
- * 0x004 has different semantics and is not translated here.
+/* XCASE (Linux 0x004, rarely used, no macOS equivalent) is dropped; macOS 0x004
+ * has different semantics and is not translated here.
  */
 #define LINUX_ISIG 0x00001
 #define LINUX_ICANON 0x00002
@@ -703,10 +702,11 @@ static uint32_t mac_lflag_to_linux(tcflag_t mf)
 
 /* read/write and positional variants. */
 
-/* Open a host fd reference for regular I/O, checking type and seals
- * under fd_lock for thread safety.  Returns -LINUX_EBADF for path-only
- * or closed fds, -LINUX_EPERM for write-sealed fds (when check_seal
- * is set), or 0 on success.
+/* Open a host fd reference for regular I/O, checking type and seals under
+ * fd_lock for thread safety.
+ *
+ * Returns -LINUX_EBADF for path-only or closed fds, -LINUX_EPERM for
+ * write-sealed fds (when check_seal is set), or 0 on success.
  */
 static int64_t host_fd_ref_open_checked(int guest_fd,
                                         host_fd_ref_t *ref,
@@ -858,9 +858,9 @@ int64_t sys_write(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         return io_return_zero(&host_ref);
 
     /* Resolve buffer and cap count to available contiguous guest bytes.
-     * guest_ptr_avail returns the host pointer and remaining bytes in
-     * the current region. This prevents host write() from reading past
-     * the guest buffer boundary.
+     * guest_ptr_avail returns the host pointer and remaining bytes in the
+     * current region. This prevents host write() from reading past the guest
+     * buffer boundary.
      */
     uint64_t avail = 0;
     void *buf = guest_ptr_bound(g, buf_gva, &avail, MEM_PERM_R, count);
@@ -893,9 +893,9 @@ int64_t sys_write(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
 
 int64_t sys_read(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
 {
-    /* Read the type once under fd_lock so a concurrent close/reopen cannot
-     * make different dispatch checks disagree. Each handler still
-     * re-validates internally and returns EBADF if its slot changed.
+    /* Read the type once under fd_lock so a concurrent close/reopen cannot make
+     * different dispatch checks disagree. Each handler still re-validates
+     * internally and returns EBADF if its slot changed.
      */
     int type = fd_get_type(fd);
     switch (type) {
@@ -1033,10 +1033,10 @@ int64_t sys_pwrite64(guest_t *g,
     return io_write_result(ret);
 }
 
-/* Helper: build host iovec array from guest iovec array.
- * Uses guest_read for the iovec array (may cross 2MiB block boundary)
- * and guest_ptr_avail for each buffer (caps to contiguous bytes).
- * required_perms: MEM_PERM_W for readv (host writes to guest buffers),
+/* Helper: build host iovec array from guest iovec array. Uses guest_read for
+ * the iovec array (may cross 2MiB block boundary) and guest_ptr_avail for each
+ * buffer (caps to contiguous bytes). required_perms: MEM_PERM_W for readv (host
+ * writes to guest buffers),
  *                 MEM_PERM_R for writev (host reads from guest buffers).
  * Returns 0 on success, -LINUX_EFAULT on bad guest pointer.
  */
@@ -1073,12 +1073,12 @@ static int64_t build_host_iov(guest_t *g,
                 free(guest_iov);
             return -LINUX_EFAULT;
         }
-        /* Cap to contiguous permitted bytes. When the guest iov entry
-         * spans a non-contiguous boundary (different mapping or
-         * permission), zero every subsequent host iov length so the
-         * host readv/writev returns a POSIX-compliant short I/O rather
-         * than silently packing the truncated tail of buffer i into
-         * buffer i+1 -- which corrupts the guest's data layout.
+        /* Cap to contiguous permitted bytes. When the guest iov entry spans a
+         * non-contiguous boundary (different mapping or permission), zero every
+         * subsequent host iov length so the host readv/writev returns a
+         * POSIX-compliant short I/O rather than silently packing the truncated
+         * tail of buffer i into buffer i+1 -- which corrupts the guest's data
+         * layout.
          */
         uint64_t len = guest_iov[i].iov_len;
         host_iov[i].iov_base = base;
@@ -1172,10 +1172,10 @@ int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
     }
 
     /* Special FD types need their custom read handlers because glibc may use
-     * readv() instead of read() for the same logical operation. Delegate
-     * scalar special fds to the first iov entry's buffer. Use the first iov's
-     * length (not the sum of all iovs) because the data goes into
-     * giov[0].iov_base which is only giov[0].iov_len bytes long.
+     * readv() instead of read() for the same logical operation. Delegate scalar
+     * special fds to the first iov entry's buffer. Use the first iov's length
+     * (not the sum of all iovs) because the data goes into giov[0].iov_base
+     * which is only giov[0].iov_len bytes long.
      */
     int type = fd_get_type(fd);
     if (type == FD_URANDOM) {
@@ -1191,10 +1191,10 @@ int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
             return err;
         int64_t ret = urandom_fill_iov(fd, host_iov.iov, iovcnt);
         host_iov_free(&host_iov);
-        /* Mirror sys_read's slow-path refill so a readv consumer that
-         * drains the shim ring leaves it ready for the next call,
-         * instead of forcing every subsequent EL1 fast-path attempt
-         * back through HVC until some other path triggers a refill.
+        /* Mirror sys_read's slow-path refill so a readv consumer that drains
+         * the shim ring leaves it ready for the next call, instead of forcing
+         * every subsequent EL1 fast-path attempt back through HVC until some
+         * other path triggers a refill.
          */
         shim_globals_refill_urandom_ring(g);
         return ret;
@@ -1203,8 +1203,8 @@ int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
         type == FD_INOTIFY) {
         if (iovcnt <= 0)
             return -LINUX_EINVAL;
-        /* Use guest_read for the iov array since guest_ptr alone is unsafe
-         * if the array spans a 2MiB block boundary.
+        /* Use guest_read for the iov array since guest_ptr alone is unsafe if
+         * the array spans a 2MiB block boundary.
          */
         linux_iovec_t giov;
         if (guest_read_small(g, iov_gva, &giov, sizeof(giov)) < 0)
@@ -1253,9 +1253,9 @@ int64_t sys_writev(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
     }
 
     /* Special FD types: glibc may use writev() for eventfd wakeup writes.
-     * Delegate using the first iov entry.  Use giov.iov_len (not the
-     * sum of all iovs) because the data is at giov.iov_base which is only
-     * giov.iov_len bytes.  eventfd expects exactly 8 bytes.
+     * Delegate using the first iov entry. Use giov.iov_len (not the sum of all
+     * iovs) because the data is at giov.iov_base which is only giov.iov_len
+     * bytes. eventfd expects exactly 8 bytes.
      */
     if (fd_get_type(fd) == FD_EVENTFD) {
         if (iovcnt <= 0)
@@ -1438,8 +1438,8 @@ int64_t sys_preadv2(guest_t *g,
         return -LINUX_EOPNOTSUPP;
     if (flags & RWF_APPEND)
         return -LINUX_EINVAL; /* RWF_APPEND is write-only */
-    /* RWF_HIPRI, RWF_NOWAIT: best-effort hints, safe to ignore.
-     * RWF_DSYNC, RWF_SYNC: no effect on reads.
+    /* RWF_HIPRI, RWF_NOWAIT: best-effort hints, safe to ignore. RWF_DSYNC,
+     * RWF_SYNC: no effect on reads.
      */
     if (offset == -1)
         return sys_readv(g, fd, iov_gva, iovcnt);
@@ -1487,7 +1487,8 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
      * O_PATH descriptors. Validate the slot and mutate the flag in a single
      * fd_lock section so there is no validate-then-mutate window in which a
      * concurrent close/reuse could flip CLOEXEC on a different file that took
-     * the slot. The arg is ignored. */
+     * the slot. The arg is ignored.
+     */
     if (request == LINUX_FIOCLEX || request == LINUX_FIONCLEX) {
         if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
             return -LINUX_EBADF;
@@ -1601,7 +1602,8 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
 
     case LINUX_TCGETS: {
         /* Get terminal attributes. c_cc index mapping is in file-scope
-         * linux_mac_cc[]. */
+         * linux_mac_cc[].
+         */
         struct termios t;
         if (tcgetattr(host_fd, &t) < 0) {
             host_fd_ref_close(&host_ref);
@@ -1649,9 +1651,9 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
     }
 
     case LINUX_TCGETS2: {
-        /* termios2 variant: same as TCGETS but with c_ispeed/c_ospeed.
-         * Set BOTHER in c_cflag so the guest uses the numeric speed fields
-         * rather than decoding CBAUD (which mac_cflag_to_linux drops).
+        /* termios2 variant: same as TCGETS but with c_ispeed/c_ospeed. Set
+         * BOTHER in c_cflag so the guest uses the numeric speed fields rather
+         * than decoding CBAUD (which mac_cflag_to_linux drops).
          */
         struct termios t;
         if (tcgetattr(host_fd, &t) < 0) {
@@ -1677,8 +1679,9 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
     case LINUX_TCSETS2:
     case LINUX_TCSETSW2:
     case LINUX_TCSETSF2: {
-        /* termios2 set: decode CBAUD for standard rates, use c_ispeed/
-         * c_ospeed when BOTHER is set. */
+        /* termios2 set: decode CBAUD for standard rates, use c_ispeed/ c_ospeed
+         * when BOTHER is set.
+         */
         linux_termios2_t lt2;
         if (guest_read_small(g, arg, &lt2, sizeof(lt2)) < 0) {
             host_fd_ref_close(&host_ref);
@@ -1695,7 +1698,8 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         t.c_lflag = linux_lflag_to_mac(lt2.c_lflag);
         termios_copy_cc_to_mac(t.c_cc, lt2.c_cc);
         /* Resolve baud rate: BOTHER means use numeric c_ispeed/c_ospeed;
-         * otherwise decode the standard CBAUD index to a numeric rate. */
+         * otherwise decode the standard CBAUD index to a numeric rate.
+         */
         uint32_t cbaud = lt2.c_cflag & LINUX_CBAUD;
         speed_t ispeed, ospeed;
         if (cbaud == LINUX_BOTHER) {
@@ -1745,12 +1749,12 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
     }
 
     case LINUX_TIOCGPTN: {
-        /* Get the slave pty number associated with a /dev/ptmx master fd.
-         * Pass the guest fd: proc_pty_master_adopt snapshots the canonical
-         * (host_fd, generation) under fd_lock, performs the slave open on a
-         * private dup, then re-validates the slot before publishing the
-         * keepalive. Passing the per-syscall host_fd_ref dup or a raw host
-         * fd would race with sibling close+reuse.
+        /* Get the slave pty number associated with a /dev/ptmx master fd. Pass
+         * the guest fd: proc_pty_master_adopt snapshots the canonical (host_fd,
+         * generation) under fd_lock, performs the slave open on a private dup,
+         * then re-validates the slot before publishing the keepalive. Passing
+         * the per-syscall host_fd_ref dup or a raw host fd would race with
+         * sibling close+reuse.
          */
         uint32_t val = proc_pty_master_adopt(fd);
         if (val == UINT32_MAX) {
@@ -1765,12 +1769,12 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         return 0;
     }
     case LINUX_TIOCSPTLCK: {
-        /* Lock/unlock the slave side of a pty. glibc unlockpt() always passes
-         * 0 (unlock); util-linux's setlock(1) passes 1 to lock. macOS exposes
+        /* Lock/unlock the slave side of a pty. glibc unlockpt() always passes 0
+         * (unlock); util-linux's setlock(1) passes 1 to lock. macOS exposes
          * unlockpt(3) but no re-lock primitive, so the lock branch is accepted
-         * as a best-effort no-op for real ptmx masters rather than surfacing
-         * as -EINVAL: an application probing the result would otherwise
-         * misread the failure as "this kernel has no devpts".
+         * as a best-effort no-op for real ptmx masters rather than surfacing as
+         * -EINVAL: an application probing the result would otherwise misread
+         * the failure as "this kernel has no devpts".
          */
         int32_t lock = 0;
         if (guest_read_small(g, arg, &lock, sizeof(lock)) < 0) {
@@ -1797,8 +1801,8 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
          * flags. Restrict to the bits Linux's pty driver actually honors
          * (accmode + O_NOCTTY + O_NONBLOCK + O_CLOEXEC); any other bit, in
          * particular O_CREAT / O_TRUNC / O_EXCL / O_PATH, would be silently
-         * ignored on Linux and is rejected with EINVAL here so misuse does
-         * not leak nonsense flags into the guest fd table.
+         * ignored on Linux and is rejected with EINVAL here so misuse does not
+         * leak nonsense flags into the guest fd table.
          */
         int linux_flags = (int) arg;
         const int allowed = LINUX_O_ACCMODE | LINUX_O_NOCTTY |
@@ -1878,22 +1882,21 @@ int64_t sys_fallocate(int fd, int mode, int64_t offset, int64_t len)
         return -LINUX_EINVAL;
     }
 
-    /* FALLOC_FL_PUNCH_HOLE always requires FALLOC_FL_KEEP_SIZE on Linux;
-     * map both to macOS F_PUNCHHOLE on the host fd, with a pwrite-zeros
-     * fallback for misalignment.
+    /* FALLOC_FL_PUNCH_HOLE always requires FALLOC_FL_KEEP_SIZE on Linux; map
+     * both to macOS F_PUNCHHOLE on the host fd, with a pwrite-zeros fallback
+     * for misalignment.
      *
-     * The Linux semantic is "reads in [offset, offset+len) return zero;
-     * file size unchanged". macOS F_PUNCHHOLE enforces filesystem block
-     * alignment on both ends and rejects sub-block requests with EINVAL --
-     * that one-byte probe (offset=0 len=1) foot's wl_shm pool issues
-     * surfaces as "fallocate(FALLOC_FL_PUNCH_HOLE) not supported (Invalid
-     * argument)" otherwise, and foot disables punch-hole for the whole
-     * session.
+     * The Linux semantic is "reads in [offset, offset+len) return zero; file
+     * size unchanged". macOS F_PUNCHHOLE enforces filesystem block alignment on
+     * both ends and rejects sub-block requests with EINVAL -- that one-byte
+     * probe (offset=0 len=1) foot's wl_shm pool issues surfaces as
+     * "fallocate(FALLOC_FL_PUNCH_HOLE) not supported (Invalid argument)"
+     * otherwise, and foot disables punch-hole for the whole session.
      *
-     * Writing zeros over the region produces the same observable result:
-     * reads return zero, file size unchanged. The disk-space deallocation
-     * optimisation is lost on the pwrite path, but the probe succeeds, so
-     * foot keeps punch-hole enabled and the later, properly aligned calls
+     * Writing zeros over the region produces the same observable result: reads
+     * return zero, file size unchanged. The disk-space deallocation
+     * optimisation is lost on the pwrite path, but the probe succeeds, so foot
+     * keeps punch-hole enabled and the later, properly aligned calls
      * (page-sized buffers) still take the F_PUNCHHOLE fast path.
      */
     const int kPunchHole =
@@ -1909,9 +1912,9 @@ int64_t sys_fallocate(int fd, int mode, int64_t offset, int64_t len)
             host_fd_ref_close(&host_ref);
             return 0;
         }
-        /* EINVAL: misaligned, sub-block, or non-regular file. pwrite zeros
-         * only through the current EOF so KEEP_SIZE remains guest-visible.
-         * Any other host errno propagates verbatim.
+        /* EINVAL: misaligned, sub-block, or non-regular file. pwrite zeros only
+         * through the current EOF so KEEP_SIZE remains guest-visible. Any other
+         * host errno propagates verbatim.
          */
         if (errno != EINVAL) {
             host_fd_ref_close(&host_ref);
@@ -1952,9 +1955,9 @@ int64_t sys_fallocate(int fd, int mode, int64_t offset, int64_t len)
         return 0;
     }
 
-    /* mode 0 = basic allocation -> ftruncate fallback. Anything else
-     * (collapse range, zero range, insert range, unshare range) stays
-     * unsupported and surfaces as -EOPNOTSUPP for the guest to handle.
+    /* mode 0 = basic allocation -> ftruncate fallback. Anything else (collapse
+     * range, zero range, insert range, unshare range) stays unsupported and
+     * surfaces as -EOPNOTSUPP for the guest to handle.
      */
     if (mode != 0) {
         host_fd_ref_close(&host_ref);
@@ -2061,9 +2064,9 @@ int64_t sys_sendfile(guest_t *g,
             break; /* Short write */
     }
 
-    /* Write back updated offset (even on partial transfer).
-     * Preserve partial success: if bytes were transferred but offset
-     * writeback fails, return the count rather than -EFAULT.
+    /* Write back updated offset (even on partial transfer). Preserve partial
+     * success: if bytes were transferred but offset writeback fails, return the
+     * count rather than -EFAULT.
      */
     if (offset_gva != 0) {
         if (guest_write_small(g, offset_gva, &offset, sizeof(offset)) < 0)
@@ -2167,8 +2170,8 @@ int64_t sys_copy_file_range(guest_t *g,
             break;
     }
 
-    /* Write back updated offsets (even on partial transfer).
-     * Preserve partial success on writeback failure.
+    /* Write back updated offsets (even on partial transfer). Preserve partial
+     * success on writeback failure.
      */
     if (off_in_gva != 0) {
         if (guest_write_small(g, off_in_gva, &off_in, sizeof(off_in)) < 0)
@@ -2273,9 +2276,9 @@ int64_t sys_splice(guest_t *g,
     }
 
 done:
-    /* Write back updated offsets. Preserve partial transfer success:
-     * if bytes were already moved, return that count even if the
-     * offset writeback fails (consistent with sendfile/copy_file_range).
+    /* Write back updated offsets. Preserve partial transfer success: if bytes
+     * were already moved, return that count even if the offset writeback fails
+     * (consistent with sendfile/copy_file_range).
      */
     if (off_in_gva && off_in >= 0 &&
         guest_write_small(g, off_in_gva, &off_in, sizeof(off_in)) < 0) {
@@ -2292,8 +2295,8 @@ done:
         return ret;
     }
 
-    /* Return bytes transferred, or errno only if read/write failed.
-     * Restore saved_errno since free/guest_write may have clobbered it.
+    /* Return bytes transferred, or errno only if read/write failed. Restore
+     * saved_errno since free/guest_write may have clobbered it.
      */
     if (total > 0) {
         host_fd_ref_close(&out_ref);
@@ -2366,9 +2369,9 @@ int64_t sys_vmsplice(guest_t *g,
     return (int64_t) total;
 }
 
-/* tee: copy data between two pipes without consuming it.
- * Full emulation would need pipe peeking semantics that macOS does not expose;
- * report EINVAL rather than consuming data incorrectly.
+/* tee: copy data between two pipes without consuming it. Full emulation would
+ * need pipe peeking semantics that macOS does not expose; report EINVAL rather
+ * than consuming data incorrectly.
  */
 int64_t sys_tee(int fd_in, int fd_out, size_t len, unsigned int flags)
 {

--- a/src/syscall/io.h
+++ b/src/syscall/io.h
@@ -8,8 +8,8 @@
  * Translates Linux aarch64 I/O syscalls into macOS equivalents, handling
  * terminal attribute translation and pipe splice emulation.
  *
- * Poll/select/epoll declarations are in syscall/poll.h.
- * Special FD types (eventfd, signalfd, timerfd) are in syscall/fd.h.
+ * Poll/select/epoll declarations are in syscall/poll.h. Special FD types
+ * (eventfd, signalfd, timerfd) are in syscall/fd.h.
  */
 
 #pragma once
@@ -24,9 +24,9 @@ int64_t sys_write(guest_t *g, int fd, uint64_t buf_gva, uint64_t count);
 int64_t sys_read(guest_t *g, int fd, uint64_t buf_gva, uint64_t count);
 void urandom_fd_cleanup(int guest_fd);
 void urandom_fd_reset_cache(int guest_fd);
-/* Initialize the per-fd urandom cache locks. Must run before any guest
- * thread enters sys_read or sys_readv on /dev/urandom. Called from
- * syscall_init alongside the other subsystem init hooks.
+/* Initialize the per-fd urandom cache locks. Must run before any guest thread
+ * enters sys_read or sys_readv on /dev/urandom. Called from syscall_init
+ * alongside the other subsystem init hooks.
  */
 void io_init(void);
 int64_t sys_pread64(guest_t *g,

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -280,8 +280,8 @@ static uint64_t find_free_gap_inner(const guest_t *g,
 
     /* Skip the prefix of regions entirely below gap_start in O(log n). After a
      * successful allocation the gap hint advances near or past the existing
-     * region tail, so the linear walk would otherwise re-scan that whole
-     * prefix on every mmap, addr-hint probe, or hint-miss full scan.
+     * region tail, so the linear walk would otherwise re-scan that whole prefix
+     * on every mmap, addr-hint probe, or hint-miss full scan.
      */
     for (int i = guest_region_first_end_above(g, gap_start); i < g->nregions;
          i++) {
@@ -291,9 +291,9 @@ static uint64_t find_free_gap_inner(const guest_t *g,
         if (g->regions[i].end <= gap_start)
             continue;
 
-        /* The search is bounded to [min_addr, max_addr). Once the sorted
-         * region stream reaches max_addr, later regions cannot affect any
-         * candidate gap inside the window.
+        /* The search is bounded to [min_addr, max_addr). Once the sorted region
+         * stream reaches max_addr, later regions cannot affect any candidate
+         * gap inside the window.
          */
         if (g->regions[i].start >= max_addr)
             break;
@@ -356,8 +356,8 @@ static uint64_t find_free_gap(guest_t *g,
     return result;
 }
 
-/* Convert Linux PROT_* flags to guest page table permission bits.
- * MEM_PERM_R is always set. PROT_NONE callers should skip this.
+/* Convert Linux PROT_* flags to guest page table permission bits. MEM_PERM_R is
+ * always set. PROT_NONE callers should skip this.
  */
 static int prot_to_perms(int prot)
 {
@@ -507,11 +507,11 @@ static int64_t sys_mmap_high_va(guest_t *g,
     bool replaced_ptes_modified = false;
     uint8_t *map_host = NULL;
     /* When the high-VA replacement reuses an existing host backing,
-     * populate_existing is about to clobber map_host with memset / pread
-     * before guest_install_va_pages and guest_region_add_ex_owned_gpa commit.
-     * Snapshot the original bytes so the fail path can restore them; without
-     * this, a late-step failure leaves the guest's old mapping pointing at
-     * corrupted memory.
+     * populate_existing is about to clobber map_host with memset / pread before
+     * guest_install_va_pages and guest_region_add_ex_owned_gpa commit. Snapshot
+     * the original bytes so the fail path can restore them; without this, a
+     * late-step failure leaves the guest's old mapping pointing at corrupted
+     * memory.
      */
     uint8_t *replaced_bytes_snap = NULL;
     bool replaced_bytes_dirty = false;
@@ -520,8 +520,8 @@ static int64_t sys_mmap_high_va(guest_t *g,
      * contents, or rollback bytes while populate_existing rewrites map_host in
      * place. The overlay paths already use the same pattern; mmap_lock only
      * serializes memory syscalls, not vCPU execution. Track whether the
-     * siblings_quiesced bracket is open so the success-return and the
-     * fail-path both resume.
+     * siblings_quiesced bracket is open so the success-return and the fail-path
+     * both resume.
      */
     bool siblings_quiesced = false;
 
@@ -545,12 +545,12 @@ static int64_t sys_mmap_high_va(guest_t *g,
 
     /* Set when this call enters the replace-an-existing-mapping branch
      * (region_range_overlaps + replaceable + snapshots captured). Used
-     * everywhere the function needs to decide between the fresh-allocation
-     * path and the reuse-the-existing-backing path. The earlier proxy
-     * (replaced_gpa_base != 0) mis-classified replacements targeting a
-     * region backed at GPA 0 (a valid guest physical address) as fresh
-     * allocations, which silently bypassed the byte snapshot, region
-     * remove, and rollback restore work.
+     * everywhere the function needs to decide between the fresh-allocation path
+     * and the reuse-the-existing-backing path. The earlier proxy
+     * (replaced_gpa_base != 0) mis-classified replacements targeting a region
+     * backed at GPA 0 (a valid guest physical address) as fresh allocations,
+     * which silently bypassed the byte snapshot, region remove, and rollback
+     * restore work.
      */
     bool replacing_existing = false;
 
@@ -558,10 +558,10 @@ static int64_t sys_mmap_high_va(guest_t *g,
      * rollback. The mapping itself can still be arbitrarily large in the
      * fresh-allocation path; only the replace-an-existing branch needs the
      * host-side malloc, so the cap only applies to replacement. 256 MiB is
-     * comfortably above realistic Rosetta dynamic-linker reservations and
-     * far below the multi-GiB malloc bombs a hostile guest could otherwise
-     * force. Reject early with -ENOMEM so the caller falls back to a smaller
-     * MAP_FIXED footprint rather than triggering the host OOM killer.
+     * comfortably above realistic Rosetta dynamic-linker reservations and far
+     * below the multi-GiB malloc bombs a hostile guest could otherwise force.
+     * Reject early with -ENOMEM so the caller falls back to a smaller MAP_FIXED
+     * footprint rather than triggering the host OOM killer.
      */
     enum { HIGH_VA_SNAPSHOT_MAX = (size_t) 256 << 20 };
 
@@ -680,8 +680,7 @@ static int64_t sys_mmap_high_va(guest_t *g,
          * confused by a prior high-VA mmap into the same 2 MiB block. A fresh
          * block needs its split-inherited L3 entries zeroed so gap pages do not
          * silently inherit block-level perms; a pre-existing block must be left
-         * alone so earlier mappings into the same block
-         * survive.
+         * alone so earlier mappings into the same block survive.
          */
         bool fresh_block = !guest_va_block_mapped(g, va);
 
@@ -690,9 +689,9 @@ static int64_t sys_mmap_high_va(guest_t *g,
         va_installed_end = va + BLOCK_2MIB;
 
         /* Fresh blocks are live with full-2 MiB block-level perms from here
-         * until guest_invalidate_ptes zeros the split-inherited L3 entries.
-         * If split or invalidate fails in between, the rollback must scrub
-         * the entire block; record it for the fail path.
+         * until guest_invalidate_ptes zeros the split-inherited L3 entries. If
+         * split or invalidate fails in between, the rollback must scrub the
+         * entire block; record it for the fail path.
          */
         if (fresh_block)
             inflight_fresh_block_va = va;
@@ -718,13 +717,13 @@ static int64_t sys_mmap_high_va(guest_t *g,
         goto fail;
 
 populate_existing:
-    /* Snapshot the existing host backing before the destructive write so
-     * a later guest_install_va_pages / guest_region_add failure can
-     * restore the guest's original mapping bytes from the fail path
-     * instead of leaving it pointing at zeroed-or-partially-written
-     * memory. The fresh-allocation path lands here too, but its map_host
-     * sits on a brand-new GPA range that no guest mapping currently
-     * observes, so the snapshot is only needed when replacing_existing.
+    /* Snapshot the existing host backing before the destructive write so a
+     * later guest_install_va_pages / guest_region_add failure can restore the
+     * guest's original mapping bytes from the fail path instead of leaving it
+     * pointing at zeroed-or-partially-written memory. The fresh-allocation path
+     * lands here too, but its map_host sits on a brand-new GPA range that no
+     * guest mapping currently observes, so the snapshot is only needed when
+     * replacing_existing.
      */
     if (replacing_existing && (is_anon || prot != LINUX_PROT_NONE)) {
         replaced_bytes_snap = malloc(length);
@@ -732,11 +731,11 @@ populate_existing:
             ret = -LINUX_ENOMEM;
             goto fail;
         }
-        /* Quiesce siblings before the snapshot read so the memcpy
-         * cannot see torn writes from another vCPU running guest code
-         * on the existing mapping, and so the destructive memset /
-         * pread below stays invisible to concurrent readers until the
-         * region tables commit (or the fail path restores the bytes).
+        /* Quiesce siblings before the snapshot read so the memcpy cannot see
+         * torn writes from another vCPU running guest code on the existing
+         * mapping, and so the destructive memset / pread below stays invisible
+         * to concurrent readers until the region tables commit (or the fail
+         * path restores the bytes).
          */
         thread_quiesce_siblings();
         siblings_quiesced = true;
@@ -778,9 +777,9 @@ populate_existing:
      * high-VA mmaps into the same 2 MiB block survive.
      *
      * PROT_NONE still needs an explicit invalidate for the requested pages:
-     * when the range lands inside a reused 2 MiB block, leaving the
-     * inherited L3 descriptors intact would make the new guard range
-     * spuriously accessible.
+     * when the range lands inside a reused 2 MiB block, leaving the inherited
+     * L3 descriptors intact would make the new guard range spuriously
+     * accessible.
      */
     if (prot == LINUX_PROT_NONE) {
         replaced_ptes_modified = replacing_existing;
@@ -816,10 +815,10 @@ populate_existing:
                                       flags, offset, NULL,
                                       track_backing_fd) < 0)
         goto fail;
-    /* Ownership of track_backing_fd is now held by the new region. The
-     * fail handler below skips closing when track_backing_fd < 0, so
-     * subsequent steps must not goto fail or the region's backing fd
-     * would be double-closed.
+    /* Ownership of track_backing_fd is now held by the new region. The fail
+     * handler below skips closing when track_backing_fd < 0, so subsequent
+     * steps must not goto fail or the region's backing fd would be
+     * double-closed.
      */
     if (close_host_backing_fd && host_backing_fd >= 0)
         close(host_backing_fd);
@@ -841,8 +840,8 @@ fail:
     /* If populate_existing already overwrote the original mapping's bytes, the
      * snapshot has the pre-replacement contents; copy them back before any
      * later cleanup so the guest's old mapping comes out of rollback pointing
-     * at the same data it had before this
-     * call. The snapshot is freed unconditionally below.
+     * at the same data it had before this call. The snapshot is freed
+     * unconditionally below.
      */
     if (replaced_bytes_dirty && replaced_bytes_snap && map_host)
         memcpy(map_host, replaced_bytes_snap, length);
@@ -886,15 +885,14 @@ fail:
     }
     if (track_backing_fd >= 0)
         close(track_backing_fd);
-    /* Restore region/PTE snapshots when this call mutated regions[] or
-     * the page tables; otherwise just drop the snapshot allocation.
-     * Whichever path runs, the common cleanup below frees snapshots
-     * and fds and resumes siblings, so a restore failure only needs
-     * to override the returned errno -- it must not skip cleanup.
-     * (Earlier code used replaced_gpa_base != 0 as the proxy for
-     * "replacing existing", which mis-classified replacements over a
-     * GPA-0-backed region; replacing_existing is now set explicitly
-     * when snapshots are captured.)
+    /* Restore region/PTE snapshots when this call mutated regions[] or the page
+     * tables; otherwise just drop the snapshot allocation. Whichever path runs,
+     * the common cleanup below frees snapshots and fds and resumes siblings, so
+     * a restore failure only needs to override the returned errno -- it must
+     * not skip cleanup. (Earlier code used replaced_gpa_base != 0 as the proxy
+     * for "replacing existing", which mis-classified replacements over a
+     * GPA-0-backed region; replacing_existing is now set explicitly when
+     * snapshots are captured.)
      */
     if (replaced_snaps && replacing_existing && replaced_region_removed) {
         int restore_err =
@@ -922,9 +920,9 @@ fail:
     if (close_host_backing_fd && host_backing_fd >= 0)
         close(host_backing_fd);
     host_fd_ref_close(&backing_ref);
-    /* Close the siblings_quiesced bracket as the very last step, so
-     * the byte restore + region/PTE restore + fd cleanup all complete
-     * before any sibling vCPU resumes guest execution.
+    /* Close the siblings_quiesced bracket as the very last step, so the byte
+     * restore + region/PTE restore + fd cleanup all complete before any sibling
+     * vCPU resumes guest execution.
      */
     if (siblings_quiesced)
         thread_resume_siblings();
@@ -1031,10 +1029,10 @@ static void close_region_snapshots(region_snapshot_t *snaps, int n)
 }
 
 /* Close any open dup'd backing fds in *snaps_ptr, free the heap buffer, and
- * zero out the caller's pointer/count so a follow-on call is a no-op. Used
- * for buffers allocated via malloc by sys_mmap and sys_mremap; the
- * stack-allocated callers in capture_region_snapshots itself keep using
- * close_region_snapshots directly.
+ * zero out the caller's pointer/count so a follow-on call is a no-op. Used for
+ * buffers allocated via malloc by sys_mmap and sys_mremap; the stack-allocated
+ * callers in capture_region_snapshots itself keep using close_region_snapshots
+ * directly.
  */
 static void dispose_region_snapshots(region_snapshot_t **snaps_ptr, int *n_ptr)
 {
@@ -1311,13 +1309,13 @@ static int hvf_segment_find(const guest_t *g, uint64_t ipa)
     return -1;
 }
 
-/* Restore the slab backing for [ipa, ipa+len) in the host VA. Used to
- * undo a previous file overlay. Maps shm_fd MAP_SHARED if the slab is
- * shm-backed (so subsequent fork CoW snapshots see consistent content),
- * otherwise MAP_ANON|MAP_PRIVATE. The IPA is unmapped from the guest's
- * perspective by the caller (page tables invalidated, region removed),
- * so the content of the restored backing is not directly observable
- * to the guest until a subsequent mmap targets the same IPA.
+/* Restore the slab backing for [ipa, ipa+len) in the host VA. Used to undo a
+ * previous file overlay. Maps shm_fd MAP_SHARED if the slab is shm-backed (so
+ * subsequent fork CoW snapshots see consistent content), otherwise
+ * MAP_ANON|MAP_PRIVATE. The IPA is unmapped from the guest's perspective by the
+ * caller (page tables invalidated, region removed), so the content of the
+ * restored backing is not directly observable to the guest until a subsequent
+ * mmap targets the same IPA.
  *
  * The caller must ensure no HVF segment currently covers [ipa, ipa+len).
  * Returns 0 on success, -errno on failure.
@@ -1338,16 +1336,17 @@ static int hvf_restore_slab_backing(guest_t *g, uint64_t ipa, uint64_t len)
     return 0;
 }
 
-/* Split the segment that exactly contains [aligned_start, aligned_end) so
- * that the middle range becomes its own segment. The caller MUST have
- * quiesced sibling vCPUs before calling so HVF's brief unmap window does
- * not race with concurrent guest accesses through stage-2.
+/* Split the segment that exactly contains [aligned_start, aligned_end) so that
+ * the middle range becomes its own segment. The caller MUST have quiesced
+ * sibling vCPUs before calling so HVF's brief unmap window does not race with
+ * concurrent guest accesses through stage-2.
  *
- * Up to two new segments may be inserted on either side. If the segment
- * already exactly matches the requested bounds, this is a no-op.
+ * Up to two new segments may be inserted on either side. If the segment already
+ * exactly matches the requested bounds, this is a no-op.
  *
- * Both bounds must be 2 MiB-aligned. Returns 0 on success, -errno on
- * failure.
+ * Both bounds must be 2 MiB-aligned.
+ *
+ * Returns 0 on success, -errno on failure.
  */
 static int hvf_segment_split(guest_t *g,
                              uint64_t aligned_start,
@@ -1383,14 +1382,14 @@ static int hvf_segment_split(guest_t *g,
         void *host_va = (uint8_t *) g->host_base + pieces[i].ipa;
         if (hv_vm_map(host_va, pieces[i].ipa, pieces[i].len,
                       HVF_SEGMENT_FLAGS) != HV_SUCCESS) {
-            /* Best-effort recovery: tear down whatever pieces we already
-             * mapped (HVF would reject hv_vm_map(orig) as overlapping if we
-             * left them in place) and re-map the original segment. Sibling
-             * vCPUs are quiesced so they cannot observe the gap. If the
-             * final remap also fails the IPA range stays without stage-2
-             * entries and the guest will fault on access; log the
-             * unrecoverable state so post-mortem points at the right
-             * culprit instead of the unrelated downstream fault.
+            /* Best-effort recovery: tear down whatever pieces we already mapped
+             * (HVF would reject hv_vm_map(orig) as overlapping if we left them
+             * in place) and re-map the original segment. Sibling vCPUs are
+             * quiesced so they cannot observe the gap. If the final remap also
+             * fails the IPA range stays without stage-2 entries and the guest
+             * will fault on access; log the unrecoverable state so post-mortem
+             * points at the right culprit instead of the unrelated downstream
+             * fault.
              */
             for (int j = 0; j < i; j++)
                 hv_vm_unmap(pieces[j].ipa, pieces[j].len);
@@ -1417,12 +1416,76 @@ static int hvf_segment_split(guest_t *g,
     return 0;
 }
 
+static int hvf_segment_split_range_boundaries(guest_t *g,
+                                              uint64_t aligned_start,
+                                              uint64_t aligned_end)
+{
+    int idx;
+
+    idx = hvf_segment_find(g, aligned_start);
+    if (idx < 0)
+        return -LINUX_EFAULT;
+    if (g->segments[idx].ipa < aligned_start) {
+        int err = hvf_segment_split(
+            g, aligned_start, g->segments[idx].ipa + g->segments[idx].len);
+        if (err < 0)
+            return err;
+    }
+
+    idx = hvf_segment_find(g, aligned_end - 1);
+    if (idx < 0)
+        return -LINUX_EFAULT;
+    if (aligned_end < g->segments[idx].ipa + g->segments[idx].len) {
+        int err = hvf_segment_split(g, g->segments[idx].ipa, aligned_end);
+        if (err < 0)
+            return err;
+    }
+    return 0;
+}
+
+static int hvf_segment_collect_range(guest_t *g,
+                                     uint64_t aligned_start,
+                                     uint64_t aligned_end,
+                                     hvf_segment_t *segments,
+                                     int max_segments)
+{
+    uint64_t cursor = aligned_start;
+    int n = 0;
+
+    while (cursor < aligned_end) {
+        int idx = hvf_segment_find(g, cursor);
+        if (idx < 0 || g->segments[idx].ipa != cursor)
+            return -LINUX_EFAULT;
+        if (n >= max_segments)
+            return -LINUX_ENOMEM;
+        segments[n++] = g->segments[idx];
+        cursor += g->segments[idx].len;
+    }
+    return cursor == aligned_end ? n : -LINUX_EFAULT;
+}
+
+static void hvf_remap_segments_best_effort(guest_t *g,
+                                           const hvf_segment_t *segments,
+                                           int nsegments)
+{
+    for (int i = 0; i < nsegments; i++) {
+        hv_return_t r =
+            hv_vm_map((uint8_t *) g->host_base + segments[i].ipa,
+                      segments[i].ipa, segments[i].len, HVF_SEGMENT_FLAGS);
+        if (r != HV_SUCCESS)
+            log_error(
+                "hvf: recovery hv_vm_map(0x%llx, 0x%llx) failed with 0x%x",
+                (unsigned long long) segments[i].ipa,
+                (unsigned long long) segments[i].len, (int) r);
+    }
+}
+
 /* Apply a real MAP_SHARED file overlay at [ipa, ipa+len) backed by [fd,
- * file_off). The IPA range may be sub-2 MiB; the containing 2 MiB
- * segment is split out first if it is not already isolated. Caller
- * holds mmap_lock and has already quiesced sibling vCPUs (or has none).
- * The fork pre-snapshot path quiesces siblings before calling this so
- * the overlay install does not trigger a nested quiesce.
+ * file_off). The IPA range may be sub-2 MiB; the containing 2 MiB segment is
+ * split out first if it is not already isolated. Caller holds mmap_lock and has
+ * already quiesced sibling vCPUs (or has none). The fork pre-snapshot path
+ * quiesces siblings before calling this so the overlay install does not trigger
+ * a nested quiesce.
  */
 static int hvf_apply_file_overlay_quiesced(guest_t *g,
                                            uint64_t ipa,
@@ -1432,63 +1495,72 @@ static int hvf_apply_file_overlay_quiesced(guest_t *g,
 {
     uint64_t aligned_start = ALIGN_2MIB_DOWN(ipa);
     uint64_t aligned_end = ALIGN_2MIB_UP(ipa + len);
+    hvf_segment_t segments[GUEST_MAX_HVF_SEGMENTS];
+    int nsegments;
 
-    int err = hvf_segment_split(g, aligned_start, aligned_end);
+    int err = hvf_segment_split_range_boundaries(g, aligned_start, aligned_end);
     if (err < 0)
         return err;
+    nsegments = hvf_segment_collect_range(g, aligned_start, aligned_end,
+                                          segments, GUEST_MAX_HVF_SEGMENTS);
+    if (nsegments < 0)
+        return nsegments;
 
-    int idx = hvf_segment_find(g, aligned_start);
-    if (idx < 0 || g->segments[idx].ipa != aligned_start ||
-        g->segments[idx].len != aligned_end - aligned_start)
-        return -LINUX_EFAULT;
-    hvf_segment_t seg = g->segments[idx];
-
-    if (hv_vm_unmap(seg.ipa, seg.len) != HV_SUCCESS)
-        return -LINUX_EIO;
+    int unmapped = 0;
+    for (int i = 0; i < nsegments; i++) {
+        if (hv_vm_unmap(segments[i].ipa, segments[i].len) != HV_SUCCESS) {
+            hvf_remap_segments_best_effort(g, segments, unmapped);
+            return -LINUX_EIO;
+        }
+        unmapped++;
+    }
 
     void *target = (uint8_t *) g->host_base + ipa;
     void *p = mmap(target, len, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
                    fd, file_off);
     if (p == MAP_FAILED) {
         int saved = linux_errno();
-        /* The overlay failed; restore the segment to slab backing so the
-         * host VA range stays consistent. The host VA was untouched by
-         * the failed mmap, so nothing else to undo.
+        /* The overlay failed; restore the segment to slab backing so the host
+         * VA range stays consistent. The host VA was untouched by the failed
+         * mmap, so nothing else to undo.
          */
-        hv_vm_map((uint8_t *) g->host_base + seg.ipa, seg.ipa, seg.len,
-                  HVF_SEGMENT_FLAGS);
+        hvf_remap_segments_best_effort(g, segments, nsegments);
         return saved < 0 ? saved : -saved;
     }
 
-    if (hv_vm_map((uint8_t *) g->host_base + seg.ipa, seg.ipa, seg.len,
-                  HVF_SEGMENT_FLAGS) != HV_SUCCESS) {
-        /* Restore slab backing so the host VA stops referencing the
-         * caller's file fd (which they expect to take back), then
-         * re-issue hv_vm_map so the IPA range is not left without
-         * stage-2 entries. Without the second hv_vm_map, sibling vCPUs
-         * would page-fault on this IPA after thread_resume_siblings
-         * with no chance of recovery short of process exit.
+    for (int i = 0; i < nsegments; i++) {
+        if (hv_vm_map((uint8_t *) g->host_base + segments[i].ipa,
+                      segments[i].ipa, segments[i].len,
+                      HVF_SEGMENT_FLAGS) == HV_SUCCESS)
+            continue;
+        /* Restore slab backing so the host VA stops referencing the caller's
+         * file fd (which they expect to take back), then re-issue hv_vm_map so
+         * the IPA range is not left without stage-2 entries. Without the second
+         * hv_vm_map, sibling vCPUs would page-fault on this IPA after
+         * thread_resume_siblings with no chance of recovery short of process
+         * exit.
          */
         hvf_restore_slab_backing(g, ipa, len);
-        hv_vm_map((uint8_t *) g->host_base + seg.ipa, seg.ipa, seg.len,
-                  HVF_SEGMENT_FLAGS);
+        hvf_remap_segments_best_effort(g, segments, nsegments);
         return -LINUX_EIO;
     }
 
     return 0;
 }
 
-/* True when the backing fd allows writes through. The overlay path replaces
- * the slab's RW host VA with MAP_SHARED|MAP_FIXED of this fd, and Apple HVF
- * refuses hv_vm_map of any permission onto a host VA whose write capability
- * does not cover the requested stage-2 perms. A read-only fd lands there
- * with the kernel rejecting either PROT_WRITE on the host mmap or, after a
- * PROT_READ downgrade, the post-overlay hv_vm_map with HV_DENIED.
- * Centralises that decision: both the overlay entry (hvf_apply_file_overlay)
- * and the sys_mmap fast-path skip share this gate so read-only backers are
- * routed straight to the snapshot pread path. Returns true on the optimistic
- * path when fcntl itself fails: the subsequent mmap / hv_vm_map will surface
- * the real error rather than this helper synthesising one.
+/* True when the backing fd allows writes through. The overlay path replaces the
+ * slab's RW host VA with MAP_SHARED|MAP_FIXED of this fd, and Apple HVF refuses
+ * hv_vm_map of any permission onto a host VA whose write capability does not
+ * cover the requested stage-2 perms. A read-only fd lands there with the kernel
+ * rejecting either PROT_WRITE on the host mmap or, after a PROT_READ downgrade,
+ * the post-overlay hv_vm_map with HV_DENIED. Centralises that decision: both
+ * the overlay entry (hvf_apply_file_overlay) and the sys_mmap fast-path skip
+ * share this gate so read-only backers are routed straight to the snapshot
+ * pread path.
+ *
+ * Returns true on the optimistic path when fcntl itself fails: the subsequent
+ * mmap / hv_vm_map will surface the real error rather than this helper
+ * synthesising one.
  */
 static bool overlay_fd_writable(int fd)
 {
@@ -1499,11 +1571,11 @@ static bool overlay_fd_writable(int fd)
 }
 
 /* Apply a real MAP_SHARED file overlay at [ipa, ipa+len) backed by [fd,
- * file_off). The IPA range may be sub-2 MiB; the containing 2 MiB
- * segment is split out first if it is not already isolated. Caller
- * holds mmap_lock and has not quiesced siblings yet. The function
- * quiesces siblings around the unmap+remap window so concurrent vCPUs
- * cannot fault on the temporarily-unmapped IPA range.
+ * file_off). The IPA range may be sub-2 MiB; the containing 2 MiB segment is
+ * split out first if it is not already isolated. Caller holds mmap_lock and has
+ * not quiesced siblings yet. The function quiesces siblings around the
+ * unmap+remap window so concurrent vCPUs cannot fault on the
+ * temporarily-unmapped IPA range.
  */
 static int hvf_apply_file_overlay(guest_t *g,
                                   uint64_t ipa,
@@ -1523,35 +1595,51 @@ static int hvf_remove_file_overlay_quiesced(guest_t *g,
                                             uint64_t ipa,
                                             uint64_t len)
 {
-    int idx = hvf_segment_find(g, ipa);
-    if (idx < 0)
-        return -LINUX_EFAULT;
-    hvf_segment_t seg = g->segments[idx];
+    uint64_t aligned_start = ALIGN_2MIB_DOWN(ipa);
+    uint64_t aligned_end = ALIGN_2MIB_UP(ipa + len);
+    hvf_segment_t segments[GUEST_MAX_HVF_SEGMENTS];
+    int nsegments;
 
-    if (hv_vm_unmap(seg.ipa, seg.len) != HV_SUCCESS)
-        return -LINUX_EIO;
+    int err = hvf_segment_split_range_boundaries(g, aligned_start, aligned_end);
+    if (err < 0)
+        return err;
+    nsegments = hvf_segment_collect_range(g, aligned_start, aligned_end,
+                                          segments, GUEST_MAX_HVF_SEGMENTS);
+    if (nsegments < 0)
+        return nsegments;
 
-    int err = hvf_restore_slab_backing(g, ipa, len);
+    int unmapped = 0;
+    for (int i = 0; i < nsegments; i++) {
+        if (hv_vm_unmap(segments[i].ipa, segments[i].len) != HV_SUCCESS) {
+            hvf_remap_segments_best_effort(g, segments, unmapped);
+            return -LINUX_EIO;
+        }
+        unmapped++;
+    }
+
+    err = hvf_restore_slab_backing(g, ipa, len);
     if (err < 0) {
         /* Best-effort: re-establish the segment with whatever the host VA
-         * currently has (still the file overlay) so the guest can see
-         * something rather than nothing.
+         * currently has (still the file overlay) so the guest can see something
+         * rather than nothing.
          */
-        hv_vm_map((uint8_t *) g->host_base + seg.ipa, seg.ipa, seg.len,
-                  HVF_SEGMENT_FLAGS);
+        hvf_remap_segments_best_effort(g, segments, nsegments);
         return err;
     }
 
-    if (hv_vm_map((uint8_t *) g->host_base + seg.ipa, seg.ipa, seg.len,
-                  HVF_SEGMENT_FLAGS) != HV_SUCCESS)
-        return -LINUX_EIO;
+    for (int i = 0; i < nsegments; i++) {
+        if (hv_vm_map((uint8_t *) g->host_base + segments[i].ipa,
+                      segments[i].ipa, segments[i].len,
+                      HVF_SEGMENT_FLAGS) != HV_SUCCESS)
+            return -LINUX_EIO;
+    }
 
     return 0;
 }
 
-/* Undo a file overlay at [ipa, ipa+len) by restoring the slab backing
- * and refreshing the containing HVF segment. Caller holds mmap_lock.
- * Sibling vCPUs are quiesced around the brief unmap window.
+/* Undo a file overlay at [ipa, ipa+len) by restoring the slab backing and
+ * refreshing the containing HVF segment. Caller holds mmap_lock. Sibling vCPUs
+ * are quiesced around the brief unmap window.
  */
 static int hvf_remove_file_overlay(guest_t *g, uint64_t ipa, uint64_t len)
 {
@@ -1562,15 +1650,16 @@ static int hvf_remove_file_overlay(guest_t *g, uint64_t ipa, uint64_t len)
 }
 
 /* Walk semantic regions in [start, end) and undo any active MAP_SHARED file
- * overlays on the underlying host VA. Used before sys_mmap MAP_FIXED replaces
- * a previously-overlaid range with a new mapping (anonymous or different
- * file): without restoring the slab backing first, stale file pages would
- * leak into the new mapping. Returns 0 on success, -errno on failure;
- * region overlay metadata is cleared only for ranges where the underlying
- * host-VA overlay was successfully torn down so a partial failure does not
- * leave the runtime believing an overlay is gone while the file mmap is
- * still live (which would cause a later memset to write into the file).
- * Caller holds mmap_lock.
+ * overlays on the underlying host VA. Used before sys_mmap MAP_FIXED replaces a
+ * previously-overlaid range with a new mapping (anonymous or different file):
+ * without restoring the slab backing first, stale file pages would leak into
+ * the new mapping.
+ *
+ * Returns 0 on success, -errno on failure; region overlay metadata is cleared
+ * only for ranges where the underlying host-VA overlay was successfully torn
+ * down so a partial failure does not leave the runtime believing an overlay is
+ * gone while the file mmap is still live (which would cause a later memset to
+ * write into the file). Caller holds mmap_lock.
  */
 static int cleanup_overlays_in_range(guest_t *g, uint64_t start, uint64_t end)
 {
@@ -1582,9 +1671,9 @@ static int cleanup_overlays_in_range(guest_t *g, uint64_t start, uint64_t end)
     split_regions_at_boundary(g, host_end);
 
     /* Snapshot affected ranges first; the host-side mmap calls below do not
-     * touch the region array, but a future caller invariant is to allow
-     * this loop to mutate metadata only after the unmap-and-restore dance
-     * succeeds. The bounded buffer keeps the function stack-only.
+     * touch the region array, but a future caller invariant is to allow this
+     * loop to mutate metadata only after the unmap-and-restore dance succeeds.
+     * The bounded buffer keeps the function stack-only.
      */
     struct {
         uint64_t off, len;
@@ -1620,10 +1709,9 @@ static int cleanup_overlays_in_range(guest_t *g, uint64_t start, uint64_t end)
     for (int i = 0; i < n; i++) {
         int rc = hvf_remove_file_overlay(g, overlays[i].off, overlays[i].len);
         if (rc < 0) {
-            /* Stop on first failure; leave overlay_active set on regions
-             * we could not tear down so subsequent operations still see a
-             * live overlay there and route through the overlay-aware
-             * paths.
+            /* Stop on first failure; leave overlay_active set on regions we
+             * could not tear down so subsequent operations still see a live
+             * overlay there and route through the overlay-aware paths.
              */
             if (!err)
                 err = rc;
@@ -1681,9 +1769,9 @@ int64_t sys_brk(guest_t *g, uint64_t addr)
 
     g->brk_current = new_off;
 
-    /* Update "[heap]" region tracking atomically.
-     * Find-and-update-in-place avoids the remove+add gap where a
-     * concurrent /proc/self/maps reader could see no heap region.
+    /* Update "[heap]" region tracking atomically. Find-and-update-in-place
+     * avoids the remove+add gap where a concurrent /proc/self/maps reader could
+     * see no heap region.
      */
     if (new_off > g->brk_base) {
         bool found = false;
@@ -1724,11 +1812,11 @@ int64_t sys_mmap(guest_t *g,
     host_fd_ref_t backing_ref = {.fd = -1, .owned = 0};
     int host_backing_fd = -1, track_backing_fd = -1;
     /* Tracks whether hvf_apply_file_overlay has installed a host
-     * MAP_FIXED|MAP_SHARED mapping that the failure paths must undo if
-     * later steps (page tables, region tracking) fall over. Without this,
-     * a partial-success rollback leaves the file mmap'd at host_base+ipa
-     * with no region tracking, and the next operation in that range would
-     * memset zeros directly into the user's file.
+     * MAP_FIXED|MAP_SHARED mapping that the failure paths must undo if later
+     * steps (page tables, region tracking) fall over. Without this, a
+     * partial-success rollback leaves the file mmap'd at host_base+ipa with no
+     * region tracking, and the next operation in that range would memset zeros
+     * directly into the user's file.
      */
     bool overlay_installed = false;
     uint64_t overlay_ipa = 0;
@@ -1740,10 +1828,10 @@ int64_t sys_mmap(guest_t *g,
     uint64_t saved_rw_gap_hint = g->mmap_rw_gap_hint;
     uint64_t saved_rx_gap_hint = g->mmap_rx_gap_hint;
     /* Heap-allocated to avoid blowing the ~512 KiB default stack on macOS
-     * worker threads: GUEST_MAX_REGIONS * sizeof(region_snapshot_t) is on
-     * the order of half a megabyte. Allocated lazily inside the FIXED
-     * path that actually consumes it; non-FIXED mmaps never touch this
-     * pointer. Always free()'d (free(NULL) is a no-op) before return.
+     * worker threads: GUEST_MAX_REGIONS * sizeof(region_snapshot_t) is on the
+     * order of half a megabyte. Allocated lazily inside the FIXED path that
+     * actually consumes it; non-FIXED mmaps never touch this pointer. Always
+     * free()'d (free(NULL) is a no-op) before return.
      */
     region_snapshot_t *replaced_snaps = NULL;
     int replaced_nsnaps = 0;
@@ -1758,10 +1846,9 @@ int64_t sys_mmap(guest_t *g,
         track_flags |= LINUX_MAP_NORESERVE;
 
     /* The memory syscall layer handles all mmap variants. For file-backed
-     * MAP_SHARED, it falls
-     * back to MAP_PRIVATE semantics (copy-on-write). All threads share
-     * the same guest_t address space (CLONE_VM semantics), so MAP_SHARED
-     * and MAP_PRIVATE are equivalent within the guest.
+     * MAP_SHARED, it falls back to MAP_PRIVATE semantics (copy-on-write). All
+     * threads share the same guest_t address space (CLONE_VM semantics), so
+     * MAP_SHARED and MAP_PRIVATE are equivalent within the guest.
      */
 
     /* Linux rejects zero-length mmap */
@@ -1795,15 +1882,15 @@ int64_t sys_mmap(guest_t *g,
     if (is_fixed && (addr & 4095))
         return -LINUX_EINVAL;
 
-    /* MAP_FIXED_NOREPLACE: like MAP_FIXED but fail with -EEXIST if the
-     * range overlaps any existing mapping.
+    /* MAP_FIXED_NOREPLACE: like MAP_FIXED but fail with -EEXIST if the range
+     * overlaps any existing mapping.
      */
     bool is_noreplace = (flags & LINUX_MAP_FIXED_NOREPLACE) != 0;
 
     uint64_t result_off; /* Result as offset (0-based) */
     if (is_fixed) {
-        /* Addresses above TASK_SIZE (bit 63 set or beyond user VA range)
-         * are rejected, matching real Linux kernel behavior.
+        /* Addresses above TASK_SIZE (bit 63 set or beyond user VA range) are
+         * rejected, matching real Linux kernel behavior.
          */
         if (addr > 0x0000FFFFFFFFFFFFULL)
             return -LINUX_ENOMEM;
@@ -1812,32 +1899,30 @@ int64_t sys_mmap(guest_t *g,
             return sys_mmap_high_va(g, addr, length, prot, flags, fd, offset,
                                     true, is_noreplace);
 
-        /* High-VA MAP_FIXED (rosetta's JIT slabs at 240 TiB, code caches
-         * at 85 TiB, etc.) is not safe to expose yet. The previous draft
-         * could install TTBR0 aliases for addresses above the primary guest
-         * buffer, but munmap/mprotect/fork bookkeeping still track regions
-         * by low GPA and mmap_next only. Returning success here therefore
-         * created mappings that later teardown paths could not manage and
-         * let overflow-backed aliases corrupt the fork snapshot high-water
-         * mark. Fail closed until the region metadata and teardown paths are
-         * made VA-aware end-to-end.
+        /* High-VA MAP_FIXED (rosetta's JIT slabs at 240 TiB, code caches at 85
+         * TiB, etc.) is not safe to expose yet. The previous draft could
+         * install TTBR0 aliases for addresses above the primary guest buffer,
+         * but munmap/mprotect/fork bookkeeping still track regions by low GPA
+         * and mmap_next only. Returning success here therefore created mappings
+         * that later teardown paths could not manage and let overflow-backed
+         * aliases corrupt the fork snapshot high-water mark. Fail closed until
+         * the region metadata and teardown paths are made VA-aware end-to-end.
          */
         /* MAP_FIXED: addr is IPA-based, convert to offset */
         uint64_t off = addr - g->ipa_base;
-        /* Use subtraction-based check to avoid off+length overflow.
-         * Stays primary-buffer-only for the low-VA path because the body
-         * below issues raw host_base+off arithmetic (memset, pread, etc.).
-         * The high-VA path above is the alternate route for rosetta.
+        /* Use subtraction-based check to avoid off+length overflow. Stays
+         * primary-buffer-only for the low-VA path because the body below issues
+         * raw host_base+off arithmetic (memset, pread, etc.). The high-VA path
+         * above is the alternate route for rosetta.
          */
         if (off > g->guest_size || length > g->guest_size - off)
             return -LINUX_ENOMEM;
 
-        /* Reject MAP_FIXED targeting VM infrastructure: page table pool,
-         * shim code, and shim data/stack regions.  A guest must not be
-         * able to overwrite EL1 exception vectors or page tables. The
-         * reserve sits at high IPA (just below g->interp_base) so the
-         * range check uses the runtime fields rather than compile-time
-         * low-memory constants.
+        /* Reject MAP_FIXED targeting VM infrastructure: page table pool, shim
+         * code, and shim data/stack regions. A guest must not be able to
+         * overwrite EL1 exception vectors or page tables. The reserve sits at
+         * high IPA (just below g->interp_base) so the range check uses the
+         * runtime fields rather than compile-time low-memory constants.
          */
         uint64_t fix_end = off + length;
         if (guest_range_hits_infra(g, off, fix_end))
@@ -1845,10 +1930,9 @@ int64_t sys_mmap(guest_t *g,
 
         result_off = off;
 
-        /* MAP_FIXED_NOREPLACE: reject if any existing region overlaps.
-         * Use binary search (regions are sorted by start address) to
-         * find the first region that could overlap [result_off,
-         * result_off+length).
+        /* MAP_FIXED_NOREPLACE: reject if any existing region overlaps. Use
+         * binary search (regions are sorted by start address) to find the first
+         * region that could overlap [result_off, result_off+length).
          */
         if (is_noreplace) {
             int lo = 0, hi = g->nregions - 1, first = g->nregions;
@@ -1913,13 +1997,12 @@ int64_t sys_mmap(guest_t *g,
         }
 
         if (!is_prot_none) {
-            /* Ensure page table entries exist for the fixed range.
-             * PROT_NONE reservations skip page table creation, so when
-             * MAP_FIXED commits pages within a PROT_NONE region (e.g., a
-             * runtime carves an RW slab out of its previously reserved
-             * PROT_NONE heap), the memory syscall layer must create L2
-             * block descriptors first. guest_extend_page_tables is
-             * idempotent for already-mapped blocks.
+            /* Ensure page table entries exist for the fixed range. PROT_NONE
+             * reservations skip page table creation, so when MAP_FIXED commits
+             * pages within a PROT_NONE region (e.g., a runtime carves an RW
+             * slab out of its previously reserved PROT_NONE heap), the memory
+             * syscall layer must create L2 block descriptors first.
+             * guest_extend_page_tables is idempotent for already-mapped blocks.
              */
             int page_perms = prot_to_perms(prot);
 
@@ -1962,19 +2045,18 @@ int64_t sys_mmap(guest_t *g,
             guest_region_remove(g, result_off, result_off + length);
             replaced_regions_removed = true;
 
-            /* Fine-tune permissions for the exact range. Handles L3
-             * splitting when MAP_FIXED overlays different permissions
-             * onto an existing 2MiB block (e.g., .data RW over .text RX).
+            /* Fine-tune permissions for the exact range. Handles L3 splitting
+             * when MAP_FIXED overlays different permissions onto an existing
+             * 2MiB block (e.g., .data RW over .text RX).
              */
             guest_update_perms(g, result_off, result_off + length, page_perms);
 
-            /* For MAP_ANONYMOUS: zero the region (host memory may contain
-             * stale data from earlier mappings).
-             * For MAP_SHARED + regular file: install a real host mmap
-             * MAP_FIXED|MAP_SHARED overlay so the guest sees live host
-             * writes and its own writes hit the file directly.
-             * For MAP_PRIVATE file-backed: read file contents into guest
-             * memory; private writes stay in the slab.  Short reads leave
+            /* For MAP_ANONYMOUS: zero the region (host memory may contain stale
+             * data from earlier mappings). For MAP_SHARED + regular file:
+             * install a real host mmap MAP_FIXED|MAP_SHARED overlay so the
+             * guest sees live host writes and its own writes hit the file
+             * directly. For MAP_PRIVATE file-backed: read file contents into
+             * guest memory; private writes stay in the slab. Short reads leave
              * the remainder zeroed (memset first).
              */
             if (is_anon) {
@@ -2022,12 +2104,11 @@ int64_t sys_mmap(guest_t *g,
                     if (nr < 0) {
                         if (errno == EINTR)
                             continue;
-                        /* Real host I/O error (not EINTR). EOF zero-
-                         * fill stays an accepted outcome (nr == 0
-                         * below); an I/O failure returning a
-                         * "successful" partially-zero mapping is not.
-                         * Restore the prior region/PTE state and
-                         * surface the errno to the caller.
+                        /* Real host I/O error (not EINTR). EOF zero- fill stays
+                         * an accepted outcome (nr == 0 below); an I/O failure
+                         * returning a "successful" partially-zero mapping is
+                         * not. Restore the prior region/PTE state and surface
+                         * the errno to the caller.
                          */
                         read_io_err = true;
                         saved_errno = errno;
@@ -2080,20 +2161,20 @@ int64_t sys_mmap(guest_t *g,
             guest_region_remove(g, result_off, result_off + length);
             replaced_regions_removed = true;
 
-            /* PROT_NONE with MAP_FIXED: invalidate existing page table
-             * entries so the region becomes truly inaccessible. Without
-             * this, stale PTEs from initial page table setup (e.g., ELF
-             * segment pre-mapping) remain valid, making pages accessible
-             * when they should fault on access. A real Linux kernel's
-             * mmap(MAP_FIXED, PROT_NONE) removes existing VMAs and their
-             * page table entries, making the range fault on access.
+            /* PROT_NONE with MAP_FIXED: invalidate existing page table entries
+             * so the region becomes truly inaccessible. Without this, stale
+             * PTEs from initial page table setup (e.g., ELF segment
+             * pre-mapping) remain valid, making pages accessible when they
+             * should fault on access. A real Linux kernel's mmap(MAP_FIXED,
+             * PROT_NONE) removes existing VMAs and their page table entries,
+             * making the range fault on access.
              */
             guest_invalidate_ptes(g, result_off, result_off + length);
         }
     }
 
-    /* Non-fixed mmap: allocate from the gap-finding allocator and snapshot
-     * file backing once the final guest range is known.
+    /* Non-fixed mmap: allocate from the gap-finding allocator and snapshot file
+     * backing once the final guest range is known.
      */
     if (!is_fixed) {
         if (g->is_rosetta && addr >= g->guest_size &&
@@ -2129,8 +2210,8 @@ int64_t sys_mmap(guest_t *g,
              * Honor the address hint if provided and within bounds. Some
              * managed-runtime allocators need the heap at a specific high
              * address range (e.g., ~264GiB for a megablock-style map) and
-             * spin-retry if they get a low address instead. On real Linux,
-             * mmap tries the hint first and falls back to any suitable address.
+             * spin-retry if they get a low address instead. On real Linux, mmap
+             * tries the hint first and falls back to any suitable address.
              */
             result_off = UINT64_MAX;
             if (addr != 0) {
@@ -2141,9 +2222,9 @@ int64_t sys_mmap(guest_t *g,
                      * hint, including low canonical addresses such as the
                      * traditional x86-64 ET_EXEC base at 0x400000. box64 uses
                      * this pattern when reserving address space for static
-                     * ET_EXEC binaries; forcing every hint below MMAP_BASE
-                     * into the high RW arena breaks that expectation and the
-                     * guest later still dereferences the low address.
+                     * ET_EXEC binaries; forcing every hint below MMAP_BASE into
+                     * the high RW arena breaks that expectation and the guest
+                     * later still dereferences the low address.
                      *
                      * Probe the hinted range first. Keep low-hint searches
                      * below MMAP_BASE so an unresolved low hint does not
@@ -2191,9 +2272,9 @@ int64_t sys_mmap(guest_t *g,
 
     /* PROT_NONE mappings do not need new page table entries, but mmap must
      * invalidate any stale PTEs from previous allocations at this address.
-     * Without this, a freed-then-reallocated-as-PROT_NONE range retains
-     * the old RW page table entries, letting the guest read/write what
-     * should be inaccessible memory.
+     * Without this, a freed-then-reallocated-as-PROT_NONE range retains the old
+     * RW page table entries, letting the guest read/write what should be
+     * inaccessible memory.
      */
     if (is_prot_none && !is_fixed) {
         guest_invalidate_ptes(g, result_off, result_off + length);
@@ -2201,9 +2282,9 @@ int64_t sys_mmap(guest_t *g,
 
     if (!is_prot_none && !is_fixed && !is_noreserve) {
         /* Extend page tables for this specific allocation range only.
-         * guest_extend_page_tables skips already-mapped blocks, so
-         * calling it on pre-mapped regions is a no-op. This avoids
-         * creating entries for PROT_NONE gaps between allocations.
+         * guest_extend_page_tables skips already-mapped blocks, so calling it
+         * on pre-mapped regions is a no-op. This avoids creating entries for
+         * PROT_NONE gaps between allocations.
          */
         if (needs_exec && !(prot & LINUX_PROT_WRITE)) {
             uint64_t ext_start = ALIGN_DOWN(result_off, BLOCK_2MIB);
@@ -2217,8 +2298,8 @@ int64_t sys_mmap(guest_t *g,
                 host_fd_ref_close(&backing_ref);
                 return -LINUX_ENOMEM;
             }
-            /* Re-validate any previously-invalidated L3 entries (see
-             * the RW path comment below for the full explanation).
+            /* Re-validate any previously-invalidated L3 entries (see the RW
+             * path comment below for the full explanation).
              */
             guest_update_perms(g, result_off, result_off + length, MEM_PERM_RX);
             if (ext_end > g->mmap_rx_end)
@@ -2228,11 +2309,10 @@ int64_t sys_mmap(guest_t *g,
             uint64_t ext_end = ALIGN_UP(result_off + length, BLOCK_2MIB);
             if (ext_end > g->mmap_limit)
                 ext_end = g->mmap_limit;
-            /* Preserve execute permission for RWX requests. Stage-2
-             * (hv_vm_map) is RWX for the whole buffer; stage-1 PTEs set
-             * AP=RW_EL0 with UXN/PXN=0 for combined W+X. HVF allows
-             * this in stage-1 even though normal W^X enforcement
-             * disallows it per HV_MEMORY flags.
+            /* Preserve execute permission for RWX requests. Stage-2 (hv_vm_map)
+             * is RWX for the whole buffer; stage-1 PTEs set AP=RW_EL0 with
+             * UXN/PXN=0 for combined W+X. HVF allows this in stage-1 even
+             * though normal W^X enforcement disallows it per HV_MEMORY flags.
              */
             int ext_perms = MEM_PERM_RW;
             if (prot & LINUX_PROT_EXEC)
@@ -2263,37 +2343,35 @@ int64_t sys_mmap(guest_t *g,
         memset((uint8_t *) g->host_base + result_off, 0, length);
     }
 
-    /* MAP_NORESERVE: invalidate any stale PTEs (like PROT_NONE path)
-     * but track the region for lazy materialization on first fault.
-     * Page table entries will be created by guest_materialize_lazy()
-     * when the guest first touches a page in this range.
+    /* MAP_NORESERVE: invalidate any stale PTEs (like PROT_NONE path) but track
+     * the region for lazy materialization on first fault. Page table entries
+     * will be created by guest_materialize_lazy() when the guest first touches
+     * a page in this range.
      */
     if (is_noreserve && !is_fixed) {
         guest_invalidate_ptes(g, result_off, result_off + length);
     }
 
-    /* For file-backed mmap, populate the region with file contents.
-     * MAP_SHARED installs a real host mmap MAP_FIXED|MAP_SHARED overlay so
-     * guest reads observe concurrent host writes and guest writes hit the
-     * file directly.  MAP_PRIVATE pread-snapshots into private guest pages
-     * so writes stay local.  Skip for PROT_NONE: the region has no page
-     * table entries yet; data is faulted in when mprotect makes the pages
-     * accessible.
+    /* For file-backed mmap, populate the region with file contents. MAP_SHARED
+     * installs a real host mmap MAP_FIXED|MAP_SHARED overlay so guest reads
+     * observe concurrent host writes and guest writes hit the file directly.
+     * MAP_PRIVATE pread-snapshots into private guest pages so writes stay
+     * local. Skip for PROT_NONE: the region has no page table entries yet; data
+     * is faulted in when mprotect makes the pages accessible.
      */
     if (!is_anon && fd >= 0 && !is_prot_none) {
         size_t hps = host_page_size_cached();
-        /* mmap rounds length up to the host page size internally; only
-         * addr and offset alignment matter for MAP_FIXED on macOS Apple
-         * Silicon (16 KiB host pages). The "extra" trailing bytes inside
-         * the host page are never reachable by the guest because the
-         * gap-finder advances the hint to the next host-page boundary
-         * after each allocation.
+        /* mmap rounds length up to the host page size internally; only addr and
+         * offset alignment matter for MAP_FIXED on macOS Apple Silicon (16 KiB
+         * host pages). The "extra" trailing bytes inside the host page are
+         * never reachable by the guest because the gap-finder advances the hint
+         * to the next host-page boundary after each allocation.
          */
         /* overlay_fd_writable rejects read-only backing fds inside
-         * hvf_apply_file_overlay; mirror the check here so a read-only
-         * mmap takes the snapshot pread path directly, skipping the
-         * thread_quiesce / segment_split cycle the overlay would
-         * otherwise perform before returning EACCES.
+         * hvf_apply_file_overlay; mirror the check here so a read-only mmap
+         * takes the snapshot pread path directly, skipping the thread_quiesce /
+         * segment_split cycle the overlay would otherwise perform before
+         * returning EACCES.
          */
         bool overlay_aligned = (flags & LINUX_MAP_SHARED) &&
                                overlay_fd_writable(host_backing_fd) &&
@@ -2340,12 +2418,11 @@ int64_t sys_mmap(guest_t *g,
                 file_off += nr;
             }
             if (read_err) {
-                /* Any host I/O error (total OR partial) is fatal. The
-                 * previous "remaining == length" gate silently kept
-                 * partial-read mappings with a zeroed tail when an
-                 * I/O error fired mid-stream, which made truncated
-                 * file contents visible to the guest as a successful
-                 * mmap.
+                /* Any host I/O error (total OR partial) is fatal. The previous
+                 * "remaining == length" gate silently kept partial-read
+                 * mappings with a zeroed tail when an I/O error fired
+                 * mid-stream, which made truncated file contents visible to the
+                 * guest as a successful mmap.
                  */
                 int rollback_err = rollback_fresh_mmap_allocation(
                     g, result_off, length, false, 0, 0, saved_mmap_next,
@@ -2362,17 +2439,16 @@ int64_t sys_mmap(guest_t *g,
         }
     }
 
-    /* Record the new region. guest_region_add_ex derives shared from
-     * the LINUX_MAP_SHARED bit in track_flags for msync write-back.
+    /* Record the new region. guest_region_add_ex derives shared from the
+     * LINUX_MAP_SHARED bit in track_flags for msync write-back.
      */
     if (guest_region_add_ex_owned(g, result_off, result_off + length, prot,
                                   track_flags, is_anon ? 0 : (uint64_t) offset,
                                   NULL, track_backing_fd) < 0) {
-        /* Region table was full: undo any host overlay we just installed
-         * so the file is not left mmap'd at host_base+ipa with no
-         * tracking. Without this, a later operation in that range would
-         * memset zeros directly into the user's file via the leaked
-         * overlay.
+        /* Region table was full: undo any host overlay we just installed so the
+         * file is not left mmap'd at host_base+ipa with no tracking. Without
+         * this, a later operation in that range would memset zeros directly
+         * into the user's file via the leaked overlay.
          */
         int rollback_err = 0;
         if (replaced_regions_removed) {
@@ -2399,9 +2475,9 @@ int64_t sys_mmap(guest_t *g,
     }
 
     /* Mark the region as overlay-backed when sys_mmap installed a real
-     * MAP_FIXED|MAP_SHARED overlay on the host VA. Used by msync to skip
-     * the snapshot-style pwrite/refresh paths for regions that the kernel
-     * already keeps coherent with the file's page cache.
+     * MAP_FIXED|MAP_SHARED overlay on the host VA. Used by msync to skip the
+     * snapshot-style pwrite/refresh paths for regions that the kernel already
+     * keeps coherent with the file's page cache.
      */
     if (!is_anon && fd >= 0 && !is_prot_none && (flags & LINUX_MAP_SHARED)) {
         size_t hps = host_page_size_cached();
@@ -2466,8 +2542,8 @@ int64_t sys_mremap(guest_t *g,
         return -LINUX_EINVAL;
 
     /* Overflow check on old range. mremap's body shrinks, copies, and zeroes
-     * via raw host_base+off arithmetic, so the check stays primary-only
-     * here until the data-movement paths are made region-aware.
+     * via raw host_base+off arithmetic, so the check stays primary-only here
+     * until the data-movement paths are made region-aware.
      */
     uint64_t old_off = old_addr - g->ipa_base;
     if (old_off > g->guest_size)
@@ -2475,12 +2551,12 @@ int64_t sys_mremap(guest_t *g,
     if (old_size > 0 && old_size > g->guest_size - old_off)
         return -LINUX_EFAULT;
 
-    /* Reject mremap whose source range touches VM infrastructure (page
-     * tables, shim code, shim data). Without this guard a guest can move
-     * the shim_data block out from under the EL1 stack or the shim-
-     * globals identity cache, since the move path issues raw memmove,
-     * memset, region removal and PTE invalidation. Matches the parallel
-     * guards in sys_mmap MAP_FIXED, sys_munmap and sys_mprotect.
+    /* Reject mremap whose source range touches VM infrastructure (page tables,
+     * shim code, shim data). Without this guard a guest can move the shim_data
+     * block out from under the EL1 stack or the shim- globals identity cache,
+     * since the move path issues raw memmove, memset, region removal and PTE
+     * invalidation. Matches the parallel guards in sys_mmap MAP_FIXED,
+     * sys_munmap and sys_mprotect.
      */
     if (guest_range_hits_infra(g, old_off, old_off + old_size))
         return -LINUX_EINVAL;
@@ -2527,10 +2603,10 @@ int64_t sys_mremap(guest_t *g,
         if (new_off > g->guest_size || new_size > g->guest_size - new_off)
             return -LINUX_ENOMEM;
 
-        /* Same infrastructure protection as the source range: the move
-         * tail removes any existing dest region and rewrites PTEs, which
-         * would corrupt page tables / shim text / shim data if the dest
-         * lands inside infra.
+        /* Same infrastructure protection as the source range: the move tail
+         * removes any existing dest region and rewrites PTEs, which would
+         * corrupt page tables / shim text / shim data if the dest lands inside
+         * infra.
          */
         if (guest_range_hits_infra(g, new_off, new_off + new_size))
             return -LINUX_EINVAL;
@@ -2547,10 +2623,10 @@ int64_t sys_mremap(guest_t *g,
         if (!region_has_capacity_after_removes(g, removed, 2, 1))
             return -LINUX_ENOMEM;
 
-        /* Capture old region metadata BEFORE modifying any regions.
-         * If mremap removed destination first, an overlapping source would
-         * lose its metadata. The overlap check above prevents this case,
-         * but capturing first is still the safe ordering.
+        /* Capture old region metadata BEFORE modifying any regions. If mremap
+         * removed destination first, an overlapping source would lose its
+         * metadata. The overlap check above prevents this case, but capturing
+         * first is still the safe ordering.
          */
         const guest_region_t *old_reg = guest_region_find(g, old_off);
         int prot =
@@ -2567,9 +2643,9 @@ int64_t sys_mremap(guest_t *g,
         char track_name[sizeof(old_reg->name)] = {0};
         /* Heap-allocated to avoid blowing the ~512 KiB default macOS thread
          * stack: each region_snapshot_t array is GUEST_MAX_REGIONS *
-         * sizeof(region_snapshot_t), so two of them on the stack would be
-         * close to a megabyte. Freed via dispose_region_snapshots on every
-         * exit path below.
+         * sizeof(region_snapshot_t), so two of them on the stack would be close
+         * to a megabyte. Freed via dispose_region_snapshots on every exit path
+         * below.
          */
         region_snapshot_t *source_snaps = NULL;
         region_snapshot_t *dest_snaps = NULL;
@@ -2665,11 +2741,11 @@ int64_t sys_mremap(guest_t *g,
          */
         guest_region_remove(g, new_off, new_off + new_size);
 
-        /* Copy data (use memmove for potential overlap).  If the source
-         * has a live overlay, the read side of the memmove pulls live
-         * file content; the destination receives a private snapshot at
-         * mremap time (no overlay reapplied), and msync's emulated
-         * pwrite-the-diff path keeps subsequent writes consistent.
+        /* Copy data (use memmove for potential overlap). If the source has a
+         * live overlay, the read side of the memmove pulls live file content;
+         * the destination receives a private snapshot at mremap time (no
+         * overlay reapplied), and msync's emulated pwrite-the-diff path keeps
+         * subsequent writes consistent.
          */
         uint64_t copy_len = old_size < new_size ? old_size : new_size;
         if (prot == LINUX_PROT_NONE) {
@@ -2685,12 +2761,12 @@ int64_t sys_mremap(guest_t *g,
                     copy_err = restore_err;
                 restore_err =
                     restore_region_snapshots(g, dest_snaps, dest_nsnaps);
-                /* Re-establish the destination's page-table state to match
-                 * the regions we just restored. mremap_extend_range above
-                 * had filled in PTEs for the new mremap target; without
-                 * this rollback those PTEs would outlive the regions and
-                 * the guest would see live mappings where its own metadata
-                 * (after the restore) says nothing is mapped.
+                /* Re-establish the destination's page-table state to match the
+                 * regions we just restored. mremap_extend_range above had
+                 * filled in PTEs for the new mremap target; without this
+                 * rollback those PTEs would outlive the regions and the guest
+                 * would see live mappings where its own metadata (after the
+                 * restore) says nothing is mapped.
                  */
                 int pt_err = restore_snapshot_page_tables(
                     g, new_off, new_off + new_size, dest_snaps, dest_nsnaps);
@@ -2741,10 +2817,10 @@ int64_t sys_mremap(guest_t *g,
     if (new_size > old_size) {
         uint64_t grow_off = old_off + old_size, grow_len = new_size - old_size;
 
-        /* Reject growing into infrastructure (page tables, shim text,
-         * shim data). The source-range infra guard above only covers
-         * [old_off, old_off+old_size); the grown tail can still spill
-         * into infra without it.
+        /* Reject growing into infrastructure (page tables, shim text, shim
+         * data). The source-range infra guard above only covers [old_off,
+         * old_off+old_size); the grown tail can still spill into infra without
+         * it.
          */
         if (guest_range_hits_infra(g, grow_off, grow_off + grow_len))
             return -LINUX_EINVAL;
@@ -2900,10 +2976,10 @@ int64_t sys_mremap(guest_t *g,
             return -LINUX_ENOMEM;
         }
 
-        /* Copy old data, zero extension. The new range was just allocated
-         * from a free gap so it has no overlays to clean up; the source
-         * may have an overlay, which is read transparently by the memcpy
-         * before its underlying slab is restored below.
+        /* Copy old data, zero extension. The new range was just allocated from
+         * a free gap so it has no overlays to clean up; the source may have an
+         * overlay, which is read transparently by the memcpy before its
+         * underlying slab is restored below.
          */
         if (prot == LINUX_PROT_NONE) {
             memset((uint8_t *) g->host_base + new_off, 0, new_size);
@@ -2915,8 +2991,8 @@ int64_t sys_mremap(guest_t *g,
                 /* Roll back both sides: re-apply the source overlay so the
                  * caller's MAP_SHARED is not silently demoted to a slab
                  * snapshot, and tear down the destination PTEs we just
-                 * allocated via mremap_extend_range so the guest does not
-                 * see phantom zero pages where the failed mremap landed.
+                 * allocated via mremap_extend_range so the guest does not see
+                 * phantom zero pages where the failed mremap landed.
                  */
                 (void) restore_file_overlay_range(
                     g, old_off, old_off + old_size, source_overlay_start,
@@ -2970,9 +3046,9 @@ int64_t sys_mremap(guest_t *g,
 
 /* sys_madvise. */
 
-/* Returns true if [off, off+length) is fully covered by mapped regions.
- * Mirrors Linux madvise_walk_vmas, which returns -ENOMEM whenever it would step
- * over an unmapped sub-range. Caller holds mmap_lock.
+/* Returns true if [off, off+length) is fully covered by mapped regions. Mirrors
+ * Linux madvise_walk_vmas, which returns -ENOMEM whenever it would step over an
+ * unmapped sub-range. Caller holds mmap_lock.
  */
 static bool madvise_range_mapped(const guest_t *g,
                                  uint64_t off,
@@ -3004,39 +3080,37 @@ int64_t sys_madvise(guest_t *g, uint64_t addr, uint64_t length, int advice)
     if (length == 0)
         return 0;
 
-    /* Range must lie within the guest IPA window. Linux returns -ENOMEM
-     * (not -EINVAL) for addresses outside the process address space; see
-     * madvise(2): "Addresses in the specified range are not currently
-     * mapped, or are outside the address space of the process." Stays
-     * primary-only because MADV_DONTNEED zeroes via raw host_base+off and
-     * the slab restore path likewise assumes primary backing. The
-     * region-aware variant will consume guest_is_valid_range once the body
-     * is updated.
+    /* Range must lie within the guest IPA window. Linux returns -ENOMEM (not
+     * -EINVAL) for addresses outside the process address space; see madvise(2):
+     * "Addresses in the specified range are not currently mapped, or are
+     * outside the address space of the process." Stays primary-only because
+     * MADV_DONTNEED zeroes via raw host_base+off and the slab restore path
+     * likewise assumes primary backing. The region-aware variant will consume
+     * guest_is_valid_range once the body is updated.
      */
     uint64_t off = addr - g->ipa_base;
     if (off > g->guest_size || length > g->guest_size - off)
         return -LINUX_ENOMEM;
 
-    /* Defensive guard against destructive advice on infrastructure
-     * ranges (page tables, shim text, shim data). MADV_DONTNEED would
-     * zero shim data via raw host_base+off arithmetic; MADV_FREE on a
-     * future flag change could do the same. Today the destructive
-     * advice paths happen to skip non-anonymous regions, but a future
-     * regression should not silently reopen the hole.
+    /* Defensive guard against destructive advice on infrastructure ranges (page
+     * tables, shim text, shim data). MADV_DONTNEED would zero shim data via raw
+     * host_base+off arithmetic; MADV_FREE on a future flag change could do the
+     * same. Today the destructive advice paths happen to skip non-anonymous
+     * regions, but a future regression should not silently reopen the hole.
      */
     if (guest_range_hits_infra(g, off, off + length))
         return -LINUX_EINVAL;
 
     switch (advice) {
     case LINUX_MADV_DONTNEED: {
-        /* MADV_DONTNEED: zero anon pages so next access sees zero-fill,
-         * restore file-backed pages from the current backing file contents.
-         * Linux returns -ENOMEM if any part of the range is unmapped.
+        /* MADV_DONTNEED: zero anon pages so next access sees zero-fill, restore
+         * file-backed pages from the current backing file contents. Linux
+         * returns -ENOMEM if any part of the range is unmapped.
          *
-         * Writable MAP_SHARED file-backed regions are preserved so elfuse
-         * does not overwrite unsynced in-memory writes with backing-file
-         * contents. Read-only MAP_SHARED mappings can be invalidated safely
-         * and should refault from the current file image.
+         * Writable MAP_SHARED file-backed regions are preserved so elfuse does
+         * not overwrite unsynced in-memory writes with backing-file contents.
+         * Read-only MAP_SHARED mappings can be invalidated safely and should
+         * refault from the current file image.
          *
          * PROT_NONE anonymous regions still get zeroed so the guest's next
          * mprotect-and-read sees zero-fill (Linux semantics: pages are
@@ -3058,9 +3132,9 @@ int64_t sys_madvise(guest_t *g, uint64_t addr, uint64_t length, int advice)
                 continue;
             /* Overlay-backed regions already serve their content from the
              * file's page cache. The "zero + pread" reset would write zeros
-             * straight into the file because the host VA is the file. Skip
-             * the reset; the next guest read already sees the current file
-             * image, which is what MADV_DONTNEED promises.
+             * straight into the file because the host VA is the file. Skip the
+             * reset; the next guest read already sees the current file image,
+             * which is what MADV_DONTNEED promises.
              */
             if (r->overlay_active)
                 continue;
@@ -3069,9 +3143,8 @@ int64_t sys_madvise(guest_t *g, uint64_t addr, uint64_t length, int advice)
             uint64_t zend = (r->end < end) ? r->end : end;
             memset((uint8_t *) g->host_base + zstart, 0, zend - zstart);
             if (!(r->flags & LINUX_MAP_ANONYMOUS)) {
-                /* EOF leaves the tail zero per mmap rules; the helper
-                 * already returns 0 in that case after stopping the
-                 * read loop.
+                /* EOF leaves the tail zero per mmap rules; the helper already
+                 * returns 0 in that case after stopping the read loop.
                  */
                 int err = read_file_range_to_guest(
                     g, zstart, r->backing_fd, r->offset + (zstart - r->start),
@@ -3115,10 +3188,10 @@ int64_t sys_madvise(guest_t *g, uint64_t addr, uint64_t length, int advice)
     case LINUX_MADV_NOHUGEPAGE:
     case LINUX_MADV_COLD:
     case LINUX_MADV_PAGEOUT:
-        /* Advisory hints: accept silently.  Linux walks vmas and returns
-         * -ENOMEM for any unmapped sub-range; mirror that for fidelity.
-         * No host swap means PAGEOUT/COLD do not actually evict -- keeping
-         * data in place is a stricter guarantee than Linux's.
+        /* Advisory hints: accept silently. Linux walks vmas and returns -ENOMEM
+         * for any unmapped sub-range; mirror that for fidelity. No host swap
+         * means PAGEOUT/COLD do not actually evict -- keeping data in place is
+         * a stricter guarantee than Linux's.
          */
         if (!madvise_range_mapped(g, off, length))
             return -LINUX_ENOMEM;
@@ -3162,9 +3235,9 @@ static int munmap_guest_range(guest_t *g, uint64_t unmap_off, uint64_t end)
     if (cleanup_err < 0)
         return cleanup_err;
 
-    /* Invalidate PTEs first. This may need to split a 2MiB block which can
-     * fail if the page table pool is exhausted. Failing before region removal
-     * keeps metadata consistent.
+    /* Invalidate PTEs first. This may need to split a 2MiB block which can fail
+     * if the page table pool is exhausted. Failing before region removal keeps
+     * metadata consistent.
      */
     if (guest_invalidate_ptes(g, unmap_off, end) < 0)
         return -LINUX_ENOMEM;
@@ -3320,10 +3393,10 @@ int64_t sys_mprotect(guest_t *g, uint64_t addr, uint64_t length, int prot)
 
             /* Fast path: if the tracker already records this prot for every
              * overlapping region and none are MAP_NORESERVE, page tables are
-             * already in sync and no PTE work is required. The tracker
-             * update is also a no-op, so skip it. Read-only same-prot
-             * requests still need PTE work because some mmap paths install
-             * RW PTEs while recording PROT_READ in the tracker. Disabled once
+             * already in sync and no PTE work is required. The tracker update
+             * is also a no-op, so skip it. Read-only same-prot requests still
+             * need PTE work because some mmap paths install RW PTEs while
+             * recording PROT_READ in the tracker. Disabled once
              * regions_tracker_stale is set: prior set_prot calls hit
              * GUEST_MAX_REGIONS and left the tracker out of sync with PTEs.
              */
@@ -3334,9 +3407,9 @@ int64_t sys_mprotect(guest_t *g, uint64_t addr, uint64_t length, int prot)
                 return 0;
 
             /* Do PTE work BEFORE updating the tracker. If page-table
-             * maintenance fails, regions[] still reflects the old prot, so
-             * a retry will see the mismatch and re-attempt the update
-             * instead of short-circuiting on stale tracker state.
+             * maintenance fails, regions[] still reflects the old prot, so a
+             * retry will see the mismatch and re-attempt the update instead of
+             * short-circuiting on stale tracker state.
              */
             if (prot != LINUX_PROT_NONE) {
                 if (guest_update_perms(g, addr, mprot_end,
@@ -3545,10 +3618,10 @@ int64_t sys_msync(guest_t *g, uint64_t addr, uint64_t length, int flags)
         return -LINUX_ENOMEM;
 
     uint64_t off = addr - g->ipa_base;
-    /* sys_msync stays primary-only here for the same reason as madvise:
-     * msync iterates regions and reaches into host_base+off to read pages
-     * back from the file overlay. Widening to extra-region ranges needs a
-     * region-aware iterator landing alongside the data-movement refactor.
+    /* sys_msync stays primary-only here for the same reason as madvise: msync
+     * iterates regions and reaches into host_base+off to read pages back from
+     * the file overlay. Widening to extra-region ranges needs a region-aware
+     * iterator landing alongside the data-movement refactor.
      */
     if (off > g->guest_size || length > g->guest_size - off)
         return -LINUX_ENOMEM;
@@ -3576,12 +3649,11 @@ int64_t sys_msync(guest_t *g, uint64_t addr, uint64_t length, int flags)
         uint64_t file_start = r->offset + (sync_start - r->start);
         uint64_t file_end = file_start + (sync_end - sync_start);
 
-        /* Real overlay regions are kept coherent with the file by the
-         * kernel's page cache. The snapshot-style pwrite-the-diff would
-         * compare the live file against itself and may trip on macOS's
-         * page-cache write path; the refresh-from-file pass would do the
-         * same self-write. Both are no-ops for overlays, so MS_SYNC
-         * collapses to a plain fsync.
+        /* Real overlay regions are kept coherent with the file by the kernel's
+         * page cache. The snapshot-style pwrite-the-diff would compare the live
+         * file against itself and may trip on macOS's page-cache write path;
+         * the refresh-from-file pass would do the same self-write. Both are
+         * no-ops for overlays, so MS_SYNC collapses to a plain fsync.
          */
         if (!r->overlay_active) {
             int64_t err = sync_shared_aliases_range(g, r->backing_fd,
@@ -3599,10 +3671,9 @@ int64_t sys_msync(guest_t *g, uint64_t addr, uint64_t length, int flags)
             guest_region_t *dst = &g->regions[j];
             if (!dst->shared || dst->backing_fd < 0)
                 continue;
-            /* Skip self and overlay-backed peers: the page cache already
-             * keeps them coherent with the file. Only legacy snapshot
-             * regions (e.g., a region created by mremap that lost its
-             * overlay) need refresh.
+            /* Skip self and overlay-backed peers: the page cache already keeps
+             * them coherent with the file. Only legacy snapshot regions (e.g.,
+             * a region created by mremap that lost its overlay) need refresh.
              */
             if (dst == r || dst->overlay_active)
                 continue;
@@ -3619,9 +3690,9 @@ int64_t sys_msync(guest_t *g, uint64_t addr, uint64_t length, int flags)
     return 0;
 }
 
-/* See mem.h. Walk regions, convert each MAP_SHARED|MAP_ANONYMOUS region
- * without backing fd into a memfd-backed overlay so fork can hand the fd
- * to the child for live coherence. Caller has quiesced sibling vCPUs.
+/* See mem.h. Walk regions, convert each MAP_SHARED|MAP_ANONYMOUS region without
+ * backing fd into a memfd-backed overlay so fork can hand the fd to the child
+ * for live coherence. Caller has quiesced sibling vCPUs.
  */
 static void mmap_fork_dispose_anon_shared_txn(
     mmap_fork_anon_shared_txn_t **txn_ptr)
@@ -3638,10 +3709,9 @@ static void mmap_fork_dispose_anon_shared_txn(
 int mmap_fork_prepare_anon_shared(guest_t *g,
                                   mmap_fork_anon_shared_txn_t **txn_out)
 {
-    /* Callers must provide a non-NULL txn_out: the transaction handle is
-     * the only way to commit or abort the partial state mutated below.
-     * Reject up front so the body can assume *txn_out is writable on
-     * every exit path.
+    /* Callers must provide a non-NULL txn_out: the transaction handle is the
+     * only way to commit or abort the partial state mutated below. Reject up
+     * front so the body can assume *txn_out is writable on every exit path.
      */
     if (!txn_out)
         return -LINUX_EINVAL;
@@ -3655,9 +3725,9 @@ int mmap_fork_prepare_anon_shared(guest_t *g,
 
     size_t hps = host_page_size_cached();
 
-    /* Snapshot candidate ranges first; conversion mutates the region
-     * table via hvf_segment_split / mark_overlay_metadata_range and
-     * would invalidate the walk indices.
+    /* Snapshot candidate ranges first; conversion mutates the region table via
+     * hvf_segment_split / mark_overlay_metadata_range and would invalidate the
+     * walk indices.
      */
     struct {
         uint64_t start;
@@ -3675,13 +3745,12 @@ int mmap_fork_prepare_anon_shared(guest_t *g,
         if ((r->start % hps) != 0)
             continue; /* misaligned start: snapshot fallback */
         /* If the region is shorter than a host page, the host
-         * MAP_FIXED|MAP_SHARED mmap rounds up to ALIGN_UP(len, hps) and
-         * may alias the next region's host page. Codex flagged this
-         * tail-aliasing hazard. Skip when any subsequent region's tail
-         * crosses r->end into the same host page. The leading region
-         * is always the one we convert, so backing_fd is naturally -1
-         * for it; sibling regions in the host-page tail will each be
-         * inspected on their own iteration.
+         * MAP_FIXED|MAP_SHARED mmap rounds up to ALIGN_UP(len, hps) and may
+         * alias the next region's host page. Codex flagged this tail-aliasing
+         * hazard. Skip when any subsequent region's tail crosses r->end into
+         * the same host page. The leading region is always the one we convert,
+         * so backing_fd is naturally -1 for it; sibling regions in the
+         * host-page tail will each be inspected on their own iteration.
          */
         uint64_t aligned_end = ALIGN_UP(r->end, hps);
         if (aligned_end > r->end) {
@@ -3725,9 +3794,8 @@ int mmap_fork_prepare_anon_shared(guest_t *g,
             continue;
         }
 
-        /* Seed the temp file with the parent's current bytes so the
-         * child sees pre-fork content through the kernel page cache
-         * after re-installation.
+        /* Seed the temp file with the parent's current bytes so the child sees
+         * pre-fork content through the kernel page cache after re-installation.
          */
         const uint8_t *src = (const uint8_t *) g->host_base + start;
         uint64_t remain = len;
@@ -3757,12 +3825,12 @@ int mmap_fork_prepare_anon_shared(guest_t *g,
             continue;
         }
 
-        /* Pre-stage the per-region backing_fd dups before installing
-         * the overlay. A post-install dup failure would otherwise leave
-         * the parent live on the temp file but with regions stuck at
-         * backing_fd=-1, which the SCM_RIGHTS sender silently skips.
-         * Reserving fds up front and aborting on failure preserves the
-         * snapshot fallback when the host runs out of fds.
+        /* Pre-stage the per-region backing_fd dups before installing the
+         * overlay. A post-install dup failure would otherwise leave the parent
+         * live on the temp file but with regions stuck at backing_fd=-1, which
+         * the SCM_RIGHTS sender silently skips. Reserving fds up front and
+         * aborting on failure preserves the snapshot fallback when the host
+         * runs out of fds.
          */
         int region_idxs[GUEST_MAX_REGIONS];
         int dup_fds[GUEST_MAX_REGIONS];
@@ -3838,12 +3906,11 @@ int mmap_fork_prepare_anon_shared(guest_t *g,
             .nsnaps = nsnaps,
         };
 
-        /* Mark every region in [start, end) with overlay span
-         * [start, start+aligned_len). The candidate filter guarantees
-         * the host-page tail is empty of other tracked regions, so the
-         * extended overlay span never aliases a neighbor's backing.
-         * Assign the pre-staged dups in lockstep with the iteration
-         * order used to size n_regions above.
+        /* Mark every region in [start, end) with overlay span [start,
+         * start+aligned_len). The candidate filter guarantees the host-page
+         * tail is empty of other tracked regions, so the extended overlay span
+         * never aliases a neighbor's backing. Assign the pre-staged dups in
+         * lockstep with the iteration order used to size n_regions above.
          */
         mark_overlay_metadata_range(g, start, end, start, start + aligned_len);
         for (int k = 0; k < n_regions; k++) {
@@ -3878,16 +3945,15 @@ int mmap_fork_abort_anon_shared(guest_t *g,
     for (int i = txn->noverlays - 1; i >= 0; i--) {
         const fork_overlay_snapshot_t *ovl = &txn->overlays[i];
 
-        /* Validate every captured region snapshot for this overlay
-         * BEFORE tearing down the host MAP_SHARED|MAP_FIXED mapping.
-         * Removing the overlay first and then discovering the region
-         * shape has drifted (e.g., a sibling vCPU that returned from a
-         * long host syscall after the quiesce timeout ran mmap or
-         * munmap during the prepare/abort window) leaves the host VA
-         * restored to slab while the region metadata still claims the
-         * temp-file overlay -- a silent desync. By verifying first the
-         * function leaves the overlay live and surfaces -EFAULT so the
-         * caller can decide what to do (still better than a partial
+        /* Validate every captured region snapshot for this overlay BEFORE
+         * tearing down the host MAP_SHARED|MAP_FIXED mapping. Removing the
+         * overlay first and then discovering the region shape has drifted
+         * (e.g., a sibling vCPU that returned from a long host syscall after
+         * the quiesce timeout ran mmap or munmap during the prepare/abort
+         * window) leaves the host VA restored to slab while the region metadata
+         * still claims the temp-file overlay -- a silent desync. By verifying
+         * first the function leaves the overlay live and surfaces -EFAULT so
+         * the caller can decide what to do (still better than a partial
          * teardown).
          */
         bool drifted = false;
@@ -3918,9 +3984,9 @@ int mmap_fork_abort_anon_shared(guest_t *g,
             region_snapshot_t *snap = &txn->snaps[ovl->snap_base + j];
             const guest_region_t *found = guest_region_find(g, snap->start);
             guest_region_t *r = (guest_region_t *) found;
-            /* Validation above ensured r exists with matching bounds.
-             * Re-check defensively in case hvf_remove_file_overlay_quiesced
-             * itself mutated the region table on its failure paths.
+            /* Validation above ensured r exists with matching bounds. Re-check
+             * defensively in case hvf_remove_file_overlay_quiesced itself
+             * mutated the region table on its failure paths.
              */
             if (!r || r->start != snap->start || r->end != snap->end) {
                 if (rc == 0)
@@ -3948,9 +4014,9 @@ int mmap_fork_abort_anon_shared(guest_t *g,
     return rc;
 }
 
-/* See mem.h. Re-install host MAP_SHARED|MAP_FIXED overlays on the child
- * after IPC restore using parent-side overlay metadata captured before
- * the recv path cleared the inherited overlay flags.
+/* See mem.h. Re-install host MAP_SHARED|MAP_FIXED overlays on the child after
+ * IPC restore using parent-side overlay metadata captured before the recv path
+ * cleared the inherited overlay flags.
  */
 int mmap_fork_restore_overlays(guest_t *g,
                                const bool *parent_active,
@@ -3974,11 +4040,11 @@ int mmap_fork_restore_overlays(guest_t *g,
         if (ovl_e <= ovl_s)
             continue;
 
-        /* file_off corresponding to ovl_s. The standard install path
-         * keeps ovl_s == r->start (host-page-aligned guest start), so
-         * file_off == r->offset. Handle the defensive clip-extends-low
-         * case by shifting r->offset down by the missing bytes; if that
-         * would underflow, skip the region (cannot honestly recreate).
+        /* file_off corresponding to ovl_s. The standard install path keeps
+         * ovl_s == r->start (host-page-aligned guest start), so file_off ==
+         * r->offset. Handle the defensive clip-extends-low case by shifting
+         * r->offset down by the missing bytes; if that would underflow, skip
+         * the region (cannot honestly recreate).
          */
         uint64_t file_off;
         if (ovl_s >= r->start) {
@@ -4011,8 +4077,8 @@ int mmap_fork_restore_overlays(guest_t *g,
              * shared library file-backed regions, etc.). The fallback to
              * snapshot semantics is correct for those: the child reads the
              * pre-fork bytes and never writes back, which is what the parent
-             * already did. Log at debug level so the success path stays
-             * quiet. Any other failure is unexpected and stays at warn.
+             * already did. Log at debug level so the success path stays quiet.
+             * Any other failure is unexpected and stays at warn.
              */
             if (err == -LINUX_EACCES)
                 log_debug(
@@ -4029,12 +4095,12 @@ int mmap_fork_restore_overlays(guest_t *g,
             continue;
         }
 
-        /* Mark each region that the parent had attached to this same
-         * overlay span. Calling mark_overlay_metadata_range with the
-         * region's own [start, end) bounds marks only that region (the
-         * region table is sorted and non-overlapping). The outer loop
-         * later sees overlay_active=true for sibling regions and skips
-         * the redundant install.
+        /* Mark each region that the parent had attached to this same overlay
+         * span. Calling mark_overlay_metadata_range with the region's own
+         * [start, end) bounds marks only that region (the region table is
+         * sorted and non-overlapping). The outer loop later sees
+         * overlay_active=true for sibling regions and skips the redundant
+         * install.
          */
         for (int j = 0; j < g->nregions; j++) {
             if (!parent_active[j])

--- a/src/syscall/mem.h
+++ b/src/syscall/mem.h
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Declarations for brk, mmap, munmap, mprotect, mremap, madvise, msync.
- * All sys_xxx functions assume mmap_lock is held by the caller.
+ * Declarations for brk, mmap, munmap, mprotect, mremap, madvise, msync. All
+ * sys_xxx functions assume mmap_lock is held by the caller.
  */
 
 #pragma once
@@ -50,46 +50,46 @@ int64_t sys_msync(guest_t *g, uint64_t addr, uint64_t length, int flags);
 /* Apply deferred guest-stack munmap work for an exiting thread. */
 void mem_cleanup_deferred_stack_unmaps(guest_t *g, thread_entry_t *t);
 
-/* Fork preparation: convert MAP_SHARED|MAP_ANONYMOUS regions that have
- * no backing fd into memfd-backed overlay regions. Each converted region
- * gets a private mkstemp+unlink temp file seeded from the current host
- * bytes; a host MAP_SHARED|MAP_FIXED overlay is then installed so the
- * parent's subsequent writes flow through the kernel page cache. The
- * region's backing_fd is set to a dup of the temp file so the regular
- * SCM_RIGHTS handover feeds the child a coherent fd.
+/* Fork preparation: convert MAP_SHARED|MAP_ANONYMOUS regions that have no
+ * backing fd into memfd-backed overlay regions. Each converted region gets a
+ * private mkstemp+unlink temp file seeded from the current host bytes; a host
+ * MAP_SHARED|MAP_FIXED overlay is then installed so the parent's subsequent
+ * writes flow through the kernel page cache. The region's backing_fd is set to
+ * a dup of the temp file so the regular SCM_RIGHTS handover feeds the child a
+ * coherent fd.
  *
  * Caller must already hold sibling vCPUs quiesced. mmap_lock is acquired
- * internally. Per-region failures are logged and skipped (snapshot
- * fallback persists for those regions); structural failure returns
- * -errno. Regions whose start address is not host-page-aligned are
- * skipped (overlay-eligibility requirement). On success, *txn_out owns
- * rollback metadata that must later be committed or aborted.
+ * internally. Per-region failures are logged and skipped (snapshot fallback
+ * persists for those regions); structural failure returns -errno. Regions whose
+ * start address is not host-page-aligned are skipped (overlay-eligibility
+ * requirement). On success, *txn_out owns rollback metadata that must later be
+ * committed or aborted.
  */
 int mmap_fork_prepare_anon_shared(guest_t *g,
                                   mmap_fork_anon_shared_txn_t **txn_out);
 
-/* Finalize or roll back mmap_fork_prepare_anon_shared(). Callers must
- * still have sibling vCPUs quiesced when aborting so the host overlay
- * removal cannot race guest accesses.
+/* Finalize or roll back mmap_fork_prepare_anon_shared(). Callers must still
+ * have sibling vCPUs quiesced when aborting so the host overlay removal cannot
+ * race guest accesses.
  */
 void mmap_fork_commit_anon_shared(mmap_fork_anon_shared_txn_t **txn_ptr);
 int mmap_fork_abort_anon_shared(guest_t *g,
                                 mmap_fork_anon_shared_txn_t **txn_ptr);
 
-/* Fork restore: re-install host MAP_SHARED|MAP_FIXED overlays on the
- * child after IPC restore. parent_active[i] / parent_ovl_start[i] /
- * parent_ovl_end[i] capture each region's parent-side overlay metadata,
- * sampled before fork_ipc_recv_process_state cleared the inherited
- * overlay flags. For each region that was overlay-active in the parent
- * and now has a valid backing_fd (received via SCM_RIGHTS), the function
- * calls hv_vm_unmap + mmap MAP_FIXED|MAP_SHARED + hv_vm_map to bind the
- * host VA to the same backing file so the child observes parent writes
- * (and vice-versa). Caller must hold no locks; the child has not yet
- * created worker vCPUs so no quiesce is needed.
+/* Fork restore: re-install host MAP_SHARED|MAP_FIXED overlays on the child
+ * after IPC restore. parent_active[i] / parent_ovl_start[i] / parent_ovl_end[i]
+ * capture each region's parent-side overlay metadata, sampled before
+ * fork_ipc_recv_process_state cleared the inherited overlay flags. For each
+ * region that was overlay-active in the parent and now has a valid backing_fd
+ * (received via SCM_RIGHTS), the function calls hv_vm_unmap + mmap
+ * MAP_FIXED|MAP_SHARED + hv_vm_map to bind the host VA to the same backing file
+ * so the child observes parent writes (and vice-versa). Caller must hold no
+ * locks; the child has not yet created worker vCPUs so no quiesce is needed.
  *
- * Per-region failures are logged and skipped. Returns 0 on full success
- * or the last error encountered (best-effort: a partial failure leaves
- * snapshot semantics intact for the failed regions).
+ * Per-region failures are logged and skipped.
+ *
+ * Returns 0 on full success or the last error encountered (best-effort: a
+ * partial failure leaves snapshot semantics intact for the failed regions).
  */
 int mmap_fork_restore_overlays(guest_t *g,
                                const bool *parent_active,

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -28,9 +28,8 @@
 /* Linux SCM_MAX_FD: maximum number of file descriptors in SCM_RIGHTS */
 #define LINUX_SCM_MAX_FD 253
 
-/* Linux only delivers SCM_CREDENTIALS on AF_UNIX sockets even when
- * SO_PASSCRED is set, so PASSCRED toggled on AF_INET / AF_INET6 must
- * stay a no-op.
+/* Linux only delivers SCM_CREDENTIALS on AF_UNIX sockets even when SO_PASSCRED
+ * is set, so PASSCRED toggled on AF_INET / AF_INET6 must stay a no-op.
  */
 static bool host_socket_is_unix(int host_fd)
 {
@@ -186,9 +185,9 @@ int64_t sys_sendmsg(guest_t *g, int fd, uint64_t msg_gva, int linux_flags)
         dest_len = (socklen_t) ml;
     }
 
-    /* msg_iovlen is uint64_t on Linux; bound it against SYSCALL_IOV_MAX
-     * before the int narrowing below so a 64-bit value whose low 32 bits
-     * fall inside [0, SYSCALL_IOV_MAX] cannot slip past the cap.
+    /* msg_iovlen is uint64_t on Linux; bound it against SYSCALL_IOV_MAX before
+     * the int narrowing below so a 64-bit value whose low 32 bits fall inside
+     * [0, SYSCALL_IOV_MAX] cannot slip past the cap.
      */
     if (lmsg.msg_iovlen > SYSCALL_IOV_MAX) {
         host_fd_ref_close(&host_ref);

--- a/src/syscall/net-sockopt.c
+++ b/src/syscall/net-sockopt.c
@@ -223,9 +223,9 @@ void net_socket_cache_init_accept(int guest_fd, int inherit_passcred)
 
     net_socket_cache_set_many_zero(guest_fd, zero_opts, ARRAY_SIZE(zero_opts));
 
-    /* AF_UNIX accept inherits SO_PASSCRED from the listener. For local
-     * connects the accept path receives the value captured when the
-     * connection was queued; otherwise it falls back to the listener value.
+    /* AF_UNIX accept inherits SO_PASSCRED from the listener. For local connects
+     * the accept path receives the value captured when the connection was
+     * queued; otherwise it falls back to the listener value.
      */
     net_socket_cache_set_index(guest_fd, SOCK_OPT_PASSCRED,
                                inherit_passcred ? 1 : 0);

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Translates Linux aarch64 socket syscalls into macOS equivalents.
- * Key differences handled:
+ * Translates Linux aarch64 socket syscalls into macOS equivalents. Key
+ * differences handled:
  *   - Address families: Linux AF_INET6=10, macOS AF_INET6=30
  *   - sockaddr layout: macOS has sa_len byte, Linux does not
  *   - Socket type flags: Linux packs SOCK_NONBLOCK/SOCK_CLOEXEC into type
@@ -92,12 +92,12 @@ int64_t sys_socket(guest_t *g, int domain, int type, int protocol)
     int nonblock = extract_sock_nonblock(type);
     int cloexec = extract_sock_cloexec(type);
 
-    /* Rosetta opens AF_UNIX SOCK_SEQPACKET to talk to rosettad. macOS does
-     * not support SOCK_SEQPACKET on AF_UNIX, so while the translator process
-     * is active we create an unconnected SOCK_STREAM placeholder instead.
+    /* Rosetta opens AF_UNIX SOCK_SEQPACKET to talk to rosettad. macOS does not
+     * support SOCK_SEQPACKET on AF_UNIX, so while the translator process is
+     * active we create an unconnected SOCK_STREAM placeholder instead.
      * sys_connect() upgrades only the specific rosettad path to the private
-     * socketpair/handler transport; any other connect on this placeholder
-     * fails so unrelated Unix IPC is not silently downgraded to STREAM.
+     * socketpair/handler transport; any other connect on this placeholder fails
+     * so unrelated Unix IPC is not silently downgraded to STREAM.
      */
     if (rosetta_socket_shim_enabled(g) && mac_domain == AF_UNIX &&
         real_type == LINUX_SOCK_SEQPACKET) {
@@ -452,8 +452,8 @@ int64_t sys_connect(guest_t *g, int fd, uint64_t addr_gva, uint32_t addrlen)
     }
 
     /* glibc probes UDP connect(addr, port 0) during getaddrinfo() source
-     * address selection. Linux accepts this; macOS rejects it. Use discard
-     * port 9 for the host-only probe so getsockname() can still discover the
+     * address selection. Linux accepts this; macOS rejects it. Use discard port
+     * 9 for the host-only probe so getsockname() can still discover the
      * selected local address.
      */
     int so_type = 0;
@@ -691,8 +691,8 @@ int64_t sys_sendto(guest_t *g,
         len = avail;
 
     int mac_flags = translate_msg_flags(linux_flags);
-    /* MSG_NOSIGNAL (0x4000): suppress SIGPIPE on EPIPE.
-     * macOS has no MSG_NOSIGNAL; elfuse handles it by not queuing SIGPIPE.
+    /* MSG_NOSIGNAL (0x4000): suppress SIGPIPE on EPIPE. macOS has no
+     * MSG_NOSIGNAL; elfuse handles it by not queuing SIGPIPE.
      */
     int suppress_sigpipe = (linux_flags & 0x4000);
 
@@ -824,8 +824,8 @@ int64_t sys_setsockopt(guest_t *g,
     int small_int_opt = socket_opt_uses_small_int(level, optname);
 
     /* SO_PASSCRED: emulated entirely in elfuse. Cache the flag value so
-     * getsockopt returns it and recvmsg knows to inject SCM_CREDENTIALS.
-     * macOS has no equivalent. Do not forward.
+     * getsockopt returns it and recvmsg knows to inject SCM_CREDENTIALS. macOS
+     * has no equivalent. Do not forward.
      */
     if (level == LINUX_SOL_SOCKET && optname == LINUX_SO_PASSCRED) {
         if (!net_socket_fd_is_valid(fd))
@@ -843,12 +843,11 @@ int64_t sys_setsockopt(guest_t *g,
 
     if (level == LINUX_IPPROTO_IP && optname == LINUX_IP_MTU_DISCOVER) {
         /* P2P networking tools (libp2p, syncthing, WireGuard userland,
-         * Tailscale's bundled tailscaled) set IP_MTU_DISCOVER early in
-         * connect and abort on -ENOPROTOOPT. macOS has no direct
-         * equivalent; accept the option, cache the Linux PMTUD mode for
-         * getsockopt round-trip, and where the host can honour it, push
-         * the closest IP_DONTFRAG setting onto the underlying socket.
-         * Linux PMTUD modes:
+         * Tailscale's bundled tailscaled) set IP_MTU_DISCOVER early in connect
+         * and abort on -ENOPROTOOPT. macOS has no direct equivalent; accept the
+         * option, cache the Linux PMTUD mode for getsockopt round-trip, and
+         * where the host can honour it, push the closest IP_DONTFRAG setting
+         * onto the underlying socket. Linux PMTUD modes:
          *   0 DONT  / 1 WANT  -> allow fragmentation (DONTFRAG off)
          *   2 DO   / 3 PROBE  / 4 INTERFACE -> set DF (DONTFRAG on)
          *   5 OMIT -> behave like DONT (best-effort)
@@ -872,8 +871,8 @@ int64_t sys_setsockopt(guest_t *g,
         return 0;
     }
     if (level == LINUX_IPPROTO_IP && optname == LINUX_IP_RECVERR) {
-        /* No macOS equivalent for the Linux extended-error queue. Accept
-         * and discard; the queue stays empty, so subsequent recvmsg with
+        /* No macOS equivalent for the Linux extended-error queue. Accept and
+         * discard; the queue stays empty, so subsequent recvmsg with
          * MSG_ERRQUEUE returns -EAGAIN as Linux would for a quiescent
          * connection.
          */
@@ -939,8 +938,8 @@ int64_t sys_setsockopt(guest_t *g,
     } else if (level == LINUX_IPPROTO_IP) {
         mac_level = IPPROTO_IP;
         mac_optname = translate_ip_sockopt_to_mac(optname);
-        /* IP_MTU_DISCOVER and IP_RECVERR are handled by the early return
-         * above (before host_fd_ref_open), so they never reach here.
+        /* IP_MTU_DISCOVER and IP_RECVERR are handled by the early return above
+         * (before host_fd_ref_open), so they never reach here.
          */
         if (mac_optname < 0) {
             host_fd_ref_close(&host_ref);
@@ -981,8 +980,8 @@ setsockopt_translated:
         /* Linux accepts shorter optlen for many int-valued options and
          * zero-extends the value. macOS rejects optlen < sizeof(int) with
          * EINVAL (notably for IP_TOS / IP_TTL / IP_PKTINFO / IP_RECVTTL /
-         * IP_RECVTOS). The value has already been zero-extended into an int,
-         * so always call the host with sizeof(int).
+         * IP_RECVTOS). The value has already been zero-extended into an int, so
+         * always call the host with sizeof(int).
          */
         if (setsockopt(host_ref.fd, mac_level, mac_optname, &value,
                        sizeof(value)) < 0) {
@@ -1019,9 +1018,9 @@ setsockopt_translated:
     return 0;
 }
 
-/* Mirrors Linux ip_sockglue copyval: when an IP-level getsockopt has a
- * caller buffer shorter than int and the int-sized value fits in a byte,
- * report and write a single byte. Otherwise leaves actual_len untouched.
+/* Mirrors Linux ip_sockglue copyval: when an IP-level getsockopt has a caller
+ * buffer shorter than int and the int-sized value fits in a byte, report and
+ * write a single byte. Otherwise leaves actual_len untouched.
  */
 static inline uint32_t ip_copyval_clamp(int level,
                                         uint32_t guest_optlen,
@@ -1046,10 +1045,10 @@ int64_t sys_getsockopt(guest_t *g,
         0)
         return -LINUX_EFAULT;
 
-    /* SO_PEERCRED: synthesize struct ucred from guest identity.
-     * macOS has LOCAL_PEERCRED but returns a different struct; we fabricate
-     * the Linux ucred with the guest's own PID/UID/GID, which is correct
-     * for AF_UNIX sockets within the same elfuse instance.
+    /* SO_PEERCRED: synthesize struct ucred from guest identity. macOS has
+     * LOCAL_PEERCRED but returns a different struct; fabricate the Linux ucred
+     * with the guest's own PID/UID/GID, which is correct for AF_UNIX sockets
+     * within the same elfuse instance.
      */
     if (level == LINUX_SOL_SOCKET && optname == LINUX_SO_PEERCRED) {
         if (!net_socket_fd_is_valid(fd))
@@ -1151,8 +1150,8 @@ int64_t sys_getsockopt(guest_t *g,
     } else if (level == LINUX_IPPROTO_IP) {
         mac_level = IPPROTO_IP;
         mac_optname = translate_ip_sockopt_to_mac(optname);
-        /* IP_MTU_DISCOVER and IP_RECVERR are handled by the early return
-         * above (before host_fd_ref_open), so they never reach here.
+        /* IP_MTU_DISCOVER and IP_RECVERR are handled by the early return above
+         * (before host_fd_ref_open), so they never reach here.
          */
         if (mac_optname < 0) {
             host_fd_ref_close(&host_ref);
@@ -1227,10 +1226,10 @@ getsockopt_translated:
         return linux_errno();
     }
 
-    /* SO_TYPE: macOS returns the raw socket type. On Linux, getsockopt
-     * SO_TYPE returns the base type without SOCK_NONBLOCK/SOCK_CLOEXEC
-     * flags, and the numeric values happen to match (SOCK_STREAM=1,
-     * SOCK_DGRAM=2, SOCK_RAW=3). Strip any flag bits for safety.
+    /* SO_TYPE: macOS returns the raw socket type. On Linux, getsockopt SO_TYPE
+     * returns the base type without SOCK_NONBLOCK/SOCK_CLOEXEC flags, and the
+     * numeric values happen to match (SOCK_STREAM=1, SOCK_DGRAM=2, SOCK_RAW=3).
+     * Strip any flag bits for safety.
      */
     if (level == LINUX_SOL_SOCKET && optname == LINUX_SO_TYPE &&
         mac_optlen >= (socklen_t) sizeof(int)) {
@@ -1248,10 +1247,10 @@ getsockopt_translated:
         }
     }
 
-    /* Write option value, truncating to guest buffer size if needed.
-     * Write back actual length (not truncated) per Linux semantics: Linux
-     * getsockopt returns the real option size so the caller can detect
-     * truncation and retry with a larger buffer.
+    /* Write option value, truncating to guest buffer size if needed. Write back
+     * actual length (not truncated) per Linux semantics: Linux getsockopt
+     * returns the real option size so the caller can detect truncation and
+     * retry with a larger buffer.
      */
     uint32_t actual_len = (uint32_t) mac_optlen, write_len = actual_len;
     if (write_len > guest_optlen)

--- a/src/syscall/net.h
+++ b/src/syscall/net.h
@@ -6,8 +6,8 @@
  *
  * Translates Linux socket syscalls into macOS equivalents, handling the
  * differences in address family constants, sockaddr layout (sa_len byte),
- * socket option constants, and flag encoding (SOCK_NONBLOCK/SOCK_CLOEXEC
- * packed into the type argument).
+ * socket option constants, and flag encoding (SOCK_NONBLOCK/SOCK_CLOEXEC packed
+ * into the type argument).
  */
 
 #pragma once
@@ -173,8 +173,10 @@ int64_t sys_recvmmsg(guest_t *g,
 /* Initialize netlink subsystem. Called from syscall_init(). */
 void netlink_init(void);
 
-/* Create a synthetic netlink socket fd. Returns guest fd, or negative errno.
- * Only NETLINK_ROUTE is supported; others return -EAFNOSUPPORT.
+/* Create a synthetic netlink socket fd.
+ *
+ * Returns guest fd, or negative errno. Only NETLINK_ROUTE is supported; others
+ * return -EAFNOSUPPORT.
  */
 int64_t netlink_socket(int protocol, int type);
 

--- a/src/syscall/netlink.c
+++ b/src/syscall/netlink.c
@@ -4,10 +4,10 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Emulates Linux NETLINK_ROUTE sockets so that glibc's getifaddrs()
- * works. macOS has no AF_NETLINK; netlink emulation synthesizes responses by
- * querying the host via getifaddrs(3) and formatting into Linux netlink message
- * headers (struct nlmsghdr, struct ifinfomsg, struct ifaddrmsg, etc.).
+ * Emulates Linux NETLINK_ROUTE sockets so that glibc's getifaddrs() works.
+ * macOS has no AF_NETLINK; netlink emulation synthesizes responses by querying
+ * the host via getifaddrs(3) and formatting into Linux netlink message headers
+ * (struct nlmsghdr, struct ifinfomsg, struct ifaddrmsg, etc.).
  *
  * Supported operations:
  *   socket(AF_NETLINK, SOCK_RAW|SOCK_DGRAM, NETLINK_ROUTE) -> synthetic fd
@@ -36,9 +36,8 @@
 
 static void netlink_close(int guest_fd);
 
-/* Linux netlink message structures.
- * These structures are defined manually to match the Linux ABI exactly,
- * since macOS has no <linux/netlink.h>.
+/* Linux netlink message structures. These structures are defined manually to
+ * match the Linux ABI exactly, since macOS has no <linux/netlink.h>.
  */
 
 /* Netlink message header (struct nlmsghdr) */
@@ -64,9 +63,9 @@ typedef struct {
 #define RTM_NEWLINK 16
 #define RTM_NEWADDR 20
 
-/* NLM_F_* flags. Only NLM_F_MULTI is set on synthesized replies; the
- * dump-style request flags (NLM_F_ROOT|NLM_F_MATCH) are recognized in the
- * request but never echoed back, so they have no constants here.
+/* NLM_F_* flags. Only NLM_F_MULTI is set on synthesized replies; the dump-style
+ * request flags (NLM_F_ROOT|NLM_F_MATCH) are recognized in the request but
+ * never echoed back, so they have no constants here.
  */
 #define NLM_F_MULTI 0x02
 
@@ -223,8 +222,8 @@ static int nl_build_getlink(netlink_state_t *ns)
         if (nseen < 64)
             seen[nseen++] = idx;
 
-        /* Build message: nlmsghdr + ifinfomsg + attributes.
-         * Check minimum space before advancing off.
+        /* Build message: nlmsghdr + ifinfomsg + attributes. Check minimum space
+         * before advancing off.
          */
         size_t min_msg = NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(ifinfomsg_t));
         if (off + min_msg > max)
@@ -252,8 +251,8 @@ static int nl_build_getlink(netlink_state_t *ns)
         n = nl_put_attr(buf + off, max - off, IFLA_MTU, &mtu, 4);
         off += n;
 
-        /* Backfill nlmsghdr now that nlmsg_len is known (header is reserved
-         * at msg_start; attributes were written after it).
+        /* Backfill nlmsghdr now that nlmsg_len is known (header is reserved at
+         * msg_start; attributes were written after it).
          */
         nlmsghdr_t hdr = {
             .nlmsg_len = (uint32_t) (off - msg_start),
@@ -579,8 +578,8 @@ int64_t netlink_recvmsg(int guest_fd, guest_t *g, uint64_t msg_gva, int flags)
     size_t avail = ns->buf_len - ns->buf_pos;
     size_t to_copy = (avail < iov.iov_len) ? avail : iov.iov_len;
 
-    /* Return complete netlink messages only. Walk from buf_pos to find
-     * the last complete message that fits in the buffer.
+    /* Return complete netlink messages only. Walk from buf_pos to find the last
+     * complete message that fits in the buffer.
      */
     size_t msg_end = 0, pos = ns->buf_pos;
     while (pos < ns->buf_len && (pos - ns->buf_pos + NLMSG_HDRLEN) <= to_copy) {
@@ -595,8 +594,9 @@ int64_t netlink_recvmsg(int guest_fd, guest_t *g, uint64_t msg_gva, int flags)
     }
 
     if (msg_end == 0) {
-        /* Buffer too small for even one message. Return what fits
-         * with MSG_TRUNC semantics
+        /* Buffer too small for even one message.
+         *
+         * Return what fits with MSG_TRUNC semantics
          */
         msg_end = to_copy;
     }

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -148,12 +148,11 @@ int path_translate_at(guest_fd_t dirfd,
         return -1;
     }
 
-    /* Only the fields read on the no-rewrite fast path need explicit
-     * defaults; proc_path / guest_buf / host_buf are read-after-written
-     * by their respective resolvers. memset of all three 4 KiB buffers
-     * would add ~12 KiB of zeroing per call, which became visible at
-     * ~30 calls per dynamic-linker startup after the sidecar caches
-     * dropped the rest of the openat overhead.
+    /* Only the fields read on the no-rewrite fast path need explicit defaults;
+     * proc_path / guest_buf / host_buf are read-after-written by their
+     * respective resolvers. memset of all three 4 KiB buffers would add ~12 KiB
+     * of zeroing per call, which became visible at ~30 calls per dynamic-linker
+     * startup after the sidecar caches dropped the rest of the openat overhead.
      */
     tx->guest_path = path;
     tx->intercept_path = path;
@@ -755,10 +754,9 @@ int path_openat2_resolved_within_root(guest_fd_t dirfd,
     return 0;
 }
 
-/* Mount-class taxonomy used by RESOLVE_NO_XDEV. Distinct return values
- * mean distinct logical filesystems from the guest's perspective. FUSE
- * mounts encode mount_id into the high bits so two distinct FUSE mounts
- * compare unequal.
+/* Mount-class taxonomy used by RESOLVE_NO_XDEV. Distinct return values mean
+ * distinct logical filesystems from the guest's perspective. FUSE mounts encode
+ * mount_id into the high bits so two distinct FUSE mounts compare unequal.
  */
 #define PATH_MOUNT_ROOT 0
 #define PATH_MOUNT_PROC 1
@@ -766,12 +764,11 @@ int path_openat2_resolved_within_root(guest_fd_t dirfd,
 #define PATH_MOUNT_SYS 3
 #define PATH_MOUNT_TMP 4
 #define PATH_MOUNT_DEV_SHM 5
-/* fuse_next_mount_id is a monotonic int starting at 100 (see fuse.c).
- * The base is sized well clear of any realistic mount_id so the four
- * non-FUSE classes never collide with the FUSE class numbers even after
- * hundreds of millions of mount cycles. mount_id values that ever do
- * approach this bound would represent a runtime that long outlived
- * elfuse's intended lifetime.
+/* fuse_next_mount_id is a monotonic int starting at 100 (see fuse.c). The base
+ * is sized well clear of any realistic mount_id so the four non-FUSE classes
+ * never collide with the FUSE class numbers even after hundreds of millions of
+ * mount cycles. mount_id values that ever do approach this bound would
+ * represent a runtime that long outlived elfuse's intended lifetime.
  */
 #define PATH_MOUNT_FUSE_BASE 0x10000000
 
@@ -925,11 +922,11 @@ bool path_openat2_is_fd_magiclink_anchor(guest_fd_t dirfd, const char *path)
            normalized_proc_self_fd_anchor(normalized);
 }
 
-/* Pop one trailing component from an absolute path, refusing to drop
- * below the supplied floor length. floor_len is strlen of the walk root
- * (1 == "/" for the bare-absolute case, dirfd-base length for IN_ROOT
- * resolution). At the floor the path is left unchanged, matching Linux's
- * ".." at "/" semantics and RESOLVE_IN_ROOT's clamp-at-dirfd rule.
+/* Pop one trailing component from an absolute path, refusing to drop below the
+ * supplied floor length. floor_len is strlen of the walk root (1 == "/" for the
+ * bare-absolute case, dirfd-base length for IN_ROOT resolution). At the floor
+ * the path is left unchanged, matching Linux's ".." at "/" semantics and
+ * RESOLVE_IN_ROOT's clamp-at-dirfd rule.
  */
 static void guest_path_pop(char *current, size_t floor_len)
 {
@@ -1035,11 +1032,11 @@ int path_openat2_crosses_mount(guest_fd_t dirfd,
 
     /* The walk has to track every intermediate prefix because lexical
      * collapsing of ".." would erase a transient mount crossing (e.g.
-     * "/proc/self/../../tmp" passes through /proc before the upward
-     * components apply, and Linux NO_XDEV detects that). The start frame
-     * matches how the kernel anchors resolution: absolute paths begin at
-     * "/" regardless of dirfd; relative paths and RESOLVE_IN_ROOT begin at
-     * the dirfd's tracked guest path.
+     * "/proc/self/../../tmp" passes through /proc before the upward components
+     * apply, and Linux NO_XDEV detects that). The start frame matches how the
+     * kernel anchors resolution: absolute paths begin at "/" regardless of
+     * dirfd; relative paths and RESOLVE_IN_ROOT begin at the dirfd's tracked
+     * guest path.
      */
     if (path[0] == '/' && !in_root) {
         current[0] = '/';
@@ -1048,11 +1045,11 @@ int path_openat2_crosses_mount(guest_fd_t dirfd,
         goto out;
     }
 
-    /* IN_ROOT clamps ".." at dirfd; outside IN_ROOT the walker can
-     * traverse up to "/" so a transition like /proc/1 -> /proc -> /
-     * surfaces as the expected cross. The floor matches whichever rule
-     * applies so the precheck never out-rejects the actual resolution
-     * that follows in path_openat2_normalize_in_root.
+    /* IN_ROOT clamps ".." at dirfd; outside IN_ROOT the walker can traverse up
+     * to "/" so a transition like /proc/1 -> /proc -> / surfaces as the
+     * expected cross. The floor matches whichever rule applies so the precheck
+     * never out-rejects the actual resolution that follows in
+     * path_openat2_normalize_in_root.
      */
     size_t floor_len = in_root ? strlen(current) : 1;
 

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -70,34 +70,32 @@ int path_openat2_resolved_within_root(guest_fd_t dirfd,
                                       const char *path,
                                       uint64_t oflags,
                                       bool in_root);
-/* Returns 1 if resolving path against dirfd would cross a mount boundary
- * from the guest's perspective, 0 if it stays inside the same logical
- * filesystem, and -1 with errno set on dirfd lookup failures. Mount
- * classes are: regular guest filesystem, /proc, /dev, /sys, /tmp,
- * /dev/shm, and each live or tombstoned FUSE mount (keyed by mount_id).
- * The walker classifies every intermediate prefix as it advances, so
- * transient excursions through /proc that lexically resolve back into
- * the root class still surface as a crossing. Symlink components are
- * expanded inline against the host-walk fd when possible so a link
- * whose target lives in a different class is caught at the precheck.
+/* Returns 1 if resolving path against dirfd would cross a mount boundary from
+ * the guest's perspective, 0 if it stays inside the same logical filesystem,
+ * and -1 with errno set on dirfd lookup failures. Mount classes are: regular
+ * guest filesystem, /proc, /dev, /sys, /tmp, /dev/shm, and each live or
+ * tombstoned FUSE mount (keyed by mount_id). The walker classifies every
+ * intermediate prefix as it advances, so transient excursions through /proc
+ * that lexically resolve back into the root class still surface as a crossing.
+ * Symlink components are expanded inline against the host-walk fd when possible
+ * so a link whose target lives in a different class is caught at the precheck.
  *
- * When out_start_class is non-NULL it is populated with the dirfd's
- * mount class on every non-error return so the caller can re-run the
- * check against the actually opened fd via path_openat2_check_fd_xdev.
- * The post-open check is what closes the symlink bypass for callers
- * that do not also set RESOLVE_NO_SYMLINKS: the precheck's fstatat
- * walk cannot see symlinks that live in a sidecar shadow directory
- * (case-fold sysroot), so the kernel may follow a link the walker did
- * not, and only F_GETPATH on the resulting fd reveals the real
- * landing site.
+ * When out_start_class is non-NULL it is populated with the dirfd's mount class
+ * on every non-error return so the caller can re-run the check against the
+ * actually opened fd via path_openat2_check_fd_xdev. The post-open check is
+ * what closes the symlink bypass for callers that do not also set
+ * RESOLVE_NO_SYMLINKS: the precheck's fstatat walk cannot see symlinks that
+ * live in a sidecar shadow directory (case-fold sysroot), so the kernel may
+ * follow a link the walker did not, and only F_GETPATH on the resulting fd
+ * reveals the real landing site.
  *
  * Known gaps (best-effort by design):
- *  - host_path_to_guest_path strips the configured sysroot prefix with
+ * - host_path_to_guest_path strips the configured sysroot prefix with
  *    a case-sensitive strncmp; on case-insensitive macOS volumes a
  *    differently-cased F_GETPATH could fail to strip and the dirfd is
  *    then classified as the root class. Sysroots that happen to live
  *    under /proc, /dev, or /sys on the host are not supported.
- *  - A sibling vCPU that chdir(2)s, dup3(2)s over dirfd, or mounts /
+ * - A sibling vCPU that chdir(2)s, dup3(2)s over dirfd, or mounts /
  *    unmounts a FUSE filesystem between this check and the subsequent
  *    sys_openat may shift the resolution into a different mount class
  *    without the cross being detected. The race window is narrow and
@@ -108,14 +106,14 @@ int path_openat2_crosses_mount(guest_fd_t dirfd,
                                bool in_root,
                                int *out_start_class);
 
-/* Post-open verification for RESOLVE_NO_XDEV. Reads the host-side
- * canonical path of the just-opened guest fd via fcntl(F_GETPATH),
- * strips the sysroot prefix, and classifies the result against the
- * start class captured by path_openat2_crosses_mount. Returns 1 if
- * the resolved fd sits in a different mount class than the resolution
- * started in, 0 if it stays in the same class, -1 with errno set on
+/* Post-open verification for RESOLVE_NO_XDEV. Reads the host-side canonical
+ * path of the just-opened guest fd via fcntl(F_GETPATH), strips the sysroot
+ * prefix, and classifies the result against the start class captured by
+ * path_openat2_crosses_mount.
+ *
+ * Returns 1 if the resolved fd sits in a different mount class than the
+ * resolution started in, 0 if it stays in the same class, -1 with errno set on
  * lookup failures (e.g. fd closed, F_GETPATH refused). Catches the
- * symlink-driven crossings that the string-only precheck misses by
- * design.
+ * symlink-driven crossings that the string-only precheck misses by design.
  */
 int path_openat2_check_fd_xdev(int guest_fd, int start_class);

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * ppoll, pselect6, and epoll (emulated via macOS kqueue). All functions
- * are called from syscall_dispatch() in syscall/syscall.c.
+ * ppoll, pselect6, and epoll (emulated via macOS kqueue). All functions are
+ * called from syscall_dispatch() in syscall/syscall.c.
  */
 
 #include <stdbool.h>
@@ -182,10 +182,10 @@ int64_t sys_ppoll(guest_t *g,
         mask_installed = true;
     }
 
-    /* For indefinite polls, add the wakeup pipe so exit_group can
-     * interrupt threads blocked in host poll(). Without this, threads
-     * in poll(timeout=-1) cannot be interrupted by hv_vcpus_exit()
-     * because they're not in hv_vcpu_run().
+    /* For indefinite polls, add the wakeup pipe so exit_group can interrupt
+     * threads blocked in host poll(). Without this, threads in poll(timeout=-1)
+     * cannot be interrupted by hv_vcpus_exit() because they're not in
+     * hv_vcpu_run().
      */
     bool added_wakeup = false;
     if (timeout_ms < 0 && wakeup_pipe_rd >= 0 && nfds < 256) {
@@ -205,6 +205,7 @@ int64_t sys_ppoll(guest_t *g,
         poll_timeout_ms = 0;
 
     int ret;
+ppoll_retry:
     do {
         ret = poll(host_fds, nfds + added_wakeup,
                    poll_timeout_ms < 0 ? 200 : poll_timeout_ms);
@@ -222,9 +223,9 @@ int64_t sys_ppoll(guest_t *g,
          */
     } while (ret == 0 && poll_timeout_ms < 0);
 
-    /* POSIX poll() ignores entries with fd < 0 and resets revents to 0,
-     * so re-stamp POLLNVAL on the invalid slots and credit them to the
-     * return count.
+    /* POSIX poll() ignores entries with fd < 0 and resets revents to 0, so
+     * re-stamp POLLNVAL on the invalid slots and credit them to the return
+     * count.
      */
     if (ret >= 0 && invalid_count > 0) {
         for (uint32_t i = 0; i < nfds; i++)
@@ -244,6 +245,8 @@ int64_t sys_ppoll(guest_t *g,
             ;
         if (ret > 0)
             ret--;
+        if (ret == 0 && poll_timeout_ms < 0)
+            goto ppoll_retry;
     }
 
     /* Restore original signal mask */
@@ -284,8 +287,8 @@ int64_t sys_pselect6(guest_t *g,
                      uint64_t timeout_gva,
                      uint64_t sigmask_gva)
 {
-    /* pselect6 atomically sets the signal mask during the wait, then
-     * restores it. The sixth argument is a pointer to a struct:
+    /* pselect6 atomically sets the signal mask during the wait, then restores
+     * it. The sixth argument is a pointer to a struct:
      *   { const sigset_t *ss; size_t ss_len; }
      */
     if (nfds < 0 || nfds > FD_SETSIZE)
@@ -424,10 +427,9 @@ int64_t sys_pselect6(guest_t *g,
         ts.tv_nsec = lts.tv_nsec;
     }
 
-    /* Apply signal mask atomically around the select.
-     * Linux pselect6 arg6 points to { sigset_t *ss; size_t ss_len }.
-     * Save the current blocked mask, apply the new one, do the select, then
-     * restore the original mask.
+    /* Apply signal mask atomically around the select. Linux pselect6 arg6
+     * points to { sigset_t *ss; size_t ss_len }. Save the current blocked mask,
+     * apply the new one, do the select, then restore the original mask.
      */
     uint64_t saved_blocked = 0;
     bool mask_applied = false;
@@ -492,6 +494,10 @@ int64_t sys_pselect6(guest_t *g,
 
     int ret;
     bool poll_wakeup_fired = false;
+pselect_retry:
+    poll_wakeup_fired = false;
+    for (int i = 0; i < req_count; i++)
+        reqs[i].revents = 0;
     do {
         if (!has_timeout) {
             if (read_setp)
@@ -573,6 +579,8 @@ int64_t sys_pselect6(guest_t *g,
             FD_CLR(wakeup_pipe_rd, &read_set);
         if (ret > 0)
             ret--;
+        if (ret == 0 && !has_timeout)
+            goto pselect_retry;
     }
 
     /* Restore original signal mask */
@@ -657,9 +665,9 @@ pselect_cleanup:
 
 /* epoll emulation via kqueue
  *
- * Linux epoll is emulated using macOS kqueue. Each epoll_create1() creates
- * a kqueue fd. epoll_ctl translates to kevent() calls. epoll_pwait translates
- * to kevent() with timeout.
+ * Linux epoll is emulated using macOS kqueue. Each epoll_create1() creates a
+ * kqueue fd. epoll_ctl translates to kevent() calls. epoll_pwait translates to
+ * kevent() with timeout.
  *
  * Limitations:
  *   - EPOLLEXCLUSIVE not supported (rare, for load balancing)
@@ -707,9 +715,9 @@ typedef struct {
                           */
 } epoll_reg_t;
 
-/* Per-epoll-instance data, stored in fd_table[epfd].dir. Each instance
- * has its own registration table so multiple epoll instances watching
- * the same FD do not overwrite each other's user data.
+/* Per-epoll-instance data, stored in fd_table[epfd].dir. Each instance has its
+ * own registration table so multiple epoll instances watching the same FD do
+ * not overwrite each other's user data.
  */
 typedef struct {
     epoll_reg_t regs[FD_TABLE_SIZE];
@@ -797,7 +805,8 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      * separate fd_to_host()) keeps the validate and the ident read atomic under
      * one fd_lock. The snapshot's generation then guards the cross-call ABA
      * below. Result mapping uses udata (the guest fd), so the ident only needs
-     * to stay open and refer to the same open file description. */
+     * to stay open and refer to the same open file description.
+     */
     fd_entry_t target_snap;
     if (!fd_snapshot(fd, &target_snap)) {
         host_fd_ref_close(&epoll_ref);
@@ -813,7 +822,8 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      * number -- and thus reg->active -- still looks live. Acting on it would
      * EV_DELETE/EV_MOD the wrong knote on the reused host fd. A mismatched
      * generation means the registration is gone: drop it so DEL/MOD report
-     * ENOENT (matching Linux's auto-removal on close) and ADD starts fresh. */
+     * ENOENT (matching Linux's auto-removal on close) and ADD starts fresh.
+     */
     if ((reg->active || reg->oneshot_armed) &&
         reg->generation != target_snap.generation) {
         reg->active = false;
@@ -854,8 +864,8 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     }
 
     /* Linux semantics: ADD fails with EEXIST if already registered; MOD fails
-     * with ENOENT if not registered. oneshot_armed registrations
-     * (EPOLLONESHOT fired, waiting for re-arm) are still valid for MOD.
+     * with ENOENT if not registered. oneshot_armed registrations (EPOLLONESHOT
+     * fired, waiting for re-arm) are still valid for MOD.
      */
     if (op == LINUX_EPOLL_CTL_ADD && reg->active) {
         host_fd_ref_close(&epoll_ref);
@@ -876,12 +886,12 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     /* For MOD, remove old registrations first if they exist in kqueue.
      * EPOLLRDHUP alone registers EVFILT_READ (see ADD path), so check both
      * EPOLLIN and EPOLLRDHUP (same logic as CTL_DEL). Always attempt the
-     * deletes even when oneshot_armed: with multi-filter EPOLLONESHOT, only
-     * the filter that fired was removed by EV_ONESHOT; the other filter is
-     * still registered and must be cleaned. Issue each delete in its own
-     * kevent call so an ENOENT on one filter does not abort the other --
-     * with a single batched call and NULL eventlist, kevent stops at the
-     * first failed change and leaks the survivor.
+     * deletes even when oneshot_armed: with multi-filter EPOLLONESHOT, only the
+     * filter that fired was removed by EV_ONESHOT; the other filter is still
+     * registered and must be cleaned. Issue each delete in its own kevent call
+     * so an ENOENT on one filter does not abort the other -- with a single
+     * batched call and NULL eventlist, kevent stops at the first failed change
+     * and leaks the survivor.
      */
     if (op == LINUX_EPOLL_CTL_MOD && reg->active) {
         struct kevent del;
@@ -937,10 +947,10 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         }
     }
 
-    /* Store registration data in per-instance table.
-     * Clear oneshot_armed when MOD successfully re-arms. Stamp the snapshot's
-     * generation so a later close+reopen of this guest fd is detected as a
-     * stale registration by the ABA guard above.
+    /* Store registration data in per-instance table. Clear oneshot_armed when
+     * MOD successfully re-arms. Stamp the snapshot's generation so a later
+     * close+reopen of this guest fd is detected as a stale registration by the
+     * ABA guard above.
      */
     reg->events = ev.events;
     reg->data = ev.data;
@@ -998,8 +1008,9 @@ int64_t sys_epoll_pwait(guest_t *g,
         ts.tv_nsec = (timeout_ms % 1000) * 1000000L;
     }
 
-    /* For indefinite waits, register the wakeup pipe with the kqueue
-     * so exit_group can interrupt threads blocked in kevent().
+epoll_retry:;
+    /* For indefinite waits, register the wakeup pipe with the kqueue so
+     * exit_group can interrupt threads blocked in kevent().
      */
     bool added_wakeup = false;
     if (!has_timeout && wakeup_pipe_rd >= 0) {
@@ -1056,6 +1067,8 @@ int64_t sys_epoll_pwait(guest_t *g,
                 i--;
             }
         }
+        if (nready == 0 && !has_timeout)
+            goto epoll_retry;
     }
 
     /* Restore original signal mask after the blocking wait */
@@ -1069,9 +1082,9 @@ int64_t sys_epoll_pwait(guest_t *g,
     }
 
     /* Merge kevent results into epoll_event results. Multiple kevents for the
-     * same fd (READ + WRITE) merge into one epoll_event.
-     * Use guest FD (not user data) as the merge key, since two different FDs
-     * could legitimately share the same epoll_data value.
+     * same fd (READ + WRITE) merge into one epoll_event. Use guest FD (not user
+     * data) as the merge key, since two different FDs could legitimately share
+     * the same epoll_data value.
      */
     linux_epoll_event_t out[256];
     /* Parallel array tracking which guest FD each output entry represents. */
@@ -1086,8 +1099,8 @@ int64_t sys_epoll_pwait(guest_t *g,
         if (!RANGE_CHECK(gfd, 0, FD_TABLE_SIZE) || !inst->regs[gfd].active)
             continue;
 
-        /* EPOLLONESHOT semantics: once any event fired and was reported, the
-         * fd stays disarmed until EPOLL_CTL_MOD re-arms it. With multi-filter
+        /* EPOLLONESHOT semantics: once any event fired and was reported, the fd
+         * stays disarmed until EPOLL_CTL_MOD re-arms it. With multi-filter
          * registrations (e.g. EPOLLIN | EPOLLOUT), EV_ONESHOT only removed the
          * filter that fired; surviving filters can still fire later and would
          * be reported here without this guard.
@@ -1112,9 +1125,9 @@ int64_t sys_epoll_pwait(guest_t *g,
         epoll_merge_event(&out[idx], &kevents[i], reg);
     }
 
-    /* Mark EPOLLONESHOT FDs as armed (fired but waiting for MOD re-arm).
-     * kqueue already removed the event (EV_ONESHOT), so poll emulation marks
-     * the registration as oneshot_armed to allow MOD but prevent further event
+    /* Mark EPOLLONESHOT FDs as armed (fired but waiting for MOD re-arm). kqueue
+     * already removed the event (EV_ONESHOT), so poll emulation marks the
+     * registration as oneshot_armed to allow MOD but prevent further event
      * reporting until re-armed.
      */
     for (int i = 0; i < nout; i++) {

--- a/src/syscall/poll.h
+++ b/src/syscall/poll.h
@@ -36,10 +36,10 @@ int64_t sys_epoll_pwait(guest_t *g,
                         int timeout_ms,
                         uint64_t sigmask_gva);
 
-/* Global wakeup pipe for interrupting blocking poll/select/epoll.
- * When exit_group or futex_interrupt is requested, write to
- * wakeup_pipe_wr to unblock any thread stuck in a host-side
- * poll/select/kevent with infinite timeout.
+/* Global wakeup pipe for interrupting blocking poll/select/epoll. When
+ * exit_group or futex_interrupt is requested, write to wakeup_pipe_wr to
+ * unblock any thread stuck in a host-side poll/select/kevent with infinite
+ * timeout.
  */
 void wakeup_pipe_init(void);
 void wakeup_pipe_signal(void);

--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -32,9 +32,9 @@ static bool shim_blob_owned = false;
 /* Current ELF and launcher paths. */
 static char elf_path[LINUX_PATH_MAX] = {0};
 static char elfuse_path[LINUX_PATH_MAX] = {0};
-/* Serializes proc_set_elf_path against readers that consume the string.
- * Without this, an execve on one vCPU can tear the buffer underneath a
- * sibling vCPU resolving /proc/self/exe.
+/* Serializes proc_set_elf_path against readers that consume the string. Without
+ * this, an execve on one vCPU can tear the buffer underneath a sibling vCPU
+ * resolving /proc/self/exe.
  */
 static pthread_mutex_t elf_path_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -47,8 +47,8 @@ static uint8_t auxv_buf[1024] = {0};
 static size_t auxv_len = 0;
 static char sysroot_path[LINUX_PATH_MAX] = {0};
 
-/* Serializes proc_set_sysroot against path-helper snapshots. Without this,
- * a sibling vCPU running chroot during another vCPU's path resolution can tear
+/* Serializes proc_set_sysroot against path-helper snapshots. Without this, a
+ * sibling vCPU running chroot during another vCPU's path resolution can tear
  * the snprintf input buffer underneath that thread.
  */
 static pthread_mutex_t sysroot_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -264,10 +264,10 @@ void proc_set_elf_path(const char *path)
     pthread_mutex_unlock(&elf_path_lock);
 }
 
-/* Returns the elf_path buffer pointer. Boolean-test callers tolerate the
- * racy read since the first byte transitions atomically. Callers that
- * consume the string content must use proc_elf_path_snapshot() to avoid
- * a torn read against a concurrent proc_set_elf_path().
+/* Returns the elf_path buffer pointer. Boolean-test callers tolerate the racy
+ * read since the first byte transitions atomically. Callers that consume the
+ * string content must use proc_elf_path_snapshot() to avoid a torn read against
+ * a concurrent proc_set_elf_path().
  */
 const char *proc_get_elf_path(void)
 {
@@ -463,10 +463,10 @@ static bool sysroot_path_is_contained(const char *resolved_path,
     } else {
         const char *base = strrchr(resolved_path, '/');
         /* "." and ".." basenames navigate the directory tree and cannot
-         * themselves be symlinks, so realpath the full path: appending
-         * the literal basename onto realpath(parent) would let
-         * "${sysroot}/x/.." pass the prefix check while the kernel
-         * resolves the syscall target above sysroot.
+         * themselves be symlinks, so realpath the full path: appending the
+         * literal basename onto realpath(parent) would let "${sysroot}/x/.."
+         * pass the prefix check while the kernel resolves the syscall target
+         * above sysroot.
          */
         if (base && (!strcmp(base + 1, "..") || !strcmp(base + 1, "."))) {
             if (!realpath(resolved_path, real_path))
@@ -477,12 +477,11 @@ static bool sysroot_path_is_contained(const char *resolved_path,
 
             str_copy_trunc(parent, resolved_path, sizeof(parent));
             slash = strrchr(parent, '/');
-            /* resolved_path is always ${sysroot}${guest_path} where sysroot
-             * is non-empty (caller short-circuits otherwise) and guest_path
-             * starts with '/'. The result therefore contains at least two
-             * '/' bytes, so the basename slash is never at parent[0].
-             * Reject anything that violates the invariant rather than
-             * carrying dead code for it.
+            /* resolved_path is always ${sysroot}${guest_path} where sysroot is
+             * non-empty (caller short-circuits otherwise) and guest_path starts
+             * with '/'. The result therefore contains at least two '/' bytes,
+             * so the basename slash is never at parent[0]. Reject anything that
+             * violates the invariant rather than carrying dead code for it.
              */
             if (!slash || slash == parent)
                 return false;
@@ -610,8 +609,8 @@ const char *proc_resolve_sysroot_create_path(const char *path,
 
     /* access() failed for a reason other than "parent missing" (e.g. EACCES,
      * ELOOP, ENAMETOOLONG, EIO). Treating those as "parent absent" would let
-     * the redirect logic auto-create or silently fall back to the host
-     * literal, which can bypass sysroot resolution. Surface the real error.
+     * the redirect logic auto-create or silently fall back to the host literal,
+     * which can bypass sysroot resolution. Surface the real error.
      */
     if (errno != ENOENT && errno != ENOTDIR)
         return NULL;

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -4,10 +4,10 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Owns all static process state: guest PID/PPID, shim blob reference,
- * ELF path, command line, and the process table for tracking fork
- * children. Provides accessor functions for modules that need this
- * state (forkipc.c, syscall/exec.c, procemu.c).
+ * Owns all static process state: guest PID/PPID, shim blob reference, ELF path,
+ * command line, and the process table for tracking fork children. Provides
+ * accessor functions for modules that need this state (forkipc.c,
+ * syscall/exec.c, procemu.c).
  *
  * Also contains wait4, waitid, and the vCPU run loop.
  */
@@ -55,17 +55,17 @@ static _Atomic uint64_t wxcount_to_rx = 0; /* RW->RX (exec fault) */
 static _Atomic uint64_t wxcount_to_rw = 0; /* RX->RW (write fault) */
 static _Atomic uint64_t sysreg_write_count =
     0; /* EC=0x18 Dir=0 (DC CVAU, IC IVAU, etc.) */
-/* x86_64-via-Rosetta is on by default: the architecture is auto-detected
- * from the ELF header (EM_X86_64), and rosetta is the only viable path for
- * those binaries on Apple Silicon. The --no-rosetta CLI flag (or
- * ELFUSE_NO_ROSETTA=1) disables it; without rosetta installed, the rosetta
- * loader fails its access() check and surfaces an install hint regardless.
+/* x86_64-via-Rosetta is on by default: the architecture is auto-detected from
+ * the ELF header (EM_X86_64), and rosetta is the only viable path for those
+ * binaries on Apple Silicon. The --no-rosetta CLI flag (or ELFUSE_NO_ROSETTA=1)
+ * disables it; without rosetta installed, the rosetta loader fails its access()
+ * check and surfaces an install hint regardless.
  */
 static _Atomic bool rosetta_enabled = true;
-/* Runtime indicator: distinct from rosetta_enabled (user opt-in). Set when
- * the active guest_t is actually running under rosetta, so callers without
- * direct guest_t access (proc_intercept_readlink, log paths) can branch on
- * runtime state without threading g through every signature.
+/* Runtime indicator: distinct from rosetta_enabled (user opt-in). Set when the
+ * active guest_t is actually running under rosetta, so callers without direct
+ * guest_t access (proc_intercept_readlink, log paths) can branch on runtime
+ * state without threading g through every signature.
  */
 static _Atomic bool rosetta_active = false;
 
@@ -76,9 +76,9 @@ static pthread_mutex_t pid_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 6 */
 static pthread_cond_t pid_cond =
     PTHREAD_COND_INITIALIZER; /* Signaled on child exit */
 
-/* Global flag for exit_group: signals all threads to terminate.
- * Atomic to avoid undefined behavior under C11 memory model when
- * multiple threads read/write concurrently.
+/* Global flag for exit_group: signals all threads to terminate. Atomic to avoid
+ * undefined behavior under C11 memory model when multiple threads read/write
+ * concurrently.
  */
 static _Atomic int exit_group_requested = 0;
 
@@ -248,9 +248,11 @@ int64_t proc_alloc_pid(void)
     return pid;
 }
 
-/* Try to reap exited children from the process table. Calls waitpid
- * with WNOHANG on each active entry; entries whose host process has
- * exited are freed. Returns the number of slots reclaimed.
+/* Try to reap exited children from the process table. Calls waitpid with
+ * WNOHANG on each active entry; entries whose host process has exited are
+ * freed.
+ *
+ * Returns the number of slots reclaimed.
  */
 static int proc_reap_finished(void)
 {
@@ -369,10 +371,10 @@ int proc_get_child_pids(pid_t *out, int max_pids)
     }
     pthread_mutex_unlock(&pid_lock);
 
-    /* Recursively collect descendants via proc_listchildpids.
-     * Orphaned grandchildren (PPID=1) are not found this way, so also
-     * check all host processes with the current elfuse binary name.  This is
-     * O(n_procs) but /proc/net reads are infrequent.
+    /* Recursively collect descendants via proc_listchildpids. Orphaned
+     * grandchildren (PPID=1) are not found this way, so also check all host
+     * processes with the current elfuse binary name. This is O(n_procs) but
+     * /proc/net reads are infrequent.
      */
     pid_t all_pids[4096];
     int n = proc_listpids(PROC_ALL_PIDS, 0, all_pids, sizeof(all_pids));
@@ -418,10 +420,9 @@ int64_t sys_ptrace(guest_t *g,
 {
     switch (request) {
     case LINUX_PTRACE_SEIZE: {
-        /* Attach to target thread without stopping it. The tracee
-         * can later be stopped via PTRACE_INTERRUPT or BRK-induced
-         * ptrace-stop. Unlike PTRACE_ATTACH, SEIZE does not send
-         * SIGSTOP.
+        /* Attach to target thread without stopping it. The tracee can later be
+         * stopped via PTRACE_INTERRUPT or BRK-induced ptrace-stop. Unlike
+         * PTRACE_ATTACH, SEIZE does not send SIGSTOP.
          */
         thread_entry_t *target = thread_find(pid);
         if (!target)
@@ -435,8 +436,8 @@ int64_t sys_ptrace(guest_t *g,
     }
 
     case LINUX_PTRACE_CONT: {
-        /* Resume a stopped tracee, optionally injecting a signal.
-         * data = signal to inject (0 = none).
+        /* Resume a stopped tracee, optionally injecting a signal. data = signal
+         * to inject (0 = none).
          */
         thread_entry_t *target = thread_find(pid);
         if (!target || !target->ptraced)
@@ -449,9 +450,9 @@ int64_t sys_ptrace(guest_t *g,
     }
 
     case LINUX_PTRACE_INTERRUPT: {
-        /* Force a running tracee into ptrace-stop. Uses hv_vcpus_exit
-         * to break the tracee out of hv_vcpu_run; the tracee will then
-         * enter ptrace-stop in its HV_EXIT_REASON_CANCELED handler.
+        /* Force a running tracee into ptrace-stop. Uses hv_vcpus_exit to break
+         * the tracee out of hv_vcpu_run; the tracee will then enter ptrace-stop
+         * in its HV_EXIT_REASON_CANCELED handler.
          */
         thread_entry_t *target = thread_find(pid);
         if (!target || !target->ptraced)
@@ -464,8 +465,8 @@ int64_t sys_ptrace(guest_t *g,
     }
 
     case LINUX_PTRACE_GETREGSET: {
-        /* Read tracee registers via iovec. addr = NT_PRSTATUS (1),
-         * data = guest pointer to linux iovec_t {base, len}.
+        /* Read tracee registers via iovec. addr = NT_PRSTATUS (1), data = guest
+         * pointer to linux iovec_t {base, len}.
          */
         if (addr != LINUX_NT_PRSTATUS)
             return -LINUX_EINVAL;
@@ -496,8 +497,8 @@ int64_t sys_ptrace(guest_t *g,
     }
 
     case LINUX_PTRACE_SETREGSET: {
-        /* Write tracee registers via iovec. addr = NT_PRSTATUS (1),
-         * data = guest pointer to linux iovec_t {base, len}.
+        /* Write tracee registers via iovec. addr = NT_PRSTATUS (1), data =
+         * guest pointer to linux iovec_t {base, len}.
          */
         if (addr != LINUX_NT_PRSTATUS)
             return -LINUX_EINVAL;
@@ -534,9 +535,9 @@ int64_t sys_ptrace(guest_t *g,
     }
 }
 
-/* Write a macOS struct rusage to guest memory as linux_rusage_t.
- * Field layout matches on LP64, but ru_maxrss must be converted
- * from macOS bytes to Linux kilobytes.
+/* Write a macOS struct rusage to guest memory as linux_rusage_t. Field layout
+ * matches on LP64, but ru_maxrss must be converted from macOS bytes to Linux
+ * kilobytes.
  */
 _Static_assert(sizeof(struct rusage) == sizeof(linux_rusage_t),
                "host and guest rusage layouts must match on LP64");
@@ -574,8 +575,8 @@ int64_t sys_wait4(guest_t *g,
             }
             return ptrace_tid;
         }
-        /* ptrace_tid == 0: no matching children or WNOHANG; fall through
-         * to the process table for regular fork children.
+        /* ptrace_tid == 0: no matching children or WNOHANG; fall through to the
+         * process table for regular fork children.
          */
     }
 
@@ -591,10 +592,10 @@ int64_t sys_wait4(guest_t *g,
     pthread_mutex_lock(&pid_lock);
 
     if (pid == -1) {
-        /* Wait for any child.  Always poll with WNOHANG first so wait4
-         * does not block on one specific child while another exits.  If
-         * blocking (no WNOHANG) and no child is ready, sleep briefly
-         * and retry; this gives correct "wait for any" semantics.
+        /* Wait for any child. Always poll with WNOHANG first so wait4 does not
+         * block on one specific child while another exits. If blocking (no
+         * WNOHANG) and no child is ready, sleep briefly and retry; this gives
+         * correct "wait for any" semantics.
          */
         for (;;) {
             bool found_any_child = false;
@@ -633,8 +634,7 @@ int64_t sys_wait4(guest_t *g,
                         int32_t linux_status = status;
                         if (guest_write_small(g, status_gva, &linux_status,
                                               sizeof(linux_status)) < 0) {
-                            /* Child already reaped. Match Linux: return
-                             * EFAULT
+                            /* Child already reaped. Match Linux: return EFAULT
                              */
                             pthread_mutex_lock(&pid_lock);
                             if (proc_table[slot].active &&
@@ -673,11 +673,11 @@ int64_t sys_wait4(guest_t *g,
                 return 0;
             }
 
-            /* Blocking mode: no child exited yet.  Wait on condvar for
-             * a child exit notification (signaled by proc_mark_child_exited).
-             * Use timedwait with 100ms timeout as a safety net; the condvar
-             * handles normal exits, the timeout catches edge cases where
-             * the host wait4 detects exit before proc_mark_child_exited.
+            /* Blocking mode: no child exited yet. Wait on condvar for a child
+             * exit notification (signaled by proc_mark_child_exited). Use
+             * timedwait with 100ms timeout as a safety net; the condvar handles
+             * normal exits, the timeout catches edge cases where the host wait4
+             * detects exit before proc_mark_child_exited.
              */
             struct timespec ts;
             timespec_deadline_in_ms(&ts, 100);
@@ -782,8 +782,8 @@ int64_t sys_waitid(guest_t *g,
                    uint64_t infop_gva,
                    int options)
 {
-    /* Translate options: Linux WEXITED=4, WNOHANG=1, WSTOPPED=2,
-     * WCONTINUED=8, WNOWAIT=0x01000000
+    /* Translate options: Linux WEXITED=4, WNOHANG=1, WSTOPPED=2, WCONTINUED=8,
+     * WNOWAIT=0x01000000
      */
 #define LINUX_WNOWAIT 0x01000000
     int mac_options = 0;
@@ -818,10 +818,10 @@ int64_t sys_waitid(guest_t *g,
         return -LINUX_EINVAL;
     }
 
-    /* Search process table for matching entry.  P_ALL must scan all
-     * children (not block on the first non-exited one), so the wait loop always
-     * use WNOHANG in the inner loop and retry with timedwait if the
-     * caller requested blocking.
+    /* Search process table for matching entry. P_ALL must scan all children
+     * (not block on the first non-exited one), so the wait loop always use
+     * WNOHANG in the inner loop and retry with timedwait if the caller
+     * requested blocking.
      */
     pthread_mutex_lock(&pid_lock);
     for (;;) {
@@ -850,8 +850,8 @@ int64_t sys_waitid(guest_t *g,
                 pthread_mutex_unlock(&pid_lock);
                 ret = waitpid(host_pid, &status, WNOHANG);
                 if (ret == 0) {
-                    /* This child hasn't exited yet; continue checking
-                     * others (P_ALL must scan all children).
+                    /* This child hasn't exited yet; continue checking others
+                     * (P_ALL must scan all children).
                      */
                     pthread_mutex_lock(&pid_lock);
                     continue;
@@ -895,9 +895,9 @@ int64_t sys_waitid(guest_t *g,
                 }
             }
 
-            /* Keep the table entry when WNOWAIT is set.
-             * Re-validate slot after re-locking (another thread may have
-             * reused it while the wait loop released the lock for waitpid).
+            /* Keep the table entry when WNOWAIT is set. Re-validate slot after
+             * re-locking (another thread may have reused it while the wait loop
+             * released the lock for waitpid).
              */
             if (!(options & LINUX_WNOWAIT) && proc_table[i].active &&
                 proc_table[i].host_pid == ret)
@@ -914,8 +914,8 @@ int64_t sys_waitid(guest_t *g,
 
         if (mac_options & WNOHANG) {
             pthread_mutex_unlock(&pid_lock);
-            /* Per POSIX/Linux: zero siginfo when WNOHANG returns with
-             * no waitable children, so callers can distinguish via si_pid.
+            /* Per POSIX/Linux: zero siginfo when WNOHANG returns with no
+             * waitable children, so callers can distinguish via si_pid.
              */
             if (infop_gva) {
                 uint8_t zeros[SIGINFO_SIZE] = {0};
@@ -944,8 +944,8 @@ void proc_request_hvc6_yield(void)
  * signal handlers cannot receive context parameters).
  */
 /* Written once by vcpu_run_loop before signal(SIGALRM), then only read by
- * alarm_handler / guest_signal_transport_handler. The write happens-before
- * the signal() call that installs the handlers, so no volatile needed.
+ * alarm_handler / guest_signal_transport_handler. The write happens-before the
+ * signal() call that installs the handlers, so no volatile needed.
  */
 static hv_vcpu_t g_timeout_vcpu;
 static volatile sig_atomic_t g_timed_out, g_external_guest_signal;
@@ -1015,9 +1015,9 @@ static void drain_external_guest_signal(void)
     }
 }
 
-/* HVC #4 (set sysreg) register index -> hv_sys_reg_t mapping.
- * Index must match the encoding the shim writes to X0 in shim.S; out-of-range
- * IDs trip the HVC #4 default branch in vcpu_run_loop().
+/* HVC #4 (set sysreg) register index -> hv_sys_reg_t mapping. Index must match
+ * the encoding the shim writes to X0 in shim.S; out-of-range IDs trip the HVC
+ * #4 default branch in vcpu_run_loop().
  */
 static const hv_sys_reg_t hvc4_sysregs[] = {
     HV_SYS_REG_VBAR_EL1,  /* 0 */
@@ -1033,16 +1033,16 @@ static const hv_sys_reg_t hvc4_sysregs[] = {
 
 /* Unified vCPU execution loop for both main and worker threads.
  *
- * When timeout_sec > 0 (main thread): uses alarm() for per-iteration
- * safety timeout, logs with "elfuse:" prefix.
+ * When timeout_sec > 0 (main thread): uses alarm() for per-iteration safety
+ * timeout, logs with "elfuse:" prefix.
  *
- * When timeout_sec == 0 (worker thread): skips alarm() setup (SIGALRM
- * is process-wide and would conflict). Workers are terminated by
- * exit_group setting proc_exit_group_requested and calling hv_vcpus_exit()
- * to cancel pending hv_vcpu_run calls. Logs with "elfuse: worker" prefix.
+ * When timeout_sec == 0 (worker thread): skips alarm() setup (SIGALRM is
+ * process-wide and would conflict). Workers are terminated by exit_group
+ * setting proc_exit_group_requested and calling hv_vcpus_exit() to cancel
+ * pending hv_vcpu_run calls. Logs with "elfuse: worker" prefix.
  *
- * Both modes check proc_exit_group_requested so the main thread also reacts
- * to exit_group called by a worker.
+ * Both modes check proc_exit_group_requested so the main thread also reacts to
+ * exit_group called by a worker.
  */
 int vcpu_run_loop(hv_vcpu_t vcpu,
                   hv_vcpu_exit_t *vexit,
@@ -1056,18 +1056,18 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
     const int is_main = (timeout_sec > 0);
     const char *prefix = is_main ? "elfuse" : "elfuse: worker";
 
-    /* Pin vCPU thread to a performance core via QoS class.
-     * On Apple Silicon, USER_INTERACTIVE maps to P-cores, avoiding
-     * E-core migration that causes measurable jank in HVF workloads.
+    /* Pin vCPU thread to a performance core via QoS class. On Apple Silicon,
+     * USER_INTERACTIVE maps to P-cores, avoiding E-core migration that causes
+     * measurable jank in HVF workloads.
      */
     pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
 
     install_guest_signal_transport();
 
-    /* Main thread: set up alarm-based per-iteration timeout.
-     * Guest ITIMER_REAL is emulated internally by signal_check_timer()
-     * rather than using host setitimer, because macOS shares alarm()
-     * and setitimer(ITIMER_REAL) as the same underlying timer.
+    /* Main thread: set up alarm-based per-iteration timeout. Guest ITIMER_REAL
+     * is emulated internally by signal_check_timer() rather than using host
+     * setitimer, because macOS shares alarm() and setitimer(ITIMER_REAL) as the
+     * same underlying timer.
      */
     if (is_main) {
         g_timeout_vcpu = vcpu;
@@ -1164,13 +1164,13 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                      * the flag back to zero so the identity fast path
                      * re-engages for the next getpid loop. Without this clear,
                      * the attention flag set by signal_queue (e.g., on a
-                     * subprocess's SIGCHLD) would stick forever and
-                     * permanently disable the fast path.
+                     * subprocess's SIGCHLD) would stick forever and permanently
+                     * disable the fast path.
                      */
                     shim_globals_recompute_attention(g);
 
-                    /* Diagnostic: log signal state after exec/sigreturn
-                     * to help debug signal delivery issues.
+                    /* Diagnostic: log signal state after exec/sigreturn to help
+                     * debug signal delivery issues.
                      */
                     if (ret == SYSCALL_EXEC_HAPPENED && verbose) {
                         const signal_state_t *ss = signal_get_state();
@@ -1193,9 +1193,9 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                     }
 
                     /* After exec, verify critical registers before resuming
-                     * vCPU. This closes any gap where signal delivery or
-                     * other code between sys_execve's sync flush and
-                     * hv_vcpu_run could have modified ELR_EL1.
+                     * vCPU. This closes any gap where signal delivery or other
+                     * code between sys_execve's sync flush and hv_vcpu_run
+                     * could have modified ELR_EL1.
                      */
                     if (running && ret == SYSCALL_EXEC_HAPPENED) {
                         uint64_t verify_elr;
@@ -1228,8 +1228,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 }
 
                 case 4: {
-                    /* HVC #4: Set system register (from shim).
-                     * X0 = reg index into hvc4_sysregs, X1 = value.
+                    /* HVC #4: Set system register (from shim). X0 = reg index
+                     * into hvc4_sysregs, X1 = value.
                      */
                     uint64_t reg_id, value;
                     hv_vcpu_get_reg(vcpu, HV_REG_X0, &reg_id);
@@ -1252,10 +1252,11 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 }
 
                 case 7: {
-                    /* HVC #7: MRS trap emulation. Guest EL0 code read a
-                     * system register. Extract the register encoding from
-                     * ESR_EL1's ISS field and read it via HVF. Return
-                     * value in X0 for the shim to store into the saved
+                    /* HVC #7: MRS trap emulation. Guest EL0 code read a system
+                     * register. Extract the register encoding from ESR_EL1's
+                     * ISS field and read it via HVF.
+                     *
+                     * Return value in X0 for the shim to store into the saved
                      * register frame.
                      */
                     uint64_t esr;
@@ -1282,14 +1283,14 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                     uint64_t value = 0;
 
                     /* ID register emulation: return VZ-sanitized values
-                     * matching a real VZ (Lima) VM BEFORE trying HVF.
-                     * HVF's hv_vcpu_get_sys_reg succeeds for ID registers
-                     * but returns raw hardware values, which include
-                     * features the hypervisor does not actually virtualize.
+                     * matching a real VZ (Lima) VM BEFORE trying HVF. HVF's
+                     * hv_vcpu_get_sys_reg succeeds for ID registers but returns
+                     * raw hardware values, which include features the
+                     * hypervisor does not actually virtualize.
                      *
-                     * Values captured from a Lima VZ VM on Apple Silicon
-                     * via inline MRS from EL0 (kernel trap-and-emulate).
-                     * These are checked first, before the HVF call.
+                     * Values captured from a Lima VZ VM on Apple Silicon via
+                     * inline MRS from EL0 (kernel trap-and-emulate). These are
+                     * checked first, before the HVF call.
                      */
                     bool have_vz_override = false;
 
@@ -1299,9 +1300,9 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                         value = 0x00000111ff000000ULL;
                         have_vz_override = true;
                     }
-                    /* ID_AA64MMFR1_EL1 (3,0,0,7,1): VZ returns 0.
-                     * Raw hardware (e.g., 0x11212000) exposes HPDS, PAN,
-                     * LO, XNX etc. that VZ does not virtualize.
+                    /* ID_AA64MMFR1_EL1 (3,0,0,7,1): VZ returns 0. Raw hardware
+                     * (e.g., 0x11212000) exposes HPDS, PAN, LO, XNX etc. that
+                     * VZ does not virtualize.
                      */
                     if (op0 == 3 && op1 == 0 && crn == 0 && crm == 7 &&
                         op2 == 1) {
@@ -1357,9 +1358,9 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                          */
                         bool have_fallback = false;
 
-                        /* CNTFRQ_EL0 (3,3,14,0,0): counter frequency.
-                         * Read directly from host hardware (Apple Silicon
-                         * uses 24MHz).
+                        /* CNTFRQ_EL0 (3,3,14,0,0): counter frequency. Read
+                         * directly from host hardware (Apple Silicon uses
+                         * 24MHz).
                          */
                         if (op0 == 3 && op1 == 3 && crn == 14 && crm == 0 &&
                             op2 == 0) {
@@ -1368,9 +1369,9 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                             have_fallback = true;
                         }
 
-                        /* Non-ID register fallbacks for registers
-                         * that HVF does not expose. ID registers are
-                         * handled above (VZ overrides).
+                        /* Non-ID register fallbacks for registers that HVF does
+                         * not expose. ID registers are handled above (VZ
+                         * overrides).
                          */
 
                         if (verbose) {
@@ -1405,23 +1406,21 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 case 9: {
                     /* HVC #9: W^X page permission toggle for JIT.
                      *
-                     * Apple HVF enforces W^X: pages cannot be both writable
-                     * and executable simultaneously. JIT code needs to be
-                     * written (RW), then executed (RX). The shim
-                     * detects permission faults (EC=0x20 instruction abort,
-                     * EC=0x24 data abort) and forwards the faulting address
-                     * here.
+                     * Apple HVF enforces W^X: pages cannot be both writable and
+                     * executable simultaneously. JIT code needs to be written
+                     * (RW), then executed (RX). The shim detects permission
+                     * faults (EC=0x20 instruction abort, EC=0x24 data abort)
+                     * and forwards the faulting address here.
                      *
                      * Toggling at 2MiB granularity causes thrashing when the
-                     * JIT writes new code and executes existing code within
-                     * the same 2MiB block. Instead, the code splits the 2MiB
-                     * block into 4KiB L3 pages and toggle only the faulting
-                     * 4KiB page. This allows different pages within a 2MiB
-                     * block to have independent RW/RX permissions
-                     * simultaneously.
+                     * JIT writes new code and executes existing code within the
+                     * same 2MiB block. Instead, the code splits the 2MiB block
+                     * into 4KiB L3 pages and toggle only the faulting 4KiB
+                     * page. This allows different pages within a 2MiB block to
+                     * have independent RW/RX permissions simultaneously.
                      *
-                     * x0 = FAR_EL1 (faulting virtual address)
-                     * x1 = type: 0 = exec fault -> flip to RX
+                     * x0 = FAR_EL1 (faulting virtual address) x1 = type: 0 =
+                     * exec fault -> flip to RX
                      *            1 = write fault -> flip to RW
                      */
                     uint64_t far, type;
@@ -1432,17 +1431,17 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                     uint64_t page_end = page_start + 4096;
                     int new_perms = (type == 0) ? MEM_PERM_RX : MEM_PERM_RW;
 
-                    /* Hold mmap_lock for page table modifications AND
-                     * region lookups to prevent races with concurrent
+                    /* Hold mmap_lock for page table modifications AND region
+                     * lookups to prevent races with concurrent
                      * mmap/mprotect/munmap from other vCPU threads.
                      */
                     pthread_mutex_lock(&mmap_lock);
 
-                    /* Check if this is a genuine permission violation
-                     * (not a W^X toggle).  If the guest region lacks
-                     * the required permission, deliver SIGSEGV instead
-                     * of toggling.  This handles mprotect(PROT_READ),
-                     * SHM_RDONLY, PROT_NONE, and non-exec pages.
+                    /* Check if this is a genuine permission violation (not a
+                     * W^X toggle). If the guest region lacks the required
+                     * permission, deliver SIGSEGV instead of toggling. This
+                     * handles mprotect(PROT_READ), SHM_RDONLY, PROT_NONE, and
+                     * non-exec pages.
                      */
                     {
                         uint64_t off = far - g->ipa_base;
@@ -1484,11 +1483,11 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                             "%s: W^X toggle FAILED "
                             "(split=%d update=%d) far=0x%llx",
                             prefix, sr, ur, (unsigned long long) far);
-                    /* TLB flush is done by the shim (tlbi_restore_eret) for
-                     * the single faulting page. Clear this thread's pending
-                     * request so the next syscall epilogue does not re-flush
-                     * the W^X page. cpu_tlbi_req is per-vCPU, so this only
-                     * touches our own slot -- concurrent vCPUs are unaffected.
+                    /* TLB flush is done by the shim (tlbi_restore_eret) for the
+                     * single faulting page. Clear this thread's pending request
+                     * so the next syscall epilogue does not re-flush the W^X
+                     * page. cpu_tlbi_req is per-vCPU, so this only touches our
+                     * own slot -- concurrent vCPUs are unaffected.
                      */
                     tlbi_request_clear();
                     break;
@@ -1531,8 +1530,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                                 running = false;
                         }
                     } else {
-                        /* Non-ptraced: deliver SIGTRAP via signal frame.
-                         * Read ESR_EL1 to include in sigcontext.
+                        /* Non-ptraced: deliver SIGTRAP via signal frame. Read
+                         * ESR_EL1 to include in sigcontext.
                          */
                         uint64_t brk_esr;
                         hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ESR_EL1, &brk_esr);
@@ -1573,10 +1572,10 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                      *   Other ECs from EL0           -> SIGILL (catch-all)
                      *
                      * For SIGSEGV, si_code is SEGV_MAPERR (translation fault)
-                     * or SEGV_ACCERR (permission fault) based on xFSC[5:2].
-                     * For SIGILL, si_code is ILL_ILLOPC (illegal opcode).
-                     * si_addr is FAR_EL1 for aborts, ELR_EL1 for SIGILL
-                     * (FAR_EL1 is UNKNOWN for EC=0 per ARM ARM).
+                     * or SEGV_ACCERR (permission fault) based on xFSC[5:2]. For
+                     * SIGILL, si_code is ILL_ILLOPC (illegal opcode). si_addr
+                     * is FAR_EL1 for aborts, ELR_EL1 for SIGILL (FAR_EL1 is
+                     * UNKNOWN for EC=0 per ARM ARM).
                      */
                     uint64_t esr, far_addr, elr_addr;
                     hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ESR_EL1, &esr);
@@ -1585,23 +1584,21 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
 
                     uint32_t fault_ec = (uint32_t) ((esr >> 26) & 0x3F);
 
-                    /* Non-abort EC -> SIGILL. Branch out early so the
-                     * abort / SIGSEGV path below stays at the case-body
-                     * indent rather than nested inside an else branch.
-                     * FAR_EL1 is UNKNOWN for non-abort exceptions, so use
-                     * ELR_EL1 for si_addr.
+                    /* Non-abort EC -> SIGILL. Branch out early so the abort /
+                     * SIGSEGV path below stays at the case-body indent rather
+                     * than nested inside an else branch. FAR_EL1 is UNKNOWN for
+                     * non-abort exceptions, so use ELR_EL1 for si_addr.
                      *
-                     * Only EC 0x20 (instruction abort from a lower EL) and
-                     * EC 0x24 (data abort from a lower EL) are intentionally
+                     * Only EC 0x20 (instruction abort from a lower EL) and EC
+                     * 0x24 (data abort from a lower EL) are intentionally
                      * routed to the SIGSEGV path that follows. Every other
                      * forwarded EC -- 0x00 (undefined instruction), 0x18
-                     * (system instruction trap), 0x32/0x33 (software
-                     * step), 0x3C (BRK), and any unrecognized class --
-                     * lands here as SIGILL. If a future change adds a new
-                     * lower-EL abort class (e.g. 0x21 / 0x25 for higher
-                     * exception levels) that should map to SIGSEGV, the
-                     * test below needs explicit widening; do NOT relax
-                     * the check casually.
+                     * (system instruction trap), 0x32/0x33 (software step),
+                     * 0x3C (BRK), and any unrecognized class -- lands here as
+                     * SIGILL. If a future change adds a new lower-EL abort
+                     * class (e.g. 0x21 / 0x25 for higher exception levels) that
+                     * should map to SIGSEGV, the test below needs explicit
+                     * widening; do NOT relax the check casually.
                      */
                     if (fault_ec != 0x20 && fault_ec != 0x24) {
                         if (verbose)
@@ -1631,9 +1628,9 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                     }
 
                     /* Instruction or data abort. Try lazy page materialization
-                     * before declaring SIGSEGV: translation faults
-                     * (xFSC[5:2] == 0x1) may come from a MAP_NORESERVE region
-                     * with deferred page-table creation.
+                     * before declaring SIGSEGV: translation faults (xFSC[5:2]
+                     * == 0x1) may come from a MAP_NORESERVE region with
+                     * deferred page-table creation.
                      */
                     uint32_t fsc = (uint32_t) (esr & 0x3F);
                     uint32_t fsc_type = (fsc >> 2) & 0xF;
@@ -1644,25 +1641,25 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                         pthread_mutex_unlock(&mmap_lock);
                         if (mat == 0) {
                             /* Page materialized; the helpers inside
-                             * guest_materialize_lazy populated the
-                             * per-vCPU TLBI accumulator with the range
-                             * just installed (plus the I-cache hint if
-                             * the region's prot includes PROT_EXEC).
-                             * Drain it through the shared emit helper
-                             * so the shim's post-HVC-11 dispatch
-                             * (handle_el0_fault) actually issues the
-                             * TLBI before ERET. Without this, a PE that
-                             * caches translation-fault (negative)
-                             * entries would re-fault on the retry,
-                             * looping until the entry self-evicts. */
+                             * guest_materialize_lazy populated the per-vCPU
+                             * TLBI accumulator with the range just installed
+                             * (plus the I-cache hint if the region's prot
+                             * includes PROT_EXEC). Drain it through the shared
+                             * emit helper so the shim's post-HVC-11 dispatch
+                             * (handle_el0_fault) actually issues the TLBI
+                             * before ERET. Without this, a PE that caches
+                             * translation-fault (negative) entries would
+                             * re-fault on the retry, looping until the entry
+                             * self-evicts.
+                             */
                             tlbi_request_emit_to_vcpu(vcpu);
                             break;
                         }
                     }
 
-                    /* Real SIGSEGV. Permission faults (xFSC[5:2] == 0x3) map
-                     * to SEGV_ACCERR; address size, translation, and
-                     * access-flag faults map to SEGV_MAPERR for Linux.
+                    /* Real SIGSEGV. Permission faults (xFSC[5:2] == 0x3) map to
+                     * SEGV_ACCERR; address size, translation, and access-flag
+                     * faults map to SEGV_MAPERR for Linux.
                      */
                     int si_code = (fsc_type == 0x03) ? LINUX_SEGV_ACCERR
                                                      : LINUX_SEGV_MAPERR;
@@ -1684,11 +1681,11 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                     signal_queue(LINUX_SIGSEGV);
                     int sig_ret = signal_deliver(vcpu, g, &exit_code);
                     /* HVC #11 consumes X8 as the post-fault TLBI opcode.
-                     * signal_deliver() may leave it unchanged when no
-                     * handler is materialized, or set the syscall-path
-                     * frame-drop marker when one is. Neither is a TLBI
-                     * request here; lazy materialization emits its own
-                     * request and exits before this path.
+                     * signal_deliver() may leave it unchanged when no handler
+                     * is materialized, or set the syscall-path frame-drop
+                     * marker when one is. Neither is a TLBI request here; lazy
+                     * materialization emits its own request and exits before
+                     * this path.
                      */
                     hv_vcpu_set_reg(vcpu, HV_REG_X8, 0);
                     if (verbose)
@@ -1705,8 +1702,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                      * (DC CVAU, IC IVAU, etc.) here for logging/counting. It
                      * also passes the original Rt value in X0 so host-side
                      * emulation can handle MSR writes such as TPIDR_EL0. The
-                     * shim has already advanced PC and will restore X0 from
-                     * its saved frame before returning to EL0.
+                     * shim has already advanced PC and will restore X0 from its
+                     * saved frame before returning to EL0.
                      */
                     atomic_fetch_add(&sysreg_write_count, 1);
                     uint64_t rt_value = 0;
@@ -1722,10 +1719,10 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                     uint32_t op1 = (iss >> 14) & 0x7, crn = (iss >> 10) & 0xF;
                     uint32_t crm = (iss >> 1) & 0xF, rt = (iss >> 5) & 0x1F;
 
-                    /* TPIDR_EL0 (S3_3_C13_C0_2): userspace TLS base.
-                     * Static glibc writes this during early startup. HVF
-                     * traps the MSR, so Linux-compatible execution requires
-                     * reflecting the write into the virtual sysreg.
+                    /* TPIDR_EL0 (S3_3_C13_C0_2): userspace TLS base. Static
+                     * glibc writes this during early startup. HVF traps the
+                     * MSR, so Linux-compatible execution requires reflecting
+                     * the write into the virtual sysreg.
                      */
                     if (op0 == 3 && op1 == 3 && crn == 13 && crm == 0 &&
                         op2 == 2) {
@@ -1733,8 +1730,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                                                      rt_value));
                     }
                     if (verbose) {
-                        /* DC CVAU: Op0=1,Op1=3,CRn=7,CRm=11,Op2=1
-                         * IC IVAU: Op0=1,Op1=3,CRn=7,CRm=5,Op2=1
+                        /* DC CVAU: Op0=1,Op1=3,CRn=7,CRm=11,Op2=1 IC IVAU:
+                         * Op0=1,Op1=3,CRn=7,CRm=5,Op2=1
                          */
                         const char *name = "unknown";
                         if (op0 == 1 && op1 == 3 && crn == 7 && crm == 11 &&
@@ -1766,9 +1763,9 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 }
 
                 case 2: {
-                    /* HVC #2: Bad exception in guest.
-                     * Shim clobbers X0-X3,X5 with exception info.
-                     * X4,X6-X30 and SP_EL0 still hold faulting values.
+                    /* HVC #2: Bad exception in guest. Shim clobbers X0-X3,X5
+                     * with exception info. X4,X6-X30 and SP_EL0 still hold
+                     * faulting values.
                      */
                     uint64_t x0, x1, x2, x3, x5;
                     hv_vcpu_get_reg(vcpu, HV_REG_X0, &x0);
@@ -1823,11 +1820,11 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 }
 
                 case 6: {
-                    /* HVC #6: embedder extension hook.
-                     * X8 = call number, X0-X7 = arguments.
-                     * If a dispatch function is registered via
-                     * elfuse_set_hvc6_handler(), it is called here.
-                     * Otherwise falls through as a no-op. */
+                    /* HVC #6: embedder extension hook. X8 = call number, X0-X7
+                     * = arguments. If a dispatch function is registered via
+                     * elfuse_set_hvc6_handler(), it is called here. Otherwise
+                     * falls through as a no-op.
+                     */
                     if (g->hvc6_handler) {
                         uint64_t x8 = 0;
                         hv_vcpu_get_reg(vcpu, HV_REG_X8, &x8);
@@ -1858,26 +1855,25 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 }
                 }
             } else if (ec == 0x30 || ec == 0x32) {
-                /* EC=0x30: Hardware breakpoint from lower EL (EL0).
-                 * EC=0x32: Software step exception from lower EL.
-                 * Both are debug exceptions trapped to host via
+                /* EC=0x30: Hardware breakpoint from lower EL (EL0). EC=0x32:
+                 * Software step exception from lower EL. Both are debug
+                 * exceptions trapped to host via
                  * hv_vcpu_set_trap_debug_exceptions(). Forward to GDB.
                  *
-                 * TDE causes debug exceptions to bypass EL1 entirely
-                 * (EL0 -> EL2), so ELR_EL1 is NOT updated; it still
-                 * holds the stale value from the shim's last ERET.
-                 * Read the actual stop PC from HV_REG_PC and sync it
-                 * to ELR_EL1 so the GDB register snapshot sees the
-                 * correct value.
+                 * TDE causes debug exceptions to bypass EL1 entirely (EL0 ->
+                 * EL2), so ELR_EL1 is NOT updated; it still holds the stale
+                 * value from the shim's last ERET. Read the actual stop PC from
+                 * HV_REG_PC and sync it to ELR_EL1 so the GDB register snapshot
+                 * sees the correct value.
                  */
                 if (gdb_stub_is_active()) {
                     int reason =
                         (ec == 0x30) ? GDB_STOP_BREAKPOINT : GDB_STOP_STEP;
                     uint64_t stop_pc = vcpu_get_reg(vcpu, HV_REG_PC);
                     /* TDE routes debug exceptions EL0->EL2, bypassing EL1.
-                     * ELR_EL1 and SPSR_EL1 are NOT updated; sync them
-                     * from HV_REG_PC/HV_REG_CPSR so the GDB register
-                     * snapshot reads correct values.
+                     * ELR_EL1 and SPSR_EL1 are NOT updated; sync them from
+                     * HV_REG_PC/HV_REG_CPSR so the GDB register snapshot reads
+                     * correct values.
                      */
                     vcpu_set_sysreg(vcpu, HV_SYS_REG_ELR_EL1, stop_pc);
                     vcpu_set_sysreg(vcpu, HV_SYS_REG_SPSR_EL1,
@@ -1895,12 +1891,11 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                               prefix, ec);
                 }
             } else if (ec == 0x34 || ec == 0x35) {
-                /* EC=0x34: Watchpoint from lower EL (EL0, data abort).
-                 * EC=0x35: Watchpoint from current EL (shouldn't happen).
-                 * Same TDE bypass as breakpoints: ELR_EL1 and FAR_EL1
-                 * are stale because the exception went EL0->EL2. Use
-                 * HV_REG_PC for the stop PC and vexit->exception for
-                 * the watched address.
+                /* EC=0x34: Watchpoint from lower EL (EL0, data abort). EC=0x35:
+                 * Watchpoint from current EL (shouldn't happen). Same TDE
+                 * bypass as breakpoints: ELR_EL1 and FAR_EL1 are stale because
+                 * the exception went EL0->EL2. Use HV_REG_PC for the stop PC
+                 * and vexit->exception for the watched address.
                  */
                 if (gdb_stub_is_active()) {
                     uint64_t wp_pc = vcpu_get_reg(vcpu, HV_REG_PC);
@@ -1942,14 +1937,14 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 running = false;
             }
         } else if (vexit->reason == HV_EXIT_REASON_CANCELED) {
-            /* Canceled by hv_vcpus_exit(). Can be: alarm timeout,
-             * exit_group from another thread, or signal preemption
-             * (signal_queue called hv_vcpus_exit to deliver a signal
-             * while the guest was in a tight loop).
+            /* Canceled by hv_vcpus_exit(). Can be: alarm timeout, exit_group
+             * from another thread, or signal preemption (signal_queue called
+             * hv_vcpus_exit to deliver a signal while the guest was in a tight
+             * loop).
              */
             if (is_main && g_timed_out) {
-                /* Timeout already handled above the exception switch --
-                 * loop back so the timeout check fires.
+                /* Timeout already handled above the exception switch -- loop
+                 * back so the timeout check fires.
                  */
                 continue;
             }
@@ -1958,8 +1953,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 break;
             }
 
-            /* GDB stub: if GDB requested a stop (Ctrl+C or another thread
-             * hit a breakpoint), enter GDB stop state.
+            /* GDB stub: if GDB requested a stop (Ctrl+C or another thread hit a
+             * breakpoint), enter GDB stop state.
              */
             if (gdb_stub_stop_requested()) {
                 if (verbose)
@@ -1971,8 +1966,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
             }
 
             /* PTRACE_INTERRUPT: if this thread is ptraced and not already
-             * stopped, enter ptrace-stop so the tracer can inspect state.
-             * This handles hv_vcpus_exit from sys_ptrace PTRACE_INTERRUPT.
+             * stopped, enter ptrace-stop so the tracer can inspect state. This
+             * handles hv_vcpus_exit from sys_ptrace PTRACE_INTERRUPT.
              */
             if (current_thread->ptraced && !current_thread->ptrace_stopped) {
                 if (verbose)
@@ -1987,8 +1982,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 continue;
             }
 
-            /* rseq preemption abort: mirrors Linux rseq_ip_fixup() on
-             * context switch.
+            /* rseq preemption abort: mirrors Linux rseq_ip_fixup() on context
+             * switch.
              */
             if (current_thread->rseq_gva != 0) {
                 uint64_t cur_pc;
@@ -2007,23 +2002,23 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
             /* Check guest ITIMER_REAL (may have fired during tight loop) */
             signal_check_timer();
 
-            /* Signal preemption: if a signal is pending, deliver it and
-             * resume the vCPU. This enables alarm()/SIGALRM delivery
-             * and tgkill-based signals in compute-bound loops.
+            /* Signal preemption: if a signal is pending, deliver it and resume
+             * the vCPU. This enables alarm()/SIGALRM delivery and tgkill-based
+             * signals in compute-bound loops.
              */
             if (signal_pending()) {
                 int sig_ret = signal_deliver(vcpu, g, &exit_code);
                 if (sig_ret < 0)
                     running = false;
-                /* sig_ret >= 0: signal delivered or nothing pending,
-                 * loop back and resume vCPU execution
+                /* sig_ret >= 0: signal delivered or nothing pending, loop back
+                 * and resume vCPU execution
                  */
                 continue;
             }
 
-            /* Fork quiesce barrier: if a sibling is performing a fork
-             * snapshot, block here until the snapshot is complete. This
-             * prevents torn memory snapshots in multithreaded guests.
+            /* Fork quiesce barrier: if a sibling is performing a fork snapshot,
+             * block here until the snapshot is complete. This prevents torn
+             * memory snapshots in multithreaded guests.
              */
             if (thread_fork_barrier_check())
                 continue;

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -43,13 +43,13 @@ int proc_cwd_refresh(void);
 void proc_cwd_set_virtual(const char *path);
 void proc_cwd_invalidate(void);
 
-/* Store shim blob pointer/size (called from main.c at startup).
- * Avoids #including shim_blob.h in this module.
+/* Store shim blob pointer/size (called from main.c at startup). Avoids
+ * #including shim_blob.h in this module.
  */
 void proc_set_shim(const unsigned char *blob, unsigned int len);
 
-/* Like proc_set_shim but takes ownership of the malloc'd blob.
- * Used by fork_child_main which allocates the blob from IPC.
+/* Like proc_set_shim but takes ownership of the malloc'd blob. Used by
+ * fork_child_main which allocates the blob from IPC.
  */
 void proc_set_shim_owned(unsigned char *blob, unsigned int len);
 
@@ -57,25 +57,29 @@ void proc_set_shim_owned(unsigned char *blob, unsigned int len);
 const unsigned char *proc_get_shim_blob(void);
 unsigned int proc_get_shim_size(void);
 
-/* Store the current ELF binary path for /proc/self/exe emulation.
- * Called from main.c at startup and after execve.
+/* Store the current ELF binary path for /proc/self/exe emulation. Called from
+ * main.c at startup and after execve.
  */
 void proc_set_elf_path(const char *path);
 
-/* Get the stored ELF binary path. Returns NULL if not set. The returned
- * pointer references shared mutable state and is safe only for boolean
- * tests; callers that consume the string must use proc_elf_path_snapshot.
+/* Get the stored ELF binary path.
+ *
+ * Returns NULL if not set. The returned pointer references shared mutable state
+ * and is safe only for boolean tests; callers that consume the string must use
+ * proc_elf_path_snapshot.
  */
 const char *proc_get_elf_path(void);
 
-/* Copy the stored ELF binary path into out. Returns true on success, false
- * if no path is set or outsz is too small. Locked against concurrent
- * proc_set_elf_path() so the returned content is consistent.
+/* Copy the stored ELF binary path into out.
+ *
+ * Returns true on success, false if no path is set or outsz is too small.
+ * Locked against concurrent proc_set_elf_path() so the returned content is
+ * consistent.
  */
 bool proc_elf_path_snapshot(char *out, size_t outsz);
 
-/* Store the absolute path of the elfuse binary itself.  Used to spawn
- * fork/clone children.  Set once at startup via _NSGetExecutablePath().
+/* Store the absolute path of the elfuse binary itself. Used to spawn fork/clone
+ * children. Set once at startup via _NSGetExecutablePath().
  */
 void proc_set_elfuse_path(const char *path);
 
@@ -87,36 +91,36 @@ void proc_set_rosetta_enabled(bool enabled);
 bool proc_rosetta_enabled(void);
 
 /* Runtime indicator: true once the guest_t has been initialized in rosetta
- * mode. Distinct from proc_rosetta_enabled which reflects the user opt-in.
- * Code paths that lack direct guest_t access (proc_intercept_readlink) can
- * branch on the runtime state without threading g through every signature.
+ * mode. Distinct from proc_rosetta_enabled which reflects the user opt-in. Code
+ * paths that lack direct guest_t access (proc_intercept_readlink) can branch on
+ * the runtime state without threading g through every signature.
  */
 void proc_set_rosetta_active(bool active);
 bool proc_rosetta_active(void);
 
-/* Store the guest command line for /proc/self/cmdline emulation.
- * argv is a NULL-terminated array of strings.
+/* Store the guest command line for /proc/self/cmdline emulation. argv is a
+ * NULL-terminated array of strings.
  */
 void proc_set_cmdline(int argc, const char **argv);
 
-/* Set cmdline from a raw pre-formatted buffer (NUL-separated args).
- * Used by fork_child_main to restore parent's cmdline from IPC.
+/* Set cmdline from a raw pre-formatted buffer (NUL-separated args). Used by
+ * fork_child_main to restore parent's cmdline from IPC.
  */
 void proc_set_cmdline_raw(const char *buf, size_t len);
 
 /* Get the stored cmdline buffer and its length. Returns NULL if not set. */
 const char *proc_get_cmdline(size_t *len_out);
 
-/* Store the guest environment for /proc/self/environ emulation.
- * envp is a NULL-terminated array of "KEY=val" strings.
+/* Store the guest environment for /proc/self/environ emulation. envp is a
+ * NULL-terminated array of "KEY=val" strings.
  */
 void proc_set_environ(const char **envp);
 
 /* Get the stored environ buffer (NUL-separated). Returns NULL if not set. */
 const char *proc_get_environ(size_t *len_out);
 
-/* Store the guest auxiliary vector for /proc/self/auxv emulation.
- * data is the raw auxv key-value pairs as pushed on the stack.
+/* Store the guest auxiliary vector for /proc/self/auxv emulation. data is the
+ * raw auxv key-value pairs as pushed on the stack.
  */
 void proc_set_auxv(const void *data, size_t len);
 
@@ -134,8 +138,8 @@ int64_t proc_get_pgid(void);
 int64_t proc_get_fg_pgrp(void);
 
 /* Publish the current pgid/sid pair into the shim cache while holding
- * session_lock. Use this at cache initialization points so an external
- * snapshot cannot overwrite a newer setpgid/setsid publish.
+ * session_lock. Use this at cache initialization points so an external snapshot
+ * cannot overwrite a newer setpgid/setsid publish.
  */
 void proc_publish_pgsid_snapshot(guest_t *g);
 
@@ -167,10 +171,10 @@ uint32_t proc_get_gid(void);
 uint32_t proc_get_egid(void);
 uint32_t proc_get_sgid(void);
 
-/* Linux setuid semantics for non-root processes:
- * setuid(uid)      : set euid; if uid == ruid or suid, also set ruid+suid
- * setreuid(r,e)    : swap real/effective within {ruid, euid, suid}
- * setresuid(r,e,s) : set any combination within {ruid, euid, suid}
+/* Linux setuid semantics for non-root processes: setuid(uid) : set euid; if uid
+ * == ruid or suid, also set ruid+suid setreuid(r,e) : swap real/effective
+ * within {ruid, euid, suid} setresuid(r,e,s) : set any combination within
+ * {ruid, euid, suid}
  * Returns 0 on success, -EPERM if transition is not allowed.
  */
 int64_t proc_sys_setuid(uint32_t uid);
@@ -192,16 +196,15 @@ void proc_set_ids(uint32_t uid,
 int32_t proc_get_nice(void);
 void proc_set_nice(int32_t val);
 
-/* setpriority/getpriority: only PRIO_PROCESS for self.
- * setpriority clamps prio to [-20, 19].
- * getpriority returns 20-nice (always > 0 per Linux convention).
+/* setpriority/getpriority: only PRIO_PROCESS for self. setpriority clamps prio
+ * to [-20, 19]. getpriority returns 20-nice (always > 0 per Linux convention).
  */
 int64_t proc_sys_setpriority(int which, int who, int prio);
 int64_t proc_sys_getpriority(int which, int who);
 
 /* rseq abort: check if the thread is inside a restartable sequence critical
  * section and abort it. Called from signal delivery and vCPU preemption.
- * Returns:  0 = no active critical section (or no rseq registered)
+ * Returns: 0 = no active critical section (or no rseq registered)
  *           1 = PC redirected to abort_ip (*pc updated)
  *          -1 = signature mismatch (caller should deliver SIGSEGV)
  * Always clears rseq_cs pointer in the guest struct rseq.
@@ -219,35 +222,40 @@ int64_t proc_alloc_pid(void);
  */
 void proc_set_sysroot(const char *path);
 
-/* Get the stored sysroot path. Returns NULL if not set.
+/* Get the stored sysroot path.
+ *
+ * Returns NULL if not set.
  *
  * The returned pointer aliases a static buffer mutated by proc_set_sysroot()
  * under a private lock; callers that only test for NULL are safe, but any
- * caller that reads the string content must use proc_sysroot_snapshot()
- * instead to avoid a torn read against a concurrent chroot.
+ * caller that reads the string content must use proc_sysroot_snapshot() instead
+ * to avoid a torn read against a concurrent chroot.
  */
 const char *proc_get_sysroot(void);
 
 /* Copy the current sysroot into out (NUL-terminated) under the same lock that
- * serializes proc_set_sysroot(). Returns true if a sysroot is configured and
- * fits in outsz; false if unset, truncating, or out/outsz is invalid (in which
- * case out[0] is set to '\0' when possible).
+ * serializes proc_set_sysroot().
+ *
+ * Returns true if a sysroot is configured and fits in outsz; false if unset,
+ * truncating, or out/outsz is invalid (in which case out[0] is set to '\0' when
+ * possible).
  */
 bool proc_sysroot_snapshot(char *out, size_t outsz);
 void proc_set_sysroot_casefold(bool enabled);
 bool proc_sysroot_casefold_enabled(void);
 
-/* Resolve an absolute guest path through the stored sysroot. Returns path
- * unchanged when no sysroot applies or when the sysroot-backed path does not
- * exist, buf when a sysroot-backed file exists, or NULL if sysroot path
- * construction would truncate or escape containment checks.
+/* Resolve an absolute guest path through the stored sysroot.
+ *
+ * Returns path unchanged when no sysroot applies or when the sysroot-backed
+ * path does not exist, buf when a sysroot-backed file exists, or NULL if
+ * sysroot path construction would truncate or escape containment checks.
  */
 const char *proc_resolve_sysroot_path(const char *path,
                                       char *buf,
                                       size_t bufsz);
 
-/* Resolve an absolute guest path through the stored sysroot for operations
- * that must not follow the final path component (readlinkat, O_NOFOLLOW,
+/* Resolve an absolute guest path through the stored sysroot for operations that
+ * must not follow the final path component (readlinkat, O_NOFOLLOW,
  * AT_SYMLINK_NOFOLLOW).
  */
 const char *proc_resolve_sysroot_nofollow_path(const char *path,
@@ -267,10 +275,10 @@ const char *proc_resolve_sysroot_create_path(const char *path,
 
 /* Return value sentinel from syscall_dispatch (returns int):
  *   0 = continue, 1 = exit, SYSCALL_EXEC_HAPPENED = exec/sigreturn.
- * Also used as int64_t return from sc_xxx handlers where it must not
- * collide with valid syscall returns (>=0), Linux errno (-1..-4095),
- * or SC_EXIT_SENTINEL (INT64_MIN | code).  -0x10000 is outside all
- * these ranges and fits in int.
+ * Also used as int64_t return from sc_xxx handlers where it must not collide
+ * with valid syscall returns (>=0), Linux errno (-1..-4095), or
+ * SC_EXIT_SENTINEL (INT64_MIN | code). -0x10000 is outside all these ranges and
+ * fits in int.
  */
 #define SYSCALL_EXEC_HAPPENED (-0x10000)
 
@@ -294,8 +302,10 @@ int proc_register_child(pid_t host_pid, int64_t guest_pid);
 /* Mark a child as exited by host PID (for CLONE_VFORK wait). */
 void proc_mark_child_exited(pid_t host_pid, int status);
 
-/* Collect host PIDs of active (non-exited) fork children.
- * Writes up to max_pids entries into out[]. Returns the count written.
+/* Collect host PIDs of active (non-exited) fork children. Writes up to max_pids
+ * entries into out[].
+ *
+ * Returns the count written.
  */
 int proc_get_child_pids(pid_t *out, int max_pids);
 
@@ -338,8 +348,8 @@ int64_t sys_wait4(guest_t *g,
                   int options,
                   uint64_t rusage_gva);
 
-/* waitid: wait for child process using idtype/id semantics.
- * Fills siginfo_t at infop_gva on success.
+/* waitid: wait for child process using idtype/id semantics. Fills siginfo_t at
+ * infop_gva on success.
  */
 int64_t sys_waitid(guest_t *g,
                    int idtype,
@@ -362,12 +372,14 @@ int proc_exit_group_requested(void);
  */
 void proc_request_hvc6_yield(void);
 
-/* Run the vCPU execution loop. Returns the exit code.
+/* Run the vCPU execution loop.
  *
- * When timeout_sec > 0 (main thread): uses alarm() for per-iteration
- * safety timeout. When timeout_sec == 0 (worker thread): skips alarm()
- * (SIGALRM is process-wide). Workers are terminated by exit_group via
- * hv_vcpus_exit(). Both modes check proc_exit_group_requested.
+ * Returns the exit code.
+ *
+ * When timeout_sec > 0 (main thread): uses alarm() for per-iteration safety
+ * timeout. When timeout_sec == 0 (worker thread): skips alarm() (SIGALRM is
+ * process-wide). Workers are terminated by exit_group via hv_vcpus_exit(). Both
+ * modes check proc_exit_group_requested.
  */
 int vcpu_run_loop(hv_vcpu_t vcpu,
                   hv_vcpu_exit_t *vexit,

--- a/src/syscall/sidecar.c
+++ b/src/syscall/sidecar.c
@@ -40,24 +40,24 @@
 /* fcntl POSIX advisory locks are per-process. Within a single elfuse instance,
  * multiple vCPU threads all "hold" the same fcntl lock simultaneously. This
  * mutex serializes index updates across vCPU threads; the fcntl lock on the
- * dedicated lock sentinel still serializes against forked elfuse processes
- * that share the same sysroot.
+ * dedicated lock sentinel still serializes against forked elfuse processes that
+ * share the same sysroot.
  */
 static pthread_mutex_t sidecar_global_lock = PTHREAD_MUTEX_INITIALIZER;
 
-/* Per-directory cache: did this directory lack a sidecar index file
- * for the current directory metadata version? Keyed by (st_dev, st_ino) so a
- * renamed or moved directory does not leak a stale answer. Sidecar's
- * case-fold walker visits every parent directory of every translated path;
- * during dynamic-linker bring-up that walker fires per guest openat and
- * dominates startup (histogram showed openat at 61% of getent's 7.5 ms warm
- * path). The cache lets the common "no index here" answer return after a
- * 5 us fstat instead of a ~30 us openat per directory traversed.
+/* Per-directory cache: did this directory lack a sidecar index file for the
+ * current directory metadata version? Keyed by (st_dev, st_ino) so a renamed or
+ * moved directory does not leak a stale answer. Sidecar's case-fold walker
+ * visits every parent directory of every translated path; during dynamic-linker
+ * bring-up that walker fires per guest openat and dominates startup (histogram
+ * showed openat at 61% of getent's 7.5 ms warm path). The cache lets the common
+ * "no index here" answer return after a 5 us fstat instead of a ~30 us openat
+ * per directory traversed.
  *
- * 64 slots, single-level open-addressing (last writer wins on collision).
- * The directory ctime/mtime pair is part of the cache key: publishing an
- * index from another elfuse process changes the directory entry set, so a
- * stale ABSENT entry becomes UNKNOWN on the next lookup.
+ * 64 slots, single-level open-addressing (last writer wins on collision). The
+ * directory ctime/mtime pair is part of the cache key: publishing an index from
+ * another elfuse process changes the directory entry set, so a stale ABSENT
+ * entry becomes UNKNOWN on the next lookup.
  */
 enum {
     SIDECAR_IDX_UNKNOWN = 0,
@@ -76,9 +76,9 @@ static pthread_mutex_t sidecar_idx_cache_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static size_t sidecar_idx_cache_slot(dev_t dev, ino_t ino)
 {
-    /* Mix dev into ino so two filesystems with overlapping inode numbers
-     * do not pin the same slot. The golden-ratio multiplier scatters small
-     * inode numbers across the table without needing a real hash.
+    /* Mix dev into ino so two filesystems with overlapping inode numbers do not
+     * pin the same slot. The golden-ratio multiplier scatters small inode
+     * numbers across the table without needing a real hash.
      */
     uint64_t key = (uint64_t) ino ^ ((uint64_t) dev * 0x9E3779B97F4A7C15ULL);
     return (size_t) (key % SIDECAR_IDX_CACHE_SLOTS);
@@ -118,10 +118,10 @@ static void sidecar_idx_cache_set_stat(const struct stat *st, int state)
     pthread_mutex_unlock(&sidecar_idx_cache_lock);
 }
 
-/* Roll the cache entry back to UNKNOWN. Used by the index publish path
- * before the renameat so a concurrent reader entering the post-rename
- * window cannot consume a stale ABSENT and skip the openat. UNKNOWN forces
- * the reader to consult the filesystem.
+/* Roll the cache entry back to UNKNOWN. Used by the index publish path before
+ * the renameat so a concurrent reader entering the post-rename window cannot
+ * consume a stale ABSENT and skip the openat. UNKNOWN forces the reader to
+ * consult the filesystem.
  */
 static void sidecar_idx_cache_invalidate(int dirfd)
 {
@@ -131,15 +131,14 @@ static void sidecar_idx_cache_invalidate(int dirfd)
     sidecar_idx_cache_set_stat(&st, SIDECAR_IDX_UNKNOWN);
 }
 
-/* Cached sysroot dirfd. sidecar_open_base opens the sysroot directory on
- * every translated absolute path; for dynamic-linker bring-up that fires
- * once per openat / fstat / access / readlink. Caching the host fd and
- * handing the walker a dup turns that ~30 us open into a ~5 us dup. The
- * cache invalidates lazily by comparing the path string -- proc_set_sysroot
- * is rare (once at startup, once on fork-child IPC restore), so the
- * snapshot+strcmp on every call is still a net win over the open it
- * replaces. Concurrent vCPU lookups serialize on the lock for the cache check
- * and dup.
+/* Cached sysroot dirfd. sidecar_open_base opens the sysroot directory on every
+ * translated absolute path; for dynamic-linker bring-up that fires once per
+ * openat / fstat / access / readlink. Caching the host fd and handing the
+ * walker a dup turns that ~30 us open into a ~5 us dup. The cache invalidates
+ * lazily by comparing the path string -- proc_set_sysroot is rare (once at
+ * startup, once on fork-child IPC restore), so the snapshot+strcmp on every
+ * call is still a net win over the open it replaces. Concurrent vCPU lookups
+ * serialize on the lock for the cache check and dup.
  */
 static int sidecar_sysroot_cached_fd = -1;
 static char sidecar_sysroot_cached_path[LINUX_PATH_MAX] = {0};
@@ -152,23 +151,21 @@ static int sidecar_open_sysroot_cached(const char *path)
     pthread_mutex_lock(&sidecar_sysroot_cached_lock);
     int cached = sidecar_sysroot_cached_fd;
     if (cached >= 0 && !strcmp(path, sidecar_sysroot_cached_path)) {
-        /* Path text alone is not a sufficient cache key: a host-side
-         * rename or replace can rebind the same path to a different
-         * inode while the cached fd still resolves to the original.
-         * Stat the path on every hit and accept the cache only when
-         * (dev, ino) still match the inode captured at fill time. The
-         * stat is one host syscall per call, much cheaper than the
-         * open it replaces.
+        /* Path text alone is not a sufficient cache key: a host-side rename or
+         * replace can rebind the same path to a different inode while the
+         * cached fd still resolves to the original. Stat the path on every hit
+         * and accept the cache only when (dev, ino) still match the inode
+         * captured at fill time. The stat is one host syscall per call, much
+         * cheaper than the open it replaces.
          *
-         * Race window: a host-side mutation between this stat and the
-         * dup below can leave the cache returning the pre-mutation fd
-         * even though a fresh open(path) at that instant would resolve
-         * the post-mutation binding. The window is microseconds. It
-         * only matters under adversarial host-side sysroot mutation;
-         * normal sysroot configuration is canonicalized once at
-         * proc_set_sysroot time and never changes. Closing it
-         * adversarially would require dropping the cache, which gives
-         * back the ~25 us per-call win; not worth it absent a real
+         * Race window: a host-side mutation between this stat and the dup below
+         * can leave the cache returning the pre-mutation fd even though a fresh
+         * open(path) at that instant would resolve the post-mutation binding.
+         * The window is microseconds. It only matters under adversarial
+         * host-side sysroot mutation; normal sysroot configuration is
+         * canonicalized once at proc_set_sysroot time and never changes.
+         * Closing it adversarially would require dropping the cache, which
+         * gives back the ~25 us per-call win; not worth it absent a real
          * reproducer.
          */
         struct stat current;
@@ -191,9 +188,9 @@ static int sidecar_open_sysroot_cached(const char *path)
         pthread_mutex_unlock(&sidecar_sysroot_cached_lock);
         return -1;
     }
-    /* Capture the inode of the freshly-opened dir so subsequent cache
-     * hits can validate against it. Using fstat on the open fd gives
-     * the same (dev, ino) as a path stat would, with no second walk.
+    /* Capture the inode of the freshly-opened dir so subsequent cache hits can
+     * validate against it. Using fstat on the open fd gives the same (dev, ino)
+     * as a path stat would, with no second walk.
      */
     struct stat fresh_st;
     if (fstat(fresh, &fresh_st) < 0) {
@@ -201,10 +198,10 @@ static int sidecar_open_sysroot_cached(const char *path)
         pthread_mutex_unlock(&sidecar_sysroot_cached_lock);
         return -1;
     }
-    /* CLOEXEC dup: a concurrent posix_spawn from another vCPU thread
-     * must not inherit the sysroot dirfd into the fork-child. F_DUPFD_CLOEXEC
-     * sets the flag atomically with the dup, closing the inheritance window
-     * that plain dup() leaves open.
+    /* CLOEXEC dup: a concurrent posix_spawn from another vCPU thread must not
+     * inherit the sysroot dirfd into the fork-child. F_DUPFD_CLOEXEC sets the
+     * flag atomically with the dup, closing the inheritance window that plain
+     * dup() leaves open.
      */
     int cache_fd = fcntl(fresh, F_DUPFD_CLOEXEC, 0);
     if (cache_fd >= 0) {
@@ -245,9 +242,11 @@ static void sidecar_index_free(sidecar_index_t *index)
     index->count = 0;
 }
 
-/* Deep-copy src into dst so the caller can mutate dst freely and still
- * recover src for rollback. Returns 0 on success, -1 with errno on alloc
- * failure (dst is left empty in that case).
+/* Deep-copy src into dst so the caller can mutate dst freely and still recover
+ * src for rollback.
+ *
+ * Returns 0 on success, -1 with errno on alloc failure (dst is left empty in
+ * that case).
  */
 static int sidecar_index_clone(const sidecar_index_t *src, sidecar_index_t *dst)
 {
@@ -585,15 +584,15 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
         }
         scan = normalized;
 
-        /* Kernel virtual filesystems live in procemu, not on the sysroot
-         * disk tree. Walking them here would openat() against a directory
-         * that never exists in the sysroot and short-circuit the procemu
-         * intercept downstream of path_translate_at(). Punt to that layer
-         * instead. Check the normalized form so "/./proc/..." and
-         * "//proc/..." also skip; match only on a full top-level component
-         * so siblings like "/procfoo" still go through sidecar. Note that
-         * path_openat2_normalize_in_root() strips the leading '/' from
-         * absolute inputs, so the prefixes here are unrooted.
+        /* Kernel virtual filesystems live in procemu, not on the sysroot disk
+         * tree. Walking them here would openat() against a directory that never
+         * exists in the sysroot and short-circuit the procemu intercept
+         * downstream of path_translate_at(). Punt to that layer instead. Check
+         * the normalized form so "/./proc/..." and "//proc/..." also skip;
+         * match only on a full top-level component so siblings like "/procfoo"
+         * still go through sidecar. Note that path_openat2_normalize_in_root()
+         * strips the leading '/' from absolute inputs, so the prefixes here are
+         * unrooted.
          */
         size_t plen = 0;
         if (!strncmp(normalized, "proc", 4))
@@ -777,8 +776,8 @@ static ssize_t sidecar_find_guest_index(const sidecar_index_t *index,
     return -1;
 }
 
-/* fcntl-only lock acquisition. Caller must hold sidecar_global_lock so that
- * the lock_two_indices nested path does not need a recursive mutex.
+/* fcntl-only lock acquisition. Caller must hold sidecar_global_lock so that the
+ * lock_two_indices nested path does not need a recursive mutex.
  */
 static int sidecar_lock_index_fcntl(int dirfd, int *lock_fd)
 {
@@ -880,11 +879,11 @@ static int sidecar_load_locked_index(int parent_dirfd,
         return -1;
     }
 
-    /* readv() avoids tripping clang's unix.BlockInCriticalSection
-     * checker. The checker flags read() while a pthread mutex is held
-     * (the global sidecar lock here), but regular-file reads do not
-     * actually block in any user-observable sense. readv with a single
-     * iovec slice is functionally identical to read.
+    /* readv() avoids tripping clang's unix.BlockInCriticalSection checker. The
+     * checker flags read() while a pthread mutex is held (the global sidecar
+     * lock here), but regular-file reads do not actually block in any
+     * user-observable sense. readv with a single iovec slice is functionally
+     * identical to read.
      */
     size_t off = 0;
     while (off < size) {
@@ -967,8 +966,10 @@ static int sidecar_load_locked_index(int parent_dirfd,
     return 0;
 }
 
-/* Write all bytes or fail. Returns 0 on success, -1 with errno set on error.
- * Handles short writes by retrying until everything is committed.
+/* Write all bytes or fail.
+ *
+ * Returns 0 on success, -1 with errno set on error. Handles short writes by
+ * retrying until everything is committed.
  */
 static int sidecar_write_all(int fd, const char *buf, size_t len)
 {
@@ -989,9 +990,9 @@ static int sidecar_write_all(int fd, const char *buf, size_t len)
     return 0;
 }
 
-/* Serialize the index into a malloc'd buffer. *out_len receives the byte
- * count. Returns 0 on success, -1 with errno on error; *out is NULL on
- * failure.
+/* Serialize the index into a malloc'd buffer. *out_len receives the byte count.
+ *
+ * Returns 0 on success, -1 with errno on error; *out is NULL on failure.
  */
 static int sidecar_serialize_index(const sidecar_index_t *index,
                                    char **out,
@@ -1000,8 +1001,8 @@ static int sidecar_serialize_index(const sidecar_index_t *index,
     *out = NULL;
     *out_len = 0;
 
-    /* Estimate capacity: each row is enc(name) + '\t' + token + '\n'.
-     * enc is at most 2 * NAME_MAX (hex encoding) plus a null. Round up.
+    /* Estimate capacity: each row is enc(name) + '\t' + token + '\n'. enc is at
+     * most 2 * NAME_MAX (hex encoding) plus a null. Round up.
      */
     size_t cap = 256;
     char *buf = (char *) malloc(cap);
@@ -1049,9 +1050,8 @@ static int sidecar_serialize_index(const sidecar_index_t *index,
 }
 
 /* Write the index atomically: serialize into memory, write to a tmp file
- * adjacent to the real index, then renameat() over the real index. The
- * caller already holds a separate lock sentinel for cross-process
- * serialization.
+ * adjacent to the real index, then renameat() over the real index. The caller
+ * already holds a separate lock sentinel for cross-process serialization.
  */
 static int sidecar_write_locked_index(int parent_dirfd,
                                       int lock_fd,
@@ -1088,12 +1088,12 @@ static int sidecar_write_locked_index(int parent_dirfd,
         errno = saved_errno;
         return -1;
     }
-    /* Invalidate the cache to UNKNOWN BEFORE the rename so a concurrent
-     * walker that loses the race to read the new file does not return a
-     * stale ABSENT verdict from this slot. A reader entering the window
-     * between rename and post-rename mark would otherwise skip the openat
-     * and miss the freshly-published index. UNKNOWN forces the reader to
-     * do the openat and observe the new file directly.
+    /* Invalidate the cache to UNKNOWN BEFORE the rename so a concurrent walker
+     * that loses the race to read the new file does not return a stale ABSENT
+     * verdict from this slot. A reader entering the window between rename and
+     * post-rename mark would otherwise skip the openat and miss the
+     * freshly-published index. UNKNOWN forces the reader to do the openat and
+     * observe the new file directly.
      */
     sidecar_idx_cache_invalidate(parent_dirfd);
     if (renameat(parent_dirfd, SIDECAR_INDEX_TMP_NAME, parent_dirfd,
@@ -1506,17 +1506,17 @@ int64_t sidecar_unlinkat(guest_fd_t dirfd, const char *path, int flags)
 
     int64_t rc = 0;
     if (have_host_name) {
-        /* Write the index update first so that an interrupted unlinkat
-         * does not leave the on-disk token without a mapping. If the
-         * unlinkat fails, restore the mapping and rewrite the index;
-         * the second write going wrong is logged but cannot be helped.
+        /* Write the index update first so that an interrupted unlinkat does not
+         * leave the on-disk token without a mapping. If the unlinkat fails,
+         * restore the mapping and rewrite the index; the second write going
+         * wrong is logged but cannot be helped.
          */
         sidecar_row_t saved_row = index.rows[remove_idx];
         char *saved_name = strdup(saved_row.guest_name);
         if (!saved_name) {
             rc = linux_errno();
-            /* No mutation happened yet, so reporting the allocation
-             * failure keeps the index and host state unchanged.
+            /* No mutation happened yet, so reporting the allocation failure
+             * keeps the index and host state unchanged.
              */
         } else {
             sidecar_remove_guest_locked(&index, remove_idx);
@@ -1886,10 +1886,10 @@ int64_t sidecar_renameat(guest_fd_t olddirfd,
         return linux_errno();
     }
 
-    /* Snapshot the loaded indices so that a host renameat failure later
-     * can roll the on-disk index back. Without this, an index update
-     * followed by a failed host renameat leaves the mapping pointing at
-     * a moved or missing token.
+    /* Snapshot the loaded indices so that a host renameat failure later can
+     * roll the on-disk index back. Without this, an index update followed by a
+     * failed host renameat leaves the mapping pointing at a moved or missing
+     * token.
      */
     sidecar_index_t saved_old = {0};
     sidecar_index_t saved_new = {0};
@@ -2016,10 +2016,10 @@ int64_t sidecar_renameat(guest_fd_t olddirfd,
         goto cleanup;
     }
 
-    /* Commit the index changes to disk before any host filesystem
-     * mutation so a failed write does not leave an orphan host file. The
-     * host renameat is the actual commit point; on host failure, revert
-     * the on-disk index by writing the saved snapshot back.
+    /* Commit the index changes to disk before any host filesystem mutation so a
+     * failed write does not leave an orphan host file. The host renameat is the
+     * actual commit point; on host failure, revert the on-disk index by writing
+     * the saved snapshot back.
      */
     if (same_dir) {
         rc = sidecar_write_locked_index(old_parent.dirfd, first_lock_fd,
@@ -2047,10 +2047,10 @@ int64_t sidecar_renameat(guest_fd_t olddirfd,
         if (renameat(old_parent.dirfd, old_state.host_name, new_parent.dirfd,
                      target_host) < 0) {
             result = linux_errno();
-            /* Roll the index back to the pre-modification state so the
-             * mapping stays consistent with the unchanged host tree. A
-             * failed rollback write is the best-effort case; the guest
-             * sees the original renameat errno regardless.
+            /* Roll the index back to the pre-modification state so the mapping
+             * stays consistent with the unchanged host tree. A failed rollback
+             * write is the best-effort case; the guest sees the original
+             * renameat errno regardless.
              */
             if (same_dir) {
                 (void) sidecar_write_locked_index(old_parent.dirfd,

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -41,12 +41,12 @@
 /* Signal state (module-level, process-wide). */
 static signal_state_t sig_state;
 
-/* Per-thread pending fault info.
- * When a synchronous fault (BRK, segfault, etc.) needs to deliver a signal,
- * the caller sets this before signal_queue()+signal_deliver(). signal_deliver()
- * consumes it to populate si_code/si_addr/fault_address in the signal frame
- * instead of the default SI_USER/si_pid fields. Thread-local because each
- * vCPU thread delivers signals independently.
+/* Per-thread pending fault info. When a synchronous fault (BRK, segfault, etc.)
+ * needs to deliver a signal, the caller sets this before
+ * signal_queue()+signal_deliver(). signal_deliver() consumes it to populate
+ * si_code/si_addr/fault_address in the signal frame instead of the default
+ * SI_USER/si_pid fields. Thread-local because each vCPU thread delivers signals
+ * independently.
  */
 typedef struct {
     bool valid;    /* True if fault info is pending */
@@ -57,37 +57,36 @@ typedef struct {
 
 static _Thread_local pending_fault_t pending_fault;
 
-/* Per-delivery SROP cookie. Stored when signal_deliver builds the frame
- * (in uc_flags), validated when signal_rt_sigreturn reads it back.
- * Thread-local because each vCPU thread delivers independently.
- * A stack of cookies handles nested signals (up to 16 deep).
+/* Per-delivery SROP cookie. Stored when signal_deliver builds the frame (in
+ * uc_flags), validated when signal_rt_sigreturn reads it back. Thread-local
+ * because each vCPU thread delivers independently. A stack of cookies handles
+ * nested signals (up to 16 deep).
  */
 #define MAX_NESTED_SIGNALS 16
 static _Thread_local uint64_t sigreturn_cookies[MAX_NESTED_SIGNALS];
 static _Thread_local int sigreturn_cookie_depth;
 
 /* Protects signal actions array. Multiple threads may call rt_sigaction
- * concurrently (e.g., during musl init). Blocked masks are per-thread
- * (each thread_entry_t has its own blocked / saved_blocked).
+ * concurrently (e.g., during musl init). Blocked masks are per-thread (each
+ * thread_entry_t has its own blocked / saved_blocked).
  */
 static pthread_mutex_t sig_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 4 */
 
 /* Atomic "maybe pending" hint. signal_queue() sets it before releasing the
- * queue lock, and signal_deliver() clears it after draining visible state.
- * The vCPU hot path uses it to skip the locked signal_pending() check when
- * no thread can possibly observe a queued signal. False positives cost one
- * extra lock acquisition; false negatives would lose delivery, so ordering
- * here stays conservative.
+ * queue lock, and signal_deliver() clears it after draining visible state. The
+ * vCPU hot path uses it to skip the locked signal_pending() check when no
+ * thread can possibly observe a queued signal. False positives cost one extra
+ * lock acquisition; false negatives would lose delivery, so ordering here stays
+ * conservative.
  */
 #include <stdatomic.h>
 static _Atomic uint64_t sig_pending_hint = 0;
 
-/* Guest ITIMER_REAL emulation.
- * Signal emulation keeps the guest's ITIMER_REAL internally rather than
- * forwarding to the host setitimer(), because macOS shares alarm() and
- * setitimer(ITIMER_REAL) as the same underlying timer, and elfuse needs
- * alarm() for its own vCPU per-iteration timeout. The guest timer is checked
- * after each syscall in the vCPU loop via signal_check_timer().
+/* Guest ITIMER_REAL emulation. Signal emulation keeps the guest's ITIMER_REAL
+ * internally rather than forwarding to the host setitimer(), because macOS
+ * shares alarm() and setitimer(ITIMER_REAL) as the same underlying timer, and
+ * elfuse needs alarm() for its own vCPU per-iteration timeout. The guest timer
+ * is checked after each syscall in the vCPU loop via signal_check_timer().
  */
 typedef struct {
     int active;              /* Non-zero if timer is armed */
@@ -231,9 +230,9 @@ static int signal_rt_dequeue_locked(int signum, signal_rt_info_t *out)
     return 1;
 }
 
-/* Per-thread signal mask accessors.  POSIX requires each thread to
- * have its own blocked mask.  Falls back to sig_state.blocked when
- * current_thread is NULL (early startup, before threads are initialized).
+/* Per-thread signal mask accessors. POSIX requires each thread to have its own
+ * blocked mask. Falls back to sig_state.blocked when current_thread is NULL
+ * (early startup, before threads are initialized).
  */
 static inline uint64_t *thread_blocked_ptr(void)
 {
@@ -256,35 +255,34 @@ static inline bool *thread_saved_valid_ptr(void)
 
 /* Public API. */
 
-/* Singleton guest pointer used by attention-flag setters in this file.
- * elfuse runs one VM per process so a single global is correct. The
- * setter (signal_set_shim_globals_guest) asserts NULL-or-same to catch
- * a lifecycle bug in any future multi-VM design.
+/* Singleton guest pointer used by attention-flag setters in this file. elfuse
+ * runs one VM per process so a single global is correct. The setter
+ * (signal_set_shim_globals_guest) asserts NULL-or-same to catch a lifecycle bug
+ * in any future multi-VM design.
  *
- * Atomic because attention_raise runs on every signal queue from any
- * thread without holding sig_lock, while signal_init clears it across
- * the execve reset window. ARM64 aligned 64-bit pointer writes are
- * single-copy atomic, but plain reads/writes have no ordering, so a
- * concurrent attention_raise could observe a stale value or fail to
- * see a fresh registration. The release-acquire pair seals the window.
+ * Atomic because attention_raise runs on every signal queue from any thread
+ * without holding sig_lock, while signal_init clears it across the execve reset
+ * window. ARM64 aligned 64-bit pointer writes are single-copy atomic, but plain
+ * reads/writes have no ordering, so a concurrent attention_raise could observe
+ * a stale value or fail to see a fresh registration. The release-acquire pair
+ * seals the window.
  */
 static _Atomic(guest_t *) attention_guest;
 
 void signal_init(void)
 {
     memset(&sig_state, 0, sizeof(sig_state));
-    /* Clear the attention singleton on every init pass. Bootstrap and
-     * the fork-child receive path both call this before
-     * signal_set_shim_globals_guest publishes the live g; the reset
-     * keeps the setter's NULL-or-same assertion from latching onto a
-     * stale parent pointer in the child process. Release-store so a
-     * sibling thread that ACQUIRE-loads the slot after init observes
-     * NULL and falls back to thread_interrupt_all instead of a stale
-     * parent pointer.
+    /* Clear the attention singleton on every init pass. Bootstrap and the
+     * fork-child receive path both call this before
+     * signal_set_shim_globals_guest publishes the live g; the reset keeps the
+     * setter's NULL-or-same assertion from latching onto a stale parent pointer
+     * in the child process. Release-store so a sibling thread that
+     * ACQUIRE-loads the slot after init observes NULL and falls back to
+     * thread_interrupt_all instead of a stale parent pointer.
      */
     atomic_store_explicit(&attention_guest, NULL, memory_order_release);
-    /* Altstack is now per-thread (in thread_entry_t), initialized to
-     * SS_DISABLE by thread_register_main() and thread_alloc().
+    /* Altstack is now per-thread (in thread_entry_t), initialized to SS_DISABLE
+     * by thread_register_main() and thread_alloc().
      */
 }
 
@@ -301,10 +299,10 @@ void signal_set_shim_globals_guest(guest_t *g)
     atomic_store_explicit(&attention_guest, g, memory_order_release);
 }
 
-/* Raise the shim-globals attention flag if the singleton has been
- * registered; otherwise fall back to a bare vCPU interrupt. Both paths
- * end up running thread_interrupt_all (shim_globals_raise_attention
- * issues it internally), so callers only need this single helper.
+/* Raise the shim-globals attention flag if the singleton has been registered;
+ * otherwise fall back to a bare vCPU interrupt. Both paths end up running
+ * thread_interrupt_all (shim_globals_raise_attention issues it internally), so
+ * callers only need this single helper.
  */
 static inline void attention_raise(void)
 {
@@ -316,9 +314,9 @@ static inline void attention_raise(void)
 }
 
 /* Predicate matches the deliverability gate used by signal_queue and
- * signal_queue_info: SIGKILL/SIGSTOP are uncatchable and must always
- * interrupt; other signals only interrupt when at least one active
- * thread does not block them.
+ * signal_queue_info: SIGKILL/SIGSTOP are uncatchable and must always interrupt;
+ * other signals only interrupt when at least one active thread does not block
+ * them.
  */
 static inline bool signal_should_interrupt(int signum)
 {
@@ -356,9 +354,9 @@ void signal_reset_for_exec(void)
     }
     pthread_mutex_unlock(&sig_lock);
 
-    /* Clear any stale pending fault info so it does not leak into the
-     * new program's first signal delivery (e.g., if a BRK handler
-     * called execve with pending_fault still valid).
+    /* Clear any stale pending fault info so it does not leak into the new
+     * program's first signal delivery (e.g., if a BRK handler called execve
+     * with pending_fault still valid).
      */
     pending_fault.valid = false;
 }
@@ -377,25 +375,23 @@ void signal_queue(int signum)
                           memory_order_release);
     pthread_mutex_unlock(&sig_lock);
 
-    /* Notify any signalfd instances whose mask includes this signal.
-     * This makes the signalfd pipe readable so poll/epoll sees it.
+    /* Notify any signalfd instances whose mask includes this signal. This makes
+     * the signalfd pipe readable so poll/epoll sees it.
      */
     signalfd_notify(signum);
 
-    /* Only force vCPUs out of hv_vcpu_run(), and only force the shim's
-     * identity fast path off, if the signal is actually deliverable to
-     * at least one thread. SIGKILL/SIGSTOP cannot be blocked and always
-     * need interruption. For other signals, check per-thread blocked masks
-     * to avoid spurious context switches -- Go, JVM, and Node.js mask
-     * signals in worker threads, causing thousands of unnecessary ~1000ns
-     * VM exit+re-entry cycles per second if signal emulation interrupts
-     * unconditionally.
+    /* Only force vCPUs out of hv_vcpu_run(), and only force the shim's identity
+     * fast path off, if the signal is actually deliverable to at least one
+     * thread. SIGKILL/SIGSTOP cannot be blocked and always need interruption.
+     * For other signals, check per-thread blocked masks to avoid spurious
+     * context switches -- Go, JVM, and Node.js mask signals in worker threads,
+     * causing thousands of unnecessary ~1000ns VM exit+re-entry cycles per
+     * second if signal emulation interrupts unconditionally.
      *
-     * Race: if a thread concurrently unblocks this signal via
-     * rt_sigprocmask, the pending signal could be missed here.
-     * signal_rt_sigprocmask handles this by re-checking pending
-     * signals after unblocking and interrupting the current thread
-     * if delivery became possible.
+     * Race: if a thread concurrently unblocks this signal via rt_sigprocmask,
+     * the pending signal could be missed here. signal_rt_sigprocmask handles
+     * this by re-checking pending signals after unblocking and interrupting the
+     * current thread if delivery became possible.
      */
     if (signal_should_interrupt(signum))
         attention_raise();
@@ -437,8 +433,8 @@ void signal_queue_info(int signum,
                           memory_order_release);
     pthread_mutex_unlock(&sig_lock);
     signalfd_notify(signum);
-    /* Same shim-globals attention raise as signal_queue: force the fast
-     * path off only when the queued signal can reach signal_deliver.
+    /* Same shim-globals attention raise as signal_queue: force the fast path
+     * off only when the queued signal can reach signal_deliver.
      */
     if (signal_should_interrupt(signum))
         attention_raise();
@@ -454,11 +450,10 @@ void signal_set_fault_info(int si_code, uint64_t addr, uint64_t esr)
 
 int signal_pending(void)
 {
-    /* Fast path: check atomic hint to avoid locking on the hot path.
-     * If the hint says nothing is pending, skip the lock entirely.
-     * The hint can have false positives (stale pending bit after
-     * mask change) but never false negatives (signal_queue always
-     * sets it before unlock).
+    /* Fast path: check atomic hint to avoid locking on the hot path. If the
+     * hint says nothing is pending, skip the lock entirely. The hint can have
+     * false positives (stale pending bit after mask change) but never false
+     * negatives (signal_queue always sets it before unlock).
      */
     uint64_t hint =
         atomic_load_explicit(&sig_pending_hint, memory_order_acquire);
@@ -476,20 +471,19 @@ int signal_pending(void)
 
 bool signal_attention_needed(void)
 {
-    /* Cheap atomic load on the sig-pending hint first; if a signal is
-     * queued and deliverable to at least one active thread, the shim should
-     * drop to the slow path even before we touch the itimer state. A pending
-     * signal blocked by every active thread is not useful slow-path work and
-     * should not keep identity syscalls out of the fast path indefinitely.
+    /* Cheap atomic load on the sig-pending hint first; if a signal is queued
+     * and deliverable to at least one active thread, the shim should drop to
+     * the slow path even before we touch the itimer state. A pending signal
+     * blocked by every active thread is not useful slow-path work and should
+     * not keep identity syscalls out of the fast path indefinitely.
      */
     uint64_t hint =
         atomic_load_explicit(&sig_pending_hint, memory_order_acquire);
     if (hint != 0 && thread_signal_deliverable(hint))
         return true;
-    /* Active guest itimers: even if no signal is queued YET, the
-     * timer can fire at any moment, and signal_check_timer needs an
-     * HVC #5 epilogue to notice it. Keep attention raised while any
-     * timer is armed.
+    /* Active guest itimers: even if no signal is queued YET, the timer can fire
+     * at any moment, and signal_check_timer needs an HVC #5 epilogue to notice
+     * it. Keep attention raised while any timer is armed.
      */
     if (__atomic_load_n(&guest_itimer.active, __ATOMIC_ACQUIRE) ||
         __atomic_load_n(&guest_itimer_virt.active, __ATOMIC_ACQUIRE) ||
@@ -518,9 +512,9 @@ bool signal_pending_interruption(bool *restart_out)
      *     ditto.
      *   - User handler with SA_RESTART: handler runs but the syscall is
      *     expected to be retried transparently.
-     * Any other signal (default-TERM, default-CORE, non-restart handler)
-     * forces the wait to be treated as interrupted; otherwise a SIGTERM
-     * hiding behind an ignored SIGCHLD would never wake the caller.
+     * Any other signal (default-TERM, default-CORE, non-restart handler) forces
+     * the wait to be treated as interrupted; otherwise a SIGTERM hiding behind
+     * an ignored SIGCHLD would never wake the caller.
      */
     bool all_noninterrupt = true;
     uint64_t bits = deliverable;
@@ -536,12 +530,11 @@ bool signal_pending_interruption(bool *restart_out)
         if (act->sa_handler == LINUX_SIG_IGN) {
             noninterrupt = true;
         } else if (act->sa_handler == LINUX_SIG_DFL) {
-            /* Mirror signal_deliver's SIG_DFL switch: IGN, CONT, and STOP
-             * are all discarded with no guest-visible effect on elfuse
-             * (STOP/CONT are not meaningful here), so they cannot
-             * legitimately interrupt a FUSE wait. Treating CONT or STOP
-             * as disruptive would force a spurious EINTR that never
-             * corresponds to an actual delivery.
+            /* Mirror signal_deliver's SIG_DFL switch: IGN, CONT, and STOP are
+             * all discarded with no guest-visible effect on elfuse (STOP/CONT
+             * are not meaningful here), so they cannot legitimately interrupt a
+             * FUSE wait. Treating CONT or STOP as disruptive would force a
+             * spurious EINTR that never corresponds to an actual delivery.
              */
             sig_disposition_t disp = signal_default_disposition(idx + 1);
             noninterrupt = disp == SIG_DISP_IGN || disp == SIG_DISP_CONT ||
@@ -563,10 +556,10 @@ bool signal_pending_interruption(bool *restart_out)
 
 const signal_state_t *signal_get_state(void)
 {
-    /* Populate IPC-serializable fields from per-thread state under the
-     * lock to avoid data races with concurrent sigaction calls.
-     * This ensures fork children inherit the parent thread's blocked
-     * mask and altstack (POSIX: fork preserves signal mask).
+    /* Populate IPC-serializable fields from per-thread state under the lock to
+     * avoid data races with concurrent sigaction calls. This ensures fork
+     * children inherit the parent thread's blocked mask and altstack (POSIX:
+     * fork preserves signal mask).
      */
     pthread_mutex_lock(&sig_lock);
     if (current_thread) {
@@ -610,10 +603,10 @@ static size_t signal_collect_signalfd(uint64_t mask,
 
     pthread_mutex_lock(&sig_lock);
     uint64_t deliverable = sig_state.pending & mask;
-    /* signum runs 1..LINUX_NSIG inclusive (64 is the highest valid RT signal
-     * on aarch64 Linux). Bare-musl applications can target SIGRTMAX directly,
-     * so the inclusive bound matters even though glibc reserves the top of the
-     * RT range for itself.
+    /* signum runs 1..LINUX_NSIG inclusive (64 is the highest valid RT signal on
+     * aarch64 Linux). Bare-musl applications can target SIGRTMAX directly, so
+     * the inclusive bound matters even though glibc reserves the top of the RT
+     * range for itself.
      */
     for (int signum = 1; signum <= LINUX_NSIG && total < max; signum++) {
         uint64_t bit = BIT64(signum - 1);
@@ -769,8 +762,8 @@ static int timeval_cmp(const struct timeval *a, const struct timeval *b)
     return 0;
 }
 
-/* Helper: add two timevals with overflow saturation.
- * Uses pre-check to avoid signed overflow UB.
+/* Helper: add two timevals with overflow saturation. Uses pre-check to avoid
+ * signed overflow UB.
  */
 static struct timeval timeval_add(const struct timeval *a,
                                   const struct timeval *b)
@@ -795,8 +788,8 @@ static struct timeval timeval_add(const struct timeval *a,
     return r;
 }
 
-/* Helper: subtract b from a (a must be >= b).
- * Clamps to zero if a < b to avoid negative results.
+/* Helper: subtract b from a (a must be >= b). Clamps to zero if a < b to avoid
+ * negative results.
  */
 static struct timeval timeval_sub(const struct timeval *a,
                                   const struct timeval *b)
@@ -849,11 +842,11 @@ void signal_set_itimer(const struct timeval *value,
         __atomic_store_n(&guest_itimer.active, 0, __ATOMIC_RELEASE);
     } else {
         /* Publish expiry and interval BEFORE the release-store of active.
-         * signal_check_timer and signal_attention_needed ACQUIRE-load
-         * active without holding sig_lock; if active is published before
-         * its associated fields, a consumer can observe active=1 with
-         * stale expiry/interval and decide an early or late SIGALRM.
-         * Matches the field order in signal_set_itimer_virt.
+         * signal_check_timer and signal_attention_needed ACQUIRE-load active
+         * without holding sig_lock; if active is published before its
+         * associated fields, a consumer can observe active=1 with stale
+         * expiry/interval and decide an early or late SIGALRM. Matches the
+         * field order in signal_set_itimer_virt.
          */
         guest_itimer.expiry = timeval_add(&now, value);
         guest_itimer.interval = interval ? *interval : (struct timeval) {0, 0};
@@ -861,11 +854,10 @@ void signal_set_itimer(const struct timeval *value,
     }
     pthread_mutex_unlock(&sig_lock);
 
-    /* Arming any timer requires the shim's identity fast path to drop
-     * to the slow path so signal_check_timer can see the expiry. The
-     * disarm case is handled by signal_attention_needed returning
-     * false at the next HVC epilogue recompute -- no explicit clear
-     * here.
+    /* Arming any timer requires the shim's identity fast path to drop to the
+     * slow path so signal_check_timer can see the expiry. The disarm case is
+     * handled by signal_attention_needed returning false at the next HVC
+     * epilogue recompute -- no explicit clear here.
      */
     if (arm)
         attention_raise();
@@ -894,7 +886,9 @@ void signal_get_itimer(struct timeval *value, struct timeval *interval)
 }
 
 /* Check a single timer; if expired, re-arm or deactivate, return signal to
- * queue. Must be called with sig_lock held. Returns 0 if not expired.
+ * queue. Must be called with sig_lock held.
+ *
+ * Returns 0 if not expired.
  */
 static int check_one_timer(guest_itimer_t *timer, const struct timeval *now)
 {
@@ -1107,20 +1101,20 @@ int64_t signal_rt_sigprocmask(guest_t *g,
             return -LINUX_EINVAL;
         }
         new_mask &= ~unmaskable;
-        /* Atomic store: thread_signal_deliverable reads this field
-         * lock-free via __atomic_load_n. Without atomic stores, the
-         * concurrent read is a C data race (UB).
+        /* Atomic store: thread_signal_deliverable reads this field lock-free
+         * via __atomic_load_n. Without atomic stores, the concurrent read is a
+         * C data race (UB).
          */
         __atomic_store_n(blocked, new_mask, __ATOMIC_RELEASE);
 
-        /* If this mask change makes a queued signal deliverable on the
-         * current thread, refresh the global hint. The caller is already
-         * returning through the vCPU loop, so the next signal_pending()
-         * check will observe the updated mask without broadcasting a host
-         * thread interrupt.
+        /* If this mask change makes a queued signal deliverable on the current
+         * thread, refresh the global hint. The caller is already returning
+         * through the vCPU loop, so the next signal_pending() check will
+         * observe the updated mask without broadcasting a host thread
+         * interrupt.
          *
-         * This closes the race where signal_queue() saw the signal blocked
-         * on every thread, skipped the interrupt path, and this thread then
+         * This closes the race where signal_queue() saw the signal blocked on
+         * every thread, skipped the interrupt path, and this thread then
          * unblocked it.
          */
         uint64_t newly_unblocked = old_blocked & ~*blocked;
@@ -1158,8 +1152,8 @@ int64_t signal_rt_sigsuspend(guest_t *g, uint64_t mask_gva, uint64_t sigsetsize)
         uint64_t unmaskable = sig_bit(LINUX_SIGKILL) | sig_bit(LINUX_SIGSTOP);
         *blocked = mask & ~unmaskable;
 
-        /* If no signal is pending with the new mask, restore immediately.
-         * In a real kernel, sigsuspend blocks until a signal arrives. Signal
+        /* If no signal is pending with the new mask, restore immediately. In a
+         * real kernel, sigsuspend blocks until a signal arrives. Signal
          * emulation check if any signal became deliverable with the new mask.
          * If yes, the vCPU loop will deliver it. If no, restore the mask; the
          * caller will loop (musl retries on -EINTR).
@@ -1168,10 +1162,10 @@ int64_t signal_rt_sigsuspend(guest_t *g, uint64_t mask_gva, uint64_t sigsetsize)
             *blocked = saved_blocked;
         }
         /* If a signal IS pending, the mask stays temporarily modified.
-         * signal_deliver() will execute the handler, and rt_sigreturn
-         * will restore uc_sigmask. But signal delivery needs to set uc_sigmask
-         * to the ORIGINAL mask (saved_blocked), not the sigsuspend mask. Store
-         * it for signal_deliver to use.
+         * signal_deliver() will execute the handler, and rt_sigreturn will
+         * restore uc_sigmask. But signal delivery needs to set uc_sigmask to
+         * the ORIGINAL mask (saved_blocked), not the sigsuspend mask. Store it
+         * for signal_deliver to use.
          */
         else {
             *saved_ptr = saved_blocked;
@@ -1195,9 +1189,9 @@ int64_t signal_rt_sigpending(guest_t *g, uint64_t set_gva, uint64_t sigsetsize)
         return -LINUX_EFAULT;
 
     pthread_mutex_lock(&sig_lock);
-    /* Return all pending signals (matching Linux kernel do_sigpending).
-     * In practice unblocked signals are delivered before sigpending can
-     * observe them, but returning the full set is strictly correct.
+    /* Return all pending signals (matching Linux kernel do_sigpending). In
+     * practice unblocked signals are delivered before sigpending can observe
+     * them, but returning the full set is strictly correct.
      */
     uint64_t result = sig_state.pending;
     pthread_mutex_unlock(&sig_lock);
@@ -1255,8 +1249,8 @@ int64_t signal_sigaltstack(guest_t *g, uint64_t ss_gva, uint64_t old_ss_gva)
 
 /* Signal delivery. */
 
-/* FPSIMD context header (required by musl for setjmp/longjmp).
- * Linux places this immediately after sigcontext.__reserved starts.
+/* FPSIMD context header (required by musl for setjmp/longjmp). Linux places
+ * this immediately after sigcontext.__reserved starts.
  */
 #define FPSIMD_MAGIC 0x46508001U
 #define FPSIMD_CONTEXT_SIZE (8 + 4 + 4 + 32 * 16) /* 528 bytes */
@@ -1267,8 +1261,8 @@ int64_t signal_sigaltstack(guest_t *g, uint64_t ss_gva, uint64_t old_ss_gva)
 #define ESR_MAGIC 0x45535201U
 #define ESR_CONTEXT_SIZE 16 /* { __u32 magic, size; __u64 esr; } */
 
-/* Build the extended context chain in the __reserved area.
- * Linux kernel (arch/arm64/kernel/signal.c) builds:
+/* Build the extended context chain in the __reserved area. Linux kernel
+ * (arch/arm64/kernel/signal.c) builds:
  *   1. FPSIMD context (always present)
  *   2. ESR context (present for synchronous faults: BRK, segfault, etc.)
  *   3. Terminator (magic=0, size=0)
@@ -1281,9 +1275,9 @@ static void build_sigcontext_reserved(uint8_t *reserved,
 {
     uint32_t off = 0;
 
-    /* 1. FPSIMD context: save actual FP/SIMD state so it is correctly
-     * restored by rt_sigreturn. Without this, a signal handler that
-     * modifies FP registers would corrupt the interrupted code's state.
+    /* 1. FPSIMD context: save actual FP/SIMD state so it is correctly restored
+     * by rt_sigreturn. Without this, a signal handler that modifies FP
+     * registers would corrupt the interrupted code's state.
      */
     uint32_t fpsimd_magic = FPSIMD_MAGIC, fpsimd_size = FPSIMD_CONTEXT_SIZE;
     memcpy(reserved + off, &fpsimd_magic, 4);
@@ -1333,9 +1327,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     int signum = bit_ctz64(deliverable) + 1;
     signal_rt_info_t rt_info = signal_default_info(signum);
 
-    /* Dequeue: for RT signals, decrement count and only clear the
-     * pending bit when the queue is empty. Standard signals are
-     * always cleared (single instance, bitmask semantics).
+    /* Dequeue: for RT signals, decrement count and only clear the pending bit
+     * when the queue is empty. Standard signals are always cleared (single
+     * instance, bitmask semantics).
      */
     if (signum >= LINUX_SIGRTMIN) {
         signal_rt_dequeue_locked(signum, &rt_info);
@@ -1345,9 +1339,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
         sig_state.pending &= ~sig_bit(signum);
     }
 
-    /* signum is bit_ctz64(deliverable) + 1, bounded 1..64 by the 64-bit
-     * pending mask. The static analyzer cannot see the bound, so gate the
-     * array access defensively.
+    /* signum is bit_ctz64(deliverable) + 1, bounded 1..64 by the 64-bit pending
+     * mask. The static analyzer cannot see the bound, so gate the array access
+     * defensively.
      */
     int idx = signum - 1;
     if (!RANGE_CHECK(idx, 0, LINUX_NSIG)) {
@@ -1358,8 +1352,8 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
 
     /* Check handler type */
     if (act->sa_handler == LINUX_SIG_IGN) {
-        /* Ignored; discard signal. Clear any stale fault info so it
-         * does not leak into a later signal delivery.
+        /* Ignored; discard signal. Clear any stale fault info so it does not
+         * leak into a later signal delivery.
          */
         pending_fault.valid = false;
         pthread_mutex_unlock(&sig_lock);
@@ -1414,15 +1408,15 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     linux_rt_sigframe_t frame;
     memset(&frame, 0, sizeof(frame));
 
-    /* siginfo: fault signals use si_code/si_addr from pending_fault;
-     * queued RT signals preserve sender metadata and sigval.
+    /* siginfo: fault signals use si_code/si_addr from pending_fault; queued RT
+     * signals preserve sender metadata and sigval.
      */
     frame.info.si_signo = signum;
     if (pending_fault.valid) {
         frame.info.si_code = pending_fault.si_code;
-        /* si_addr overlaps si_pid/si_uid at offset 16 in the siginfo union.
-         * On aarch64-linux, si_addr is a 64-bit pointer occupying both
-         * int32_t fields. Write it via memcpy to avoid strict aliasing.
+        /* si_addr overlaps si_pid/si_uid at offset 16 in the siginfo union. On
+         * aarch64-linux, si_addr is a 64-bit pointer occupying both int32_t
+         * fields. Write it via memcpy to avoid strict aliasing.
          */
         memcpy(&frame.info.si_pid, &pending_fault.addr, 8);
     } else {
@@ -1432,10 +1426,10 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
         frame.info.si_value = rt_info.si_ptr;
     }
 
-    /* ucontext: embed a per-delivery cookie in uc_flags for SROP
-     * validation. rt_sigreturn checks this before restoring state.
-     * Low priority (guest is same trust domain) but prevents accidental
-     * frame corruption from redirecting execution.
+    /* ucontext: embed a per-delivery cookie in uc_flags for SROP validation.
+     * rt_sigreturn checks this before restoring state. Low priority (guest is
+     * same trust domain) but prevents accidental frame corruption from
+     * redirecting execution.
      */
     uint64_t cookie;
     arc4random_buf(&cookie, sizeof(cookie));
@@ -1454,10 +1448,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
         frame.uc.uc_sigmask = *blocked;
     }
 
-    /* sigcontext: save all registers.
-     * fault_address: for synchronous faults (BRK, segfault), set to the
-     * faulting address; for asynchronous signals, zero.
-     * frame_esr: raw ESR_EL1 for the extended context chain. SIGTRAP
+    /* sigcontext: save all registers. fault_address: for synchronous faults
+     * (BRK, segfault), set to the faulting address; for asynchronous signals,
+     * zero. frame_esr: raw ESR_EL1 for the extended context chain. SIGTRAP
      * handlers read this to determine the BRK immediate value.
      */
     uint64_t frame_esr = 0;
@@ -1472,9 +1465,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     frame.uc.uc_mcontext.pc = saved_pc;
     frame.uc.uc_mcontext.pstate = saved_pstate;
 
-    /* Extended context chain in __reserved area (FPSIMD + optional ESR).
-     * The ESR context lets signal handlers read the exception syndrome
-     * (e.g., BRK immediate from ESR ISS[15:0]) to determine trap type.
+    /* Extended context chain in __reserved area (FPSIMD + optional ESR). The
+     * ESR context lets signal handlers read the exception syndrome (e.g., BRK
+     * immediate from ESR ISS[15:0]) to determine trap type.
      */
     build_sigcontext_reserved(frame.uc.uc_mcontext.__reserved, frame_esr, vcpu);
 
@@ -1487,11 +1480,11 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     if (thr && thr->on_altstack)
         frame.uc.uc_stack.ss_flags |= LINUX_SS_ONSTACK;
 
-    /* 3. Determine stack for signal frame: use altstack if SA_ONSTACK
-     * is set, an altstack is configured, and the thread is not already on it.
-     * Across fork, only the forking thread's altstack is preserved
-     * (via signal_get_state). Worker thread altstacks start as SS_DISABLE
-     * in the child, matching Linux kernel per-thread altstack semantics.
+    /* 3. Determine stack for signal frame: use altstack if SA_ONSTACK is set,
+     * an altstack is configured, and the thread is not already on it. Across
+     * fork, only the forking thread's altstack is preserved (via
+     * signal_get_state). Worker thread altstacks start as SS_DISABLE in the
+     * child, matching Linux kernel per-thread altstack semantics.
      */
     uint64_t signal_sp = saved_sp;
     bool use_altstack = false;
@@ -1502,9 +1495,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
         use_altstack = true;
     }
 
-    /* Guard against underflow: if signal_sp is too small to hold the
-     * frame, the subtraction wraps to a huge address. guest_write_small
-     * would catch it, but report the problem early with a diagnostic.
+    /* Guard against underflow: if signal_sp is too small to hold the frame, the
+     * subtraction wraps to a huge address. guest_write_small would catch it,
+     * but report the problem early with a diagnostic.
      */
     if (signal_sp < sizeof(frame)) {
         log_error(
@@ -1517,9 +1510,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     }
     uint64_t frame_sp = (signal_sp - sizeof(frame)) & ~15ULL;
 
-    /* Push the SROP cookie for validation on rt_sigreturn.
-     * If nesting exceeds MAX_NESTED_SIGNALS, skip the cookie entirely
-     * (set uc_flags=0) so rt_sigreturn does not mis-validate.
+    /* Push the SROP cookie for validation on rt_sigreturn. If nesting exceeds
+     * MAX_NESTED_SIGNALS, skip the cookie entirely (set uc_flags=0) so
+     * rt_sigreturn does not mis-validate.
      */
     bool pushed_cookie = false;
     if (sigreturn_cookie_depth < MAX_NESTED_SIGNALS) {
@@ -1552,12 +1545,12 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     /* X0 = signal number */
     hv_vcpu_set_reg(vcpu, HV_REG_X0, (uint64_t) signum);
 
-    /* X30 (LR) = return address for signal handler.
-     * On aarch64-linux, the kernel always sets LR to the vDSO's
-     * __kernel_rt_sigreturn (mov x8,#139; svc #0; ret). The sa_restorer
-     * field is architecturally unused on aarch64; the kernel ignores it.
-     * glibc leaves sa_restorer uninitialized (garbage); musl sets it to
-     * __restore_rt.  Match the kernel: always use the vDSO trampoline.
+    /* X30 (LR) = return address for signal handler. On aarch64-linux, the
+     * kernel always sets LR to the vDSO's __kernel_rt_sigreturn (mov x8,#139;
+     * svc #0; ret). The sa_restorer field is architecturally unused on aarch64;
+     * the kernel ignores it. glibc leaves sa_restorer uninitialized (garbage);
+     * musl sets it to __restore_rt. Match the kernel: always use the vDSO
+     * trampoline.
      */
     hv_vcpu_set_reg(vcpu, HV_REG_X30, VDSO_BASE + VDSO_OFF_SIGRET);
 
@@ -1586,9 +1579,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
         act->sa_flags &= ~LINUX_SA_SIGINFO;
     }
 
-    /* If delivery happens while returning from the syscall HVC path, the
-     * shim still has the interrupted syscall frame on its EL1 stack. Tell it
-     * to drop that frame so the handler PC/SP/LR/args installed above are not
+    /* If delivery happens while returning from the syscall HVC path, the shim
+     * still has the interrupted syscall frame on its EL1 stack. Tell it to drop
+     * that frame so the handler PC/SP/LR/args installed above are not
      * overwritten before ERET. Fault/BRK delivery paths ignore this marker.
      */
     hv_vcpu_set_reg(vcpu, HV_REG_X8, 2);
@@ -1610,8 +1603,8 @@ int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g)
     if (guest_read_small(g, sp, &frame, sizeof(frame)) < 0)
         return -LINUX_EFAULT;
 
-    /* Validate SROP cookie from uc_flags. Zero means the cookie was
-     * skipped (nesting overflow or pre-existing frame); allow those.
+    /* Validate SROP cookie from uc_flags. Zero means the cookie was skipped
+     * (nesting overflow or pre-existing frame); allow those.
      */
     uint64_t frame_cookie = frame.uc.uc_flags;
     if (frame_cookie != 0 && sigreturn_cookie_depth > 0) {
@@ -1627,13 +1620,13 @@ int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g)
         sigreturn_cookie_depth--;
     }
 
-    /* Validate restored PC before touching any vCPU state. Reject
-     * addresses in the EL1 shim or page table pool region; a crafted
-     * signal frame could redirect execution into EL1 code.
-     * Must happen before GPR/SP/PSTATE restore so that a failed check
-     * does not leave the vCPU with partially-attacker-controlled state.
-     * The infra reserve sits at high IPA (just below g->interp_base);
-     * use the runtime check rather than compile-time constants.
+    /* Validate restored PC before touching any vCPU state. Reject addresses in
+     * the EL1 shim or page table pool region; a crafted signal frame could
+     * redirect execution into EL1 code. Must happen before GPR/SP/PSTATE
+     * restore so that a failed check does not leave the vCPU with
+     * partially-attacker-controlled state. The infra reserve sits at high IPA
+     * (just below g->interp_base); use the runtime check rather than
+     * compile-time constants.
      */
     uint64_t restored_pc = frame.uc.uc_mcontext.pc;
     if (guest_addr_in_infra(g, restored_pc))
@@ -1645,8 +1638,8 @@ int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g)
     /* Restore SP, PC, PSTATE */
     hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL0, frame.uc.uc_mcontext.sp);
     hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, restored_pc);
-    /* Sanitize PSTATE: preserve EL0-safe bits, clear everything else.
-     * Bit fields preserved (matching Linux kernel's valid_user_regs):
+    /* Sanitize PSTATE: preserve EL0-safe bits, clear everything else. Bit
+     * fields preserved (matching Linux kernel's valid_user_regs):
      *   [31:28] NZCV:   condition flags
      *   [27:26] RES0:   cleared
      *   [25]    TCO:    tag check override (MTE, EL0-accessible)
@@ -1663,8 +1656,8 @@ int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g)
     hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1,
                         frame.uc.uc_mcontext.pstate & 0xF3001C00ULL);
 
-    /* Restore FPSIMD state from the sigcontext __reserved area.
-     * The FPSIMD context starts at offset 0 of __reserved (after magic/size).
+    /* Restore FPSIMD state from the sigcontext __reserved area. The FPSIMD
+     * context starts at offset 0 of __reserved (after magic/size).
      */
     const uint8_t *reserved = frame.uc.uc_mcontext.__reserved;
     uint32_t fpsimd_magic;
@@ -1682,9 +1675,9 @@ int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g)
         }
     }
 
-    /* Restore signal mask and update altstack-in-use flag.
-     * If the restored SP is still within the altstack range (nested signal
-     * case), keep on_altstack=1.  Matches Linux kernel's restore_altstack.
+    /* Restore signal mask and update altstack-in-use flag. If the restored SP
+     * is still within the altstack range (nested signal case), keep
+     * on_altstack=1. Matches Linux kernel's restore_altstack.
      */
     pthread_mutex_lock(&sig_lock);
     uint64_t *blocked = thread_blocked_ptr();
@@ -1703,14 +1696,14 @@ int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g)
     pthread_mutex_unlock(&sig_lock);
 
     /* Tell the EL1 shim to drop its saved syscall frame. rt_sigreturn has
-     * restored the complete guest register state here; letting the shim
-     * restore X1-X30 from the rt_sigreturn syscall entry would corrupt the
-     * interrupted context.
+     * restored the complete guest register state here; letting the shim restore
+     * X1-X30 from the rt_sigreturn syscall entry would corrupt the interrupted
+     * context.
      */
     hv_vcpu_set_reg(vcpu, HV_REG_X8, 2);
 
-    /* Return SYSCALL_EXEC_HAPPENED to skip the normal X0 writeback,
-     * since sigreturn has restored the entire register set.
+    /* Return SYSCALL_EXEC_HAPPENED to skip the normal X0 writeback, since
+     * sigreturn has restored the entire register set.
      */
     return SYSCALL_EXEC_HAPPENED;
 }

--- a/src/syscall/signal.h
+++ b/src/syscall/signal.h
@@ -71,7 +71,7 @@
 
 /* Linux sigaction (kernel-style, aarch64). */
 /* The kernel's struct sigaction for aarch64 (from
- * include/uapi/asm-generic/signal.h): sa_handler or sa_sigaction  (8 bytes)
+ * include/uapi/asm-generic/signal.h): sa_handler or sa_sigaction (8 bytes)
  *   sa_flags                    (8 bytes on LP64)
  *   sa_restorer                 (8 bytes)
  *   sa_mask                     (8 bytes, single uint64_t for 64 signals)
@@ -190,9 +190,9 @@ typedef struct {
      */
     bool std_info_valid[LINUX_SIGRTMIN - 1];
     signal_rt_info_t std_info[LINUX_SIGRTMIN - 1];
-    /* RT signal queue: count of pending instances per signal.
-     * Standard signals (1-31) use the pending bitmask plus std_info[].
-     * RT signals (32-64) are queued: each instance is tracked separately.
+    /* RT signal queue: count of pending instances per signal. Standard signals
+     * (1-31) use the pending bitmask plus std_info[]. RT signals (32-64) are
+     * queued: each instance is tracked separately.
      */
     int rt_queue[RT_SIGNAL_COUNT];
     uint8_t rt_head[RT_SIGNAL_COUNT];
@@ -204,9 +204,9 @@ typedef struct {
 /* Initialize signal state: all SIG_DFL, nothing pending/blocked. */
 void signal_init(void);
 
-/* Reset signal state for exec (POSIX requirement).
- * Handlers set to SIG_DFL (except SIG_IGN stays SIG_IGN).
- * Pending signals and signal mask are preserved.
+/* Reset signal state for exec (POSIX requirement). Handlers set to SIG_DFL
+ * (except SIG_IGN stays SIG_IGN). Pending signals and signal mask are
+ * preserved.
  */
 void signal_reset_for_exec(void);
 
@@ -221,8 +221,8 @@ void signal_queue_rt(int signum,
                      int32_t si_int,
                      uint64_t si_ptr);
 
-/* Queue a signal with explicit siginfo metadata. Standard signals preserve
- * one payload while coalesced; RT signals enqueue every instance.
+/* Queue a signal with explicit siginfo metadata. Standard signals preserve one
+ * payload while coalesced; RT signals enqueue every instance.
  */
 void signal_queue_info(int signum,
                        int32_t si_code,
@@ -232,11 +232,11 @@ void signal_queue_info(int signum,
                        uint64_t si_ptr);
 
 /* Set fault info for the next signal delivery. When set, signal_deliver()
- * populates si_code, si_addr, fault_address, and ESR context from these
- * values instead of using the default SI_USER/si_pid fields. Consumed
- * (cleared) after one delivery. Used for synchronous faults: BRK->SIGTRAP,
- * SIGSEGV, etc. The esr parameter is the raw ESR_EL1 value; if non-zero,
- * an esr_context block is appended to __reserved after FPSIMD.
+ * populates si_code, si_addr, fault_address, and ESR context from these values
+ * instead of using the default SI_USER/si_pid fields. Consumed (cleared) after
+ * one delivery. Used for synchronous faults: BRK->SIGTRAP, SIGSEGV, etc. The
+ * esr parameter is the raw ESR_EL1 value; if non-zero, an esr_context block is
+ * appended to __reserved after FPSIMD.
  */
 void signal_set_fault_info(int si_code, uint64_t addr, uint64_t esr);
 
@@ -246,10 +246,10 @@ bool signal_pending_interruption(bool *restart_out);
 
 /* True if anything that would normally be drained by signal_check_timer is
  * currently live: an unblocked pending signal, OR any of the three guest
- * itimers is armed. The shim's identity fast path consults this (indirectly
- * via shim_globals attention flag) to decide whether to skip the HVC #5
- * round-trip. Whenever this returns true, the shim must take the slow path so
- * the epilogue's signal_check_timer + queue drain runs.
+ * itimers is armed. The shim's identity fast path consults this (indirectly via
+ * shim_globals attention flag) to decide whether to skip the HVC #5 round-trip.
+ * Whenever this returns true, the shim must take the slow path so the
+ * epilogue's signal_check_timer + queue drain runs.
  */
 bool signal_attention_needed(void);
 
@@ -257,8 +257,8 @@ bool signal_attention_needed(void);
  * signal_queue / setitimer / proc_set_exit_group. Called from bootstrap and
  * fork-child after guest_init. Asserts that the value is NULL or matches the
  * already-registered g; elfuse runs one VM per process and the singleton
- * catches lifecycle bugs (multiple concurrent VMs in one process would
- * violate this invariant).
+ * catches lifecycle bugs (multiple concurrent VMs in one process would violate
+ * this invariant).
  *
  * Passing NULL clears the registration (used by signal_init for a defensive
  * reset; the attention setters become no-ops in that state, matching the
@@ -266,16 +266,18 @@ bool signal_attention_needed(void);
  */
 void signal_set_shim_globals_guest(guest_t *g);
 
-/* Deliver the highest-priority pending unblocked signal to the guest.
- * Builds an rt_sigframe on the guest stack and redirects vCPU to handler.
+/* Deliver the highest-priority pending unblocked signal to the guest. Builds an
+ * rt_sigframe on the guest stack and redirects vCPU to handler.
  * Returns: 1 if signal was delivered, 0 if nothing pending,
  *         -1 if process should terminate (default TERM/CORE disposition).
  * On terminate, *exit_code is set to 128 + signum.
  */
 int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code);
 
-/* Handle rt_sigreturn (SYS 139): restore registers from rt_sigframe on
- * the guest stack. Returns SYSCALL_EXEC_HAPPENED to skip X0 writeback.
+/* Handle rt_sigreturn (SYS 139): restore registers from rt_sigframe on the
+ * guest stack.
+ *
+ * Returns SYSCALL_EXEC_HAPPENED to skip X0 writeback.
  */
 int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g);
 
@@ -310,27 +312,27 @@ int64_t signal_sigaltstack(guest_t *g, uint64_t ss_gva, uint64_t old_ss_gva);
 const signal_state_t *signal_get_state(void);
 void signal_set_state(const signal_state_t *state);
 
-/* Snapshot or consume pending signals for signalfd.
- * signal_peek_signalfd() snapshots up to max matching entries without consuming
- * them. signal_take_signalfd_exact() then consumes those exact entries,
- * preserving any matching signals that arrived later.
+/* Snapshot or consume pending signals for signalfd. signal_peek_signalfd()
+ * snapshots up to max matching entries without consuming them.
+ * signal_take_signalfd_exact() then consumes those exact entries, preserving
+ * any matching signals that arrived later.
  */
 size_t signal_peek_signalfd(uint64_t mask, signal_rt_info_t *out, size_t max);
 size_t signal_take_signalfd_exact(const signal_rt_info_t *expected, size_t max);
 
 /* Save and restore blocked mask for pselect6/ppoll signal mask atomicity.
- * signal_save_blocked returns the current blocked mask.
- * signal_set_blocked applies a new mask (respecting SIGKILL/SIGSTOP).
- * signal_restore_blocked restores a previously saved mask.
+ * signal_save_blocked returns the current blocked mask. signal_set_blocked
+ * applies a new mask (respecting SIGKILL/SIGSTOP). signal_restore_blocked
+ * restores a previously saved mask.
  */
 uint64_t signal_save_blocked(void);
 void signal_set_blocked(uint64_t mask);
 void signal_restore_blocked(uint64_t saved);
 
-/* Guest ITIMER_REAL emulation.
- * These emulate the guest's setitimer(ITIMER_REAL) internally rather than
- * forwarding to the host, because macOS shares alarm() and setitimer() as
- * the same underlying timer, and elfuse needs alarm() for its vCPU timeout.
+/* Guest ITIMER_REAL emulation. These emulate the guest's setitimer(ITIMER_REAL)
+ * internally rather than forwarding to the host, because macOS shares alarm()
+ * and setitimer() as the same underlying timer, and elfuse needs alarm() for
+ * its vCPU timeout.
  */
 
 /* Set the guest's ITIMER_REAL timer. value/interval are relative durations.
@@ -354,7 +356,7 @@ void signal_get_itimer_virt(int which,
                             struct timeval *value,
                             struct timeval *interval);
 
-/* Check if any guest itimer has expired; queue signals as needed.
- * Called from the vCPU loop after each syscall.
+/* Check if any guest itimer has expired; queue signals as needed. Called from
+ * the vCPU loop after each syscall.
  */
 void signal_check_timer(void);

--- a/src/syscall/sys.c
+++ b/src/syscall/sys.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Uname, getrandom, getcwd, sched_getaffinity, getgroups, getrusage,
- * sysinfo, and prlimit64. All functions are called from syscall_dispatch()
- * in syscall/syscall.c.
+ * Uname, getrandom, getcwd, sched_getaffinity, getgroups, getrusage, sysinfo,
+ * and prlimit64. All functions are called from syscall_dispatch() in
+ * syscall/syscall.c.
  */
 
 #include <stdio.h>
@@ -76,8 +76,8 @@ _Static_assert(offsetof(struct rusage, ru_maxrss) ==
                "ru_maxrss offset must stay aligned for fast translation");
 
 /* Defined below in the scheduler-policy section; forward-declared so
- * sys_sched_getaffinity (which sits above the policy stubs) can share the
- * same per-thread TID gate.
+ * sys_sched_getaffinity (which sits above the policy stubs) can share the same
+ * per-thread TID gate.
  */
 static bool sched_pid_alive(int pid);
 
@@ -127,8 +127,8 @@ static void sysinfo_refresh_cached_locked(time_t now_sec)
     if (cached_boottime_sec != 0)
         cached_sysinfo.uptime = now_sec - cached_boottime_sec;
 
-    /* Free RAM from vm_statistics64.
-     * Scale proportionally if totalram is capped.
+    /* Free RAM from vm_statistics64. Scale proportionally if totalram is
+     * capped.
      */
     vm_statistics64_data_t vmstat = {0};
     mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
@@ -182,8 +182,8 @@ int64_t sys_uname(guest_t *g, uint64_t buf_gva)
 /* Linux getrandom(2) flags. arc4random_buf is always non-blocking and always
  * seeded, so GRND_NONBLOCK / GRND_RANDOM / GRND_INSECURE all collapse to the
  * same behavior here. Unknown flag bits must still return EINVAL per kernel
- * behavior (kernel/random.c rejects flags & ~SUPPORTED_FLAGS) so callers do
- * not silently fossilize wrong assumptions about the elfuse implementation.
+ * behavior (kernel/random.c rejects flags & ~SUPPORTED_FLAGS) so callers do not
+ * silently fossilize wrong assumptions about the elfuse implementation.
  */
 #define LINUX_GRND_NONBLOCK 0x0001
 #define LINUX_GRND_RANDOM 0x0002
@@ -270,8 +270,8 @@ int64_t sys_sched_getaffinity(guest_t *g,
                               uint64_t size,
                               uint64_t mask_gva)
 {
-    /* Return a 1-CPU affinity mask for simplicity.
-     * sched_setaffinity is not implemented; all threads see CPU 0.
+    /* Return a 1-CPU affinity mask for simplicity. sched_setaffinity is not
+     * implemented; all threads see CPU 0.
      */
     if (pid < 0)
         return -LINUX_EINVAL;
@@ -291,8 +291,8 @@ int64_t sys_sched_getaffinity(guest_t *g,
                           sizeof(cached_affinity_mask)) < 0)
         return -LINUX_EFAULT;
 
-    /* Linux zeroes remaining bytes past the fixed mask.
-     * Use guest_write in chunks for bounds safety.
+    /* Linux zeroes remaining bytes past the fixed mask. Use guest_write in
+     * chunks for bounds safety.
      */
     if (size > sizeof(cached_affinity_mask)) {
         uint64_t off = sizeof(cached_affinity_mask);
@@ -312,18 +312,18 @@ int64_t sys_sched_getaffinity(guest_t *g,
 
 /* Scheduler policy stubs.
  *
- * elfuse models a single SCHED_OTHER thread group. Linux scheduler syscalls
- * are per-thread: the pid argument is actually a TID, and a worker calling
+ * elfuse models a single SCHED_OTHER thread group. Linux scheduler syscalls are
+ * per-thread: the pid argument is actually a TID, and a worker calling
  * sched_getscheduler(gettid()) must reach its own thread entry, not just the
  * thread-group leader. Live TIDs are matched via thread_tid_alive(); pid 0
  * means "the calling thread" and is always accepted.
  *
  * Any policy transition away from SCHED_OTHER is rejected unless the stub can
  * model it faithfully. Callers branch on the apparent policy, and silently
- * accepting BATCH/IDLE/RT classes while still reporting SCHED_OTHER would
- * hide guest bugs. SCHED_DEADLINE through legacy sched_setscheduler is
- * -EINVAL because the legacy syscall cannot supply the deadline attributes
- * (real Linux requires sched_setattr).
+ * accepting BATCH/IDLE/RT classes while still reporting SCHED_OTHER would hide
+ * guest bugs. SCHED_DEADLINE through legacy sched_setscheduler is -EINVAL
+ * because the legacy syscall cannot supply the deadline attributes (real Linux
+ * requires sched_setattr).
  *
  * Errno ordering follows Linux 6.x kernel/sched/syscalls.c:
  *   1. pid < 0 or NULL param pointer -> EINVAL
@@ -342,20 +342,22 @@ static bool sched_pid_alive(int pid)
     return thread_tid_alive((int64_t) pid) != 0;
 }
 
-/* Validate a sched_param for the named policy. Returns 0 if accepted by the
- * stub, or a negative Linux errno. EPERM is reserved for "request would be
- * valid on Linux but the stub refuses to honor it" -- RT priority elevation
- * and BATCH/IDLE class transitions away from SCHED_OTHER. EINVAL covers
- * every other out-of-spec input (bad priority range, SCHED_DEADLINE through
- * the legacy entry point, unknown policy bits).
+/* Validate a sched_param for the named policy.
+ *
+ * Returns 0 if accepted by the stub, or a negative Linux errno. EPERM is
+ * reserved for "request would be valid on Linux but the stub refuses to honor
+ * it" -- RT priority elevation and BATCH/IDLE class transitions away from
+ * SCHED_OTHER. EINVAL covers every other out-of-spec input (bad priority range,
+ * SCHED_DEADLINE through the legacy entry point, unknown policy bits).
  */
 static int sched_check_policy_param(int policy, int prio)
 {
     int base_policy = policy & ~LINUX_SCHED_RESET_ON_FORK;
 
-    /* Reject any unknown high bit. The mask 0x7 covers every base policy
-     * id we recognize (NORMAL=0, FIFO=1, RR=2, BATCH=3, IDLE=5, DEADLINE=6);
-     * the unused 4 and 7 fall through to the default switch arm below.
+    /* Reject any unknown high bit. The mask 0x7 covers every base policy id the
+     * dispatcher recognizes (NORMAL=0, FIFO=1, RR=2, BATCH=3, IDLE=5,
+     * DEADLINE=6); the unused 4 and 7 fall through to the default switch arm
+     * below.
      */
     if (policy & ~(LINUX_SCHED_RESET_ON_FORK | 0x7))
         return -LINUX_EINVAL;
@@ -471,11 +473,11 @@ int64_t sys_sched_rr_get_interval(guest_t *g, int pid, uint64_t ts_gva)
         return -LINUX_ESRCH;
     if (ts_gva == 0)
         return -LINUX_EFAULT;
-    /* Linux's fair_sched_class.get_rr_interval returns a CFS-derived slice
-     * for SCHED_OTHER tasks whenever the runqueue carries load. Reporting
-     * 100 ms (the sched_rr_timeslice default and a typical CFS quantum)
-     * gives querying tools a plausible non-zero value without pretending
-     * the guest is actually under SCHED_RR.
+    /* Linux's fair_sched_class.get_rr_interval returns a CFS-derived slice for
+     * SCHED_OTHER tasks whenever the runqueue carries load. Reporting 100 ms
+     * (the sched_rr_timeslice default and a typical CFS quantum) gives querying
+     * tools a plausible non-zero value without pretending the guest is actually
+     * under SCHED_RR.
      */
     linux_timespec_t ts = {.tv_sec = 0, .tv_nsec = 100 * 1000 * 1000L};
     if (guest_write_small(g, ts_gva, &ts, sizeof(ts)) < 0)
@@ -503,8 +505,8 @@ int64_t sys_getgroups(guest_t *g, int size, uint64_t list_gva)
 
 int64_t sys_getrusage(guest_t *g, int who, uint64_t usage_gva)
 {
-    /* Linux RUSAGE_SELF=0, RUSAGE_CHILDREN=-1, RUSAGE_THREAD=1.
-     * macOS has the same values. Reject unknown values early.
+    /* Linux RUSAGE_SELF=0, RUSAGE_CHILDREN=-1, RUSAGE_THREAD=1. macOS has the
+     * same values. Reject unknown values early.
      */
     if (who != 0 && who != -1 && who != 1)
         return -LINUX_EINVAL;
@@ -558,8 +560,8 @@ int64_t sys_sysinfo(guest_t *g, uint64_t info_gva)
 
 /* Resource limits. */
 
-/* Translate Linux RLIMIT_* resource numbers to macOS equivalents.
- * The numbering differs: Linux RLIMIT_NPROC=6 vs macOS RLIMIT_NPROC=7.
+/* Translate Linux RLIMIT_* resource numbers to macOS equivalents. The numbering
+ * differs: Linux RLIMIT_NPROC=6 vs macOS RLIMIT_NPROC=7.
  */
 static int translate_rlimit_resource(int linux_res)
 {
@@ -693,8 +695,8 @@ int64_t sys_prlimit64(guest_t *g,
 
         rlimit_cache_set(resource, new_lim);
 
-        /* Track RLIMIT_NOFILE in the guest FD table so fd_alloc
-         * enforces the limit and returns -EMFILE.
+        /* Track RLIMIT_NOFILE in the guest FD table so fd_alloc enforces the
+         * limit and returns -EMFILE.
          */
         if (resource == 7 /* RLIMIT_NOFILE */) {
             int cur = (new_lim.rlim_cur == UINT64_MAX) ? FD_TABLE_SIZE
@@ -754,9 +756,8 @@ int sys_format_limits(char *buf, size_t bufsz)
         if (RANGE_CHECK(res, 0, RLIMIT_CACHE_SIZE)) {
             linux_rlimit64_t lim;
             if (!rlimit_cache_get(res, &lim)) {
-                /* RLIMIT_NOFILE (Linux 7): use the guest FD table
-                 * limit rather than host getrlimit, which may return
-                 * RLIM_INFINITY on macOS.
+                /* RLIMIT_NOFILE (Linux 7): use the guest FD table limit rather
+                 * than host getrlimit, which may return RLIM_INFINITY on macOS.
                  */
                 if (res == 7) {
                     int cur = fd_get_rlimit_nofile();

--- a/src/syscall/sys.h
+++ b/src/syscall/sys.h
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Uname, getrandom, getcwd, sched_getaffinity, getgroups, getrusage,
- * sysinfo, and prlimit64. System queries that do not fit neatly into
- * filesystem, I/O, or time categories.
+ * Uname, getrandom, getcwd, sched_getaffinity, getgroups, getrusage, sysinfo,
+ * and prlimit64. System queries that do not fit neatly into filesystem, I/O, or
+ * time categories.
  */
 
 #pragma once
@@ -49,7 +49,8 @@ int64_t sys_prlimit64(guest_t *g,
                       uint64_t new_gva,
                       uint64_t old_gva);
 
-/* Format /proc/self/limits content into buf.  Returns bytes written
- * (excluding NUL) or -1 on error.
+/* Format /proc/self/limits content into buf.
+ *
+ * Returns bytes written (excluding NUL) or -1 on error.
  */
 int sys_format_limits(char *buf, size_t bufsz);

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Dispatch table, sc_xxx adapter wrappers, fast-path read/write,
- * and the main syscall_dispatch() entry point. Core infrastructure
- * and syscall implementations live in focused modules:
+ * Dispatch table, sc_xxx adapter wrappers, fast-path read/write, and the main
+ * syscall_dispatch() entry point. Core infrastructure and syscall
+ * implementations live in focused modules:
  *   syscall/fdtable.c:   FD table, bitmap allocator, alloc/close/snapshot
  *   syscall/translate.c: errno/flag translation (macOS <-> Linux)
  *   syscall/mem.c:       brk, mmap, munmap, mprotect, mremap, madvise, msync
@@ -73,8 +73,8 @@
  * (e.g., the Nix-pinned apple-sdk-14.4) lack the enumerator. The encoding is
  * stable: op0=3, op1=0, CRn=1, CRm=0, op2=1 -> 0xc081. Hypervisor.framework
  * exposes ACTLR_EL1 only on hardware/OS combinations where the bit is
- * meaningful (Apple Silicon TSO toggle); older platforms simply leave actlr
- * at 0, which falls through to PR_SET_MEM_MODEL_DEFAULT.
+ * meaningful (Apple Silicon TSO toggle); older platforms simply leave actlr at
+ * 0, which falls through to PR_SET_MEM_MODEL_DEFAULT.
  *
  * The guard checks the SDK version rather than the macro presence: on macOS 15+
  * the symbol is an enumerator (not a #define), so a plain #ifndef would always
@@ -89,9 +89,9 @@ void syscall_init(void)
 {
     fdtable_init();
     signal_init();
-    /* Mirror signal_init's attention_guest reset for the fd/urandom
-     * bitmap singleton in shim-globals. Defends against a stale
-     * parent-process pointer surviving across posix_spawn re-init.
+    /* Mirror signal_init's attention_guest reset for the fd/urandom bitmap
+     * singleton in shim-globals. Defends against a stale parent-process pointer
+     * surviving across posix_spawn re-init.
      */
     shim_globals_reset_singleton();
 
@@ -119,10 +119,12 @@ void syscall_init(void)
 /* Syscall handler table. */
 
 /* Each sc_xxx wrapper adapts one (or a group of fall-through) case(s) from the
- * old switch into a uniform signature.  Returns int64_t result, or a sentinel:
- * SYSCALL_EXEC_HAPPENED for exec/sigreturn, (INT64_MIN | code) for
- * exit/exit_group. Wrappers that need mmap_lock acquire it internally. Wrappers
- * that need the vCPU handle use current_thread->vcpu.
+ * old switch into a uniform signature.
+ *
+ * Returns int64_t result, or a sentinel: SYSCALL_EXEC_HAPPENED for
+ * exec/sigreturn, (INT64_MIN | code) for exit/exit_group. Wrappers that need
+ * mmap_lock acquire it internally. Wrappers that need the vCPU handle use
+ * current_thread->vcpu.
  */
 typedef int64_t (*syscall_handler_t)(guest_t *g,
                                      uint64_t x0,
@@ -148,8 +150,8 @@ typedef int64_t (*syscall_handler_t)(guest_t *g,
  *   SC_LOCKED(name, expr):  same, but hold mmap_lock during the call
  *   SC_STUB(name, val):     return a constant (alias for SC_FORWARD)
  *
- * All parameters are marked (void) to suppress -Wunused-parameter.
- * The body expression may reference g, x0-x5, and verbose freely.
+ * All parameters are marked (void) to suppress -Wunused-parameter. The body
+ * expression may reference g, x0-x5, and verbose freely.
  */
 
 /* clang-format off */
@@ -176,22 +178,21 @@ typedef int64_t (*syscall_handler_t)(guest_t *g,
 
 #define SC_STUB(name, val) SC_FORWARD(name, (val))
 
-/* Bracket setuid/setgid family invocations so concurrent shim-fast-path
- * readers cannot observe stale credentials. The host-side proc_sys_*
- * mutators flip the _Atomic credential slots inside proc-identity.c;
- * the shim cache must reflect that under the same atomic window.
+/* Bracket setuid/setgid family invocations so concurrent shim-fast-path readers
+ * cannot observe stale credentials. The host-side proc_sys_* mutators flip the
+ * _Atomic credential slots inside proc-identity.c; the shim cache must reflect
+ * that under the same atomic window.
  *
- * Sequence: OR ATTN_BIT_CRED -> mutator -> on success publish_creds ->
- * AND ~ATTN_BIT_CRED. The OR-only update preserves whatever
- * ATTN_BIT_SIGTIMER state the HVC #5 epilogue's recompute may have
- * set or cleared in parallel; AND-only clear at the end leaves the
- * SIGTIMER lane alone. Earlier revisions wrote the full word, which
- * let a sibling's recompute drop the flag to zero mid-publish and
- * reopened the torn-cred race the bracket was meant to close.
+ * Sequence: OR ATTN_BIT_CRED -> mutator -> on success publish_creds -> AND
+ * ~ATTN_BIT_CRED. The OR-only update preserves whatever ATTN_BIT_SIGTIMER state
+ * the HVC #5 epilogue's recompute may have set or cleared in parallel; AND-only
+ * clear at the end leaves the SIGTIMER lane alone. Earlier revisions wrote the
+ * full word, which let a sibling's recompute drop the flag to zero mid-publish
+ * and reopened the torn-cred race the bracket was meant to close.
  *
- * Implemented as a statement-expression macro so the SC_FORWARD body
- * stays a single expression and the mutator runs after the attention
- * raise as part of normal C sequencing.
+ * Implemented as a statement-expression macro so the SC_FORWARD body stays a
+ * single expression and the mutator runs after the attention raise as part of
+ * normal C sequencing.
  */
 #define CRED_BRACKETED(g_, mutator_)                                       \
     __extension__({                                                        \
@@ -221,7 +222,8 @@ SC_FORWARD(sc_pwrite64,  sys_pwrite64(g, (int) x0, x1, x2, (int64_t) x3))
 SC_FORWARD(sc_ioctl,     sys_ioctl(g, (int) x0, x1, x2))
 SC_FORWARD(sc_preadv,    sys_preadv(g, (int) x0, x1, (int) x2, (int64_t) x3))
 SC_FORWARD(sc_pwritev,   sys_pwritev(g, (int) x0, x1, (int) x2, (int64_t) x3))
-/* aarch64 LP64 raw ABI: x3=pos_l (full 64-bit offset), x4=pos_h (0), x5=flags */
+/* aarch64 LP64 raw ABI: x3=pos_l (full 64-bit offset), x4=pos_h (0), x5=flags
+ */
 SC_FORWARD(sc_preadv2,   sys_preadv2(g, (int) x0, x1, (int) x2, (int64_t) x3, (int) x5))
 SC_FORWARD(sc_pwritev2,  sys_pwritev2(g, (int) x0, x1, (int) x2, (int64_t) x3, (int) x5))
 SC_FORWARD(sc_sendfile,  sys_sendfile(g, (int) x0, (int) x1, x2, x3))
@@ -248,18 +250,18 @@ SC_FORWARD(sc_linkat,      sys_linkat(g, (int) x0, x1, (int) x2, x3, (int) x4))
 SC_FORWARD(sc_mount,       sys_mount(g, x0, x1, x2, (unsigned long) x3, x4))
 SC_FORWARD(sc_fchmod,      sys_fchmod((int) x0, (uint32_t) x1))
 
-/* Linux fchmodat (SYS 53) is 3-arg: dirfd, path, mode.
- * The flags parameter was added in fchmodat2 (SYS 452).
- * x3 contains garbage from the caller's register state.
+/* Linux fchmodat (SYS 53) is 3-arg: dirfd, path, mode. The flags parameter was
+ * added in fchmodat2 (SYS 452). x3 contains garbage from the caller's register
+ * state.
  */
 SC_FORWARD(sc_fchmodat,    sys_fchmodat(g, (int) x0, x1, (uint32_t) x2, 0))
 SC_FORWARD(sc_fchmodat2,   sys_fchmodat(g, (int) x0, x1, (uint32_t) x2, (int) x3))
 SC_FORWARD(sc_fchownat,    sys_fchownat(g, (int) x0, x1, (uint32_t) x2, (uint32_t) x3, (int) x4))
 SC_FORWARD(sc_fchown,      sys_fchown((int) x0, (uint32_t) x1, (uint32_t) x2))
 SC_FORWARD(sc_utimensat,   sys_utimensat(g, (int) x0, x1, x2, (int) x3))
-/* Linux faccessat (SYS 48) is 3-arg: dirfd, path, mode.
- * The flags parameter was added in faccessat2 (SYS 439).
- * x3 contains garbage from the caller's register state.
+/* Linux faccessat (SYS 48) is 3-arg: dirfd, path, mode. The flags parameter was
+ * added in faccessat2 (SYS 439). x3 contains garbage from the caller's register
+ * state.
  */
 SC_FORWARD(sc_faccessat,   sys_faccessat(g, (int) x0, x1, (int) x2, 0))
 SC_FORWARD(sc_faccessat2,  sys_faccessat(g, (int) x0, x1, (int) x2, (int) x3))
@@ -366,7 +368,8 @@ SC_FORWARD(sc_sched_get_priority_min, sys_sched_get_priority_min((int) x0))
 SC_FORWARD(sc_sched_get_priority_max, sys_sched_get_priority_max((int) x0))
 SC_FORWARD(sc_sched_rr_get_interval,  sys_sched_rr_get_interval(g, (int) x0, x1))
 
-/* Process identity is modeled as one Linux process inside this elfuse instance. */
+/* Process identity is modeled as one Linux process inside this elfuse instance.
+ */
 SC_FORWARD(sc_exit,    SC_EXIT_SENTINEL | ((int) x0 & 0xFF))
 SC_FORWARD(sc_getpid,  proc_get_pid())
 SC_FORWARD(sc_getppid, proc_get_ppid())
@@ -634,8 +637,8 @@ static int64_t sc_sched_setaffinity(guest_t *g,
     return 0;
 }
 
-/* Callback for thread_for_each: force-exit each worker vCPU.
- * Skips the calling thread. Used by exit_group and membarrier.
+/* Callback for thread_for_each: force-exit each worker vCPU. Skips the calling
+ * thread. Used by exit_group and membarrier.
  */
 static void thread_force_exit_cb(thread_entry_t *t, void *ctx)
 {
@@ -910,8 +913,8 @@ static int64_t sc_rt_tgsigqueueinfo(guest_t *g,
             log_debug("rt_tgsigqueueinfo(tgid=%d, tid=%d, sig=%d, si_code=%d)",
                       tgid, tid, sig, info.si_code);
     }
-    /* Queued signals carry sigval in si_value for both standard and RT
-     * signals; standard signals still coalesce to one pending instance.
+    /* Queued signals carry sigval in si_value for both standard and RT signals;
+     * standard signals still coalesce to one pending instance.
      */
     if (uinfo_gva) {
         int32_t si_int = 0;
@@ -928,23 +931,22 @@ static int64_t sc_rt_tgsigqueueinfo(guest_t *g,
 
 /* rt_sigqueueinfo(pid, sig, info) -- POSIX sigqueue() in glibc/musl uses this.
  *
- * The first argument is documented as a process identifier, but real Linux
- * is permissive: kill_pid_info() looks pid up in the task table and routes
- * the signal through PIDTYPE_TGID, so a thread id that resolves to a task
- * succeeds and the signal lands in that task's thread-group pending set.
- * Foreign pids that match no task return -ESRCH.
+ * The first argument is documented as a process identifier, but real Linux is
+ * permissive: kill_pid_info() looks pid up in the task table and routes the
+ * signal through PIDTYPE_TGID, so a thread id that resolves to a task succeeds
+ * and the signal lands in that task's thread-group pending set. Foreign pids
+ * that match no task return -ESRCH.
  *
  * elfuse mirrors this by forwarding to sc_rt_tgsigqueueinfo with
  * tgid==tid==pid: the downstream thread_find() lookup accepts any guest
- * thread's tid (collapsing to the single guest tgid), the
- * proc_get_pid() fallback accepts the main thread's tid, and unknown
- * pids fall through to -ESRCH. signal_queue_info() then queues
- * process-wide so the routing semantics match Linux even though the
- * lookup goes through the per-thread table.
+ * thread's tid (collapsing to the single guest tgid), the proc_get_pid()
+ * fallback accepts the main thread's tid, and unknown pids fall through to
+ * -ESRCH. signal_queue_info() then queues process-wide so the routing semantics
+ * match Linux even though the lookup goes through the per-thread table.
  *
- * Earlier review feedback flagged "incorrectly accepting thread ids"
- * and recommended a strict pid==tgid gate; that gate was tried and
- * rejected because the qemu/Linux reference accepts the same tids.
+ * Earlier review feedback flagged "incorrectly accepting thread ids" and
+ * recommended a strict pid==tgid gate; that gate was tried and rejected because
+ * the qemu/Linux reference accepts the same tids.
  */
 static int64_t sc_rt_sigqueueinfo(guest_t *g,
                                   uint64_t x0,
@@ -1033,9 +1035,9 @@ static int64_t sc_prctl(guest_t *g,
          */
         return (x1 <= LINUX_CAP_LAST_CAP) ? 1 : -LINUX_EINVAL;
     case LINUX_PR_SET_VMA:
-        /* PR_SET_VMA with PR_SET_VMA_ANON_NAME: accept and ignore.
-         * Android and memory profiling tools use this to name anonymous mmap
-         * regions. The name is purely advisory.
+        /* PR_SET_VMA with PR_SET_VMA_ANON_NAME: accept and ignore. Android and
+         * memory profiling tools use this to name anonymous mmap regions. The
+         * name is purely advisory.
          */
         if ((int) x1 == LINUX_PR_SET_VMA_ANON_NAME)
             return 0;
@@ -1371,12 +1373,11 @@ static int64_t sc_memfd_create(guest_t *g,
     (RESOLVE_NO_XDEV | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_SYMLINKS | \
      RESOLVE_BENEATH | RESOLVE_IN_ROOT | RESOLVE_CACHED)
 
-/* Linux openat2() treats the user-supplied open_how size as an ABI
- * version. The first published layout has three u64 fields
- * (flags, mode, resolve), so v0 is 24 bytes. Bytes beyond that are
- * future extension fields: all-zero tails are ignored, nonzero tails
- * return E2BIG. Keep the same page-sized upper bound Linux applies
- * before checking the tail.
+/* Linux openat2() treats the user-supplied open_how size as an ABI version. The
+ * first published layout has three u64 fields (flags, mode, resolve), so v0 is
+ * 24 bytes. Bytes beyond that are future extension fields: all-zero tails are
+ * ignored, nonzero tails return E2BIG. Keep the same page-sized upper bound
+ * Linux applies before checking the tail.
  */
 #define OPEN_HOW_SIZE_VER0 24
 #define OPEN_HOW_MAX_SIZE 4096
@@ -1467,9 +1468,9 @@ static int64_t sc_openat2(guest_t *g,
     if ((resolve & RESOLVE_BENEATH) && (resolve & RESOLVE_IN_ROOT))
         return -LINUX_EINVAL;
 
-    /* RESOLVE_CACHED asks the kernel to satisfy lookup from cache only.
-     * elfuse has no dentry cache, so report EAGAIN and let the guest retry
-     * without this constraint.
+    /* RESOLVE_CACHED asks the kernel to satisfy lookup from cache only. elfuse
+     * has no dentry cache, so report EAGAIN and let the guest retry without
+     * this constraint.
      */
     if (resolve & RESOLVE_CACHED)
         return -LINUX_EAGAIN;
@@ -1550,25 +1551,24 @@ static int64_t sc_openat2(guest_t *g,
                 sys_openat_path(g, (int) x0, rooted, (int) oflags, (int) mode);
         } else {
             /* Reuse the precheck-validated path[] rather than re-reading from
-             * guest VA x1, so a sibling vCPU cannot swap the string between
-             * the constraint checks above and the actual open.
+             * guest VA x1, so a sibling vCPU cannot swap the string between the
+             * constraint checks above and the actual open.
              */
             opened =
                 sys_openat_path(g, (int) x0, path, (int) oflags, (int) mode);
         }
         if (opened >= 0 && (resolve & RESOLVE_NO_XDEV) &&
             no_xdev_start_class >= 0) {
-            /* The string walker cannot see symlinks that the kernel
-             * followed during the actual open (sysroot case-fold sidecar
-             * shadows hide the link node from the precheck's fstatat
-             * walk). Re-classify the opened fd's resolved host path; if
-             * it landed in a different mount class, drop the fd and
-             * return EXDEV. This also tightens the precheck-vs-open
-             * TOCTOU window since the post-check sees the exact path
-             * the kernel resolved.
+            /* The string walker cannot see symlinks that the kernel followed
+             * during the actual open (sysroot case-fold sidecar shadows hide
+             * the link node from the precheck's fstatat walk). Re-classify the
+             * opened fd's resolved host path; if it landed in a different mount
+             * class, drop the fd and return EXDEV. This also tightens the
+             * precheck-vs-open TOCTOU window since the post-check sees the
+             * exact path the kernel resolved.
              *
-             * Fail closed on post-check errors: a fd whose class cannot
-             * be derived must not silently bypass the NO_XDEV contract.
+             * Fail closed on post-check errors: a fd whose class cannot be
+             * derived must not silently bypass the NO_XDEV contract.
              */
             int crossed =
                 path_openat2_check_fd_xdev((int) opened, no_xdev_start_class);
@@ -1686,8 +1686,8 @@ static int64_t sc_execveat(guest_t *g,
     pthread_mutex_lock(&mmap_lock);
     int64_t r;
     if (need_resolve) {
-        /* Use the host-resolved path directly so execveat does not copy a
-         * host pathname back into guest memory.
+        /* Use the host-resolved path directly so execveat does not copy a host
+         * pathname back into guest memory.
          */
         r = sys_execve(vcpu, g, 0, x2, x3, verbose, resolved);
     } else {
@@ -1934,8 +1934,8 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
                 goto slow_path;
             }
 
-            /* read() writes into the buffer (needs W); write() reads from
-             * the buffer (needs R).
+            /* read() writes into the buffer (needs W); write() reads from the
+             * buffer (needs R).
              */
             int perms = (nr == SYS_read) ? MEM_PERM_W : MEM_PERM_R;
             uint64_t avail = 0;
@@ -1965,12 +1965,12 @@ slow_path:
 /*
  * Private embedder pseudo-syscall for translated guests.
  *
- * This is not a Linux syscall number. Translated x86_64 guests cannot
- * issue native AArch64 HVC instructions, so elfuse uses this private
- * build-selected syscall number as the translated counterpart to HVC 6.
+ * This is not a Linux syscall number. Translated x86_64 guests cannot issue
+ * native AArch64 HVC instructions, so elfuse uses this private build-selected
+ * syscall number as the translated counterpart to HVC 6.
  *
- * This path is gated on g->is_rosetta so native AArch64 guests cannot
- * reach the embedder hook through SVC.
+ * This path is gated on g->is_rosetta so native AArch64 guests cannot reach the
+ * embedder hook through SVC.
  *
  * Layout:
  *   x8 = ELFUSE_ROSETTA_EMBEDDER_SYSCALL
@@ -2026,10 +2026,10 @@ slow_path:
             result = 0; /* Not written back, but keep clean */
         } else if (result == SYSCALL_EXEC_HAPPENED) {
             if (hist_start_ns) {
-                /* Guard the subtraction: syscall_hist_now_ns returns 0
-                 * if clock_gettime fails. An unsigned 0 minus a non-zero
-                 * start would underflow to a huge value and pollute the
-                 * histogram with a bogus latency sample.
+                /* Guard the subtraction: syscall_hist_now_ns returns 0 if
+                 * clock_gettime fails. An unsigned 0 minus a non-zero start
+                 * would underflow to a huge value and pollute the histogram
+                 * with a bogus latency sample.
                  */
                 uint64_t hist_end_ns = syscall_hist_now_ns();
                 if (hist_end_ns >= hist_start_ns)
@@ -2073,8 +2073,8 @@ fast_done:
          * src/core/guest.h); the helper also handles the HVC #11 EL0-fault
          * lazy-materialize path so both call sites use the same wire codes.
          * Must call the emit helper because the shim reads X8 unconditionally
-         * on return; the pre-syscall X8 is the syscall number (always
-         * non-zero) and would spuriously TLBI on every return.
+         * on return; the pre-syscall X8 is the syscall number (always non-zero)
+         * and would spuriously TLBI on every return.
          *
          * cpu_tlbi_req is a per-vCPU TLS slot, so this read needs no lock and
          * cannot be drained or torn by another vCPU's epilogue.

--- a/src/syscall/sysvipc.c
+++ b/src/syscall/sysvipc.c
@@ -4,14 +4,12 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * shmget, shmat, shmdt, shmctl, semget, semop, semctl,
- * msgget, msgsnd, msgrcv, msgctl.
- * Forwards to macOS SysV IPC with structure translation.
+ * shmget, shmat, shmdt, shmctl, semget, semop, semctl, msgget, msgsnd, msgrcv,
+ * msgctl. Forwards to macOS SysV IPC with structure translation.
  *
- * shmat limitation: HVF guest memory cannot directly map host shm
- * segments. Data is copied between host shm and guest memory on
- * attach/detach. True cross-process shared semantics require a
- * more complex synchronization scheme.
+ * shmat limitation: HVF guest memory cannot directly map host shm segments.
+ * Data is copied between host shm and guest memory on attach/detach. True
+ * cross-process shared semantics require a more complex synchronization scheme.
  */
 
 #include <errno.h>
@@ -211,8 +209,8 @@ static int translate_semctl_cmd(int linux_cmd)
 int64_t sys_shmget(guest_t *g, int32_t key, uint64_t size, int shmflg)
 {
     (void) g;
-    /* IPC_CREAT, IPC_EXCL, IPC_PRIVATE, and permission bits are the
-     * same numeric values on Linux and macOS. Pass through directly.
+    /* IPC_CREAT, IPC_EXCL, IPC_PRIVATE, and permission bits are the same
+     * numeric values on Linux and macOS. Pass through directly.
      */
     int id = shmget((key_t) key, (size_t) size, shmflg);
     if (id < 0)
@@ -238,14 +236,14 @@ int64_t sys_shmat(guest_t *g, int shmid, uint64_t shmaddr_gva, int shmflg)
     if (host_addr == (void *) -1)
         return linux_errno();
 
-    /* Allocate guest memory via anonymous mmap. shmaddr_gva hint is
-     * ignored for simplicity; SysV SHM always lets the allocator choose.
-     * A MAP_FIXED path could be added if programs depend on it.
+    /* Allocate guest memory via anonymous mmap. shmaddr_gva hint is ignored for
+     * simplicity; SysV SHM always lets the allocator choose. A MAP_FIXED path
+     * could be added if programs depend on it.
      */
     (void) shmaddr_gva;
 
-    /* Always allocate RW initially so the code can copy shm content in.
-     * For SHM_RDONLY, downgrade to read-only via mprotect after the copy.
+    /* Always allocate RW initially so the code can copy shm content in. For
+     * SHM_RDONLY, downgrade to read-only via mprotect after the copy.
      */
     int64_t gva =
         sys_mmap_anon(g, 0, seg_size, LINUX_PROT_READ | LINUX_PROT_WRITE);
@@ -260,8 +258,8 @@ int64_t sys_shmat(guest_t *g, int shmid, uint64_t shmaddr_gva, int shmflg)
         return -LINUX_EFAULT;
     }
 
-    /* Downgrade to read-only for SHM_RDONLY via the standard mprotect
-     * path, which handles L2->L3 block splitting and TLBI correctly.
+    /* Downgrade to read-only for SHM_RDONLY via the standard mprotect path,
+     * which handles L2->L3 block splitting and TLBI correctly.
      */
     if (rdonly)
         sys_mprotect(g, (uint64_t) gva, PAGE_ALIGN_UP(seg_size),
@@ -321,8 +319,8 @@ int64_t sys_shmdt(guest_t *g, uint64_t shmaddr_gva)
     shmdt(entry.host_addr);
 
     /* Guest memory remains allocated (no munmap). Linux shmdt does not
-     * guarantee immediate unmap either; the pages become undefined.
-     * A real implementation would munmap the guest region here.
+     * guarantee immediate unmap either; the pages become undefined. A real
+     * implementation would munmap the guest region here.
      */
 
     return 0;
@@ -376,9 +374,11 @@ int64_t sys_shmctl(guest_t *g, int shmid, int cmd, uint64_t buf_gva)
     case LINUX_IPC_INFO:
     case LINUX_SHM_INFO:
     case LINUX_SHM_STAT:
-        /* IPC_INFO/SHM_INFO/SHM_STAT are Linux-specific and have no
-         * direct macOS equivalent. Return EINVAL rather than ENOSYS
-         * to match what a restricted-permission kernel would do.
+        /* IPC_INFO/SHM_INFO/SHM_STAT are Linux-specific and have no direct
+         * macOS equivalent.
+         *
+         * Return EINVAL rather than ENOSYS to match what a
+         * restricted-permission kernel would do.
          */
         return -LINUX_EINVAL;
 
@@ -567,8 +567,8 @@ int64_t sys_msgsnd(guest_t *g,
                    uint64_t msgsz,
                    int msgflg)
 {
-    /* Linux msgsnd msgp layout: long mtype followed by msgsz bytes of
-     * message text. Total read from guest = sizeof(long) + msgsz.
+    /* Linux msgsnd msgp layout: long mtype followed by msgsz bytes of message
+     * text. Total read from guest = sizeof(long) + msgsz.
      */
     if (msgsz > 65536)
         return -LINUX_EINVAL;
@@ -585,8 +585,8 @@ int64_t sys_msgsnd(guest_t *g,
         goto out;
     }
 
-    /* The mtype field is a 64-bit long on aarch64-linux. macOS also uses
-     * long (64-bit on arm64). Direct passthrough.
+    /* The mtype field is a 64-bit long on aarch64-linux. macOS also uses long
+     * (64-bit on arm64). Direct passthrough.
      */
     int flags = 0;
     if (msgflg & LINUX_IPC_NOWAIT)
@@ -610,8 +610,8 @@ int64_t sys_msgrcv(guest_t *g,
     if (msgsz > 65536)
         return -LINUX_EINVAL;
 
-    /* MSG_EXCEPT and MSG_COPY are Linux-specific queue selection modes.
-     * macOS cannot emulate either with a native msgrcv call.
+    /* MSG_EXCEPT and MSG_COPY are Linux-specific queue selection modes. macOS
+     * cannot emulate either with a native msgrcv call.
      */
     if (msgflg & (LINUX_MSG_COPY | LINUX_MSG_EXCEPT))
         return -LINUX_ENOSYS;

--- a/src/syscall/sysvipc.h
+++ b/src/syscall/sysvipc.h
@@ -4,11 +4,10 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * shmget, shmat, shmdt, shmctl, semget, semop, semctl,
- * msgget, msgsnd, msgrcv, msgctl.
- * Translates Linux SysV IPC calls to macOS equivalents.
- * shmat copies data between host shm and guest memory (HVF
- * cannot map host shm directly into guest address space).
+ * shmget, shmat, shmdt, shmctl, semget, semop, semctl, msgget, msgsnd, msgrcv,
+ * msgctl. Translates Linux SysV IPC calls to macOS equivalents. shmat copies
+ * data between host shm and guest memory (HVF cannot map host shm directly into
+ * guest address space).
  */
 
 #pragma once

--- a/src/syscall/time.c
+++ b/src/syscall/time.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Clock, nanosleep, gettimeofday, and interval timer operations. All
- * functions are called from syscall_dispatch() in syscall/syscall.c.
+ * Clock, nanosleep, gettimeofday, and interval timer operations. All functions
+ * are called from syscall_dispatch() in syscall/syscall.c.
  */
 
 #include <errno.h>
@@ -34,20 +34,20 @@
  *
  *   clockid = ~pid << 3 | type [| CPUCLOCK_PERTHREAD_MASK]
  *
- * Where type is:  CPUCLOCK_PROF=0, CPUCLOCK_VIRT=1, CPUCLOCK_SCHED=2
+ * Where type is: CPUCLOCK_PROF=0, CPUCLOCK_VIRT=1, CPUCLOCK_SCHED=2
  * CPUCLOCK_PERTHREAD_MASK = 4 (bit 2): set for per-thread, clear for
  * per-process pid = 0 means "self" (current process/thread).
  *
  * Examples: -2 = per-thread SCHED (self), -6 = per-process SCHED (self)
- * Threaded language runtimes use these (via pthread_getcpuclockid()) to
- * measure per-thread CPU time without sampling the whole process.
+ * Threaded language runtimes use these (via pthread_getcpuclockid()) to measure
+ * per-thread CPU time without sampling the whole process.
  */
 #define LINUX_CPUCLOCK_PERTHREAD_MASK 4
 /* Linux encodes the dynamic-pid clock as ((~pid) << 3) | type. Decoding is
  * ~clockid >> 3, but >> on a signed negative value is implementation-defined.
- * The complement of a negative value (high bit set) is non-negative, so apply
- * ~ via unsigned arithmetic and only then cast to int for a well-defined
- * right shift.
+ * The complement of a negative value (high bit set) is non-negative, so apply ~
+ * via unsigned arithmetic and only then cast to int for a well-defined right
+ * shift.
  */
 #define LINUX_CPUCLOCK_PID(clk) ((int) (~(unsigned int) (clk)) >> 3)
 
@@ -146,10 +146,9 @@ static int64_t interruptible_sleep_ns(guest_t *g,
     return 0;
 }
 
-/* Translate Linux clock IDs to macOS.
- * Linux: REALTIME=0, MONOTONIC=1, PROCESS_CPUTIME=2, THREAD_CPUTIME=3,
- * MONOTONIC_RAW=4 macOS: REALTIME=0, MONOTONIC_RAW=4, MONOTONIC=6,
- * PROCESS_CPUTIME=12, THREAD_CPUTIME=16
+/* Translate Linux clock IDs to macOS. Linux: REALTIME=0, MONOTONIC=1,
+ * PROCESS_CPUTIME=2, THREAD_CPUTIME=3, MONOTONIC_RAW=4 macOS: REALTIME=0,
+ * MONOTONIC_RAW=4, MONOTONIC=6, PROCESS_CPUTIME=12, THREAD_CPUTIME=16
  *
  * Negative clock IDs encode Linux dynamic per-process/per-thread CPU clocks.
  * time emulation translates pid=0 (self) clocks to the macOS equivalents; for
@@ -178,20 +177,19 @@ static int translate_clockid(int linux_clockid)
          */
         return CLOCK_MONOTONIC;
     default:
-        /* Handle Linux dynamic CPU clock IDs (negative values).
-         * Decode: encoded id = ~(clockid >> 3), perthread = clockid & 4,
-         * type bits = clockid & 3 (PROF=0, VIRT=1, SCHED=2).
-         * Linux's convention:
+        /* Handle Linux dynamic CPU clock IDs (negative values). Decode: encoded
+         * id = ~(clockid >> 3), perthread = clockid & 4, type bits = clockid &
+         * 3 (PROF=0, VIRT=1, SCHED=2). Linux's convention:
          *   encoded id == 0    -> "self" (process or thread variant)
          *   encoded id == pid  -> that process
          *   per-thread variant: encoded id == 0 means current thread,
          *                       or the target TID for pthread_getcpuclockid.
          *
-         * The macOS host only exposes CLOCK_THREAD_CPUTIME_ID for the
-         * calling thread, so cross-thread or cross-process queries are
-         * unsupportable. Accept both process and per-thread clocks when
-         * they refer to self (encoded 0 or matching self pid/tid). Reject
-         * foreign ids and reserved type bits with -EINVAL.
+         * The macOS host only exposes CLOCK_THREAD_CPUTIME_ID for the calling
+         * thread, so cross-thread or cross-process queries are unsupportable.
+         * Accept both process and per-thread clocks when they refer to self
+         * (encoded 0 or matching self pid/tid). Reject foreign ids and reserved
+         * type bits with -EINVAL.
          */
         if (linux_clockid < 0) {
             int type_bits = linux_clockid & 3;
@@ -275,17 +273,16 @@ int64_t sys_clock_gettime(guest_t *g, int clockid, uint64_t tp_gva)
     if (mac_clockid < 0)
         return -LINUX_EINVAL;
 
-    /* When the trap came from the __kernel_clock_gettime vDSO
-     * svc_fallback, the trampoline parked the guest's CNTVCT_EL0 read in
-     * X9 before SVC, and ELR_EL1 holds SVC_PC + 4. Use X9 to seed (or
-     * refresh) the vvar anchor so subsequent calls hit the fast path.
-     * Reject any other trap: X9 would then be arbitrary guest state and
-     * seeding from it would poison the anchor.
+    /* When the trap came from the __kernel_clock_gettime vDSO svc_fallback, the
+     * trampoline parked the guest's CNTVCT_EL0 read in X9 before SVC, and
+     * ELR_EL1 holds SVC_PC + 4. Use X9 to seed (or refresh) the vvar anchor so
+     * subsequent calls hit the fast path. Reject any other trap: X9 would then
+     * be arbitrary guest state and seeding from it would poison the anchor.
      *
-     * Order matters: read X9 first, then sample host wall clocks
-     * back-to-back, then write the guest result and seed. Sampling host
-     * clocks before checking X9 would bake a permanent positive bias
-     * into the anchor from the HVF round-trip in the seeding gate.
+     * Order matters: read X9 first, then sample host wall clocks back-to-back,
+     * then write the guest result and seed. Sampling host clocks before
+     * checking X9 would bake a permanent positive bias into the anchor from the
+     * HVF round-trip in the seeding gate.
      */
     bool from_trampoline = (clockid == 0 /* CLOCK_REALTIME */ ||
                             clockid == 1 /* CLOCK_MONOTONIC */) &&
@@ -309,8 +306,8 @@ int64_t sys_clock_gettime(guest_t *g, int clockid, uint64_t tp_gva)
 
     /* Sample the OTHER clockid back-to-back so both anchor pairs reflect
      * roughly the same host moment. If the second clock_gettime fails
-     * (defensive; unreachable on macOS), skip seeding rather than fail
-     * the user's request.
+     * (defensive; unreachable on macOS), skip seeding rather than fail the
+     * user's request.
      */
     struct timespec ts_other;
     bool can_seed = false;
@@ -327,9 +324,8 @@ int64_t sys_clock_gettime(guest_t *g, int clockid, uint64_t tp_gva)
         const struct timespec *ts_mono = (clockid == 1) ? &ts : &ts_other;
         const struct timespec *ts_real = (clockid == 0) ? &ts : &ts_other;
 
-        /* Publish when the vvar is unseeded, has aged out, or has
-         * drifted relative to the freshly-sampled REALTIME (catches
-         * macOS NTP steps).
+        /* Publish when the vvar is unseeded, has aged out, or has drifted
+         * relative to the freshly-sampled REALTIME (catches macOS NTP steps).
          */
         if (!vdso_anchor_is_seeded(g) ||
             vdso_anchor_age_exceeded(g, guest_cntvct) ||
@@ -342,11 +338,11 @@ int64_t sys_clock_gettime(guest_t *g, int clockid, uint64_t tp_gva)
     return 0;
 }
 
-/* Interruptible nanosleep: break long sleeps into 100ms chunks so
- * exit_group and pending signals can be checked periodically. Without
- * this, a thread blocked in a multi-second nanosleep cannot be
- * interrupted by exit_group because hv_vcpus_exit only breaks hv_vcpu_run,
- * not host-side blocking syscalls.
+/* Interruptible nanosleep: break long sleeps into 100ms chunks so exit_group
+ * and pending signals can be checked periodically. Without this, a thread
+ * blocked in a multi-second nanosleep cannot be interrupted by exit_group
+ * because hv_vcpus_exit only breaks hv_vcpu_run, not host-side blocking
+ * syscalls.
  */
 int64_t sys_nanosleep(guest_t *g, uint64_t req_gva, uint64_t rem_gva)
 {
@@ -374,11 +370,11 @@ int64_t sys_clock_nanosleep(guest_t *g,
     if (flags & ~TIMER_ABSTIME)
         return -LINUX_EINVAL;
     /* Linux's hrtimer_nanosleep_clockid validates the timespec via
-     * timespec64_valid_strict() (kernel/time/hrtimer.c) before deciding
-     * whether the absolute deadline has expired. Negative tv_sec is
-     * rejected with EINVAL even when TIMER_ABSTIME is set, not silently
-     * treated as 'already expired'. Reject negative tv_sec unconditionally
-     * so both relative and absolute callers match the kernel contract.
+     * timespec64_valid_strict() (kernel/time/hrtimer.c) before deciding whether
+     * the absolute deadline has expired. Negative tv_sec is rejected with
+     * EINVAL even when TIMER_ABSTIME is set, not silently treated as 'already
+     * expired'. Reject negative tv_sec unconditionally so both relative and
+     * absolute callers match the kernel contract.
      */
     if (!linux_timespec_valid(&lreq))
         return -LINUX_EINVAL;
@@ -441,10 +437,10 @@ int64_t sys_gettimeofday(guest_t *g, uint64_t tv_gva, uint64_t tz_gva)
     if (tv_gva && guest_write_small(g, tv_gva, &ltv, sizeof(ltv)) < 0)
         return -LINUX_EFAULT;
 
-    /* tz is obsolete on Linux but the kernel still zeroes a non-null
-     * pointer (struct timezone has two int32 fields, 8 bytes total).
-     * Matching the vDSO fast path's `str xzr, [tz]` here keeps SVC and
-     * fast-path callers observationally identical.
+    /* tz is obsolete on Linux but the kernel still zeroes a non-null pointer
+     * (struct timezone has two int32 fields, 8 bytes total). Matching the vDSO
+     * fast path's STR XZR, [tz] here keeps SVC and fast-path callers
+     * observationally identical.
      */
     if (tz_gva) {
         const uint64_t tz_zero = 0;
@@ -464,8 +460,8 @@ int64_t sys_gettimeofday(guest_t *g, uint64_t tv_gva, uint64_t tz_gva)
 
 int64_t sys_setitimer(guest_t *g, int which, uint64_t new_gva, uint64_t old_gva)
 {
-    /* Linux reads new_gva before dispatching on which, so an invalid
-     * pointer takes precedence over an invalid which value (EFAULT > EINVAL).
+    /* Linux reads new_gva before dispatching on which, so an invalid pointer
+     * takes precedence over an invalid which value (EFAULT > EINVAL).
      */
     linux_itimerval_t lnew;
     bool has_new = false;
@@ -527,8 +523,8 @@ int64_t sys_setitimer(guest_t *g, int which, uint64_t new_gva, uint64_t old_gva)
 
 int64_t sys_getitimer(guest_t *g, int which, uint64_t val_gva)
 {
-    /* ITIMER_REAL/VIRTUAL/PROF are all emulated internally
-     * (see sys_setitimer comment).
+    /* ITIMER_REAL/VIRTUAL/PROF are all emulated internally (see sys_setitimer
+     * comment).
      */
     struct timeval val, itv;
     if (which == 0)

--- a/src/syscall/translate.c
+++ b/src/syscall/translate.c
@@ -16,10 +16,10 @@
 
 /* Linux errno translation. */
 
-/* X-macro table: macOS->Linux errno mappings where values differ.
- * Only entries where macOS and Linux numeric values diverge are listed.
- * Errno values 1-34 are (mostly) identical and handled by the default path,
- * except EDEADLK (macOS 11 vs Linux 35) which must be explicit.
+/* X-macro table: macOS->Linux errno mappings where values differ. Only entries
+ * where macOS and Linux numeric values diverge are listed. Errno values 1-34
+ * are (mostly) identical and handled by the default path, except EDEADLK (macOS
+ * 11 vs Linux 35) which must be explicit.
  *
  * Format: _(macOS_errno, Linux_errno)
  */
@@ -70,8 +70,8 @@
     _(EOPNOTSUPP,      LINUX_EOPNOTSUPP)      /* mac 102 -> linux 95 */
 /* clang-format on */
 
-/* Convert macOS errno to the equivalent Linux errno value.
- * macOS and Linux errno values diverge starting around errno 35.
+/* Convert macOS errno to the equivalent Linux errno value. macOS and Linux
+ * errno values diverge starting around errno 35.
  * Returns the negative Linux errno for direct use as a syscall return.
  */
 int64_t linux_errno(void)
@@ -95,10 +95,10 @@ int64_t linux_errno(void)
         return -LINUX_EOPNOTSUPP;
 #endif
         /* macOS xattr "attribute not found" lives at 93 (ENOATTR) on modern
-         * SDKs; on some versions ENOATTR is a synonym for ENODATA(96). Map
-         * both to Linux ENODATA(61) so getxattr/lgetxattr/fgetxattr report
-         * missing attrs correctly. Guarded by #if to avoid duplicate cases
-         * when the headers alias the two macros.
+         * SDKs; on some versions ENOATTR is a synonym for ENODATA(96). Map both
+         * to Linux ENODATA(61) so getxattr/lgetxattr/fgetxattr report missing
+         * attrs correctly. Guarded by #if to avoid duplicate cases when the
+         * headers alias the two macros.
          */
 #ifdef ENOATTR
 #if !defined(ENODATA) || ENOATTR != ENODATA
@@ -131,9 +131,9 @@ int64_t linux_errno(void)
 
 /* Linux AT_* flags translation. */
 
-/* Translate Linux AT_* flags to macOS equivalents.
- * For unlinkat, fstatat, linkat, fchmodat, fchownat, utimensat.
- * Linux and macOS use different values for AT_SYMLINK_NOFOLLOW etc.
+/* Translate Linux AT_* flags to macOS equivalents. For unlinkat, fstatat,
+ * linkat, fchmodat, fchownat, utimensat. Linux and macOS use different values
+ * for AT_SYMLINK_NOFOLLOW etc.
  */
 int translate_at_flags(int linux_flags)
 {
@@ -148,10 +148,10 @@ int translate_at_flags(int linux_flags)
     return mac_flags;
 }
 
-/* Translate Linux faccessat flags to macOS equivalents.
- * Linux AT_EACCESS (0x200) shares the same value as AT_REMOVEDIR; the meaning
- * is context-dependent: 0x200 means AT_REMOVEDIR for unlinkat, but AT_EACCESS
- * for faccessat.
+/* Translate Linux faccessat flags to macOS equivalents. Linux AT_EACCESS
+ * (0x200) shares the same value as AT_REMOVEDIR; the meaning is
+ * context-dependent: 0x200 means AT_REMOVEDIR for unlinkat, but AT_EACCESS for
+ * faccessat.
  */
 int translate_faccessat_flags(int linux_flags)
 {
@@ -165,9 +165,9 @@ int translate_faccessat_flags(int linux_flags)
 
 /* Linux open flags translation. */
 
-/* X-macro table: Linux open flag -> macOS open flag (1:1 bit mappings).
- * Flags that have no macOS equivalent (O_LARGEFILE, O_DIRECT) are not listed
- * and are silently dropped.
+/* X-macro table: Linux open flag -> macOS open flag (1:1 bit mappings). Flags
+ * that have no macOS equivalent (O_LARGEFILE, O_DIRECT) are not listed and are
+ * silently dropped.
  *
  * Format: _(linux_flag, macos_flag)
  */
@@ -224,8 +224,8 @@ int translate_open_flags(int linux_flags)
     return flags;
 }
 
-/* Translate macOS status flags (from fcntl F_GETFL) to Linux equivalents.
- * Only status flags differ; access mode (low 2 bits) is the same.
+/* Translate macOS status flags (from fcntl F_GETFL) to Linux equivalents. Only
+ * status flags differ; access mode (low 2 bits) is the same.
  */
 int mac_to_linux_status_flags(int mac_flags)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,10 +19,10 @@
 #include <time.h>
 #include <unistd.h>
 
-/* Align x up to the next multiple of a; a must be a power of two.
- * Both x and a are evaluated as uint64_t. Most callers manipulate guest
- * addresses or sizes that already fit, so this avoids surprises from
- * signed/unsigned mixing in alignment masks.
+/* Align x up to the next multiple of a; a must be a power of two. Both x and a
+ * are evaluated as uint64_t. Most callers manipulate guest addresses or sizes
+ * that already fit, so this avoids surprises from signed/unsigned mixing in
+ * alignment masks.
  */
 #define ALIGN_UP(x, a) \
     (((uint64_t) (x) + ((uint64_t) (a) - 1)) & ~((uint64_t) (a) - 1))
@@ -31,8 +31,8 @@
 #define ALIGN_DOWN(x, a) ((uint64_t) (x) & ~((uint64_t) (a) - 1))
 
 /* The Linux ABI fixes the page size at 4KiB on aarch64 regardless of the host
- * page size, so this is shared by every guest memory path (mmap, brk,
- * mprotect, ELF loading).
+ * page size, so this is shared by every guest memory path (mmap, brk, mprotect,
+ * ELF loading).
  */
 #define GUEST_PAGE_SIZE 4096ULL
 #define PAGE_ALIGN_UP(x) ALIGN_UP(x, GUEST_PAGE_SIZE)
@@ -46,15 +46,15 @@
 /* Branchless range check: true when minx <= x < minx + size.
  *
  * Replaces the recurring pair (x >= minx && x < minx + size) with a single
- * unsigned compare: shift x into a [0, size) window and let unsigned
- * wraparound flag both underflow (x < minx) and overflow (x >= minx + size).
- * Width-safe for any operand up to uint64_t.
+ * unsigned compare: shift x into a [0, size) window and let unsigned wraparound
+ * flag both underflow (x < minx) and overflow (x >= minx + size). Width-safe
+ * for any operand up to uint64_t.
  *
- * Operands are cast to uint64_t *before* the subtraction so signed inputs
- * near the type extremes (e.g., LONG_MIN passed by a strtol result) cannot
- * trigger signed overflow UB. Negative signed values sign-extend through the
- * unsigned conversion to a large uint64_t, which still yields the correct
- * out-of-range answer.
+ * Operands are cast to uint64_t *before* the subtraction so signed inputs near
+ * the type extremes (e.g., LONG_MIN passed by a strtol result) cannot trigger
+ * signed overflow UB. Negative signed values sign-extend through the unsigned
+ * conversion to a large uint64_t, which still yields the correct out-of-range
+ * answer.
  *
  * Caveat: x and minx are evaluated twice; do not pass expressions with side
  * effects.
@@ -99,8 +99,8 @@ static inline size_t str_copy_trunc(char *dst, const char *src, size_t dst_size)
     return src_len;
 }
 
-/* close(2) on a cleanup path: preserves errno across the close so the
- * caller's failure errno survives untouched. Skips the close when fd < 0.
+/* close(2) on a cleanup path: preserves errno across the close so the caller's
+ * failure errno survives untouched. Skips the close when fd < 0.
  */
 static inline void close_keep_errno(int fd)
 {
@@ -110,8 +110,9 @@ static inline void close_keep_errno(int fd)
     errno = saved;
 }
 
-/* Enable an fd flag if it is not already set. Returns 0 on success or -1 with
- * errno preserved from the failing fcntl call.
+/* Enable an fd flag if it is not already set.
+ *
+ * Returns 0 on success or -1 with errno preserved from the failing fcntl call.
  */
 static inline int fd_set_fd_flag(int fd, int flag)
 {
@@ -150,12 +151,12 @@ static inline int fd_set_nonblock(int fd)
 
 /* Carry overflow/underflow between tv_nsec and tv_sec so the result is a
  * canonical timespec with 0 <= tv_nsec < 1e9. Uses div/mod (which truncate
- * toward zero in C99) plus a single borrow so the LONG_MIN case never
- * negates tv_nsec -- that would be undefined behavior.
+ * toward zero in C99) plus a single borrow so the LONG_MIN case never negates
+ * tv_nsec -- that would be undefined behavior.
  *
- * NSEC_PER_SEC is also defined by mach/clock_types.h and dispatch/time.h
- * on macOS; the guard avoids redefinition warnings when those system
- * headers are pulled in transitively.
+ * NSEC_PER_SEC is also defined by mach/clock_types.h and dispatch/time.h on
+ * macOS; the guard avoids redefinition warnings when those system headers are
+ * pulled in transitively.
  */
 #ifndef NSEC_PER_SEC
 #define NSEC_PER_SEC 1000000000L
@@ -171,8 +172,8 @@ static inline void timespec_normalize(struct timespec *ts)
     }
 }
 
-/* Compute a CLOCK_REALTIME absolute deadline that is rel_ms milliseconds in
- * the future, suitable for pthread_cond_timedwait().
+/* Compute a CLOCK_REALTIME absolute deadline that is rel_ms milliseconds in the
+ * future, suitable for pthread_cond_timedwait().
  */
 static inline void timespec_deadline_in_ms(struct timespec *out, long rel_ms)
 {
@@ -184,8 +185,8 @@ static inline void timespec_deadline_in_ms(struct timespec *out, long rel_ms)
 
 /* Bitmap helpers.
  *
- * Operate on a single uint64_t word. For multi-word bitmaps, callers index
- * the word and pass the bit position within it. Centralizing the shift and
+ * Operate on a single uint64_t word. For multi-word bitmaps, callers index the
+ * word and pass the bit position within it. Centralizing the shift and
  * compiler-intrinsic calls here keeps the meaning ("the bit for slot N",
  * "lowest set bit") visible at the call site instead of leaving readers to
  * decode 1ULL << (n) and __builtin_ctzll.
@@ -200,8 +201,8 @@ static inline uint64_t bit_mask64_low(unsigned int n)
     return n >= 64 ? UINT64_MAX : (BIT64(n) - 1);
 }
 
-/* Position of the lowest set bit. word must be non-zero -- __builtin_ctzll
- * is undefined on zero. Range: 0..63.
+/* Position of the lowest set bit. word must be non-zero -- __builtin_ctzll is
+ * undefined on zero. Range: 0..63.
  */
 static inline int bit_ctz64(uint64_t word)
 {
@@ -217,7 +218,7 @@ static inline int bit_popcount64(uint64_t word)
 /* Compiler attribute wrappers.
  *
  * PACKED removes inter-field padding, used for Linux ABI structures whose
- * layout must match the kernel exactly (e.g., linux_dirent64). Apply at the
- * end of a struct definition: } PACKED name_t;.
+ * layout must match the kernel exactly (e.g., linux_dirent64). Apply at the end
+ * of a struct definition: } PACKED name_t;.
  */
 #define PACKED __attribute__((packed))

--- a/tests/bench-futex-pingpong.c
+++ b/tests/bench-futex-pingpong.c
@@ -64,8 +64,8 @@ int main(void)
     flags = 0x00000100 | 0x00010000 | 0x00000800 | 0x00000200 |
             0x00000400; /* VM|THREAD|SIGHAND|FS|FILES */
 
-    /* aarch64 clone ABI: x0=flags, x1=child_stack, x2=parent_tid,
-     * x3=tls, x4=child_tid. The child returns at the same site.
+    /* aarch64 clone ABI: x0=flags, x1=child_stack, x2=parent_tid, x3=tls,
+     * x4=child_tid. The child returns at the same site.
      */
     long rc = raw_clone((unsigned long) flags, stack_top, NULL, 0, &ctid);
     if (rc == 0) {

--- a/tests/bench-hot-guard.c
+++ b/tests/bench-hot-guard.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Minimal bench that measures the three labels the guardrail script
- * checks against the TODO ceilings:
+ * Minimal bench that measures the three labels the guardrail script checks
+ * against the TODO ceilings:
  *
  *   getpid          (raw SVC; shim identity fast path)
  *   clock_gettime   (vDSO trampoline; see -DGUARD_USE_LIBC_CG below)
@@ -35,8 +35,7 @@
  *
  *   name<padding> XX.X ns/op  last=N
  *
- * so the guardrail's awk extractor reads identical labels across both
- * variants.
+ * so the guardrail's awk extractor reads identical labels across both variants.
  */
 
 #include <elf.h>
@@ -78,8 +77,8 @@ static uint32_t sysv_hash(const char *name)
     return h;
 }
 
-/* Walk the vDSO ELF at AT_SYSINFO_EHDR and return the absolute address
- * of __kernel_clock_gettime, or NULL if anything is missing.
+/* Walk the vDSO ELF at AT_SYSINFO_EHDR and return the absolute address of
+ * __kernel_clock_gettime, or NULL if anything is missing.
  */
 static clock_gettime_fn resolve_vdso_clock_gettime(void)
 {
@@ -192,8 +191,8 @@ static void run_case(clock_gettime_fn cg,
 
 int main(int argc, char **argv)
 {
-    /* Line-buffered stdout so each completed case is visible
-     * immediately when stdout is piped or captured.
+    /* Line-buffered stdout so each completed case is visible immediately when
+     * stdout is piped or captured.
      */
     setvbuf(stdout, NULL, _IOLBF, 0);
 

--- a/tests/bench-hot-syscalls.c
+++ b/tests/bench-hot-syscalls.c
@@ -593,10 +593,10 @@ static void run_case(const bench_case_t *bc, unsigned long iters)
 
 int main(int argc, char **argv)
 {
-    /* Line-buffer stdout so each completed case is visible immediately
-     * when the bench is piped or redirected. Full buffering hides the
-     * progress and turns "the bench is slow" into "the bench appears
-     * stuck" until the buffer flushes at exit.
+    /* Line-buffer stdout so each completed case is visible immediately when the
+     * bench is piped or redirected. Full buffering hides the progress and turns
+     * "the bench is slow" into "the bench appears stuck" until the buffer
+     * flushes at exit.
      */
     setvbuf(stdout, NULL, _IOLBF, 0);
 

--- a/tests/bench-vdso.c
+++ b/tests/bench-vdso.c
@@ -3,13 +3,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Compares each elfuse vDSO trampoline against the equivalent raw SVC
- * for clock_gettime, clock_getres, gettimeofday, and getcpu. Reports
- * ns/op and the vDSO/SVC speedup ratio so the seqlock + DMB ISHLD
- * overhead introduced this cycle can be measured against the prior
- * baseline. Resolves symbol addresses by walking the vDSO ELF via
- * AT_SYSINFO_EHDR, the same path glibc uses, so the numbers reflect
- * what real workloads see.
+ * Compares each elfuse vDSO trampoline against the equivalent raw SVC for
+ * clock_gettime, clock_getres, gettimeofday, and getcpu. Reports ns/op and the
+ * vDSO/SVC speedup ratio so the seqlock + DMB ISHLD overhead introduced this
+ * cycle can be measured against the prior baseline. Resolves symbol addresses
+ * by walking the vDSO ELF via AT_SYSINFO_EHDR, the same path glibc uses, so the
+ * numbers reflect what real workloads see.
  */
 
 #include <elf.h>
@@ -79,8 +78,8 @@ typedef long (*bench_fn_t)(void *ctx);
 
 static double time_loop(bench_fn_t fn, void *ctx, unsigned long iters)
 {
-    /* Warm-up: ensure the vDSO anchor is seeded so the first loop
-     * iteration is not artificially slow.
+    /* Warm-up: ensure the vDSO anchor is seeded so the first loop iteration is
+     * not artificially slow.
      */
     for (unsigned long i = 0; i < 1000; i++)
         (void) fn(ctx);
@@ -185,8 +184,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* Resolve vDSO trampolines via the same dynsym + ELF hash path glibc
-     * uses. The trampolines are inside the 4 KiB page at AT_SYSINFO_EHDR.
+    /* Resolve vDSO trampolines via the same dynsym + ELF hash path glibc uses.
+     * The trampolines are inside the 4 KiB page at AT_SYSINFO_EHDR.
      */
     const Elf64_Ehdr *ehdr = (const Elf64_Ehdr *) base;
     const Elf64_Phdr *phdr =

--- a/tests/hello-dynamic.c
+++ b/tests/hello-dynamic.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * This program is compiled WITHOUT -static, producing a dynamically-linked
- * ELF that requires ld-musl-aarch64.so.1 and libc.so at runtime.  It
- * exercises printf (PLT call through libc.so) and argv processing.
+ * This program is compiled WITHOUT -static, producing a dynamically-linked ELF
+ * that requires ld-musl-aarch64.so.1 and libc.so at runtime. It exercises
+ * printf (PLT call through libc.so) and argv processing.
  */
 
 #include <stdio.h>

--- a/tests/hvf-test.h
+++ b/tests/hvf-test.h
@@ -20,11 +20,11 @@ enum {
 
 /* AArch64 instruction encoders.
  *
- * Three families share an encoding shape; the lists below drive a token-
- * pasted a64_<name> definition for each entry, eliminating the per-
- * instruction boilerplate. Each encoder asserts its operand preconditions
- * so a bad caller surfaces immediately instead of silently emitting a
- * different (but still valid) instruction.
+ * Three families share an encoding shape; the lists below drive a token- pasted
+ * a64_<name> definition for each entry, eliminating the per- instruction
+ * boilerplate. Each encoder asserts its operand preconditions so a bad caller
+ * surfaces immediately instead of silently emitting a different (but still
+ * valid) instruction.
  */
 
 /* MOVZ / MOVK family: opcode | (imm16 << 5) | rd */

--- a/tests/raw-syscall.h
+++ b/tests/raw-syscall.h
@@ -6,11 +6,11 @@
  *
  * Provides raw_syscall{0,1,2,3,4,5,6}() plus convenience wrappers (raw_clone,
  * raw_futex_wait, raw_futex_wake, raw_gettid, raw_getpid, raw_tgkill,
- * raw_exit).  Architecture is selected at compile time via __aarch64__
- * / __x86_64__ predefined macros.
+ * raw_exit). Architecture is selected at compile time via __aarch64__ /
+ * __x86_64__ predefined macros.
  *
- * Syscall numbers come from <sys/syscall.h> (__NR_*), which already
- * provides the correct values per architecture.
+ * Syscall numbers come from <sys/syscall.h> (__NR_*), which already provides
+ * the correct values per architecture.
  */
 
 #pragma once

--- a/tests/test-abstract-socket.c
+++ b/tests/test-abstract-socket.c
@@ -58,8 +58,8 @@ int main(void)
         socklen_t got_len = sizeof(got);
         memset(&got, 0, sizeof(got));
         if (getsockname(srv, (struct sockaddr *) &got, &got_len) == 0) {
-            /* Expect: family=AF_UNIX, sun_path[0]='\0',
-             * rest = "elfuse-test-abstract"
+            /* Expect: family=AF_UNIX, sun_path[0]='\0', rest =
+             * "elfuse-test-abstract"
              */
             if (got.sun_family == AF_UNIX && got.sun_path[0] == '\0' &&
                 !memcmp(got.sun_path + 1, "elfuse-test-abstract", 20))

--- a/tests/test-cloexec.c
+++ b/tests/test-cloexec.c
@@ -233,8 +233,8 @@ static void test_cloexec_inherited_in_fork(void)
 {
     TEST("CLOEXEC FDs inherited in fork");
 
-    /* POSIX: CLOEXEC only takes effect at exec, NOT at fork.
-     * Fork children inherit all FDs regardless of CLOEXEC.
+    /* POSIX: CLOEXEC only takes effect at exec, NOT at fork. Fork children
+     * inherit all FDs regardless of CLOEXEC.
      */
     int pipefd[2];
     if (pipe2(pipefd, O_CLOEXEC) != 0) {
@@ -261,8 +261,8 @@ static void test_cloexec_inherited_in_fork(void)
     }
 
     if (pid == 0) {
-        /* Child: try writing to the CLOEXEC pipe. Should succeed
-         * because POSIX says CLOEXEC only takes effect at exec
+        /* Child: try writing to the CLOEXEC pipe. Should succeed because POSIX
+         * says CLOEXEC only takes effect at exec
          */
         close(result[0]);
         char c;

--- a/tests/test-clone3.c
+++ b/tests/test-clone3.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests clone3 for both fork (new process) and thread (CLONE_THREAD)
- * paths, verifying that the clone_args struct is correctly parsed and
- * delegated to the existing clone infrastructure.
+ * Tests clone3 for both fork (new process) and thread (CLONE_THREAD) paths,
+ * verifying that the clone_args struct is correctly parsed and delegated to the
+ * existing clone infrastructure.
  */
 
 #include <stdarg.h>
@@ -157,16 +157,16 @@ static void test_thread(void)
     ca.stack_size = stack_size;
     ca.child_tid = (uint64_t) &thread_tid; /* set_child_tid / clear_child_tid */
 
-    /* Point the child's PC at thread_fn.
-     * clone3 with CLONE_THREAD resumes at the parent's PC but with X0=0.
-     * The caller needs the child to jump to thread_fn, so the caller sets up
-     * the stack with a return address. Actually, clone resumes at parent PC
-     * with X0=0 and the new stack, so the caller needs to arrange for the child
-     * to call thread_fn from the clone return path.
+    /* Point the child's PC at thread_fn. clone3 with CLONE_THREAD resumes at
+     * the parent's PC but with X0=0. The caller needs the child to jump to
+     * thread_fn, so the caller sets up the stack with a return address.
+     * Actually, clone resumes at parent PC with X0=0 and the new stack, so the
+     * caller needs to arrange for the child to call thread_fn from the clone
+     * return path.
      *
-     * For raw clone, the child returns from the syscall with X0=0.
-     * The code checks X0 in the caller. But since this is inline asm returning
-     * to the same PC, the test handles it by checking the return value.
+     * For raw clone, the child returns from the syscall with X0=0. The code
+     * checks X0 in the caller. But since this is inline asm returning to the
+     * same PC, the test handles it by checking the return value.
      */
 
     long ret = raw_clone3(&ca, CLONE_ARGS_SIZE_VER0);
@@ -228,8 +228,8 @@ static void test_unsupported_flags(void)
     memset(&ca, 0, sizeof(ca));
     ca.exit_signal = 17;
 
-    /* CLONE_PIDFD: now supported. Clone should succeed (returns child PID
-     * in parent, 0 in child).  Reap the child to avoid zombies.
+    /* CLONE_PIDFD: now supported. Clone should succeed (returns child PID in
+     * parent, 0 in child). Reap the child to avoid zombies.
      */
     int32_t pidfd_out = -1;
     ca.flags = 0x00001000; /* CLONE_PIDFD */
@@ -547,9 +547,9 @@ static void test_deferred_stack_munmap(void)
         munmap(reuse, stack_size);
 }
 
-/* Test 14: partial munmap overlap with a live clone3 stack must still unmap
- * the non-overlapping portion immediately, then release the deferred slice once
- * the thread exits.
+/* Test 14: partial munmap overlap with a live clone3 stack must still unmap the
+ * non-overlapping portion immediately, then release the deferred slice once the
+ * thread exits.
  */
 static void test_partial_deferred_stack_munmap(void)
 {

--- a/tests/test-comprehensive.c
+++ b/tests/test-comprehensive.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: stdio, file I/O, dir listing, env vars, time, math, memory,
- * string ops, and system info, all in one program.
+ * Tests: stdio, file I/O, dir listing, env vars, time, math, memory, string
+ * ops, and system info, all in one program.
  */
 
 #include <stdio.h>

--- a/tests/test-cow-fork.c
+++ b/tests/test-cow-fork.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Verifies that parent and child processes have independent memory
- * after fork (copy-on-write semantics). Parent writes should not
- * appear in child, and vice versa.
+ * Verifies that parent and child processes have independent memory after fork
+ * (copy-on-write semantics). Parent writes should not appear in child, and vice
+ * versa.
  *
  * Syscalls exercised: clone/fork, waitpid, pipe, read, write, mmap, brk
  */
@@ -235,8 +235,8 @@ static void test_large_cow(void)
 
 /* Test 5: brk isolation */
 
-/* Use brk syscall directly because musl's sbrk() rejects non-zero increments
- * by design (returns -ENOMEM), so the test must use the raw syscall.
+/* Use brk syscall directly because musl's sbrk() rejects non-zero increments by
+ * design (returns -ENOMEM), so the test must use the raw syscall.
  */
 static inline void *raw_brk(void *addr)
 {

--- a/tests/test-credentials.c
+++ b/tests/test-credentials.c
@@ -122,9 +122,9 @@ int main(void)
     EXPECT_TRUE(raw_syscall1(__NR_setgid, 0) == -1, "expected -EPERM");
 
     /* setfsuid / setfsgid: Linux contract is to return the previous fsuid /
-     * fsgid. elfuse reports the current euid / egid (1000) on every call,
-     * with no state mutation, which is what procps relies on when it
-     * brackets /proc reads with setfsuid(uid) / setfsuid(0).
+     * fsgid. elfuse reports the current euid / egid (1000) on every call, with
+     * no state mutation, which is what procps relies on when it brackets /proc
+     * reads with setfsuid(uid) / setfsuid(0).
      */
     TEST("setfsuid(0) returns 1000");
     EXPECT_TRUE(raw_syscall1(__NR_setfsuid, 0) == 1000,
@@ -143,8 +143,8 @@ int main(void)
                 "setfsgid(1000) did not return current egid");
 
     /* setfsuid(-1) / setfsgid(-1) is the canonical glibc "read fsuid without
-     * changing it" idiom: -1 is never a valid uid, so the kernel only
-     * reports the current fsuid.
+     * changing it" idiom: -1 is never a valid uid, so the kernel only reports
+     * the current fsuid.
      */
     TEST("setfsuid(-1) reports current fsuid");
     EXPECT_TRUE(raw_syscall1(__NR_setfsuid, (long) (unsigned) -1) == 1000,

--- a/tests/test-cross-fork-mapshared.c
+++ b/tests/test-cross-fork-mapshared.c
@@ -3,12 +3,11 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Verifies live MAP_SHARED visibility across fork(): both file-backed
- * and anonymous shared mappings must continue to propagate writes
- * between parent and child after the IPC handoff. Without the
- * overlay re-establishment in fork-state, the child sees a stale
- * snapshot of the parent's pre-fork contents and writes from each
- * side stay private.
+ * Verifies live MAP_SHARED visibility across fork(): both file-backed and
+ * anonymous shared mappings must continue to propagate writes between parent
+ * and child after the IPC handoff. Without the overlay re-establishment in
+ * fork-state, the child sees a stale snapshot of the parent's pre-fork contents
+ * and writes from each side stay private.
  *
  * Three scenarios:
  *   1. Regular file: shared mmap of a tmp file; parent writes appear
@@ -52,9 +51,9 @@ static int my_shm_unlink(const char *name)
     return unlink(path);
 }
 
-/* IPC primitives between parent and child: a single byte over a
- * pipe pair signals "go ahead" each direction. Replaces a sleep-based
- * synchronization that the test matrix would race on slow runners.
+/* IPC primitives between parent and child: a single byte over a pipe pair
+ * signals "go ahead" each direction. Replaces a sleep-based synchronization
+ * that the test matrix would race on slow runners.
  */
 typedef struct {
     int parent_to_child[2];
@@ -102,9 +101,9 @@ static void child_close_parent_ends(sync_t *s)
 }
 
 /* Drop the parent's write end so a child blocked in wait_byte() on the
- * parent_to_child read end observes EOF and exits instead of deadlocking
- * with the parent in waitpid(). Must be called on every parent-side
- * failure path that bypasses send_byte(parent_to_child[1]).
+ * parent_to_child read end observes EOF and exits instead of deadlocking with
+ * the parent in waitpid(). Must be called on every parent-side failure path
+ * that bypasses send_byte(parent_to_child[1]).
  */
 static void parent_release_writer(sync_t *s)
 {
@@ -132,8 +131,8 @@ static bool send_byte(int fd)
     return n == 1;
 }
 
-/* Test 1: File-backed MAP_SHARED -- parent and child see each other's
- * writes through the same disk file without msync.
+/* Test 1: File-backed MAP_SHARED -- parent and child see each other's writes
+ * through the same disk file without msync.
  */
 static void test_file_backed_cross_fork(void)
 {
@@ -146,9 +145,9 @@ static void test_file_backed_cross_fork(void)
         return;
     }
     /* Keep the file present so child can re-open via /proc semantics is
-     * unnecessary -- the child inherits fd from CLOEXEC=off and we map
-     * via the inherited fd. Unlink keeps the file on the FS but invisible
-     * via path; both sides hold open references.
+     * unnecessary -- the child inherits fd from CLOEXEC=off and we map via the
+     * inherited fd. Unlink keeps the file on the FS but invisible via path;
+     * both sides hold open references.
      */
     unlink(tmpl);
 
@@ -253,9 +252,9 @@ static void test_file_backed_cross_fork(void)
     close(fd);
 }
 
-/* Test 2: Anonymous MAP_SHARED -- typical parent-child IPC pattern
- * (Postgres, multi-process daemons). elfuse must convert the region
- * to memfd-backed at fork time so both sides observe writes.
+/* Test 2: Anonymous MAP_SHARED -- typical parent-child IPC pattern (Postgres,
+ * multi-process daemons). elfuse must convert the region to memfd-backed at
+ * fork time so both sides observe writes.
  */
 static void test_anon_shared_cross_fork(void)
 {
@@ -315,8 +314,8 @@ static void test_anon_shared_cross_fork(void)
         }
     }
 
-    /* See the file-backed test: drop the writer before waitpid so any
-     * failure above does not deadlock both ends of the pipe.
+    /* See the file-backed test: drop the writer before waitpid so any failure
+     * above does not deadlock both ends of the pipe.
      */
     parent_release_writer(&s);
     int status = 0;
@@ -339,8 +338,8 @@ static void test_anon_shared_cross_fork(void)
     munmap(p, 4096);
 }
 
-/* Test 3: shm-backed MAP_SHARED via /dev/shm -- same as test 1 but
- * exercises the shm path (musl/glibc shm_open emulation in elfuse).
+/* Test 3: shm-backed MAP_SHARED via /dev/shm -- same as test 1 but exercises
+ * the shm path (musl/glibc shm_open emulation in elfuse).
  */
 static void test_shm_cross_fork(void)
 {
@@ -416,8 +415,8 @@ static void test_shm_cross_fork(void)
         }
     }
 
-    /* See the file-backed test: drop the writer before waitpid so any
-     * failure above does not deadlock both ends of the pipe.
+    /* See the file-backed test: drop the writer before waitpid so any failure
+     * above does not deadlock both ends of the pipe.
      */
     parent_release_writer(&s);
     int status = 0;

--- a/tests/test-epoll-aba.c
+++ b/tests/test-epoll-aba.c
@@ -3,9 +3,9 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Companion to test-epoll-mt.c. That test covers the original dup-as-ident
- * bug (registrations vanishing across epoll_ctl). This one covers the ABA
- * race jserv flagged in review (PR #73, poll.c:723):
+ * Companion to test-epoll-mt.c. That test covers the original dup-as-ident bug
+ * (registrations vanishing across epoll_ctl). This one covers the ABA race
+ * around src/syscall/poll.c sys_epoll_ctl:
  *
  *   A registration in inst->regs[fd] is keyed on the guest fd *number*, but
  *   the kqueue knote is keyed on the underlying host fd. When the guest
@@ -16,11 +16,10 @@
  *   *new* file's host fd: EV_DELETE/EV_MOD against the wrong knote, returning
  *   success for a registration Linux considers already gone.
  *
- * The fix stamps fd_entry_t.generation into epoll_reg_t at ADD time and
- * rejects DEL/MOD when fd_table[fd].generation no longer matches, so a
- * close+reopen is detected as a stale registration. The generation counter is
- * monotonic, so the reused fd number gets a fresh stamp that never collides
- * with the old one.
+ * The fix stamps fd_entry_t.generation into epoll_reg_t at ADD time and rejects
+ * DEL/MOD when fd_table[fd].generation no longer matches, so a close+reopen is
+ * detected as a stale registration. The generation counter is monotonic, so the
+ * reused fd number gets a fresh stamp that never collides with the old one.
  *
  * Asserted behavior (matches Linux, which auto-removes an fd from the epoll
  * interest list on close):
@@ -55,7 +54,8 @@ static char sibling_stack[16384] __attribute__((aligned(16)));
 
 /* Sibling thread: stays alive so the guest is multi-threaded across the
  * parent's epoll_ctl() calls, then exits. Raw syscalls only -- a
- * clone(CLONE_THREAD) child has no libc TLS. */
+ * clone(CLONE_THREAD) child has no libc TLS.
+ */
 static int sibling_fn(void *arg)
 {
     (void) arg;
@@ -68,10 +68,13 @@ static int sibling_fn(void *arg)
     return 0;
 }
 
-/* Reopen a fresh eventfd onto exactly the guest fd number that was just
- * closed, so the ABA (same number, new open file, new generation) is exercised
+/* Reopen a fresh eventfd onto exactly the guest fd number that was just closed,
+ * so the ABA (same number, new open file, new generation) is exercised
  * regardless of fd-allocator policy. The lowest-free allocator normally hands
- * back oldfd directly; dup3() forces it otherwise. Returns oldfd, or -1. */
+ * back oldfd directly; dup3() forces it otherwise.
+ *
+ * Returns oldfd, or -1.
+ */
 static int reopen_same_number(int oldfd)
 {
     int nf = eventfd(0, EFD_NONBLOCK);
@@ -89,8 +92,11 @@ static int reopen_same_number(int oldfd)
 }
 
 /* Register fd for EPOLLIN, make it readable, and assert the edge is observed
- * with the expected data.fd within a generous finite budget. Returns 1 on
- * success. Leaves the eventfd counter signalled (caller drains/closes). */
+ * with the expected data.fd within a generous finite budget.
+ *
+ * Returns 1 on success. Leaves the eventfd counter signalled (caller
+ * drains/closes).
+ */
 static int add_and_expect_edge(int epfd, int fd)
 {
     struct epoll_event ev = {.events = EPOLLIN, .data.fd = fd};
@@ -135,8 +141,9 @@ int main(void)
     TEST("epoll_create1");
     EXPECT_TRUE(epfd >= 0, "epoll_create1 failed");
 
-    /* Control: the generation guard must not over-fire. A registration on a
-     * fd that is never closed must still DEL cleanly (generation matches). */
+    /* Control: the generation guard must not over-fire. A registration on a fd
+     * that is never closed must still DEL cleanly (generation matches).
+     */
     TEST("DEL on still-open registration succeeds");
     {
         int efd = eventfd(0, EFD_NONBLOCK);
@@ -147,8 +154,9 @@ int main(void)
         close(efd);
     }
 
-    /* Register file A on a fd number, confirm it really is live, then close
-     * it and reopen a different file B onto the same number. */
+    /* Register file A on a fd number, confirm it really is live, then close it
+     * and reopen a different file B onto the same number.
+     */
     int efd = eventfd(0, EFD_NONBLOCK);
     TEST("ABA setup: register + observe edge on file A");
     EXPECT_TRUE(efd >= 0 && add_and_expect_edge(epfd, efd),
@@ -161,7 +169,8 @@ int main(void)
     EXPECT_EQ(reused, efd, "could not reuse fd number");
 
     /* The stale registration must be treated as gone. Without the generation
-     * guard these act on file B's host fd and return success. */
+     * guard these act on file B's host fd and return success.
+     */
     TEST("DEL after close+reopen -> ENOENT");
     {
         struct epoll_event ev = {.events = EPOLLIN, .data.fd = efd};
@@ -177,9 +186,10 @@ int main(void)
                      "stale MOD did not report ENOENT");
     }
 
-    /* A fresh registration on the reused number must work end to end and
-     * report the *new* file's readiness -- proving the new knote is keyed on
-     * file B's host fd, not corrupted by the cleared stale state. */
+    /* A fresh registration on the reused number must work end to end and report
+     * the *new* file's readiness -- proving the new knote is keyed on file B's
+     * host fd, not corrupted by the cleared stale state.
+     */
     TEST("fresh ADD after ABA delivers edge for file B");
     EXPECT_TRUE(add_and_expect_edge(epfd, efd),
                 "reused fd failed to register/deliver after ABA");

--- a/tests/test-epoll-edge.c
+++ b/tests/test-epoll-edge.c
@@ -86,8 +86,8 @@ int main(void)
         close(epfd);
     }
 
-    /* Drain-to-EAGAIN consumes the edge: next epoll_wait returns 0
-     * with no new data. This is the canonical EPOLLET use pattern.
+    /* Drain-to-EAGAIN consumes the edge: next epoll_wait returns 0 with no new
+     * data. This is the canonical EPOLLET use pattern.
      */
     TEST("EPOLLET: drain-to-EAGAIN consumes edge");
     {
@@ -120,8 +120,8 @@ int main(void)
         close(epfd);
     }
 
-    /* New data after drain re-arms the edge. This proves edge transitions
-     * from not-readable to readable are observed.
+    /* New data after drain re-arms the edge. This proves edge transitions from
+     * not-readable to readable are observed.
      */
     TEST("EPOLLET: new edge after drain + new data");
     {
@@ -157,8 +157,8 @@ int main(void)
         close(epfd);
     }
 
-    /* EPOLLET on a SOCK_STREAM pair, the typical server path.
-     * Repeated drain-fill cycles, each producing exactly one edge.
+    /* EPOLLET on a SOCK_STREAM pair, the typical server path. Repeated
+     * drain-fill cycles, each producing exactly one edge.
      */
     TEST("EPOLLET: stream socket drain-fill cycles");
     {
@@ -198,8 +198,8 @@ int main(void)
         }
     }
 
-    /* EPOLLET on eventfd. Counter semantics: read() returns the
-     * accumulated count and resets to 0; that drain consumes the edge.
+    /* EPOLLET on eventfd. Counter semantics: read() returns the accumulated
+     * count and resets to 0; that drain consumes the edge.
      */
     TEST("EPOLLET: eventfd counter drain");
     {
@@ -233,8 +233,8 @@ int main(void)
         close(epfd);
     }
 
-    /* EPOLLET + EPOLLONESHOT: edge fires exactly once and stays armed
-     * until EPOLL_CTL_MOD re-arms.
+    /* EPOLLET + EPOLLONESHOT: edge fires exactly once and stays armed until
+     * EPOLL_CTL_MOD re-arms.
      */
     TEST("EPOLLET + EPOLLONESHOT");
     {
@@ -319,9 +319,9 @@ int main(void)
         close(epfd);
     }
 
-    /* EOF reports an edge: pipe write end closed -> EPOLLHUP set
-     * on the read end, observable through one EPOLLET wait. Require
-     * EPOLLHUP explicitly so a regression that drops it is caught.
+    /* EOF reports an edge: pipe write end closed -> EPOLLHUP set on the read
+     * end, observable through one EPOLLET wait. Require EPOLLHUP explicitly so
+     * a regression that drops it is caught.
      */
     TEST("EPOLLET: EOF / EPOLLHUP edge");
     {
@@ -343,9 +343,9 @@ int main(void)
         close(epfd);
     }
 
-    /* EPOLLRDHUP edge on socketpair half-close: peer shuts down its
-     * write side, the read side sees EPOLLRDHUP. Distinct from EPOLLHUP
-     * because the local write side is still functional.
+    /* EPOLLRDHUP edge on socketpair half-close: peer shuts down its write side,
+     * the read side sees EPOLLRDHUP. Distinct from EPOLLHUP because the local
+     * write side is still functional.
      */
     TEST("EPOLLET: EPOLLRDHUP on half-close");
     {
@@ -374,12 +374,12 @@ int main(void)
         }
     }
 
-    /* Multi-filter EPOLLONESHOT: register both EPOLLIN and EPOLLOUT.
-     * After EPOLLOUT fires (send buffer initially empty), the unfired
-     * EPOLLIN filter must NOT fire on a subsequent epoll_wait until
-     * EPOLL_CTL_MOD re-arms. Without the oneshot_armed guard in the
-     * wait result loop, kqueue's still-registered EVFILT_READ would
-     * leak through. Re-arm via MOD must then surface the pending IN.
+    /* Multi-filter EPOLLONESHOT: register both EPOLLIN and EPOLLOUT. After
+     * EPOLLOUT fires (send buffer initially empty), the unfired EPOLLIN filter
+     * must NOT fire on a subsequent epoll_wait until EPOLL_CTL_MOD re-arms.
+     * Without the oneshot_armed guard in the wait result loop, kqueue's
+     * still-registered EVFILT_READ would leak through. Re-arm via MOD must then
+     * surface the pending IN.
      */
     TEST("EPOLLET + EPOLLONESHOT: surviving filter stays disarmed");
     {
@@ -396,16 +396,16 @@ int main(void)
             };
             epoll_ctl(epfd, EPOLL_CTL_ADD, sv[0], &ev);
 
-            /* First wait: only EPOLLOUT is ready (send buffer empty,
-             * receive buffer empty).
+            /* First wait: only EPOLLOUT is ready (send buffer empty, receive
+             * buffer empty).
              */
             struct epoll_event out;
             int n = epoll_wait(epfd, &out, 1, 100);
             if (n != 1 || !(out.events & EPOLLOUT)) {
                 FAIL("EPOLLOUT did not fire first");
             } else {
-                /* Now make the read side ready. The disarmed fd must
-                 * stay silent until MOD re-arms.
+                /* Now make the read side ready. The disarmed fd must stay
+                 * silent until MOD re-arms.
                  */
                 write(sv[1], "x", 1);
                 n = epoll_wait(epfd, &out, 1, 50);
@@ -413,9 +413,9 @@ int main(void)
                     FAIL("EPOLLIN leaked through ONESHOT disarm");
                 } else {
                     /* Re-arm dropping OUT entirely. Pending EPOLLIN must
-                     * surface; EPOLLOUT must NOT, because MOD has to clean
-                     * up the surviving EVFILT_WRITE that ONESHOT did not
-                     * remove (only the firing filter was removed).
+                     * surface; EPOLLOUT must NOT, because MOD has to clean up
+                     * the surviving EVFILT_WRITE that ONESHOT did not remove
+                     * (only the firing filter was removed).
                      */
                     ev.events = EPOLLIN | EPOLLET | EPOLLONESHOT;
                     ev.data.fd = sv[0];
@@ -483,16 +483,16 @@ int main(void)
             };
             epoll_ctl(epfd, EPOLL_CTL_ADD, sv[0], &ev);
 
-            /* First wait: only IN fires (OUT was not ready). EV_ONESHOT
-             * removes EVFILT_READ; EVFILT_WRITE survives in kqueue.
+            /* First wait: only IN fires (OUT was not ready). EV_ONESHOT removes
+             * EVFILT_READ; EVFILT_WRITE survives in kqueue.
              */
             struct epoll_event out;
             int n = epoll_wait(epfd, &out, 1, 100);
             if (n != 1 || (out.events & EPOLLOUT)) {
                 FAIL("expected only IN to fire (OUT must not be ready)");
             } else {
-                /* MOD to IN-only -- drops OUT entirely. The implementation
-                 * must remove the surviving EVFILT_WRITE; with the kevent
+                /* MOD to IN-only -- drops OUT entirely. The implementation must
+                 * remove the surviving EVFILT_WRITE; with the kevent
                  * batched-delete bug it would leak.
                  */
                 ev.events = EPOLLIN | EPOLLET | EPOLLONESHOT;
@@ -503,8 +503,8 @@ int main(void)
                 drain_to_eagain(sv[0]);
 
                 /* Drain peer to free sv[0] send buffer. If the stale
-                 * EVFILT_WRITE leaked, the writability transition fires
-                 * and we observe a spurious EPOLLOUT.
+                 * EVFILT_WRITE leaked, the writability transition fires and we
+                 * observe a spurious EPOLLOUT.
                  */
                 char rbuf[8 * 1024];
                 ssize_t got = 0;

--- a/tests/test-epoll-mt.c
+++ b/tests/test-epoll-mt.c
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Regression for the epoll_ctl host-fd-reference bug: in a multi-threaded
- * guest, host_fd_ref_open() hands back a *dup* of the target fd that is
- * closed when the syscall returns. sys_epoll_ctl() used that transient dup
- * as the kqueue knote ident, so the kernel dropped the registration the
- * moment epoll_ctl() returned -- and epoll_pwait() never reported readiness
- * again. Single-threaded guests borrow the raw fd (no dup, no close) and so
- * never hit it; this only reproduces with at least one CLONE_THREAD sibling
- * active. Node's libuv DelayedTaskScheduler relied on exactly this path
- * (eventfd + epoll for uv_async_send) and hung forever at process exit.
+ * guest, host_fd_ref_open() hands back a *dup* of the target fd that is closed
+ * when the syscall returns. sys_epoll_ctl() used that transient dup as the
+ * kqueue knote ident, so the kernel dropped the registration the moment
+ * epoll_ctl() returned -- and epoll_pwait() never reported readiness again.
+ * Single-threaded guests borrow the raw fd (no dup, no close) and so never hit
+ * it; this only reproduces with at least one CLONE_THREAD sibling active.
+ * Node's libuv DelayedTaskScheduler relied on exactly this path (eventfd +
+ * epoll for uv_async_send) and hung forever at process exit.
  *
  * The test keeps a sibling thread alive across the epoll_ctl() call, then
- * checks that both a pipe and an eventfd registered while multi-threaded
- * still deliver an EPOLLIN edge.
+ * checks that both a pipe and an eventfd registered while multi-threaded still
+ * deliver an EPOLLIN edge.
  *
  * Syscalls exercised: clone(220), epoll_create1(20), epoll_ctl(21),
  *                     epoll_pwait(22), eventfd2(19), pipe2(59), write(64),
@@ -37,8 +37,8 @@ static volatile int child_should_exit = 0;
 static char sibling_stack[16384] __attribute__((aligned(16)));
 
 /* Sibling thread: stays alive (raw nanosleep loop) so the guest is
- * multi-threaded for the duration of the parent's epoll_ctl() calls, then
- * exits via the raw exit syscall. Uses only raw syscalls because a
+ * multi-threaded for the duration of the parent's epoll_ctl() calls, then exits
+ * via the raw exit syscall. Uses only raw syscalls because a
  * clone(CLONE_THREAD) child has no libc TLS set up.
  */
 static int sibling_fn(void *arg)
@@ -53,9 +53,11 @@ static int sibling_fn(void *arg)
     return 0;
 }
 
-/* Register host_fd for EPOLLIN on epfd, make it readable via make_ready(),
- * and assert epoll_pwait() observes the edge within the timeout. Returns 1
- * on success. */
+/* Register host_fd for EPOLLIN on epfd, make it readable via make_ready(), and
+ * assert epoll_pwait() observes the edge within the timeout.
+ *
+ * Returns 1 on success.
+ */
 static int expect_ready_edge(int epfd, int fd, void (*make_ready)(int), int arg)
 {
     struct epoll_event ev = {.events = EPOLLIN, .data.fd = fd};
@@ -66,7 +68,8 @@ static int expect_ready_edge(int epfd, int fd, void (*make_ready)(int), int arg)
 
     struct epoll_event out[4];
     /* 2s budget: the bug manifests as an indefinite miss, so any generous
-     * finite timeout distinguishes pass from fail without flaking. */
+     * finite timeout distinguishes pass from fail without flaking.
+     */
     int n = epoll_wait(epfd, out, 4, 2000);
     return n == 1 && out[0].data.fd == fd;
 }

--- a/tests/test-epoll.c
+++ b/tests/test-epoll.c
@@ -144,8 +144,8 @@ int main(void)
         close(epfd);
     }
 
-    /* Test EPOLL_CTL_DEL on an unregistered fd.
-     * Repeat the failure path enough times to catch leaked host dup refs.
+    /* Test EPOLL_CTL_DEL on an unregistered fd. Repeat the failure path enough
+     * times to catch leaked host dup refs.
      */
     TEST("CTL_DEL ENOENT does not leak refs");
     {
@@ -250,9 +250,9 @@ int main(void)
         close(epfd);
     }
 
-    /* Test EPOLLONESHOT + EPOLL_CTL_MOD re-arm
-     * This is the critical test: after EPOLLONESHOT fires and is reported,
-     * EPOLL_CTL_MOD should succeed to re-arm the registration.
+    /* Test EPOLLONESHOT + EPOLL_CTL_MOD re-arm This is the critical test: after
+     * EPOLLONESHOT fires and is reported, EPOLL_CTL_MOD should succeed to
+     * re-arm the registration.
      */
     TEST("EPOLLONESHOT re-arm with MOD");
     {

--- a/tests/test-eventfd-dup.c
+++ b/tests/test-eventfd-dup.c
@@ -3,11 +3,11 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Linux dup of an eventfd produces a second descriptor that points at the
- * same kernel object; reads and writes on either fd see the same counter.
- * elfuse used to give each dup'd guest_fd a fresh side-table slot, so
- * dup'd eventfds diverged and breaking programs that signal across the
- * pair. This test pins the contract by:
+ * Linux dup of an eventfd produces a second descriptor that points at the same
+ * kernel object; reads and writes on either fd see the same counter. elfuse
+ * used to give each dup'd guest_fd a fresh side-table slot, so dup'd eventfds
+ * diverged and breaking programs that signal across the pair. This test pins
+ * the contract by:
  *   - duping an eventfd initialised with counter=7, reading via the dup,
  *     verifying the dup observes the source's initial value
  *   - writing via the source, reading via the dup, verifying state shares

--- a/tests/test-exec.c
+++ b/tests/test-exec.c
@@ -6,9 +6,9 @@
  *
  * Usage: elfuse test-exec <path-to-echo-test> exec-works
  *
- * This test calls execve() to replace itself with echo-test, which
- * prints its arguments. If execve works correctly, "exec-works" is
- * printed and the process exits 0.
+ * This test calls execve() to replace itself with echo-test, which prints its
+ * arguments. If execve works correctly, "exec-works" is printed and the process
+ * exits 0.
  */
 
 #include <unistd.h>
@@ -22,8 +22,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* argv[1] = path to binary to exec
-     * argv[2..] = arguments to pass to it
+    /* argv[1] = path to binary to exec argv[2..] = arguments to pass to it
      */
     char *new_argv[64];
     int n = 0;

--- a/tests/test-fd-family.c
+++ b/tests/test-fd-family.c
@@ -3,11 +3,11 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Verifies semantics of the eventfd/timerfd/signalfd family of
- * descriptors. The current coverage focuses on signalfd's promise
- * that an EFAULT during read leaves the pending signal queue intact
- * so a subsequent good-pointer read still observes the signal.
- * Future eventfd and timerfd primitive tests should land here.
+ * Verifies semantics of the eventfd/timerfd/signalfd family of descriptors. The
+ * current coverage focuses on signalfd's promise that an EFAULT during read
+ * leaves the pending signal queue intact so a subsequent good-pointer read
+ * still observes the signal. Future eventfd and timerfd primitive tests should
+ * land here.
  */
 
 #include <errno.h>

--- a/tests/test-fd-race.c
+++ b/tests/test-fd-race.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Creates two threads: one doing rapid open/close cycles on temp files,
- * the other reading/writing on FDs in the same range. Verifies no EBADF
- * on wrong files or use-after-close on the wrong file.
+ * Creates two threads: one doing rapid open/close cycles on temp files, the
+ * other reading/writing on FDs in the same range. Verifies no EBADF on wrong
+ * files or use-after-close on the wrong file.
  *
  * Syscalls: clone(220), openat(56), close(57), write(64), read(63),
  *           futex(98), exit(93)

--- a/tests/test-flock.c
+++ b/tests/test-flock.c
@@ -78,7 +78,8 @@ int main(void)
     /* F_GETLK on a region this process already write-locks must report back a
      * Linux l_type. Linux reports F_UNLCK for locks held by the *same* owner,
      * so the only thing we can assert portably is that the type round-trips to
-     * a valid Linux constant and the call succeeds. */
+     * a valid Linux constant and the call succeeds.
+     */
     TEST("F_GETLK round-trips l_type");
     struct flock gfl = {
         .l_type = F_WRLCK,

--- a/tests/test-fork-exec.c
+++ b/tests/test-fork-exec.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests fork edge cases: fork + exec chain, fork with many FDs,
- * fork + pipe communication, and nested fork.
+ * Tests fork edge cases: fork + exec chain, fork with many FDs, fork + pipe
+ * communication, and nested fork.
  *
  * Usage: elfuse test-fork-exec <path-to-echo-test>
  *

--- a/tests/test-fork-lowbase.c
+++ b/tests/test-fork-lowbase.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Exercises the legacy fork IPC path from a low-linked ET_EXEC. The child
- * forks again, so the grandchild only runs correctly if the intermediate child
+ * Exercises the legacy fork IPC path from a low-linked ET_EXEC. The child forks
+ * again, so the grandchild only runs correctly if the intermediate child
  * preserved the executable's true low load address when cloning guest state.
  */
 

--- a/tests/test-fork-synthetic-fd.c
+++ b/tests/test-fork-synthetic-fd.c
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * The fork-IPC handoff does NOT serialize per-class side tables for
- * eventfd/signalfd/timerfd/inotify/netlink/pidfd. Restoring the
- * inherited host fd without that state leaves a half-functional slot,
- * so fork-state.c explicitly drops these in the child. This test pins
- * that contract:
+ * eventfd/signalfd/timerfd/inotify/netlink/pidfd. Restoring the inherited host
+ * fd without that state leaves a half-functional slot, so fork-state.c
+ * explicitly drops these in the child. This test pins that contract:
  *   - urandom IS inherited (no per-class state to lose; cache is fresh
  *     in the child and arc4random_buf works)
  *   - eventfd / signalfd / timerfd / inotify are NOT inherited; the
  *     child sees EBADF and can recreate the fd at the same slot
  *   - the inherited host fd does not leak in the child
  *
- * Once a subsystem grows a serialize/restore path, the corresponding
- * EBADF expectation here flips to a positive inheritance check.
+ * Once a subsystem grows a serialize/restore path, the corresponding EBADF
+ * expectation here flips to a positive inheritance check.
  */
 
 #include <errno.h>
@@ -97,8 +96,8 @@ static int child_ebadf_reusable_at_same_fd(int fd)
 
 static int child_eventfd_recreate(int fd)
 {
-    /* The inherited eventfd slot should be FD_CLOSED in the child; we
-     * should be able to create a fresh eventfd that works normally.
+    /* The inherited eventfd slot should be FD_CLOSED in the child; we should be
+     * able to create a fresh eventfd that works normally.
      */
     char buf[8];
     errno = 0;

--- a/tests/test-fork.c
+++ b/tests/test-fork.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests basic fork semantics: parent forks child, child writes a message
- * and exits with a specific code, parent waits and verifies exit status.
+ * Tests basic fork semantics: parent forks child, child writes a message and
+ * exits with a specific code, parent waits and verifies exit status.
  */
 
 #include <stdio.h>

--- a/tests/test-fuse-basic.c
+++ b/tests/test-fuse-basic.c
@@ -634,10 +634,9 @@ int main(void)
     }
     close(fd);
 
-    /* Canonicalization: ./ and intermediate-up traversals must collapse to
-     * the same file rather than be forwarded as literal FUSE_LOOKUP names.
-     * Without canonicalization the daemon would receive LOOKUP for "." and
-     * fail.
+    /* Canonicalization: ./ and intermediate-up traversals must collapse to the
+     * same file rather than be forwarded as literal FUSE_LOOKUP names. Without
+     * canonicalization the daemon would receive LOOKUP for "." and fail.
      */
     char dot_path[256];
     snprintf(dot_path, sizeof(dot_path), "%s/./%s", mount_dir, hello_name);
@@ -647,9 +646,9 @@ int main(void)
     expect_hello_fd(dotfd);
     close(dotfd);
 
-    /* sub/../hello must canonicalize to hello before the FUSE walk; the
-     * daemon does not implement sub or "..", so this would fail with
-     * ENOENT if the path were forwarded literally.
+    /* sub/../hello must canonicalize to hello before the FUSE walk; the daemon
+     * does not implement sub or "..", so this would fail with ENOENT if the
+     * path were forwarded literally.
      */
     char up_path[256];
     snprintf(up_path, sizeof(up_path), "%s/sub/../%s", mount_dir, hello_name);
@@ -723,18 +722,18 @@ int main(void)
 
     /* Daemon-death + post-tombstone routing test.
      *
-     * Set the virtual cwd to the FUSE mount via fchdir(dfd) so the consumer
-     * has a FUSE-rooted relative-path baseline. Close /dev/fuse from the
-     * consumer side to simulate daemon death: fuse_fd_cleanup tombstones
-     * the mount (mount->session = NULL but the slot path/source/fstype/
-     * mount_id stay intact), wakes any blocked requests, and the daemon
-     * thread's next read returns ENOTCONN and the thread exits.
+     * Set the virtual cwd to the FUSE mount via fchdir(dfd) so the consumer has
+     * a FUSE-rooted relative-path baseline. Close /dev/fuse from the consumer
+     * side to simulate daemon death: fuse_fd_cleanup tombstones the mount
+     * (mount->session = NULL but the slot path/source/fstype/ mount_id stay
+     * intact), wakes any blocked requests, and the daemon thread's next read
+     * returns ENOTCONN and the thread exits.
      *
      * After the daemon is gone, a relative open from the still-FUSE-rooted
      * virtual cwd MUST return -LINUX_ENOTCONN rather than silently falling
-     * through to host-relative open against the host cwd. The tombstoned
-     * mount keeps the path matching FUSE, and fuse_open_path detects
-     * session==NULL and returns ENOTCONN.
+     * through to host-relative open against the host cwd. The tombstoned mount
+     * keeps the path matching FUSE, and fuse_open_path detects session==NULL
+     * and returns ENOTCONN.
      */
     if (fchdir(dfd) < 0)
         die("fchdir(dfd) before daemon death");

--- a/tests/test-futex-pi.c
+++ b/tests/test-futex-pi.c
@@ -48,8 +48,8 @@ int passes = 0, fails = 0;
 #define FUTEX_TRYLOCK_PI 8
 #define FUTEX_PRIVATE 128
 
-/* PI lock word: shared between parent and child thread.
- * Must be aligned to 4 bytes (futex requirement).
+/* PI lock word: shared between parent and child thread. Must be aligned to 4
+ * bytes (futex requirement).
  */
 static volatile uint32_t pi_lock __attribute__((aligned(4))) = 0;
 
@@ -75,8 +75,8 @@ static long raw_futex_unlock_pi(uint32_t *addr)
 /* Stack for child thread (8KiB, 16-byte aligned) */
 static char child_stack_buf[8192] __attribute__((aligned(16)));
 
-/* Child: acquire PI lock, signal parent, exit WITHOUT releasing.
- * This tests elfuse's dead-owner detection in futex_lock_pi().
+/* Child: acquire PI lock, signal parent, exit WITHOUT releasing. This tests
+ * elfuse's dead-owner detection in futex_lock_pi().
  */
 static void child_acquire_and_die(void)
 {
@@ -93,8 +93,8 @@ static void child_acquire_and_die(void)
     child_ready = 1;
     raw_futex_wake((int *) &child_ready, 1);
 
-    /* Exit WITHOUT calling FUTEX_UNLOCK_PI. This is the bug scenario:
-     * elfuse's futex_lock_pi must detect the current TID is dead and recover.
+    /* Exit WITHOUT calling FUTEX_UNLOCK_PI. This is the bug scenario: elfuse's
+     * futex_lock_pi must detect the current TID is dead and recover.
      */
     raw_exit(0);
 }
@@ -177,8 +177,8 @@ static void test_pi_dead_owner(void)
         return;
     }
 
-    /* Wait for child thread to actually exit (CLONE_CHILD_CLEARTID
-     * clears child_tid_val and does futex_wake). Give it 500ms.
+    /* Wait for child thread to actually exit (CLONE_CHILD_CLEARTID clears
+     * child_tid_val and does futex_wake). Give it 500ms.
      */
     for (int i = 0; i < 50; i++) {
         if (__atomic_load_n(&child_tid_val, __ATOMIC_SEQ_CST) == 0)
@@ -186,9 +186,9 @@ static void test_pi_dead_owner(void)
         usleep(10000); /* 10ms */
     }
 
-    /* Now try to acquire the PI lock. The child exited without
-     * releasing it, so elfuse's futex_lock_pi must detect the dead
-     * owner and let the waiter acquire.
+    /* Now try to acquire the PI lock. The child exited without releasing it, so
+     * elfuse's futex_lock_pi must detect the dead owner and let the waiter
+     * acquire.
      */
     long r = raw_futex_lock_pi((uint32_t *) &pi_lock);
     if (r != 0) {
@@ -203,9 +203,9 @@ static void test_pi_dead_owner(void)
 
 /* Test 3: futex_wait without a signal blocks until woken */
 
-/* Sibling that waits ~1.2 s, flips the futex word, and issues FUTEX_WAKE on
- * the parent's address. Used to drive the parent out of an indefinite
- * futex_wait via a real wake (not synthetic EINTR).
+/* Sibling that waits ~1.2 s, flips the futex word, and issues FUTEX_WAKE on the
+ * parent's address. Used to drive the parent out of an indefinite futex_wait
+ * via a real wake (not synthetic EINTR).
  */
 static volatile int waker_word __attribute__((aligned(4))) = 0;
 static char waker_stack_buf[8192] __attribute__((aligned(16)));

--- a/tests/test-futex-waitv.c
+++ b/tests/test-futex-waitv.c
@@ -67,8 +67,8 @@ static long raw_futex_waitv(struct waitv_elem *waiters,
 
 /* Helper: wake @addr after @sleep_ms milliseconds. Used to unblock the main
  * thread's futex_waitv. The thread is joined by the test before the test
- * returns, so the wake completes before any state on the test's stack goes
- * out of scope.
+ * returns, so the wake completes before any state on the test's stack goes out
+ * of scope.
  */
 struct waker_args {
     uint32_t *addr;
@@ -300,8 +300,8 @@ static void test_einval_unaligned(void)
     TEST("EINVAL unaligned uaddr");
 
     /* Build a uaddr that is 1 byte off the natural 4-byte boundary. The
-     * underlying storage is still inside a writable mapping, so this
-     * exercises the alignment check rather than a fault path.
+     * underlying storage is still inside a writable mapping, so this exercises
+     * the alignment check rather than a fault path.
      */
     static uint8_t buf[16] __attribute__((aligned(4)));
     struct waitv_elem w = {
@@ -336,8 +336,8 @@ static void test_efault_timeout(void)
         .flags = FUTEX2_SIZE_U32 | FUTEX2_PRIVATE,
     };
 
-    /* Carve a PROT_NONE page so the timeout pointer is non-NULL but reads
-     * fault at copy time.
+    /* Carve a PROT_NONE page so the timeout pointer is non-NULL but reads fault
+     * at copy time.
      */
     void *p = mmap(NULL, 4096, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (p == MAP_FAILED) {
@@ -354,8 +354,8 @@ static void test_efault_uaddr(void)
 {
     TEST("EFAULT PROT_NONE uaddr at enqueue");
 
-    /* Map a PROT_NONE page and aim a waiter at it. Linux returns EFAULT
-     * when the kernel tries to read *uaddr to compare against val.
+    /* Map a PROT_NONE page and aim a waiter at it. Linux returns EFAULT when
+     * the kernel tries to read *uaddr to compare against val.
      */
     void *p = mmap(NULL, 4096, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (p == MAP_FAILED) {

--- a/tests/test-harness.h
+++ b/tests/test-harness.h
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Provides TEST/PASS/FAIL macros used by all test-*.c files.
- * Each test file must declare int passes = 0, fails = 0; before using.
+ * Provides TEST/PASS/FAIL macros used by all test-*.c files. Each test file
+ * must declare int passes = 0, fails = 0; before using.
  */
 
 #pragma once
@@ -43,8 +43,8 @@
     } while (0)
 
 /* Pass if a raw-syscall-style expression returned the given negative Linux
- * errno value (e.g., -EFAULT == -14). Used by tests that bypass libc and
- * read the kernel return value directly.
+ * errno value (e.g., -EFAULT == -14). Used by tests that bypass libc and read
+ * the kernel return value directly.
  */
 #define EXPECT_RAW_ERRNO(expr, expected_neg, msg) \
     do {                                          \
@@ -55,8 +55,8 @@
             FAIL(msg);                            \
     } while (0)
 
-/* Pass if cond evaluates true; otherwise FAIL with msg. Replaces the
- * recurring "if (cond) PASS(); else FAIL(msg);" idiom.
+/* Pass if cond evaluates true; otherwise FAIL with msg. Replaces the recurring
+ * "if (cond) PASS(); else FAIL(msg);" idiom.
  */
 #define EXPECT_TRUE(cond, msg) \
     do {                       \

--- a/tests/test-inotify.c
+++ b/tests/test-inotify.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests the kqueue-based inotify emulation in elfuse. Exercises
- * inotify_init1, inotify_add_watch, inotify_rm_watch, and
- * reading events for file modifications.
+ * Tests the kqueue-based inotify emulation in elfuse. Exercises inotify_init1,
+ * inotify_add_watch, inotify_rm_watch, and reading events for file
+ * modifications.
  *
  * Syscalls exercised: inotify_init1(26), inotify_add_watch(27),
  *                     inotify_rm_watch(28), read(63), write(64),
@@ -108,8 +108,8 @@ static void test_modify_event(void)
     int ready = poll(&pfd, 1, 1000);
 
     if (ready <= 0) {
-        /* inotify via kqueue may not fire within this short timeout; treat
-         * a valid fd and successful add_watch as infrastructure coverage.
+        /* inotify via kqueue may not fire within this short timeout; treat a
+         * valid fd and successful add_watch as infrastructure coverage.
          */
         PASS();
     } else {

--- a/tests/test-large-io-boundary.c
+++ b/tests/test-large-io-boundary.c
@@ -53,8 +53,8 @@ static int verify_pattern(const unsigned char *buf, size_t len)
     return 0;
 }
 
-/* Verify a repeating 4KiB seed pattern across a large buffer.
- * The seed is: seed[i] = (i * 131 + 17) for i in [0, 4096).
+/* Verify a repeating 4KiB seed pattern across a large buffer. The seed is:
+ * seed[i] = (i * 131 + 17) for i in [0, 4096).
  */
 static int verify_repeating_seed(const unsigned char *buf, size_t len)
 {
@@ -96,8 +96,8 @@ static void test_large_write(void)
     if (ok && lseek(fd, 0, SEEK_SET) != 0)
         ok = 0;
 
-    /* Read back the entire write and verify all bytes, including those
-     * spanning the 2MiB page table boundary.
+    /* Read back the entire write and verify all bytes, including those spanning
+     * the 2MiB page table boundary.
      */
     unsigned char *readback = mmap(NULL, IO_SIZE, PROT_READ | PROT_WRITE,
                                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -170,8 +170,8 @@ static void test_large_read_from_split_block(void)
         ssize_t ret = read(fd, buf, IO_SIZE);
         ok = (ret == (ssize_t) IO_SIZE);
     }
-    /* Verify the entire read buffer, including the 2MiB boundary
-     * crossing where L3-to-L2 page table transitions happen.
+    /* Verify the entire read buffer, including the 2MiB boundary crossing where
+     * L3-to-L2 page table transitions happen.
      */
     if (ok && verify_repeating_seed(buf, IO_SIZE) != 0)
         ok = false;

--- a/tests/test-lowbase-mem.c
+++ b/tests/test-lowbase-mem.c
@@ -3,15 +3,14 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Validates that sys_mprotect, sys_munmap, and the page-table build path
- * accept operations from an ET_EXEC linked below ELF_DEFAULT_BASE
- * (0x400000). The legacy layout pinned page-table pool + shim at fixed
- * low addresses [0x10000, 0x400000) and the four infra-range guards
- * (sys_mmap MAP_FIXED, sys_munmap, sys_mprotect, rt_sigreturn) blanket-
- * rejected operations on [SHIM_BASE, ELF_DEFAULT_BASE), so a low-linked
- * binary could not RELRO its own data or munmap anything in the same
- * window. The fix relocated infra to [interp_base - 4 MiB, interp_base)
- * and retargeted the guards via guest_range_hits_infra.
+ * Validates that sys_mprotect, sys_munmap, and the page-table build path accept
+ * operations from an ET_EXEC linked below ELF_DEFAULT_BASE (0x400000). The
+ * legacy layout pinned page-table pool + shim at fixed low addresses [0x10000,
+ * 0x400000) and the four infra-range guards (sys_mmap MAP_FIXED, sys_munmap,
+ * sys_mprotect, rt_sigreturn) blanket- rejected operations on [SHIM_BASE,
+ * ELF_DEFAULT_BASE), so a low-linked binary could not RELRO its own data or
+ * munmap anything in the same window. The fix relocated infra to [interp_base -
+ * 4 MiB, interp_base) and retargeted the guards via guest_range_hits_infra.
  *
  * Two link addresses are exercised:
  *   - 0x200000: inside the legacy shim_data block, was rejected.
@@ -19,9 +18,9 @@
  *     off-by-one if a future patch ever re-introduces a partial low
  *     guard at the OLD shim_data upper edge.
  *
- * Primary failure mode: the binary loads but mprotect/munmap on a low
- * address returns -EINVAL. The checks below assert the syscall return
- * values explicitly so a silent fall-through cannot mask the regression.
+ * Primary failure mode: the binary loads but mprotect/munmap on a low address
+ * returns -EINVAL. The checks below assert the syscall return values explicitly
+ * so a silent fall-through cannot mask the regression.
  */
 
 #include <errno.h>
@@ -35,9 +34,9 @@
 
 int passes = 0, fails = 0;
 
-/* A full page in the binary's own .data, forced page-aligned so the
- * mprotect target covers exactly one page and does not stomp neighboring
- * globals. The initializer keeps it out of .bss.
+/* A full page in the binary's own .data, forced page-aligned so the mprotect
+ * target covers exactly one page and does not stomp neighboring globals. The
+ * initializer keeps it out of .bss.
  */
 __attribute__((aligned(4096), used)) static volatile char data_page[4096] =
     "low-base test data page\n";
@@ -46,8 +45,8 @@ static void test_binary_low_linked(void)
 {
     TEST("binary linked below ELF_DEFAULT_BASE");
     uintptr_t pc = (uintptr_t) &test_binary_low_linked;
-    /* The legacy guard window is [0x100000, 0x400000); the test binary's
-     * .text must land inside it for the regression to be meaningful.
+    /* The legacy guard window is [0x100000, 0x400000); the test binary's .text
+     * must land inside it for the regression to be meaningful.
      */
     EXPECT_TRUE(pc >= 0x100000ULL && pc < 0x400000ULL,
                 "test binary not linked below 0x400000");
@@ -57,18 +56,18 @@ static void test_mprotect_own_data_page(void)
 {
     TEST("mprotect own .data page to PROT_READ");
     void *page = (void *) data_page;
-    /* Drop the page to read-only, RELRO-style. Pre-fix this returned
-     * -EINVAL because [SHIM_BASE, ELF_DEFAULT_BASE) was rejected outright.
+    /* Drop the page to read-only, RELRO-style. Pre-fix this returned -EINVAL
+     * because [SHIM_BASE, ELF_DEFAULT_BASE) was rejected outright.
      */
     int rc_drop = mprotect(page, 4096, PROT_READ);
     if (rc_drop != 0) {
         FAIL("mprotect(PROT_READ) on low-linked .data page failed");
         return;
     }
-    /* Restore RW immediately so any later code that touches the page
-     * (e.g. printf's stdout buffer if the linker placed it nearby, or
-     * libc exit cleanup) cannot fault. mprotect-restoring is itself
-     * the same code path; failing here also indicates a guard bug.
+    /* Restore RW immediately so any later code that touches the page (e.g.
+     * printf's stdout buffer if the linker placed it nearby, or libc exit
+     * cleanup) cannot fault. mprotect-restoring is itself the same code path;
+     * failing here also indicates a guard bug.
      */
     int rc_restore = mprotect(page, 4096, PROT_READ | PROT_WRITE);
     EXPECT_TRUE(rc_drop == 0 && rc_restore == 0,
@@ -78,11 +77,11 @@ static void test_mprotect_own_data_page(void)
 static void test_munmap_low_scratch_range(void)
 {
     TEST("munmap on scratch range below ELF_DEFAULT_BASE");
-    /* 0x180000 sits in the legacy guard window [0x100000, 0x400000) but
-     * outside the binary's loaded segments (which start at the link
-     * address >= 0x200000). With the new high-IPA infra reserve, this
-     * range has no PT entries and no tracked region, so munmap must
-     * fast-path to success (return 0). Pre-fix this returned -EINVAL.
+    /* 0x180000 sits in the legacy guard window [0x100000, 0x400000) but outside
+     * the binary's loaded segments (which start at the link address >=
+     * 0x200000). With the new high-IPA infra reserve, this range has no PT
+     * entries and no tracked region, so munmap must fast-path to success
+     * (return 0). Pre-fix this returned -EINVAL.
      */
     int rc = munmap((void *) 0x180000UL, 4096);
     EXPECT_TRUE(rc == 0, "munmap on low scratch range returned EINVAL");

--- a/tests/test-madvise.c
+++ b/tests/test-madvise.c
@@ -373,8 +373,8 @@ static void test_free_anon(void)
     memset(p, 0x77, 4096);
     int rc = madvise(p, 4096, MADV_FREE);
 
-    /* Per spec the read may return either old data or zero, so we only
-     * check the syscall succeeds and a write/read round-trip works.
+    /* Per spec the read may return either old data or zero, so we only check
+     * the syscall succeeds and a write/read round-trip works.
      */
     if (rc != 0) {
         FAIL("madvise MADV_FREE rejected anon mapping");
@@ -620,8 +620,8 @@ static void test_dontneed_prot_none_zerofill(void)
 /* Test 17: MADV_DONTNEED on MAP_SHARED file mapping preserves dirty data.
  *
  * Linux cannot discard pages from a shared page-cache mapping; in elfuse's
- * MAP_SHARED-as-CoW model, an in-memory write must not be silently
- * overwritten by stale file contents during DONTNEED.
+ * MAP_SHARED-as-CoW model, an in-memory write must not be silently overwritten
+ * by stale file contents during DONTNEED.
  */
 
 static void test_dontneed_shared_file_preserved(void)
@@ -756,11 +756,10 @@ static void test_free_shared_anon(void)
 
 /* Test 20: address outside the guest address space returns ENOMEM.
  *
- * Per madvise(2), addresses outside the process address space yield
- * ENOMEM, not EINVAL. The high half of the 64-bit space is well past
- * any IPA window elfuse can be configured with (1 TiB ceiling for
- * 40-bit IPA, 64 GiB for 36-bit), so this address is unconditionally
- * out of range.
+ * Per madvise(2), addresses outside the process address space yield ENOMEM, not
+ * EINVAL. The high half of the 64-bit space is well past any IPA window elfuse
+ * can be configured with (1 TiB ceiling for 40-bit IPA, 64 GiB for 36-bit), so
+ * this address is unconditionally out of range.
  */
 
 static void test_oob_address_enomem(void)

--- a/tests/test-mmap-hint.c
+++ b/tests/test-mmap-hint.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Verifies that non-fixed anonymous mmap() honors a free low address hint
- * such as 0x400000. box64 uses this pattern to reserve the ET_EXEC image
- * window for static x86-64 binaries.
+ * Verifies that non-fixed anonymous mmap() honors a free low address hint such
+ * as 0x400000. box64 uses this pattern to reserve the ET_EXEC image window for
+ * static x86-64 binaries.
  */
 
 #include <errno.h>

--- a/tests/test-mprotect-mt.c
+++ b/tests/test-mprotect-mt.c
@@ -21,9 +21,9 @@
  *      bounded-retry hardening item in TODO.md is gated on -- is also
  *      caught here because the test driver wraps every run in a timeout.
  *
- * The test does not try to PROVE the cross-vCPU race window absent. A
- * passing run is evidence the bounded-retry hardening lacks a concrete
- * reproducer today; a hard crash or accounting mismatch would supply one.
+ * The test does not try to PROVE the cross-vCPU race window absent. A passing
+ * run is evidence the bounded-retry hardening lacks a concrete reproducer
+ * today; a hard crash or accounting mismatch would supply one.
  */
 
 #include <errno.h>
@@ -70,8 +70,8 @@ static void *noop_reader(void *arg)
         atomic_fetch_add_explicit(&g_writes, 1, memory_order_relaxed);
         uint32_t back = ctx->page[ctx->tag];
         if (back != v) {
-            /* Another thread targets a different slot, so any value other
-             * than what this thread just wrote is a coherence bug.
+            /* Another thread targets a different slot, so any value other than
+             * what this thread just wrote is a coherence bug.
              */
             atomic_fetch_add_explicit(&g_mismatches, 1, memory_order_relaxed);
         }
@@ -283,18 +283,19 @@ static void test_alternating_mprotect_stress(void)
 }
 
 /* Single-threaded sweep across page counts that exercise the three TLBI
- * accumulator branches: <=TLBI_SELECTIVE_MAX_PAGES (per-page VAE1IS),
- * 17..64 pages (FEAT_TLBIRANGE RVAE1IS single shot), >64 pages (broadcast
- * VMALLE1IS). Each size is mprotect-cycled R<->RW with full readback. A
- * stale TLB or wrong RVAE1IS NUM/SCALE encoding would surface as a data
- * mismatch or a SIGSEGV during the readback phase. */
+ * accumulator branches: <=TLBI_SELECTIVE_MAX_PAGES (per-page VAE1IS), 17..64
+ * pages (FEAT_TLBIRANGE RVAE1IS single shot), >64 pages (broadcast VMALLE1IS).
+ * Each size is mprotect-cycled R<->RW with full readback. A stale TLB or wrong
+ * RVAE1IS NUM/SCALE encoding would surface as a data mismatch or a SIGSEGV
+ * during the readback phase.
+ */
 static void test_rvae_boundary_sweep(void)
 {
     /* 2 hits the smallest RVAE1IS encoding (NUM=0) if it ever reaches the
-     * TLBI_RANGE_LARGE path via coalescing; today the selective threshold
-     * gates it off, but the test pins the encoding contract. The remaining
-     * sizes straddle the selective / RVAE1IS / broadcast accumulator
-     * boundaries. */
+     * TLBI_RANGE_LARGE path via coalescing; today the selective threshold gates
+     * it off, but the test pins the encoding contract. The remaining sizes
+     * straddle the selective / RVAE1IS / broadcast accumulator boundaries.
+     */
     static const int sizes[] = {2, 16, 17, 32, 63, 64, 65, 128};
     static const int n_sizes = (int) (sizeof(sizes) / sizeof(sizes[0]));
     for (int k = 0; k < n_sizes; k++) {
@@ -356,11 +357,12 @@ static void test_rvae_boundary_sweep(void)
     }
 }
 
-/* Multi-vCPU variant of the alternating R<->RW test but on a 32-page region
- * so the toggler hits the TLBI_RANGE_LARGE path (RVAE1IS) instead of the
+/* Multi-vCPU variant of the alternating R<->RW test but on a 32-page region so
+ * the toggler hits the TLBI_RANGE_LARGE path (RVAE1IS) instead of the
  * single-page selective TLBI. Inner-shareable RVAE1IS must invalidate the
  * sibling vCPU TLBs; if it doesn't, the reader threads see stale TLB entries
- * and the test surfaces an unexpected read return code or a VM crash. */
+ * and the test surfaces an unexpected read return code or a VM crash.
+ */
 struct rvae_toggler_arg {
     void *page;
     size_t size;
@@ -476,21 +478,23 @@ static void test_rvae_multi_vcpu_stress(int npages)
     PASS();
 }
 
-/* 32-page mprotect cycle that deterministically straddles a 2 MiB guest
- * block boundary. The boundary forces guest_split_block on both blocks
- * the range crosses (16 pages each side), exercising the split-then-
- * tlbi-range-large code path that the ordinary boundary sweep only hits
- * by chance depending on gap-finder placement. */
+/* 32-page mprotect cycle that deterministically straddles a 2 MiB guest block
+ * boundary. The boundary forces guest_split_block on both blocks the range
+ * crosses (16 pages each side), exercising the split-then- tlbi-range-large
+ * code path that the ordinary boundary sweep only hits by chance depending on
+ * gap-finder placement.
+ */
 static void test_rvae_2mib_straddle(void)
 {
     TEST("RVAE1IS 2 MiB block-straddle cycle");
 
-    /* Allocate enough headroom to guarantee a 2 MiB boundary with at least
-     * 16 pages on each side, regardless of where mmap places the region.
-     * Worst case: mmap returns a 2 MiB-aligned base, so the first usable
-     * boundary is mmap_base + 2 MiB; we need 16 pages below that boundary
-     * (i.e. inside the first 2 MiB) and 16 pages above (inside the second
-     * 2 MiB). 4 MiB + slack covers it. */
+    /* Allocate enough headroom to guarantee a 2 MiB boundary with at least 16
+     * pages on each side, regardless of where mmap places the region. Worst
+     * case: mmap returns a 2 MiB-aligned base, so the first usable boundary is
+     * mmap_base + 2 MiB; we need 16 pages below that boundary (i.e. inside the
+     * first 2 MiB) and 16 pages above (inside the second 2 MiB). 4 MiB + slack
+     * covers it.
+     */
     const size_t mib_2 = 2 * 1024 * 1024;
     size_t alloc_sz = 4 * mib_2 + 64 * PAGE_SIZE;
     uint8_t *region = mmap(NULL, alloc_sz, PROT_READ | PROT_WRITE,
@@ -499,10 +503,11 @@ static void test_rvae_2mib_straddle(void)
         FAIL("mmap");
         return;
     }
-    /* Pick the first 2 MiB boundary AT LEAST 16 pages above the start so
-     * the 32-page protect window straddles it (16 pages below + 16 above).
-     * If the natural rounded-up boundary is too close to base, jump to the
-     * next one -- the allocation is sized to keep that within range. */
+    /* Pick the first 2 MiB boundary AT LEAST 16 pages above the start so the
+     * 32-page protect window straddles it (16 pages below + 16 above). If the
+     * natural rounded-up boundary is too close to base, jump to the next one --
+     * the allocation is sized to keep that within range.
+     */
     uintptr_t base = (uintptr_t) region;
     uintptr_t boundary = (base + mib_2 - 1) & ~(uintptr_t) (mib_2 - 1);
     if (boundary - base < 16 * PAGE_SIZE)
@@ -560,16 +565,17 @@ static void test_rvae_2mib_straddle(void)
         FAIL("straddle readback or mprotect failed");
 }
 
-/* R<->RX cycle on a 32-page region. Each cycle writes a unique
- * `mov w0, #imm; ret` epilogue to every page while RW, then mprotects to
- * RX and calls the page. The expected return value is the imm just written.
- * If the X11 I-cache hint were dropped from the TLBI_RANGE_LARGE path, the
- * call would execute stale instructions cached from a prior cycle and the
- * returned imm would mismatch.
+/* R<->RX cycle on a 32-page region. Each cycle writes a unique "mov w0, #imm;
+ * ret" epilogue to every page while RW, then mprotects to RX and calls the
+ * page. The expected return value is the imm just written. If the X11 I-cache
+ * hint were dropped from the TLBI_RANGE_LARGE path, the call would execute
+ * stale instructions cached from a prior cycle and the returned imm would
+ * mismatch.
  *
  * The RVAE1IS path is exercised because the 32-page range exceeds
  * TLBI_SELECTIVE_MAX_PAGES = 16; combined with PROT_EXEC the helper marks
- * icache_flush=1 and the shim's tlbi_range_large branch runs IC IALLU. */
+ * icache_flush=1 and the shim's tlbi_range_large branch runs IC IALLU.
+ */
 static void test_rvae_icache_stress(void)
 {
     TEST("RVAE1IS R<->RX I-cache hint coverage");
@@ -585,9 +591,10 @@ static void test_rvae_icache_stress(void)
 
     bool ok = true;
     for (int cycle = 0; cycle < 16 && ok; cycle++) {
-        /* Distinct imm per cycle so a stale I-cache fetch surfaces as a
-         * value mismatch. imm range [1, 0xFFF] -- mov-imm encoding takes a
-         * 16-bit literal at bits [20:5], easy to keep small. */
+        /* Distinct imm per cycle so a stale I-cache fetch surfaces as a value
+         * mismatch. imm range [1, 0xFFF] -- mov-imm encoding takes a 16-bit
+         * literal at bits [20:5], easy to keep small.
+         */
         uint32_t imm = (uint32_t) (cycle + 1) & 0xFFFu;
         /* mov w0, #imm  =  0x52800000 | (imm << 5) */
         uint32_t mov = 0x52800000u | (imm << 5);
@@ -606,8 +613,9 @@ static void test_rvae_icache_stress(void)
         }
 
         /* Call each page; verify the return value matches the imm we just
-         * wrote. A mismatch indicates the I-cache held a stale instruction
-         * from a prior cycle (i.e. the RVAE1IS path skipped IC IALLU). */
+         * wrote. A mismatch indicates the I-cache held a stale instruction from
+         * a prior cycle (i.e. the RVAE1IS path skipped IC IALLU).
+         */
         for (size_t i = 0; i < NPAGES; i++) {
             uint32_t (*fn)(void) =
                 (uint32_t (*)(void))((uint8_t *) p + i * PAGE_SIZE);
@@ -640,8 +648,9 @@ int main(void)
     test_rvae_boundary_sweep();
     test_rvae_2mib_straddle();
     test_rvae_icache_stress();
-    /* Drive the RVAE1IS NUM encoding across its boundaries under contention:
-     * 17 pages -> NUM=8, 32 -> NUM=15 (mid), 64 -> NUM=31 (max). */
+    /* Drive the RVAE1IS NUM encoding across its boundaries under contention: 17
+     * pages -> NUM=8, 32 -> NUM=15 (mid), 64 -> NUM=31 (max).
+     */
     test_rvae_multi_vcpu_stress(17);
     test_rvae_multi_vcpu_stress(32);
     test_rvae_multi_vcpu_stress(64);

--- a/tests/test-mremap-infra.c
+++ b/tests/test-mremap-infra.c
@@ -3,12 +3,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The infrastructure reserve at the top of guest IPA holds page tables,
- * the EL1 shim's code, and the shim's data block. None of these are
- * legal targets for guest memory management. sys_mmap MAP_FIXED,
- * sys_munmap and sys_mprotect already enforce this via
- * guest_range_hits_infra; sys_mremap and sys_madvise did not, leaving a
- * spoofing/corruption vector for code that knows the infra GVA.
+ * The infrastructure reserve at the top of guest IPA holds page tables, the EL1
+ * shim's code, and the shim's data block. None of these are legal targets for
+ * guest memory management. sys_mmap MAP_FIXED, sys_munmap and sys_mprotect
+ * already enforce this via guest_range_hits_infra; sys_mremap and sys_madvise
+ * did not, leaving a spoofing/corruption vector for code that knows the infra
+ * GVA.
  *
  * This test exercises the four guarded variants:
  *   1. mremap source range hits infra
@@ -16,9 +16,9 @@
  *   3. mremap grow-in-place tail spills into infra
  *   4. madvise(MADV_DONTNEED) on an infra range
  *
- * All four must fail with EINVAL. The infra base is read at runtime
- * from /proc/self/maps so the test stays portable across the 36-bit
- * and 40-bit IPA configurations.
+ * All four must fail with EINVAL. The infra base is read at runtime from
+ * /proc/self/maps so the test stays portable across the 36-bit and 40-bit IPA
+ * configurations.
  */
 
 #include <errno.h>
@@ -77,8 +77,8 @@ int main(void)
 {
     printf("test-mremap-infra: mremap/madvise reject infra-range targets\n");
 
-    /* Locate [shim-data]; if absent, [shim] is also acceptable as the
-     * infra reserve covers both. The test only needs ANY infra GVA.
+    /* Locate [shim-data]; if absent, [shim] is also acceptable as the infra
+     * reserve covers both. The test only needs ANY infra GVA.
      */
     uint64_t infra = find_region_base("[shim-data]");
     if (!infra)
@@ -98,9 +98,9 @@ int main(void)
         return 1;
     }
 
-    /* Case 1: mremap source range hits infra. The source must be a
-     * legal VMA for mremap to consider it, but pointing the call
-     * directly at the infra base is enough to make the kernel try.
+    /* Case 1: mremap source range hits infra. The source must be a legal VMA
+     * for mremap to consider it, but pointing the call directly at the infra
+     * base is enough to make the kernel try.
      */
     errno = 0;
     void *r = mremap((void *) (uintptr_t) infra, PAGE_SIZE, PAGE_SIZE,
@@ -115,10 +115,9 @@ int main(void)
     EXPECT(r == MAP_FAILED && errno == EINVAL,
            "mremap MREMAP_FIXED dest==infra rejected with EINVAL");
 
-    /* Case 3: grow-in-place tail spills into infra. Map a one-page
-     * region immediately below the infra base (assumes nothing
-     * else sits in that hole; if it does, the test is inconclusive
-     * but still safe).
+    /* Case 3: grow-in-place tail spills into infra. Map a one-page region
+     * immediately below the infra base (assumes nothing else sits in that hole;
+     * if it does, the test is inconclusive but still safe).
      */
     void *base = (void *) (uintptr_t) (infra - PAGE_SIZE);
     void *p = mmap(base, PAGE_SIZE, PROT_READ | PROT_WRITE,

--- a/tests/test-msync.c
+++ b/tests/test-msync.c
@@ -20,6 +20,10 @@
 
 #include "test-harness.h"
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 int passes = 0, fails = 0;
 
 /* glibc 2.28 static: shm_open is broken (returns ENOSYS without trying).
@@ -190,10 +194,10 @@ static void test_shm_name_visible_after_fork(void)
 
     char name[64];
     snprintf(name, sizeof(name), "/elfuse-msync-fork-%ld", (long) getpid());
-    /* Best-effort cleanup of stale shm objects from a previous run that
-     * was killed between create and the final unlink. macOS shm objects
-     * persist across process death, so without this O_EXCL fails with
-     * EEXIST and the test reports a spurious shm_open failure.
+    /* Best-effort cleanup of stale shm objects from a previous run that was
+     * killed between create and the final unlink. macOS shm objects persist
+     * across process death, so without this O_EXCL fails with EEXIST and the
+     * test reports a spurious shm_open failure.
      */
     my_shm_unlink(name);
     int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
@@ -257,11 +261,10 @@ static void test_shm_name_visible_after_fork(void)
     my_shm_unlink(name);
 }
 
-/* Real MAP_SHARED requires that host writes to the backing file are
- * observable through the mapping without the guest calling msync. The
- * pre-overlay implementation snapshotted file contents into private
- * guest pages and only reconciled on msync, so this is the regression
- * lock-in for the overlay path.
+/* Real MAP_SHARED requires that host writes to the backing file are observable
+ * through the mapping without the guest calling msync. The pre-overlay
+ * implementation snapshotted file contents into private guest pages and only
+ * reconciled on msync, so this is the regression lock-in for the overlay path.
  */
 static void test_shared_host_write_visible_without_msync(void)
 {
@@ -306,8 +309,8 @@ static void test_shared_host_write_visible_without_msync(void)
         return;
     }
 
-    /* Mutate the file via pwrite (host-side write). The mapping must
-     * reflect the new bytes immediately, with no msync from the guest.
+    /* Mutate the file via pwrite (host-side write). The mapping must reflect
+     * the new bytes immediately, with no msync from the guest.
      */
     char update[16];
     memset(update, 0x22, sizeof(update));
@@ -334,10 +337,9 @@ static void test_shared_host_write_visible_without_msync(void)
     close(fd);
 }
 
-/* Guest writes to a MAP_SHARED file mapping must reach the file
- * immediately so other readers (here, a sibling pread) see them without
- * the guest needing to call msync. This is the converse of the
- * host-write-visible test.
+/* Guest writes to a MAP_SHARED file mapping must reach the file immediately so
+ * other readers (here, a sibling pread) see them without the guest needing to
+ * call msync. This is the converse of the host-write-visible test.
  */
 static void test_shared_guest_write_lands_in_file(void)
 {
@@ -448,6 +450,98 @@ static void test_shared_adjacent_fixed_mapping_does_not_alias_file(void)
     close(fd);
 }
 
+static void test_shared_large_mapping_crosses_split_hvf_segments(void)
+{
+    TEST("large MAP_SHARED mmap crosses split HVF segments");
+
+    const size_t reserve_len = 8u * 1024u * 1024u;
+    const size_t large_len = 4u * 1024u * 1024u;
+    const size_t split_offset = 2u * 1024u * 1024u;
+    char small_name[64];
+    char large_name[64];
+    int small_fd = -1;
+    int large_fd = -1;
+    char *reserve;
+    char *small = MAP_FAILED;
+    char *large = MAP_FAILED;
+
+    reserve =
+        mmap(NULL, reserve_len, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (reserve == MAP_FAILED) {
+        FAIL("reserve mmap failed");
+        return;
+    }
+    if (munmap(reserve, reserve_len) != 0) {
+        FAIL("reserve munmap failed");
+        return;
+    }
+
+    snprintf(small_name, sizeof(small_name), "/elfuse-msync-split-%ld",
+             (long) getpid());
+    snprintf(large_name, sizeof(large_name), "/elfuse-msync-large-%ld",
+             (long) getpid());
+    my_shm_unlink(small_name);
+    my_shm_unlink(large_name);
+
+    small_fd = my_shm_open(small_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    large_fd = my_shm_open(large_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    my_shm_unlink(small_name);
+    my_shm_unlink(large_name);
+    if (small_fd < 0 || large_fd < 0) {
+        FAIL("shm_open failed");
+        goto out;
+    }
+    if (ftruncate(small_fd, 4096) != 0 ||
+        ftruncate(large_fd, (off_t) large_len) != 0) {
+        FAIL("ftruncate failed");
+        goto out;
+    }
+
+    small = mmap(reserve + split_offset, 4096, PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_FIXED_NOREPLACE, small_fd, 0);
+    if (small == MAP_FAILED) {
+        FAIL("splitter mmap failed");
+        goto out;
+    }
+    small[0] = 0x5a;
+    if (munmap(small, 4096) != 0) {
+        FAIL("splitter munmap failed");
+        small = MAP_FAILED;
+        goto out;
+    }
+    small = MAP_FAILED;
+
+    large = mmap(reserve, large_len, PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_FIXED_NOREPLACE, large_fd, 0);
+    if (large == MAP_FAILED) {
+        FAIL("large mmap failed");
+        goto out;
+    }
+
+    large[0] = 0x11;
+    large[split_offset] = 0x22;
+    unsigned char first = 0;
+    unsigned char across_split = 0;
+    if (pread(large_fd, &first, 1, 0) != 1 ||
+        pread(large_fd, &across_split, 1, (off_t) split_offset) != 1) {
+        FAIL("pread failed");
+    } else if (first == 0x11 && across_split == 0x22) {
+        PASS();
+    } else {
+        FAIL("large shared mapping did not stay file-backed");
+    }
+
+out:
+    if (large != MAP_FAILED)
+        munmap(large, large_len);
+    if (small != MAP_FAILED)
+        munmap(small, 4096);
+    if (small_fd >= 0)
+        close(small_fd);
+    if (large_fd >= 0)
+        close(large_fd);
+}
+
 int main(void)
 {
     printf("test-msync: MAP_SHARED msync tests\n\n");
@@ -458,6 +552,7 @@ int main(void)
     test_shared_host_write_visible_without_msync();
     test_shared_guest_write_lands_in_file();
     test_shared_adjacent_fixed_mapping_does_not_alias_file();
+    test_shared_large_mapping_crosses_split_hvf_segments();
     test_shm_name_visible_after_fork();
 
     SUMMARY("test-msync");

--- a/tests/test-mt-fork.c
+++ b/tests/test-mt-fork.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Creates N worker threads that write to shared memory, then forks
- * from the main thread. Verifies the child's snapshot is consistent
- * (no torn writes from partially-quiesced workers).
+ * Creates N worker threads that write to shared memory, then forks from the
+ * main thread. Verifies the child's snapshot is consistent (no torn writes from
+ * partially-quiesced workers).
  *
  * Syscalls: clone(220), futex(98), clone/fork, exit(93), write(64)
  */
@@ -98,12 +98,11 @@ int main(void)
     }
 
     if (child == 0) {
-        /* Child: check snapshot consistency. Workers write 8-byte
-         * patterns (0xDEAD0000|id). On aarch64, aligned 8-byte stores
-         * are atomic, so each entry must be a valid pattern (not a
-         * torn mix of two patterns). Full-array consistency is NOT
-         * guaranteed because fork snapshots memory between instructions,
-         * and a worker may be mid-loop.
+        /* Child: check snapshot consistency. Workers write 8-byte patterns
+         * (0xDEAD0000|id). On aarch64, aligned 8-byte stores are atomic, so
+         * each entry must be a valid pattern (not a torn mix of two patterns).
+         * Full-array consistency is NOT guaranteed because fork snapshots
+         * memory between instructions, and a worker may be mid-loop.
          */
         bool consistent = true;
         for (int i = 0; i < PATTERN_SIZE; i++) {

--- a/tests/test-multi-vcpu.c
+++ b/tests/test-multi-vcpu.c
@@ -4,10 +4,10 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Standalone native macOS test program (NOT a guest binary). Uses HVF
- * directly to create a VM with two vCPUs sharing the same guest physical
- * memory, page tables, and shim binary. Validates the fundamentals needed
- * for Linux clone(CLONE_THREAD) support in elfuse.
+ * Standalone native macOS test program (NOT a guest binary). Uses HVF directly
+ * to create a VM with two vCPUs sharing the same guest physical memory, page
+ * tables, and shim binary. Validates the fundamentals needed for Linux
+ * clone(CLONE_THREAD) support in elfuse.
  *
  * Tests:
  *   1. Basic dual vCPU creation: can hv_vcpu_create() be called twice?
@@ -16,8 +16,8 @@
  *   4. Register preservation: are callee-saved regs safe across SVCs?
  *   5. TLBI broadcast: does TLBI VMALLE1IS propagate across vCPUs?
  *
- * Build: clang -O2 -framework Hypervisor -arch arm64 -Ibuild -o test $<
- * Run:   codesign --entitlements entitlements.plist -f -s - test && ./test
+ * Build: clang -O2 -framework Hypervisor -arch arm64 -Ibuild -o test $< Run:
+ * codesign --entitlements entitlements.plist -f -s - test && ./test
  */
 
 #include <Hypervisor/Hypervisor.h>
@@ -114,8 +114,8 @@
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
-/* Page table pool allocator. One instance per test since each test creates
- * a fresh VM.
+/* Page table pool allocator. One instance per test since each test creates a
+ * fresh VM.
  */
 typedef struct {
     void *host_base;  /* Host mmap pointer */
@@ -266,10 +266,11 @@ typedef struct {
     uint64_t x0, x1, x8; /* Registers at exit */
 } vcpu_exit_t;
 
-/* Run the vCPU until it exits via HVC #0 or HVC #5. Handles HVC #4
- * (sysreg set) internally, same as elfuse's run loop. Returns the exit
- * reason and register values. max_hvc5 limits how many HVC #5 exits
- * to handle before returning (0 = stop on first HVC #5).
+/* Run the vCPU until it exits via HVC #0 or HVC #5. Handles HVC #4 (sysreg set)
+ * internally, same as elfuse's run loop.
+ *
+ * Returns the exit reason and register values. max_hvc5 limits how many HVC #5
+ * exits to handle before returning (0 = stop on first HVC #5).
  */
 static int run_vcpu(hv_vcpu_t vcpu,
                     hv_vcpu_exit_t *vexit,
@@ -289,8 +290,8 @@ static int run_vcpu(hv_vcpu_t vcpu,
                 uint16_t imm = vexit->exception.syndrome & 0xFFFF;
 
                 if (imm == 4) {
-                    /* HVC #4: set sysreg (from shim _start). Same encoding
-                     * as elfuse's run loop: X0 = index into hvc4_sysregs.
+                    /* HVC #4: set sysreg (from shim _start). Same encoding as
+                     * elfuse's run loop: X0 = index into hvc4_sysregs.
                      */
                     static const hv_sys_reg_t hvc4_sysregs[] = {
                         HV_SYS_REG_VBAR_EL1,  /* 0 */
@@ -384,8 +385,8 @@ typedef struct {
     char name[16];        /* For debug messages */
 } thread_ctx_t;
 
-/* Thread function: create vCPU, configure, run, record exits.
- * HVF requires vCPU operations on the creating thread.
+/* Thread function: create vCPU, configure, run, record exits. HVF requires vCPU
+ * operations on the creating thread.
  *
  * Handles HVC #5 exits:
  *   X8=93  -> treat as exit (like Linux exit syscall), stop running
@@ -416,14 +417,14 @@ static void *vcpu_thread(void *arg)
         return NULL;
     }
 
-    /* Run until exit. run_vcpu handles HVC #4 internally.
-     * The handler handles HVC #5 here: marker SVCs get resumed, X8=93 stops.
+    /* Run until exit. run_vcpu handles HVC #4 internally. The handler handles
+     * HVC #5 here: marker SVCs get resumed, X8=93 stops.
      */
     int markers_left = ctx->max_hvc5;
     for (;;) {
         vcpu_exit_t ex;
-        /* Tell run_vcpu to return on every HVC #5 (max_hvc5=0) so
-         * The handler can inspect X8 and decide whether to resume or stop.
+        /* Tell run_vcpu to return on every HVC #5 (max_hvc5=0) so the handler
+         * can inspect X8 and decide whether to resume or stop.
          */
         int rc = run_vcpu(vcpu, vexit, &ex, 0);
 
@@ -474,9 +475,9 @@ static int vm_create(vm_state_t *vm)
         return -1;
     vm->pt_next = PT_POOL_BASE;
 
-    /* Query max IPA size and configure VM (matches guest.c pattern).
-     * The test uses only 16MiB, so any IPA size works; this is for
-     * API consistency with elfuse's production code path.
+    /* Query max IPA size and configure VM (matches guest.c pattern). The test
+     * uses only 16MiB, so any IPA size works; this is for API consistency with
+     * elfuse's production code path.
      */
     uint32_t max_ipa = 0;
     hv_vm_config_get_max_ipa_size(&max_ipa);
@@ -519,11 +520,11 @@ static void vm_destroy(vm_state_t *vm)
 
 /* TEST 1: Basic Dual vCPU Creation
  *
- * Can hv_vcpu_create() be called twice in one VM? Can both vCPUs
- * execute concurrently on separate host threads?
+ * Can hv_vcpu_create() be called twice in one VM? Can both vCPUs execute
+ * concurrently on separate host threads?
  *
- * Guest code: mov x0, #0; mov x8, #93; svc #0
- * Both vCPUs run the same trivial program, exit via SVC #0 (X8=93).
+ * Guest code: mov x0, #0; mov x8, #93; svc #0. Both vCPUs run the same trivial
+ * program and exit via SVC #0 (X8=93).
  */
 
 static int test1_basic_dual_vcpu(void)
@@ -600,8 +601,8 @@ static int test1_basic_dual_vcpu(void)
 
 /* TEST 2: Shared Memory Writes
  *
- * vCPU-A writes 0xAA to DATA_BASE+0, vCPU-B writes 0xBB to DATA_BASE+8.
- * Host verifies both values after both vCPUs exit.
+ * vCPU-A writes 0xAA to DATA_BASE+0, vCPU-B writes 0xBB to DATA_BASE+8. Host
+ * verifies both values after both vCPUs exit.
  */
 
 static int test2_shared_memory(void)
@@ -704,9 +705,9 @@ static int test2_shared_memory(void)
 
 /* TEST 3: Separate SP_EL1 / Multiple SVCs
  *
- * Each vCPU does two SVCs: a marker SVC (X8=0xAAAA / 0xBBBB) then
- * an exit SVC (X8=93). Exercises the shim's 256-byte SP_EL1 stack
- * frame twice per vCPU, concurrently.
+ * Each vCPU does two SVCs: a marker SVC (X8=0xAAAA / 0xBBBB) then an exit SVC
+ * (X8=93). Exercises the shim's 256-byte SP_EL1 stack frame twice per vCPU,
+ * concurrently.
  */
 
 static int test3_separate_sp_el1(void)
@@ -804,10 +805,10 @@ static int test3_separate_sp_el1(void)
 
 /* TEST 4: Register Preservation
  *
- * Each vCPU sets X19=0x1234, X20=0x5678, does SVC (marker), then
- * reports X19/X20 via X0/X1 in a second SVC. Verifies the shim's
- * stp/ldp save/restore on per-vCPU SP_EL1 does not corrupt callee-
- * saved registers when two vCPUs run concurrently.
+ * Each vCPU sets X19=0x1234, X20=0x5678, does SVC (marker), then reports
+ * X19/X20 via X0/X1 in a second SVC. Verifies the shim's stp/ldp save/restore
+ * on per-vCPU SP_EL1 does not corrupt callee- saved registers when two vCPUs
+ * run concurrently.
  */
 
 static int test4_register_preservation(void)
@@ -929,9 +930,9 @@ static int test4_register_preservation(void)
  *   5. vCPU-B starts, reads from 0x800000, reports value via SVC, exits
  *   6. Host verifies vCPU-B read 0xDEAD
  *
- * This test runs vCPUs SEQUENTIALLY (not concurrently) to isolate
- * the TLBI broadcast question: does vCPU-A's TLBI invalidate
- * vCPU-B's TLB when B starts later?
+ * This test runs vCPUs SEQUENTIALLY (not concurrently) to isolate the TLBI
+ * broadcast question: does vCPU-A's TLBI invalidate vCPU-B's TLB when B starts
+ * later?
  */
 
 static void *vcpu_thread_tlbi_a(void *arg)

--- a/tests/test-negative.c
+++ b/tests/test-negative.c
@@ -4,10 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Exercises error paths: invalid FDs, bad syscall numbers, bad mmap
- * arguments, EFAULT (bad pointers), errno translation, EINVAL (bad flags),
- * and boundary conditions. All should return proper Linux error codes
- * without crashing.
+ * Exercises error paths: invalid FDs, bad syscall numbers, bad mmap arguments,
+ * EFAULT (bad pointers), errno translation, EINVAL (bad flags), and boundary
+ * conditions. All should return proper Linux error codes without crashing.
  */
 
 #include <stdint.h>
@@ -258,8 +257,8 @@ static void test_write_only_read(void)
 
 static void test_efault(void)
 {
-    /* Use an unmapped high address as a bad pointer.
-     * Raw syscalls return -errno directly. Linux EFAULT = 14.
+    /* Use an unmapped high address as a bad pointer. Raw syscalls return -errno
+     * directly. Linux EFAULT = 14.
      */
     void *bad_ptr = (void *) 0xDEAD000000000000ULL;
     const char *expected_efault = "expected -EFAULT (-14)";
@@ -290,8 +289,8 @@ static void test_efault(void)
 
 static void test_errno_values(void)
 {
-    /* Verify that elfuse translates macOS errno -> Linux errno correctly.
-     * These are the most commonly divergent values.
+    /* Verify that elfuse translates macOS errno -> Linux errno correctly. These
+     * are the most commonly divergent values.
      */
 
     TEST("EAGAIN is 11");
@@ -444,9 +443,9 @@ static void test_einval(void)
     TEST("clock_nanosleep(absolute past)");
     {
         /* TIMER_ABSTIME with a deadline already in the past must return 0
-         * immediately (no sleep). Use tv_sec=0 to stay in the kernel's
-         * "valid timespec" space -- Linux rejects negative tv_sec with
-         * -EINVAL even before the deadline-in-past check.
+         * immediately (no sleep). Use tv_sec=0 to stay in the kernel's "valid
+         * timespec" space -- Linux rejects negative tv_sec with -EINVAL even
+         * before the deadline-in-past check.
          */
         struct timespec ts = {.tv_sec = 0, .tv_nsec = 0};
         long r = raw_syscall4(__NR_clock_nanosleep, CLOCK_MONOTONIC,
@@ -456,10 +455,10 @@ static void test_einval(void)
 
     TEST("*at bad flags -> EINVAL");
     {
-        /* Path must exist: kernel validates flags before path resolution
-         * for the *at syscalls below, but a non-existent path can mask the
-         * flag error if the implementation reorders these (or if the flag
-         * arg is silently ignored, like sys_faccessat which only takes
+        /* Path must exist: kernel validates flags before path resolution for
+         * the *at syscalls below, but a non-existent path can mask the flag
+         * error if the implementation reorders these (or if the flag arg is
+         * silently ignored, like sys_faccessat which only takes
          * dirfd/path/mode). Using "/tmp" sidesteps both pitfalls.
          */
         const char *path = "/tmp";

--- a/tests/test-netstat.c
+++ b/tests/test-netstat.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Creates TCP and UDP sockets, then reads /proc/net/tcp and /proc/net/udp
- * to verify the sockets appear with correct addresses/ports/states.
- * Also exercises /proc/net/unix, /proc/net/tcp6, and /proc/net/raw.
+ * Creates TCP and UDP sockets, then reads /proc/net/tcp and /proc/net/udp to
+ * verify the sockets appear with correct addresses/ports/states. Also exercises
+ * /proc/net/unix, /proc/net/tcp6, and /proc/net/raw.
  */
 
 #include <stdio.h>

--- a/tests/test-opath.c
+++ b/tests/test-opath.c
@@ -5,8 +5,8 @@
  *
  * Linux O_PATH descriptors carry only a path reference: read/write/lseek/
  * ioctl/fsync/flock/ftruncate/fchmod/fchown/getdents/fsetxattr/fremovexattr
- * must all return EBADF.  fstat/fstatfs/close/dup/fcntl-cloexec/fchdir and
- * use as a *at() dirfd remain valid.
+ * must all return EBADF. fstat/fstatfs/close/dup/fcntl-cloexec/fchdir and use
+ * as a *at() dirfd remain valid.
  */
 
 #define _GNU_SOURCE
@@ -163,9 +163,9 @@ static void test_xattr_rejected(void)
         return;
 
     /* The setxattr/removexattr path may also return ENOTSUP/EOPNOTSUPP on
-     * filesystems that lack xattr support.  Only require EBADF from elfuse;
-     * skip these checks on a filesystem that rejects xattr outright on a
-     * fresh /tmp file (rare; APFS and ext4 both honor user.* xattrs).
+     * filesystems that lack xattr support. Only require EBADF from elfuse; skip
+     * these checks on a filesystem that rejects xattr outright on a fresh /tmp
+     * file (rare; APFS and ext4 both honor user.* xattrs).
      */
     int probe = setxattr(tmp_file, "user.elfuse_probe", "x", 1, 0);
     if (probe < 0 && errno != EEXIST) {
@@ -195,9 +195,9 @@ static void test_getdents_rejected(void)
     }
 
     /* glibc's readdir() works through fdopendir, but fdopendir itself uses
-     * fstat + getdents64.  The kernel returns EBADF on getdents64; glibc
-     * surfaces that via readdir errno or fdopendir failure.  Use the raw
-     * syscall to keep the contract precise.
+     * fstat + getdents64. The kernel returns EBADF on getdents64; glibc
+     * surfaces that via readdir errno or fdopendir failure. Use the raw syscall
+     * to keep the contract precise.
      */
     char buf[1024];
     TEST("getdents64(O_PATH dir) -> EBADF");

--- a/tests/test-pidfd.c
+++ b/tests/test-pidfd.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: pidfd_open, pidfd_send_signal, clone3 with CLONE_PIDFD,
- * and poll on pidfd for exit notification.
+ * Tests: pidfd_open, pidfd_send_signal, clone3 with CLONE_PIDFD, and poll on
+ * pidfd for exit notification.
  */
 
 #include <stdint.h>

--- a/tests/test-proc-fidelity.c
+++ b/tests/test-proc-fidelity.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Exercises the /proc nodes that elfuse synthesizes through procemu:
- * /proc/self/oom_score_adj (read/write/persist/range/zero-length writev),
- * the legacy /proc/self/oom_adj scaling alias, /proc/self/oom_score
- * (open-time and write-time enforcement), /proc/self/fdinfo entries for
- * generic fds plus eventfd/signalfd/timerfd, /proc/net/tcp serial-number
- * density across mixed socket types, and /proc/cpuinfo CPU enumeration.
- * These tests pin the host-visible byte format so a regression to the
- * wrong separator, scaling factor, or sparse layout fails loudly.
+ * /proc/self/oom_score_adj (read/write/persist/range/zero-length writev), the
+ * legacy /proc/self/oom_adj scaling alias, /proc/self/oom_score (open-time and
+ * write-time enforcement), /proc/self/fdinfo entries for generic fds plus
+ * eventfd/signalfd/timerfd, /proc/net/tcp serial-number density across mixed
+ * socket types, and /proc/cpuinfo CPU enumeration. These tests pin the
+ * host-visible byte format so a regression to the wrong separator, scaling
+ * factor, or sparse layout fails loudly.
  */
 
 #include <dirent.h>
@@ -36,12 +36,11 @@
 int passes = 0, fails = 0;
 
 /* Some procfs write-rejection tests can only be exercised as root (root
- * bypasses the 0444 open-time gate, so the kernel actually invokes the
- * proc node's write handler). On non-root the test cannot prove the
- * lower layer is correct without also reproducing a kernel-internal
- * regression; counting these as skips keeps the summary honest instead
- * of either masking real regressions behind a bogus PASS or pretending
- * the path was exercised.
+ * bypasses the 0444 open-time gate, so the kernel actually invokes the proc
+ * node's write handler). On non-root the test cannot prove the lower layer is
+ * correct without also reproducing a kernel-internal regression; counting these
+ * as skips keeps the summary honest instead of either masking real regressions
+ * behind a bogus PASS or pretending the path was exercised.
  */
 static int procfs_skips = 0;
 #define PROCFS_SKIP(reason)           \
@@ -115,8 +114,9 @@ static void test_proc_oom_score_adj_rejects_out_of_range(void)
         FAIL("open");
         return;
     }
-    /* Linux validates the input domain on the writer side; the kernel
-     * returns EINVAL for any value outside [-1000, 1000]. */
+    /* Linux validates the input domain on the writer side; the kernel returns
+     * EINVAL for any value outside [-1000, 1000].
+     */
     const char too_high[] = "1001\n";
     ssize_t rc = write(fd, too_high, sizeof(too_high) - 1);
     int saved = errno;
@@ -139,17 +139,18 @@ static void test_proc_oom_adj_scaling(void)
 
     int fd = open("/proc/self/oom_adj", O_RDWR);
     if (fd < 0) {
-        /* Older silent-PASS treated absence as acceptable, which turned
-         * the scaling regression into a no-op on any host that did not
-         * ship the legacy compat node. elfuse must expose it via the
-         * procemu layer, and current Linux kernels still keep the alias,
-         * so absence is a real regression.
+        /* Older silent-PASS treated absence as acceptable, which turned the
+         * scaling regression into a no-op on any host that did not ship the
+         * legacy compat node. elfuse must expose it via the procemu layer, and
+         * current Linux kernels still keep the alias, so absence is a real
+         * regression.
          */
         FAIL("open /proc/self/oom_adj");
         return;
     }
-    /* Linux fs/proc/base.c oom_adj_write special-cases OOM_ADJUST_MAX so
-     * 15 maps directly to OOM_SCORE_ADJ_MAX (1000), not 15*1000/17 = 882. */
+    /* Linux fs/proc/base.c oom_adj_write special-cases OOM_ADJUST_MAX so 15
+     * maps directly to OOM_SCORE_ADJ_MAX (1000), not 15*1000/17 = 882.
+     */
     if (write(fd, "15\n", 3) != 3) {
         close(fd);
         FAIL("write");
@@ -185,9 +186,9 @@ static void test_proc_oom_adj_same_fd_roundtrip(void)
 
     int fd = open("/proc/self/oom_adj", O_RDWR);
     if (fd < 0) {
-        /* See test_proc_oom_adj_scaling for rationale: silent PASS on
-         * absent oom_adj turned the same-fd readback regression into a
-         * no-op. Fail hard so a missing compat alias surfaces.
+        /* See test_proc_oom_adj_scaling for rationale: silent PASS on absent
+         * oom_adj turned the same-fd readback regression into a no-op. Fail
+         * hard so a missing compat alias surfaces.
          */
         FAIL("open /proc/self/oom_adj");
         return;
@@ -221,10 +222,10 @@ static void test_proc_oom_adj_same_fd_roundtrip(void)
 static void test_proc_oom_score_no_write(void)
 {
     TEST("/proc/self/oom_score writes are rejected");
-    /* Linux: open succeeds (root bypasses the 0444 check, non-root sees
-     * EACCES from the permission gate); writes always fail because there
-     * is no write handler. The test focuses on the write side, which is
-     * uniform across uids.
+    /* Linux: open succeeds (root bypasses the 0444 check, non-root sees EACCES
+     * from the permission gate); writes always fail because there is no write
+     * handler. The test focuses on the write side, which is uniform across
+     * uids.
      */
     int fd = open("/proc/self/oom_score", O_RDONLY);
     if (fd < 0) {
@@ -238,8 +239,8 @@ static void test_proc_oom_score_no_write(void)
         FAIL("read");
         return;
     }
-    /* Stub returns 0; real Linux computes a small positive score, but for
-     * a userspace bridge a constant zero is acceptable.
+    /* Stub returns 0; real Linux computes a small positive score, but for a
+     * userspace bridge a constant zero is acceptable.
      */
     EXPECT_TRUE(atoi(buf) >= 0, "score must be non-negative");
 }
@@ -247,13 +248,13 @@ static void test_proc_oom_score_no_write(void)
 static void test_proc_oom_score_write_fails(void)
 {
     TEST("/proc/self/oom_score write is rejected");
-    /* The intended coverage is the proc node's write handler returning
-     * EIO. That handler is only reached when open succeeds with write
-     * access. Only root can open the 0444 file O_WRONLY; non-root sees
-     * EACCES at open and exits the write-rejection path entirely. The
-     * sibling test_proc_oom_score_open_enforces_read_only covers the
-     * open-time EACCES branch separately, so explicitly skip here when
-     * the write path cannot be reached.
+    /* The intended coverage is the proc node's write handler returning EIO.
+     * That handler is only reached when open succeeds with write access. Only
+     * root can open the 0444 file O_WRONLY; non-root sees EACCES at open and
+     * exits the write-rejection path entirely. The sibling
+     * test_proc_oom_score_open_enforces_read_only covers the open-time EACCES
+     * branch separately, so explicitly skip here when the write path cannot be
+     * reached.
      */
     int fd = open("/proc/self/oom_score", O_WRONLY);
     if (fd < 0) {
@@ -269,10 +270,9 @@ static void test_proc_oom_score_write_fails(void)
     ssize_t w = write(fd, "0\n", 2);
     int saved = errno;
     close(fd);
-    /* Linux's proc_reg_write returns -EIO when the proc node has no
-     * write op. Older or stripped kernels may return other errno; the
-     * load-bearing assertion is that the write fails, not the exact
-     * errno value.
+    /* Linux's proc_reg_write returns -EIO when the proc node has no write op.
+     * Older or stripped kernels may return other errno; the load-bearing
+     * assertion is that the write fails, not the exact errno value.
      */
     if (w < 0)
         PASS();
@@ -311,11 +311,11 @@ static void test_proc_oom_adj_reread_tracks_score_adj_updates(void)
 
     int fd = open("/proc/self/oom_adj", O_RDONLY);
     if (fd < 0) {
-        /* The legacy oom_adj compat node must exist whenever the test
-         * runs under elfuse (procemu emits it) or under a current Linux
-         * kernel that still ships the compat alias. The previous version
-         * silently PASSed on open failure, which turned this regression
-         * into a no-op on any host where the file was absent.
+        /* The legacy oom_adj compat node must exist whenever the test runs
+         * under elfuse (procemu emits it) or under a current Linux kernel that
+         * still ships the compat alias. The previous version silently PASSed on
+         * open failure, which turned this regression into a no-op on any host
+         * where the file was absent.
          */
         FAIL("open /proc/self/oom_adj");
         return;
@@ -443,7 +443,8 @@ static void test_proc_oom_zero_length_writev(void)
         return;
     }
     /* Two empty iovecs: total length zero. Linux returns 0; the previous
-     * implementation returned EINVAL via proc_parse_int_write. */
+     * implementation returned EINVAL via proc_parse_int_write.
+     */
     char dummy = 0;
     struct iovec iov[2] = {{&dummy, 0}, {&dummy, 0}};
     ssize_t n = writev(fd, iov, 2);
@@ -464,7 +465,8 @@ static void test_proc_oom_stat_size_zero(void)
         return;
     }
     /* A non-zero st_size would cap stat-sized read buffers, truncating
-     * "-1000\n" (6 bytes) to whatever size was hardcoded. */
+     * "-1000\n" (6 bytes) to whatever size was hardcoded.
+     */
     EXPECT_TRUE(st.st_size == 0, "st_size should be 0");
 }
 
@@ -514,9 +516,9 @@ static void test_proc_fdinfo_eventfd_count(void)
         FAIL("read");
         return;
     }
-    /* Linux fs/eventfd.c emits "eventfd-count: %16llx" with a single
-     * space separator (not a tab, unlike pos:/flags:/mnt_id:). Pin the
-     * exact prefix so a regression to a tab is caught. Decimal 42 is 0x2a.
+    /* Linux fs/eventfd.c emits "eventfd-count: %16llx" with a single space
+     * separator (not a tab, unlike pos:/flags:/mnt_id:). Pin the exact prefix
+     * so a regression to a tab is caught. Decimal 42 is 0x2a.
      */
     const char *p = strstr(buf, "eventfd-count: ");
     EXPECT_TRUE(p && strstr(p, "2a") != NULL,
@@ -551,8 +553,8 @@ static void test_proc_fdinfo_signalfd_mask(void)
         return;
     }
     /* Linux fs/signalfd.c emits "sigmask:\t%016llx" with a tab separator
-     * (verified against a real /proc/self/fdinfo dump on Linux 6.x).
-     * Pin the exact prefix so a regression to a space is caught.
+     * (verified against a real /proc/self/fdinfo dump on Linux 6.x). Pin the
+     * exact prefix so a regression to a space is caught.
      */
     EXPECT_TRUE(strstr(buf, "sigmask:\t") != NULL,
                 "sigmask missing tab separator");
@@ -597,8 +599,9 @@ static void test_proc_fdinfo_timerfd_periodic_value(void)
 
     long long value_sec = -1, value_nsec = -1;
     long long interval_sec = -1, interval_nsec = -1;
-    /* Linux fs/timerfd.c emits "it_value: (S, NS)" with a single space
-     * after the colon (unlike pos:/flags: which use tabs). */
+    /* Linux fs/timerfd.c emits "it_value: (S, NS)" with a single space after
+     * the colon (unlike pos:/flags: which use tabs).
+     */
     const char *value = strstr(buf, "it_value: (");
     const char *interval = strstr(buf, "it_interval: (");
     if (!value || !interval ||
@@ -612,9 +615,9 @@ static void test_proc_fdinfo_timerfd_periodic_value(void)
     long long value_total_ns = value_sec * 1000000000LL + value_nsec;
     long long interval_total_ns = interval_sec * 1000000000LL + interval_nsec;
     /* it_interval is the static settime value and must round-trip; Linux's
-     * timerfd_get_remaining() reports 0 once the timer has fired, while
-     * elfuse computes time-until-next from the kqueue arm time. Both are
-     * non-negative and bounded by the interval, so accept either form.
+     * timerfd_get_remaining() reports 0 once the timer has fired, while elfuse
+     * computes time-until-next from the kqueue arm time. Both are non-negative
+     * and bounded by the interval, so accept either form.
      */
     EXPECT_TRUE(interval_total_ns == 50000000 && value_total_ns >= 0 &&
                     value_total_ns <= interval_total_ns,
@@ -624,12 +627,13 @@ static void test_proc_fdinfo_timerfd_periodic_value(void)
 static void test_proc_fdinfo_timerfd_ticks_drains_kqueue(void)
 {
     TEST("/proc/self/fdinfo/<N> ticks reflects pending kqueue fires");
-    /* Arm a periodic timer, wait for several fires, then read fdinfo
-     * WITHOUT first reading the timerfd. The pre-fix snapshot exported
-     * a stale expirations counter (the kqueue events had not been folded
-     * in), so ticks would read 0 even after multiple fires. Linux's
-     * fs/timerfd.c snapshots ticks under the wait-queue lock, where the
-     * counter reflects every fire that hit the kernel state. */
+    /* Arm a periodic timer, wait for several fires, then read fdinfo WITHOUT
+     * first reading the timerfd. The pre-fix snapshot exported a stale
+     * expirations counter (the kqueue events had not been folded in), so ticks
+     * would read 0 even after multiple fires. Linux's fs/timerfd.c snapshots
+     * ticks under the wait-queue lock, where the counter reflects every fire
+     * that hit the kernel state.
+     */
     int tfd = timerfd_create(CLOCK_MONOTONIC, 0);
     if (tfd < 0) {
         FAIL("timerfd_create");
@@ -669,18 +673,19 @@ static void test_proc_fdinfo_timerfd_ticks_drains_kqueue(void)
         FAIL("parse ticks");
         return;
     }
-    /* At minimum one fire should be visible; on a slow host more would
-     * be expected. Pre-fix elfuse would report 0 here. */
+    /* At minimum one fire should be visible; on a slow host more would be
+     * expected. Pre-fix elfuse would report 0 here.
+     */
     EXPECT_TRUE(ticks >= 1, "ticks should reflect at least one fire");
 }
 
 static void test_proc_fdinfo_dir_concurrent_safe(void)
 {
     TEST("/proc/self/fdinfo dir tolerates concurrent re-open");
-    /* Open the directory twice and verify both enumerate independently.
-     * The earlier shared-dir design could mutate one open's backing files
-     * while another iterated. Both Linux and the per-open scratch fix
-     * should at minimum surface stdin/out/err on each enumeration.
+    /* Open the directory twice and verify both enumerate independently. The
+     * earlier shared-dir design could mutate one open's backing files while
+     * another iterated. Both Linux and the per-open scratch fix should at
+     * minimum surface stdin/out/err on each enumeration.
      */
     DIR *d1 = opendir("/proc/self/fdinfo");
     if (!d1) {
@@ -759,16 +764,15 @@ static void test_proc_net_tcp_sl_dense(void)
 {
     TEST("/proc/net/tcp sl column stays dense across mixed sockets");
     /* Interleave non-TCP sockets BEFORE the bound TCP listeners so the
-     * proc_pidinfo iterator visits the rejected sockets first and the
-     * pre-fix sparse-slot bug would assign nonzero sl to the first
-     * emitted row. Two TCP listeners ensure the second row's sl exposes
-     * any gap created by additional non-TCP visits between them.
+     * proc_pidinfo iterator visits the rejected sockets first and the pre-fix
+     * sparse-slot bug would assign nonzero sl to the first emitted row. Two TCP
+     * listeners ensure the second row's sl exposes any gap created by
+     * additional non-TCP visits between them.
      *
-     * Pre-fix: udp1, udp2, sp[0], sp[1] all bump the iterator slot
-     * counter to 4 before tcp1 emits. tcp1 row: sl=4. tcp2 row: sl=5.
-     * The first-row check (sl == 0) would fail.
-     * Post-fix: only emitted rows increment the visitor's row counter;
-     * tcp1: sl=0, tcp2: sl=1. Dense.
+     * Pre-fix: udp1, udp2, sp[0], sp[1] all bump the iterator slot counter to 4
+     * before tcp1 emits. tcp1 row: sl=4. tcp2 row: sl=5. The first-row check
+     * (sl == 0) would fail. Post-fix: only emitted rows increment the visitor's
+     * row counter; tcp1: sl=0, tcp2: sl=1. Dense.
      */
     int udp1 = socket(AF_INET, SOCK_DGRAM, 0);
     int udp2 = socket(AF_INET, SOCK_DGRAM, 0);
@@ -821,9 +825,9 @@ static void test_proc_net_tcp_sl_dense(void)
     close(tcp2);
     buf[total] = '\0';
 
-    /* Skip the header line; collect each subsequent row's leading "sl"
-     * field. /proc/net/tcp's row format is "  N: ..." with N a decimal
-     * serial. Verify the serials form 0,1,2,... with no gaps.
+    /* Skip the header line; collect each subsequent row's leading "sl" field.
+     * /proc/net/tcp's row format is " N: ..." with N a decimal serial. Verify
+     * the serials form 0,1,2,... with no gaps.
      */
     char *line = strchr(buf, '\n');
     if (!line) {
@@ -849,8 +853,9 @@ static void test_proc_net_tcp_sl_dense(void)
         line = eol + 1;
     }
     if (expected == 0) {
-        /* The bound listener should have produced a row. Treat absence
-         * as failure since the regression coverage depends on it. */
+        /* The bound listener should have produced a row. Treat absence as
+         * failure since the regression coverage depends on it.
+         */
         FAIL("no TCP rows after bind/listen");
         return;
     }
@@ -948,10 +953,9 @@ int main(void)
     test_proc_net_dirfd_openat_uses_virtual_entries();
     test_proc_cpuinfo_all_cpus();
 
-    /* Local summary includes the skip count so missed coverage (e.g.
-     * non-root oom_score write path) is visible alongside passes and
-     * fails. Cannot reuse SUMMARY() from test-harness.h because it has
-     * no skip accounting.
+    /* Local summary includes the skip count so missed coverage (e.g. non-root
+     * oom_score write path) is visible alongside passes and fails. Cannot reuse
+     * SUMMARY() from test-harness.h because it has no skip accounting.
      */
     printf("\ntest-proc-fidelity: %d passed, %d failed, %d skipped%s\n", passes,
            fails, procfs_skips, fails == 0 ? " - PASS" : " - FAIL");

--- a/tests/test-proc-limits.c
+++ b/tests/test-proc-limits.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Verifies that /proc/self/limits is readable and contains expected
- * rows matching prlimit64 values.
+ * Verifies that /proc/self/limits is readable and contains expected rows
+ * matching prlimit64 values.
  */
 
 #include <stdio.h>
@@ -86,8 +86,8 @@ int main(void)
     TEST("Max file locks row");
     EXPECT_TRUE(strstr(buf, "Max file locks"), "missing 'Max file locks'");
 
-    /* Verify Max open files has a numeric soft limit (not unlimited).
-     * Scan from the name to the end of the line for a digit sequence.
+    /* Verify Max open files has a numeric soft limit (not unlimited). Scan from
+     * the name to the end of the line for a digit sequence.
      */
     TEST("Max open files has numeric value");
     {

--- a/tests/test-proctitle-host.c
+++ b/tests/test-proctitle-host.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * This is a native macOS test (not a guest ELF). It deterministically
- * catches two distinct regression classes against the proctitle fix:
+ * This is a native macOS test (not a guest ELF). It deterministically catches
+ * two distinct regression classes against the proctitle fix:
  *
  *   (a) any overshoot past the contiguous argv block in the current
  *       implementation. The argv strings are laid out so their NUL
@@ -37,9 +37,9 @@
 static void on_sigsegv(int sig)
 {
     (void) sig;
-    /* Cannot rely on stdio inside an async signal handler, but a single
-     * _exit with a recognizable code is sufficient: the run target prints
-     * a meaningful failure when the child exits with 139.
+    /* Cannot rely on stdio inside an async signal handler, but a single _exit
+     * with a recognizable code is sufficient: the run target prints a
+     * meaningful failure when the child exits with 139.
      */
     _exit(139);
 }
@@ -62,8 +62,8 @@ int main(void)
     size_t page = (size_t) pgsz;
     /* Layout: [page 0: writable argv] [page 1: PROT_NONE guard]
      *         [page 2: writable envp sentinel]
-     * A reverted argv+envp walk that consults environ computes an
-     * avail spanning all three pages and memsets through the guard.
+     * A reverted argv+envp walk that consults environ computes an avail
+     * spanning all three pages and memsets through the guard.
      */
     size_t map_size = page * 3;
     char *base = (char *) mmap(NULL, map_size, PROT_READ | PROT_WRITE,
@@ -77,12 +77,12 @@ int main(void)
         return 1;
     }
 
-    /* Synthesize a contiguous argv block whose tail aligns with the
-     * boundary, mimicking the host kernel placing argv at the top of the
-     * initial stack. Total length is chosen so the bin field after the
-     * last "/" character ("busybox") drives the rewritten title past the
-     * pre-existing argv[0] string length, exercising the truncation
-     * branch as well as the simple-copy branch on the next argv entry.
+    /* Synthesize a contiguous argv block whose tail aligns with the boundary,
+     * mimicking the host kernel placing argv at the top of the initial stack.
+     * Total length is chosen so the bin field after the last "/" character
+     * ("busybox") drives the rewritten title past the pre-existing argv[0]
+     * string length, exercising the truncation branch as well as the
+     * simple-copy branch on the next argv entry.
      */
     static const char *parts[] = {
         "elfuse",
@@ -118,8 +118,8 @@ int main(void)
         return 1;
     }
 
-    /* Plant a sentinel envp string above the guard so the reverted
-     * argv+envp upper-bound walk computes avail spanning the guard.
+    /* Plant a sentinel envp string above the guard so the reverted argv+envp
+     * upper-bound walk computes avail spanning the guard.
      */
     char *envp_str = base + page * 2;
     static const char sentinel[] = "ELFUSE_PROCTITLE_TEST_SENTINEL=1";
@@ -134,10 +134,10 @@ int main(void)
 
     environ = saved_environ;
 
-    /* Tail byte must be NUL, the prefix must form a non-empty C string,
-     * and the rewritten title must not have escaped the argv span (the
-     * byte after the block tail is unreadable, so verifying the tail
-     * byte alone is the strongest check available).
+    /* Tail byte must be NUL, the prefix must form a non-empty C string, and the
+     * rewritten title must not have escaped the argv span (the byte after the
+     * block tail is unreadable, so verifying the tail byte alone is the
+     * strongest check available).
      */
     if (start[total - 1] != '\0') {
         fprintf(stderr, "test-proctitle-host: tail byte was not zeroed\n");

--- a/tests/test-pthread.c
+++ b/tests/test-pthread.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Uses the standard POSIX thread API (musl implementation) to verify
- * that elfuse's clone(CLONE_THREAD) + futex + TLS support is sufficient
- * for real-world threading.
+ * Uses the standard POSIX thread API (musl implementation) to verify that
+ * elfuse's clone(CLONE_THREAD) + futex + TLS support is sufficient for
+ * real-world threading.
  */
 
 #include <pthread.h>
@@ -149,8 +149,8 @@ static void *increment_fn(void *arg)
 {
     int count = (int) (long) arg;
     for (int i = 0; i < count; i++) {
-        /* Non-atomic increment; the test only checks that the threads
-         * actually share memory, not about race conditions
+        /* Non-atomic increment; the test only checks that the threads actually
+         * share memory, not about race conditions
          */
         shared_counter++;
     }
@@ -163,8 +163,8 @@ static void test_shared_memory(void)
 
     shared_counter = 0;
 
-    /* Use a single thread to avoid race condition complexity.
-     * This tests that the thread can read/write the parent's memory.
+    /* Use a single thread to avoid race condition complexity. This tests that
+     * the thread can read/write the parent's memory.
      */
     pthread_t t;
     int err = pthread_create(&t, NULL, increment_fn, (void *) (long) 1000);

--- a/tests/test-pty.c
+++ b/tests/test-pty.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Foot, sshd, tmux, and any libvte-derived terminal need the multiplexer
- * primitives glibc's posix_openpt(3) / ptsname(3) / openpty(3) stack rests
- * on. Exercise the pieces glibc and posix-compliant pty children depend on:
+ * primitives glibc's posix_openpt(3) / ptsname(3) / openpty(3) stack rests on.
+ * Exercise the pieces glibc and posix-compliant pty children depend on:
  *
  *   1. TIOCSWINSZ on the /dev/ptmx master fd (the direct failure foot saw)
  *   2. TIOCGPTN -> /dev/pts/N path round trip
@@ -14,8 +14,8 @@
  *   5. /dev/pts/N open in a forked child after the child has already closed
  *      its master (foot/sshd/openssh sftp-server pattern)
  *
- * The test stays self-contained on the syscall surface (no libutil/openpty),
- * so it runs the same way under elfuse-aarch64, qemu-aarch64, and any future
+ * The test stays self-contained on the syscall surface (no libutil/openpty), so
+ * it runs the same way under elfuse-aarch64, qemu-aarch64, and any future
  * elfuse-x86_64 reuse.
  */
 
@@ -93,13 +93,12 @@ int main(void)
 
     /* Regression guard for the pty_keepalive_table BSS-zero collision: any
      * close that runs before the very first /dev/ptmx open would walk the
-     * still-zero-initialized table and match a master_host_fd of zero,
-     * silently closing the wrong slave_host_fd (also zero). Closing stdin
-     * here forces fd_cleanup_entry to invoke proc_pty_close_keepalive in
-     * that vulnerable window. If the fix regresses, every subsequent test
-     * still passes locally but a future stdio fd in another vCPU may go
-     * missing. The cheap sentinel makes sure stdin's close itself does
-     * not corrupt elfuse's own file table.
+     * still-zero-initialized table and match a master_host_fd of zero, silently
+     * closing the wrong slave_host_fd (also zero). Closing stdin here forces
+     * fd_cleanup_entry to invoke proc_pty_close_keepalive in that vulnerable
+     * window. If the fix regresses, every subsequent test still passes locally
+     * but a future stdio fd in another vCPU may go missing. The cheap sentinel
+     * makes sure stdin's close itself does not corrupt elfuse's own file table.
      */
     close(STDIN_FILENO);
 
@@ -169,10 +168,10 @@ int main(void)
     int unlock = 0;
     EXPECT_TRUE(ioctl(ptmx, TIOCSPTLCK, &unlock) == 0, "TIOCSPTLCK(0) failed");
 
-    /* Linux TIOCSPTLCK(non-zero) locks the slave and returns success.
-     * elfuse cannot actually enforce the lock on macOS (no re-lock primitive)
-     * but must still report success so callers do not misread the result as
-     * "this kernel has no devpts".
+    /* Linux TIOCSPTLCK(non-zero) locks the slave and returns success. elfuse
+     * cannot actually enforce the lock on macOS (no re-lock primitive) but must
+     * still report success so callers do not misread the result as "this kernel
+     * has no devpts".
      */
     TEST("TIOCSPTLCK(1) accepted as best-effort no-op");
     int lock = 1;
@@ -240,10 +239,10 @@ int main(void)
     char pts_path[32];
     snprintf(pts_path, sizeof(pts_path), "/dev/pts/%u", ptyno);
 
-    /* glibc ptsname(3) stats the formatted path before returning it.
-     * Until the path.c stat allowlist included /dev/pts/N, the stat went
-     * to the host (which has no /dev/pts at all) and ptsname returned
-     * ENOENT, leaving every caller without a usable slave path.
+    /* glibc ptsname(3) stats the formatted path before returning it. Until the
+     * path.c stat allowlist included /dev/pts/N, the stat went to the host
+     * (which has no /dev/pts at all) and ptsname returned ENOENT, leaving every
+     * caller without a usable slave path.
      */
     TEST("stat(/dev/pts/N) succeeds and reports a char device");
     struct stat st;
@@ -287,10 +286,11 @@ int main(void)
         close(slave);
     }
 
-    /* TIOCGPTPEER short-circuits the ptsname/stat/open dance. Recent foot
-     * and util-linux prefer it; older kernels return ENOTTY and the caller
-     * falls back to /dev/pts. Accept either an fd or ENOTTY (some hosts
-     * legitimately do not implement it), but never silent corruption. */
+    /* TIOCGPTPEER short-circuits the ptsname/stat/open dance. Recent foot and
+     * util-linux prefer it; older kernels return ENOTTY and the caller falls
+     * back to /dev/pts. Accept either an fd or ENOTTY (some hosts legitimately
+     * do not implement it), but never silent corruption.
+     */
     TEST("TIOCGPTPEER returns a slave fd or ENOTTY");
     int peer = ioctl(ptmx, TIOCGPTPEER, O_RDWR | O_NOCTTY);
     int peer_ok = peer >= 0 || (peer == -1 && errno == ENOTTY);
@@ -299,8 +299,8 @@ int main(void)
         close(peer);
 
     /* dup of the master must keep both aliases functional even after the
-     * original is closed. The keepalive slave needs to be mirrored across
-     * the dup so the surviving alias still observes master-side tty ioctls.
+     * original is closed. The keepalive slave needs to be mirrored across the
+     * dup so the surviving alias still observes master-side tty ioctls.
      */
     TEST("dup(ptmx) followed by close(orig) leaves alias usable");
     int alias = dup(ptmx);
@@ -320,10 +320,10 @@ int main(void)
         ptmx = alias; /* the alias is the live master from here on */
     }
 
-    /* Fork must propagate the master's keepalive across the IPC handoff so
-     * the child can do master-side tty ioctls without the macOS ENOTTY
-     * fallback. The parent's keepalive slave fd is independent (each side
-     * holds its own slot) so closing one side does not affect the other.
+    /* Fork must propagate the master's keepalive across the IPC handoff so the
+     * child can do master-side tty ioctls without the macOS ENOTTY fallback.
+     * The parent's keepalive slave fd is independent (each side holds its own
+     * slot) so closing one side does not affect the other.
      */
     TEST("child fork inherits master keepalive (TIOCSWINSZ works)");
     int sync_pipe[2];
@@ -358,7 +358,8 @@ int main(void)
                            WEXITSTATUS(wstatus) == 0;
             EXPECT_TRUE(child_ok, "child TIOCSWINSZ on master failed");
             /* Parent should still see the child's update because the slave
-             * keepalive in the parent is still alive. */
+             * keepalive in the parent is still alive.
+             */
             struct winsize ws_parent = {0};
             int parent_ok = ioctl(ptmx, TIOCGWINSZ, &ws_parent) == 0 &&
                             ws_parent.ws_row == 30 && ws_parent.ws_col == 90;
@@ -371,9 +372,9 @@ int main(void)
 
     /* Re-open and immediately close should not leak the keepalive slave.
      * Without the proc_pty_close_keepalive call in sys_close's fast path,
-     * single-thread close goes through fd_close_regular_relaxed and
-     * bypasses fd_cleanup_entry, leaving the hidden slave fd open until
-     * elfuse exits. Loop enough times to expose any per-close leak.
+     * single-thread close goes through fd_close_regular_relaxed and bypasses
+     * fd_cleanup_entry, leaving the hidden slave fd open until elfuse exits.
+     * Loop enough times to expose any per-close leak.
      */
     TEST("repeated open/close does not exhaust the keepalive table");
     int leak_loop_ok = 1;
@@ -389,11 +390,11 @@ int main(void)
                 "repeated /dev/ptmx open/close exhausted the keepalive table");
 
     /* foot/sshd/openssh sftp-server pattern: the child closes its inherited
-     * master fd before opening the slave (the child has no use for the
-     * master). Earlier, this dropped the keepalive table entry that held the
-     * macOS slave_path mapping, and the subsequent open("/dev/pts/N") in the
-     * child failed with ENOENT even though the parent still held the master
-     * and the macOS slave node was openable. The retained-path semantics in
+     * master fd before opening the slave (the child has no use for the master).
+     * Earlier, this dropped the keepalive table entry that held the macOS
+     * slave_path mapping, and the subsequent open("/dev/pts/N") in the child
+     * failed with ENOENT even though the parent still held the master and the
+     * macOS slave node was openable. The retained-path semantics in
      * proc_pty_close_keepalive must let the child still translate the path.
      */
     TEST("child can open /dev/pts/N after closing its master");
@@ -467,9 +468,9 @@ int main(void)
                     /* Both ENOENT (devfs node gone) and ENXIO (devfs node
                      * lingers but the pty pair has been torn down) are valid
                      * macOS responses depending on kernel version. The
-                     * invariant the test guards is "the stale cached path
-                     * does not silently hand back an unrelated tty"; any
-                     * open failure satisfies that.
+                     * invariant the test guards is "the stale cached path does
+                     * not silently hand back an unrelated tty"; any open
+                     * failure satisfies that.
                      */
                     int stale_ok =
                         stale_fd < 0 && (errno == ENOENT || errno == ENXIO);
@@ -494,8 +495,8 @@ int main(void)
     /* A pty master received via SCM_RIGHTS bypasses the /dev/ptmx open
      * intercept, so the receiver process has no keepalive entry for it.
      * proc_pty_master_adopt must lazily register one before master-side tty
-     * ioctls, even when TIOCSWINSZ runs before the first TIOCGPTN. Two
-     * checks live inside this block: TIOCSWINSZ-first and the post-adopt
+     * ioctls, even when TIOCSWINSZ runs before the first TIOCGPTN. Two checks
+     * live inside this block: TIOCSWINSZ-first and the post-adopt
      * stat(/dev/pts/N). Each has its own TEST() label below.
      */
     int sp[2];

--- a/tests/test-readv-writev.c
+++ b/tests/test-readv-writev.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests readv/writev scatter-gather I/O operations including
- * pipe round-trips, file I/O, and edge cases.
+ * Tests readv/writev scatter-gather I/O operations including pipe round-trips,
+ * file I/O, and edge cases.
  *
  * Syscalls exercised: writev(66), readv(65), pipe2(59), openat(56),
  *                     lseek(62), close(57), unlink(35)

--- a/tests/test-robust-futex.c
+++ b/tests/test-robust-futex.c
@@ -68,8 +68,8 @@ static int child_fn(void *arg)
     /* Register robust list with kernel */
     raw_syscall2(99, (long) &rhead, sizeof(rhead)); /* set_robust_list */
 
-    /* Exit without releasing the lock; robust walk should set
-     * FUTEX_OWNER_DIED on lock_word
+    /* Exit without releasing the lock; robust walk should set FUTEX_OWNER_DIED
+     * on lock_word
      */
     raw_syscall1(93, 0); /* exit */
     test_unreachable();

--- a/tests/test-roundtrip.c
+++ b/tests/test-roundtrip.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: fopen(w), fwrite, fclose, fopen(r), fread, fclose, remove.
- * Verifies data integrity through a complete write->read cycle.
+ * Tests: fopen(w), fwrite, fclose, fopen(r), fread, fclose, remove. Verifies
+ * data integrity through a complete write->read cycle.
  */
 
 #include <stdbool.h>

--- a/tests/test-rwx.c
+++ b/tests/test-rwx.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Standalone native macOS test program (NOT a guest binary). Uses HVF
- * directly to create a VM and test whether simultaneous read+write+execute
- * page table entries work at stage-1 when SCTLR_EL1.WXN=0.
+ * Standalone native macOS test program (NOT a guest binary). Uses HVF directly
+ * to create a VM and test whether simultaneous read+write+execute page table
+ * entries work at stage-1 when SCTLR_EL1.WXN=0.
  *
  * Tests:
  *   1. RWX 2MiB block: L2 block descriptor with AP=RW_EL0, UXN=0, PXN=0
@@ -19,12 +19,12 @@
  *   b. BR to that address to execute the written code
  *   c. The SVC forwards via HVC #5 with x0=42
  *
- * If RWX works: host receives x0=42 via HVC #5 (success).
- * If W^X is enforced: either the STR faults (data abort) or the BR faults
- * (instruction abort permission fault), causing HVC #2 (bad exception).
+ * If RWX works: host receives x0=42 via HVC #5 (success). If W^X is enforced:
+ * either the STR faults (data abort) or the BR faults (instruction abort
+ * permission fault), causing HVC #2 (bad exception).
  *
- * Build: clang -O2 -framework Hypervisor -arch arm64 -Ibuild -o $@ $<
- * Run:   codesign --entitlements entitlements.plist -f -s - $@ && ./$@
+ * Build: clang -O2 -framework Hypervisor -arch arm64 -Ibuild -o $@ $< Run:
+ * codesign --entitlements entitlements.plist -f -s - $@ && ./$@
  */
 
 #include <Hypervisor/Hypervisor.h>
@@ -229,9 +229,9 @@ static uint64_t build_page_tables(vm_state_t *vm)
     /* L2[3]: RWX block (Test 1 subject) */
     l2[3] = make_block_rwx(0x600000);
 
-    /* L2[4]: Table descriptor -> L3 page table for Test 2.
-     * the code splits this 2MiB block into 512 x 4KiB pages. The first page
-     * at 0x800000 is RWX, the rest are RW (non-executable).
+    /* L2[4]: Table descriptor -> L3 page table for Test 2. The code splits this
+     * 2 MiB block into 512 x 4 KiB pages. The first page at 0x800000 is RWX,
+     * the rest are RW (non-executable).
      */
     {
         uint64_t l3_off = pt_alloc(vm);
@@ -355,8 +355,8 @@ static const char *fsc_name(uint32_t fsc)
 }
 
 /* Run the vCPU until exit. Handles HVC #4 (sysreg set) internally.
- * Returns 0 on clean exit (HVC #0, #5, or #2), -1 on error.
- * For HVC #9 (W^X toggle), returns immediately so caller can decide.
+ * Returns 0 on clean exit (HVC #0, #5, or #2), -1 on error. For HVC #9 (W^X
+ * toggle), returns immediately so caller can decide.
  */
 static int run_vcpu_once(hv_vcpu_t vcpu,
                          hv_vcpu_exit_t *vexit,
@@ -378,8 +378,8 @@ static int run_vcpu_once(hv_vcpu_t vcpu,
                 uint16_t imm = vexit->exception.syndrome & 0xFFFF;
 
                 if (imm == 4) {
-                    /* HVC #4: set sysreg (from shim _start). Same encoding
-                     * as elfuse's run loop: X0 = index into hvc4_sysregs.
+                    /* HVC #4: set sysreg (from shim _start). Same encoding as
+                     * elfuse's run loop: X0 = index into hvc4_sysregs.
                      */
                     static const hv_sys_reg_t hvc4_sysregs[] = {
                         HV_SYS_REG_VBAR_EL1,  /* 0 */
@@ -475,8 +475,8 @@ static int vm_create(vm_state_t *vm)
         return -1;
     }
 
-    /* Map guest memory with full RWX at stage-2 (HVF level).
-     * Stage-1 (page table) permissions are what the test is checking.
+    /* Map guest memory with full RWX at stage-2 (HVF level). Stage-1 (page
+     * table) permissions are what the test is checking.
      */
     ret = hv_vm_map(vm->host_base, 0, GUEST_SIZE,
                     HV_MEMORY_READ | HV_MEMORY_WRITE | HV_MEMORY_EXEC);
@@ -530,9 +530,9 @@ static void print_bad_exception(const vcpu_exit_t *ex)
  *   2. DSB ISH + ISB for data/instruction cache coherence
  *   3. BR to 0x600000
  *
- * If successful: HVC #5 with x0=42
- * If W^X enforced on write: data abort permission fault on STR
- * If W^X enforced on exec: instruction abort permission fault on BR
+ * If successful: HVC #5 with x0=42 If W^X enforced on write: data abort
+ * permission fault on STR If W^X enforced on exec: instruction abort permission
+ * fault on BR
  */
 
 static int test1_rwx_block(void)
@@ -625,9 +625,9 @@ static int test1_rwx_block(void)
     int result = -1;
 
     if (ex.reason == HVF_EXIT_HVC9) {
-        /* W^X toggle request: the shim detected a permission fault
-         * and is asking host to flip permissions. This means HVF DOES
-         * enforce W^X even with WXN=0 in SCTLR_EL1.
+        /* W^X toggle request: the shim detected a permission fault and is
+         * asking host to flip permissions. This means HVF DOES enforce W^X even
+         * with WXN=0 in SCTLR_EL1.
          */
         printf("\n");
         printf("    W^X toggle requested: FAR=0x%llx type=%llu (%s)\n",
@@ -680,9 +680,9 @@ static int test1_rwx_block(void)
 
 /* TEST 2: RWX 4KiB Page (L3 descriptor)
  *
- * Same as test 1, but using a 4KiB L3 page descriptor at 0x800000
- * instead of a 2MiB L2 block descriptor. Tests whether the
- * granularity matters for W^X enforcement.
+ * Same as test 1, but using a 4KiB L3 page descriptor at 0x800000 instead of a
+ * 2MiB L2 block descriptor. Tests whether the granularity matters for W^X
+ * enforcement.
  */
 
 static int test2_rwx_page(void)
@@ -789,9 +789,9 @@ static int test2_rwx_page(void)
 
 /* TEST 3: Baseline RX (execution on read-only page)
  *
- * Verify that normal RX execution works. Guest code at 0x400000
- * (GUEST_CODE) is on an RX page; executing "mov x0, #99; svc #0"
- * confirms the baseline setup before RWX-specific checks.
+ * Verify that normal RX execution works. Guest code at 0x400000 (GUEST_CODE) is
+ * on an RX page; executing "mov x0, #99; svc #0" confirms the baseline setup
+ * before RWX-specific checks.
  */
 
 static int test3_baseline_rx(void)
@@ -854,8 +854,8 @@ static int test3_baseline_rx(void)
 
 /* TEST 4: Baseline RW (write to writable page)
  *
- * Verify that normal RW writes work. Guest writes a value to the
- * RW data page at 0xA00000, then reports it via SVC.
+ * Verify that normal RW writes work. Guest writes a value to the RW data page
+ * at 0xA00000, then reports it via SVC.
  */
 
 static int test4_baseline_rw(void)

--- a/tests/test-sched-policy.c
+++ b/tests/test-sched-policy.c
@@ -3,13 +3,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Exercises sched_setparam (118), sched_setscheduler (119),
- * sched_getscheduler (120), sched_getparam (121),
- * sched_get_priority_min (125), sched_get_priority_max (126),
- * sched_rr_get_interval (127). The implementation is a stub: getters
- * report SCHED_OTHER and a zero priority, RT priority elevation is
- * refused with -EPERM, SCHED_DEADLINE through the legacy entry point
- * is -EINVAL, and all entries validate guest pointers (-EFAULT).
+ * Exercises sched_setparam (118), sched_setscheduler (119), sched_getscheduler
+ * (120), sched_getparam (121), sched_get_priority_min (125),
+ * sched_get_priority_max (126), sched_rr_get_interval (127). The implementation
+ * is a stub: getters report SCHED_OTHER and a zero priority, RT priority
+ * elevation is refused with -EPERM, SCHED_DEADLINE through the legacy entry
+ * point is -EINVAL, and all entries validate guest pointers (-EFAULT).
  */
 
 #include <pthread.h>

--- a/tests/test-scm-creds.c
+++ b/tests/test-scm-creds.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: SO_PASSCRED setsockopt/getsockopt, SO_PEERCRED getsockopt,
- * and SCM_CREDENTIALS ancillary data injection on recvmsg.
+ * Tests: SO_PASSCRED setsockopt/getsockopt, SO_PEERCRED getsockopt, and
+ * SCM_CREDENTIALS ancillary data injection on recvmsg.
  */
 
 #include <stdio.h>

--- a/tests/test-session.c
+++ b/tests/test-session.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: setsid, getsid, getpgid, setpgid, and basic job-control
- * ioctl semantics (TIOCGPGRP, TIOCSPGRP).
+ * Tests: setsid, getsid, getpgid, setpgid, and basic job-control ioctl
+ * semantics (TIOCGPGRP, TIOCSPGRP).
  */
 
 #include <stdio.h>

--- a/tests/test-shim-cred-race.c
+++ b/tests/test-shim-cred-race.c
@@ -4,12 +4,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * elfuse's permission model rejects setuid/setresuid to any value not
- * already in {real, effective, saved}, which means a guest binary
- * cannot legally toggle between two distinct uids without privileged
- * setup. This test therefore exercises the no-op-publish path: the
- * mutator calls setresuid(uid, uid, uid) in a tight loop while the
- * reader spins on geteuid via the shim's identity fast path.
+ * elfuse's permission model rejects setuid/setresuid to any value not already
+ * in {real, effective, saved}, which means a guest binary cannot legally toggle
+ * between two distinct uids without privileged setup. This test therefore
+ * exercises the no-op-publish path: the mutator calls setresuid(uid, uid, uid)
+ * in a tight loop while the reader spins on geteuid via the shim's identity
+ * fast path.
  *
  * What it pins:
  *
@@ -77,8 +77,8 @@ int main(void)
     if (pthread_create(&tid, NULL, reader, NULL) != 0)
         return 1;
 
-    /* 50_000 no-op setresuid calls. Each triggers cred_publish_after
-     * on the elfuse side, racing the reader thread.
+    /* 50_000 no-op setresuid calls. Each triggers cred_publish_after on the
+     * elfuse side, racing the reader thread.
      */
     for (int i = 0; i < 50000; i++) {
         long r = raw_syscall3(__NR_setresuid, (long) expected_euid,

--- a/tests/test-shim-data-el1.c
+++ b/tests/test-shim-data-el1.c
@@ -3,11 +3,10 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The shim_data block holds the identity cache, attention flag,
- * urandom bitmap, ring, and lock. Mapping it with AP[2:1]=00
- * (privileged-only) prevents a guest from spoofing its own identity
- * by storing directly to the cache GVA, or from observing the bytes
- * the urandom fast path will hand out next.
+ * The shim_data block holds the identity cache, attention flag, urandom bitmap,
+ * ring, and lock. Mapping it with AP[2:1]=00 (privileged-only) prevents a guest
+ * from spoofing its own identity by storing directly to the cache GVA, or from
+ * observing the bytes the urandom fast path will hand out next.
  *
  * This test:
  *   1. Parses /proc/self/maps to find [shim-data].
@@ -89,10 +88,10 @@ static int probe_write(uint64_t addr)
     return 0;
 }
 
-/* Phase 2 (post-execve): only the perm-string and fault checks. The
- * identity and urandom sanity is already exercised in phase 1; here
- * the goal is to catch a regression where execve maps shim_data with
- * plain RW instead of RW_EL1_ONLY.
+/* Phase 2 (post-execve): only the perm-string and fault checks. The identity
+ * and urandom sanity is already exercised in phase 1; here the goal is to catch
+ * a regression where execve maps shim_data with plain RW instead of
+ * RW_EL1_ONLY.
  */
 static int run_post_exec_checks(void)
 {
@@ -190,12 +189,11 @@ int main(int argc, char **argv)
     }
     printf("OK urandom fast path still works\n");
 
-    /* The host syscall handlers must also refuse to act on a
-     * guest-supplied [shim-data] GVA. Without this defense, a guest
-     * could spoof the identity cache via read(fd, shim_data_gva, n)
-     * instead of a direct EL0 store. The host's gva_translate_perm
-     * rejects EL1-only descriptors before any host_base+offset write
-     * fires; the syscall returns EFAULT.
+    /* The host syscall handlers must also refuse to act on a guest-supplied
+     * [shim-data] GVA. Without this defense, a guest could spoof the identity
+     * cache via read(fd, shim_data_gva, n) instead of a direct EL0 store. The
+     * host's gva_translate_perm rejects EL1-only descriptors before any
+     * host_base+offset write fires; the syscall returns EFAULT.
      */
     errno = 0;
     ssize_t rc = read(fd, (void *) (uintptr_t) base, 1);
@@ -212,10 +210,10 @@ int main(int argc, char **argv)
 
     /* Phase 2: re-exec self with argv[1]='post-exec' so the post-execve
      * shim_data mapping path is exercised. If exec.c forgets to use
-     * RW_EL1_ONLY, the child process's [shim-data] perms come back as
-     * 'rw-p' and the probe_read in run_post_exec_checks succeeds (no
-     * SIGSEGV), failing the regression. The original child reaches
-     * argc=1 above; this path only runs once.
+     * RW_EL1_ONLY, the child process's [shim-data] perms come back as 'rw-p'
+     * and the probe_read in run_post_exec_checks succeeds (no SIGSEGV), failing
+     * the regression. The original child reaches argc=1 above; this path only
+     * runs once.
      */
     char *exec_argv[] = {argv[0], "post-exec", NULL};
     execv("/proc/self/exe", exec_argv);

--- a/tests/test-shim-identity-attention.c
+++ b/tests/test-shim-identity-attention.c
@@ -3,19 +3,18 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Slice A of the identity fast-path optimization routes getpid (and the
- * other five identity syscalls) through the EL1 shim without HVC #5.
- * That skips the post-HVC signal_check_timer epilogue in vcpu_run_loop,
- * which is what normally notices a fired guest ITIMER_REAL and queues
- * SIGALRM. Without Slice B's attention flag, a vCPU stuck in a tight
- * getpid loop would never re-enter EL1 and SIGALRM would arrive late
- * (worst case: not until the per-iteration vCPU alarm timeout fires,
- * potentially hundreds of milliseconds).
+ * Slice A of the identity fast-path optimization routes getpid (and the other
+ * five identity syscalls) through the EL1 shim without HVC #5. That skips the
+ * post-HVC signal_check_timer epilogue in vcpu_run_loop, which is what normally
+ * notices a fired guest ITIMER_REAL and queues SIGALRM. Without Slice B's
+ * attention flag, a vCPU stuck in a tight getpid loop would never re-enter EL1
+ * and SIGALRM would arrive late (worst case: not until the per-iteration vCPU
+ * alarm timeout fires, potentially hundreds of milliseconds).
  *
- * This test arms an ITIMER_REAL for 100 ms, then spins for ~1 second
- * OR until SIGALRM fires. It covers both getpid via the raw SVC and a
- * seeded CLOCK_REALTIME vDSO loop, because both fast paths otherwise
- * bypass the HVC epilogue that runs signal_check_timer().
+ * This test arms an ITIMER_REAL for 100 ms, then spins for ~1 second OR until
+ * SIGALRM fires. It covers both getpid via the raw SVC and a seeded
+ * CLOCK_REALTIME vDSO loop, because both fast paths otherwise bypass the HVC
+ * epilogue that runs signal_check_timer().
  */
 
 #include <errno.h>
@@ -73,10 +72,10 @@ static int run_alarm_spin(const char *name, int use_realtime_vdso)
         return 1;
     }
 
-    /* With attention raised on setitimer arm, fast paths fall back to
-     * HVC and signal_check_timer eventually notices the 100 ms expiry.
-     * Bound the spin to 1 s so a broken attention path manifests as
-     * test failure rather than a hang.
+    /* With attention raised on setitimer arm, fast paths fall back to HVC and
+     * signal_check_timer eventually notices the 100 ms expiry. Bound the spin
+     * to 1 s so a broken attention path manifests as test failure rather than a
+     * hang.
      */
     long iterations = 0;
     while (!alarm_fired) {
@@ -103,8 +102,8 @@ static int run_alarm_spin(const char *name, int use_realtime_vdso)
     }
 
     long delivered_ns = ns_diff((struct timespec *) &alarm_ts, &t_arm);
-    /* The 100 ms timer should deliver within ~150 ms in practice;
-     * grant 300 ms to absorb host scheduling jitter under load.
+    /* The 100 ms timer should deliver within ~150 ms in practice; grant 300 ms
+     * to absorb host scheduling jitter under load.
      */
     if (delivered_ns > 300 * 1000 * 1000L) {
         fprintf(stderr, "FAIL %s: SIGALRM delivered after %ld ns (>300 ms)\n",

--- a/tests/test-shim-urandom-smp.c
+++ b/tests/test-shim-urandom-smp.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The shim's urandom-read fast path advances a shared ring head via
- * LDXR/STXR. Concurrent vCPUs reading /dev/urandom must:
+ * The shim's urandom-read fast path advances a shared ring head via LDXR/STXR.
+ * Concurrent vCPUs reading /dev/urandom must:
  *   1. Never see a torn or zero-filled byte (host always refills
  *      with arc4random_buf output).
  *   2. Never observe the same byte sequence as a sibling thread
@@ -12,17 +12,17 @@
  *      of the ring).
  *   3. Keep the head from overflowing or underflowing the ring.
  *
- * Each thread reads N 1-byte samples and records them in a private
- * histogram. After the run we check:
+ * Each thread reads N 1-byte samples and records them in a private histogram.
+ * After the run we check:
  *   - Total bytes consumed across all threads equals N * threads.
  *   - No thread's per-byte distribution is degenerate (all-zero or
  *     all-one buckets indicate the fast path served stale memory).
  *   - The sums across threads differ from each other (a hard test
  *     that the threads are actually getting independent bytes).
  *
- * The test runs only under elfuse, where the urandom fast path is
- * live; on native Linux the read() goes straight to the kernel and
- * the same invariants hold trivially.
+ * The test runs only under elfuse, where the urandom fast path is live; on
+ * native Linux the read() goes straight to the kernel and the same invariants
+ * hold trivially.
  */
 
 #include <errno.h>
@@ -66,9 +66,9 @@ static void *worker(void *arg)
 
 int main(void)
 {
-    /* One shared fd: every thread shares the same FD_URANDOM slot,
-     * so the shim's fast path is exercised on the same bitmap bit
-     * by all threads simultaneously.
+    /* One shared fd: every thread shares the same FD_URANDOM slot, so the
+     * shim's fast path is exercised on the same bitmap bit by all threads
+     * simultaneously.
      */
     int fd = open("/dev/urandom", O_RDONLY);
     if (fd < 0) {
@@ -96,9 +96,9 @@ int main(void)
             failures++;
             continue;
         }
-        /* Per-thread distribution sanity: each bucket should be
-         * roughly NSAMPLES / 256 = 64 with stddev about 8. Flag any
-         * thread whose distribution is wildly off.
+        /* Per-thread distribution sanity: each bucket should be roughly
+         * NSAMPLES / 256 = 64 with stddev about 8. Flag any thread whose
+         * distribution is wildly off.
          */
         int min = NSAMPLES, max = 0, zeros = 0;
         for (int b = 0; b < 256; b++) {
@@ -124,9 +124,9 @@ int main(void)
     }
     close(fd);
 
-    /* Threads must have seen different total sums. Equal sums imply
-     * they consumed identical byte sequences, which means the shim's
-     * head-advance lost the race or served stale ring data.
+    /* Threads must have seen different total sums. Equal sums imply they
+     * consumed identical byte sequences, which means the shim's head-advance
+     * lost the race or served stale ring data.
      */
     for (int i = 0; i < NTHREADS; i++) {
         for (int j = i + 1; j < NTHREADS; j++) {

--- a/tests/test-shim-urandom-toctou.c
+++ b/tests/test-shim-urandom-toctou.c
@@ -1,25 +1,23 @@
-/* test-shim-urandom-toctou.c -- urandom EL1 fault recovery survives
- * concurrent mprotect(PROT_NONE) of the read buffer.
+/* test-shim-urandom-toctou.c -- urandom EL1 fault recovery survives concurrent
+ * mprotect(PROT_NONE) of the read buffer.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The urandom-read shim fast path probes the guest buffer (AT s1e0w) and
- * then performs an EL1 strb into it. A sibling vCPU can mprotect or
- * munmap the buffer between the probe and the store, faulting the EL1
- * write. Without handle_el1_data_abort_recover, that fault routes to
- * BAD_VEC and halts the VM.
+ * The urandom-read shim fast path probes the guest buffer (AT s1e0w) and then
+ * performs an EL1 strb into it. A sibling vCPU can mprotect or munmap the
+ * buffer between the probe and the store, faulting the EL1 write. Without
+ * handle_el1_data_abort_recover, that fault routes to BAD_VEC and halts the VM.
  *
- * This test runs a tight loop of read(/dev/urandom, buf, 1) while a
- * sibling thread continuously flips the buffer between PROT_READ|WRITE
- * and PROT_NONE via mprotect. Expected behavior:
+ * This test runs a tight loop of read(/dev/urandom, buf, 1) while a sibling
+ * thread continuously flips the buffer between PROT_READ|WRITE and PROT_NONE
+ * via mprotect. Expected behavior:
  *   - read returns 1 (success) when the buffer is RW
  *   - read returns -1 with errno=EFAULT when the buffer is PROT_NONE
  *   - elfuse never halts
  *
- * If the recovery handler is missing or wrong, the VM crashes mid-run
- * and the test process never returns; the make-check timeout catches
- * that as a failure.
+ * If the recovery handler is missing or wrong, the VM crashes mid-run and the
+ * test process never returns; the make-check timeout catches that as a failure.
  */
 
 #include <errno.h>
@@ -80,9 +78,9 @@ int main(void)
         return 1;
     }
 
-    /* Reader: each iteration calls read(); accepts either success or
-     * EFAULT. Any other result (or a crash, which manifests as the
-     * VM halting before we reach the join) is a failure.
+    /* Reader: each iteration calls read(); accepts either success or EFAULT.
+     * Any other result (or a crash, which manifests as the VM halting before we
+     * reach the join) is a failure.
      */
     for (int i = 0; i < ITERATIONS; i++) {
         char b;

--- a/tests/test-shim-urandom-wrap.c
+++ b/tests/test-shim-urandom-wrap.c
@@ -5,10 +5,9 @@
  *
  * The EL1 getrandom fast path copies out of a 4096-byte ring. When a read
  * starts at ring[4095], the copy splits into a one-byte tail segment plus a
- * wrapped second segment. A missing post-increment on the first segment's
- * byte store used to make the second segment overwrite byte 0 of the caller
- * buffer and leave the final requested byte untouched while still returning
- * success.
+ * wrapped second segment. A missing post-increment on the first segment's byte
+ * store used to make the second segment overwrite byte 0 of the caller buffer
+ * and leave the final requested byte untouched while still returning success.
  */
 
 #include <errno.h>

--- a/tests/test-signal-thread.c
+++ b/tests/test-signal-thread.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests signal delivery via tgkill, multiple sequential signals,
- * and per-thread signal mask operations via rt_sigprocmask.
+ * Tests signal delivery via tgkill, multiple sequential signals, and per-thread
+ * signal mask operations via rt_sigprocmask.
  *
  * Syscalls exercised: tgkill(131), kill(129), rt_sigaction(134),
  *                     rt_sigprocmask(135), getpid(172), gettid(178)

--- a/tests/test-signal.c
+++ b/tests/test-signal.c
@@ -29,13 +29,12 @@ static void sigusr1_handler(int sig)
     handler_signum = sig;
 }
 
-/* Test that callee-saved registers survive signal delivery.
- * The inline asm loads known values into callee-saved registers,
- * sends SIGUSR1 (which triggers delivery + rt_sigreturn), then
- * verifies the registers are unchanged.
+/* Test that callee-saved registers survive signal delivery. The inline asm
+ * loads known values into callee-saved registers, sends SIGUSR1 (which triggers
+ * delivery + rt_sigreturn), then verifies the registers are unchanged.
  *
- * aarch64 callee-saved: X19-X28 (10 registers)
- * x86_64 callee-saved:  rbx, r12-r15 (5 registers; rbp excluded
+ * aarch64 callee-saved: X19-X28 (10 registers) x86_64 callee-saved: rbx,
+ * r12-r15 (5 registers; rbp excluded
  *   because GCC needs it as frame pointer in functions with calls)
  */
 static int test_callee_saved(void)
@@ -173,10 +172,9 @@ int main(void)
         printf("FAIL (handler not called)\n");
         failures++;
     } else {
-        /* Handler should have been reset to SIG_DFL.
-         * Sending SIGUSR1 again should terminate the process,
-         * but the test cannot observe that directly. Instead, check that
-         * the old action is SIG_DFL now.
+        /* Handler should have been reset to SIG_DFL. Sending SIGUSR1 again
+         * should terminate the process, but the test cannot observe that
+         * directly. Instead, check that the old action is SIG_DFL now.
          */
         struct sigaction old;
         sigaction(SIGUSR1, NULL, &old);

--- a/tests/test-signalfd-hardening.c
+++ b/tests/test-signalfd-hardening.c
@@ -43,8 +43,8 @@ int passes = 0, fails = 0;
 #define SYS_rt_sigqueueinfo 138
 #endif
 
-/* siginfo_t crosses both glibc and musl, but si_value layouts differ.
- * Build the kernel-shaped buffer by hand so the test stays libc-agnostic.
+/* siginfo_t crosses both glibc and musl, but si_value layouts differ. Build the
+ * kernel-shaped buffer by hand so the test stays libc-agnostic.
  */
 static void build_kernel_siginfo(int sig,
                                  int code,
@@ -80,8 +80,8 @@ static void build_kernel_siginfo(int sig,
      */
     u64 = (uint64_t) (uintptr_t) payload_ptr;
     memcpy(out + 24, &u64, 8);
-    /* If both int and ptr are set, ptr wins because it overlaps. Tests pick
-     * one or the other.
+    /* If both int and ptr are set, ptr wins because it overlaps. Tests pick one
+     * or the other.
      */
     if (payload_ptr == NULL) {
         s32 = payload_int;
@@ -175,8 +175,8 @@ static void test_standard_coalesces(void)
         return;
     }
 
-    /* Three kill()s should produce exactly one signalfd record (Linux
-     * coalesces standard signals on the pending bitmask).
+    /* Three kill()s should produce exactly one signalfd record (Linux coalesces
+     * standard signals on the pending bitmask).
      */
     kill(getpid(), SIGUSR1);
     kill(getpid(), SIGUSR1);
@@ -212,8 +212,8 @@ static void test_standard_coalesces(void)
 static void test_sigrtmax_reachable(void)
 {
     /* SIGRTMAX (64 on aarch64) was excluded by an off-by-one in the
-     * collect/take loops (signum < LINUX_NSIG instead of <= LINUX_NSIG).
-     * This test fails before the fix and passes after.
+     * collect/take loops (signum < LINUX_NSIG instead of <= LINUX_NSIG). This
+     * test fails before the fix and passes after.
      */
     TEST("SIGRTMAX reaches signalfd");
 
@@ -258,9 +258,9 @@ static void test_sigrtmax_reachable(void)
 
 static void test_ssi_ptr_roundtrip(void)
 {
-    /* sigval has separate int and ptr forms. For the ptr form the full 64
-     * bits land in si_value; signalfd_siginfo exposes both ssi_int (low 32)
-     * and ssi_ptr (full 64). Verify both are populated from one queued ptr.
+    /* sigval has separate int and ptr forms. For the ptr form the full 64 bits
+     * land in si_value; signalfd_siginfo exposes both ssi_int (low 32) and
+     * ssi_ptr (full 64). Verify both are populated from one queued ptr.
      */
     TEST("ssi_ptr / ssi_int round-trip");
 
@@ -276,8 +276,8 @@ static void test_ssi_ptr_roundtrip(void)
         return;
     }
 
-    /* Use an arbitrary pointer-shaped value with a high bit set so a
-     * truncating implementation drops information detectably.
+    /* Use an arbitrary pointer-shaped value with a high bit set so a truncating
+     * implementation drops information detectably.
      */
     void *payload = (void *) 0x0123456789ABCDEFULL;
     pid_t pid = getpid();
@@ -367,9 +367,9 @@ static void test_sender_metadata(void)
 
 static void test_mask_filters_only(void)
 {
-    /* signalfd's own mask is the sole filter: a signal blocked from
-     * synchronous delivery via sigprocmask is still readable from the
-     * signalfd if its mask includes the signal.
+    /* signalfd's own mask is the sole filter: a signal blocked from synchronous
+     * delivery via sigprocmask is still readable from the signalfd if its mask
+     * includes the signal.
      */
     TEST("signalfd mask filters, not pthread mask");
 
@@ -442,10 +442,10 @@ static void test_mask_filters_only(void)
 
 static void test_sigqueue_libc_path(void)
 {
-    /* glibc / musl sigqueue() goes through SYS_rt_sigqueueinfo (138).
-     * Without that wired in, sigqueue() returns ENOSYS and apps that rely
-     * on POSIX queued signals (real-time apps, gdb) break. Verify the
-     * libc path produces a payload-bearing record.
+    /* glibc / musl sigqueue() goes through SYS_rt_sigqueueinfo (138). Without
+     * that wired in, sigqueue() returns ENOSYS and apps that rely on POSIX
+     * queued signals (real-time apps, gdb) break. Verify the libc path produces
+     * a payload-bearing record.
      */
     TEST("libc sigqueue() round-trip");
 
@@ -532,15 +532,14 @@ static void test_partial_fault_returns_partial_bytes(void)
 {
     /* Partial-fault recovery (write-then-take semantics).
      *
-     * Queue four RT signals (payloads 0xA1..0xA4). Place a 4-record buffer
-     * so records 0 and 1 land in a valid page but records 2 and 3 cross
-     * into an unmapped page. The bridge writes 2 records, hits EFAULT
-     * trying to write record 2, returns partial bytes (2 * 128) -- and
-     * crucially does NOT take records 2 and 3 from the rt-queue, so they
-     * remain pending in original FIFO order. The follow-up read returns
-     * exactly two records with payloads 0xA3 then 0xA4 (no duplication
-     * of 0xA1 / 0xA2; no re-queue path that could overflow RT_SIGQUEUE_MAX
-     * or desync the notification pipe).
+     * Queue four RT signals (payloads 0xA1..0xA4). Place a 4-record buffer so
+     * records 0 and 1 land in a valid page but records 2 and 3 cross into an
+     * unmapped page. The bridge writes 2 records, hits EFAULT trying to write
+     * record 2, returns partial bytes (2 * 128) -- and crucially does NOT take
+     * records 2 and 3 from the rt-queue, so they remain pending in original
+     * FIFO order. The follow-up read returns exactly two records with payloads
+     * 0xA3 then 0xA4 (no duplication of 0xA1 / 0xA2; no re-queue path that
+     * could overflow RT_SIGQUEUE_MAX or desync the notification pipe).
      */
     TEST("partial fault: partial bytes + FIFO");
 
@@ -616,16 +615,16 @@ static void test_partial_fault_returns_partial_bytes(void)
 
     /* Follow-up read into a fully-valid buffer.
      *
-     * Linux dequeues the record being copied before checking copy_to_user,
-     * so the record that hit EFAULT (payloads[2]) is lost; a follow-up
-     * read returns one record (payloads[3]). elfuse defers the take until
-     * the write succeeds, so a follow-up read returns two records
-     * (payloads[2] then payloads[3]) in original FIFO order.
+     * Linux dequeues the record being copied before checking copy_to_user, so
+     * the record that hit EFAULT (payloads[2]) is lost; a follow-up read
+     * returns one record (payloads[3]). elfuse defers the take until the write
+     * succeeds, so a follow-up read returns two records (payloads[2] then
+     * payloads[3]) in original FIFO order.
      *
-     * Both behaviors are accepted: the contract under test is "no
-     * duplication of records that already reached the guest, no
-     * out-of-order delivery within whatever survives, and the last
-     * queued payload is always preserved."
+     * Both behaviors are accepted: the contract under test is "no duplication
+     * of records that already reached the guest, no out-of-order delivery
+     * within whatever survives, and the last queued payload is always
+     * preserved."
      */
     struct signalfd_siginfo recs[8];
     memset(recs, 0, sizeof(recs));
@@ -693,12 +692,11 @@ static void test_rt_sigqueueinfo_bad_pointer_efault(void)
 
 static void test_rt_sigqueueinfo_rejects_foreign_pid(void)
 {
-    /* rt_sigqueueinfo is a process-scoped (tgid) syscall. A pid that does
-     * not name the current process must return ESRCH instead of routing
-     * the signal through whichever thread happened to share the numeric
-     * id. The first probe picks a pid the host kernel cannot have
-     * assigned to the current guest so the call cannot collide with a
-     * legitimate target.
+    /* rt_sigqueueinfo is a process-scoped (tgid) syscall. A pid that does not
+     * name the current process must return ESRCH instead of routing the signal
+     * through whichever thread happened to share the numeric id. The first
+     * probe picks a pid the host kernel cannot have assigned to the current
+     * guest so the call cannot collide with a legitimate target.
      */
     TEST("rt_sigqueueinfo rejects foreign pid");
 
@@ -716,9 +714,9 @@ static void test_rt_sigqueueinfo_rejects_foreign_pid(void)
     PASS();
 }
 
-/* Helpers for the worker-thread tid case. The worker publishes its own
- * tid via a thread-shared variable, then waits on a barrier so the main
- * thread can call rt_sigqueueinfo with that tid before the worker exits.
+/* Helpers for the worker-thread tid case. The worker publishes its own tid via
+ * a thread-shared variable, then waits on a barrier so the main thread can call
+ * rt_sigqueueinfo with that tid before the worker exits.
  */
 typedef struct {
     pthread_mutex_t mtx;
@@ -744,18 +742,17 @@ static void *tid_worker(void *arg)
 
 static void test_rt_sigqueueinfo_thread_tid_routes_to_tgid(void)
 {
-    /* Linux is permissive: rt_sigqueueinfo(tid_of_any_thread, ...)
-     * succeeds and the signal lands in the thread group's pending set
-     * (kill_pid_info routes through PIDTYPE_TGID). The contract under
-     * test is that elfuse matches that routing: a worker thread tid is
-     * accepted, and the queued signal becomes readable from the process
-     * signalfd. A regression that scoped the syscall to "tgid only"
-     * would surface here as ESRCH.
+    /* Linux is permissive: rt_sigqueueinfo(tid_of_any_thread, ...) succeeds and
+     * the signal lands in the thread group's pending set (kill_pid_info routes
+     * through PIDTYPE_TGID). The contract under test is that elfuse matches
+     * that routing: a worker thread tid is accepted, and the queued signal
+     * becomes readable from the process signalfd. A regression that scoped the
+     * syscall to "tgid only" would surface here as ESRCH.
      */
     TEST("rt_sigqueueinfo tid routes to tgid");
 
-    /* Block SIGRTMIN process-wide so the queued signal stays pending
-     * for signalfd to read instead of terminating the process.
+    /* Block SIGRTMIN process-wide so the queued signal stays pending for
+     * signalfd to read instead of terminating the process.
      */
     sigset_t block;
     sigemptyset(&block);
@@ -810,8 +807,8 @@ static void test_rt_sigqueueinfo_thread_tid_routes_to_tgid(void)
     int ret = raw_rt_sigqueueinfo(worker_tid, SIGRTMIN, info);
     int err = errno;
 
-    /* Drain any queued signal via signalfd before letting the worker
-     * exit so the signal does not leak into pthread_join.
+    /* Drain any queued signal via signalfd before letting the worker exit so
+     * the signal does not leak into pthread_join.
      */
     struct signalfd_siginfo rec;
     memset(&rec, 0, sizeof(rec));

--- a/tests/test-simd-clone.c
+++ b/tests/test-simd-clone.c
@@ -1,13 +1,12 @@
-/* Verify SIMD/FP state preservation across
- * clone(CLONE_THREAD)
+/* Verify SIMD/FP state preservation across clone(CLONE_THREAD)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Loads known patterns into V0-V3, FPSR, and FPCR before clone.
- * The child thread reads them back and verifies the values match.
- * This catches the bug where child threads inherit zeroed SIMD state.
+ * Loads known patterns into V0-V3, FPSR, and FPCR before clone. The child
+ * thread reads them back and verifies the values match. This catches the bug
+ * where child threads inherit zeroed SIMD state.
  */
 
 #include <stdint.h>
@@ -36,8 +35,8 @@ static void child_read_simd(void)
     uint64_t fpcr, fpsr;
 
     /* Single asm block: read all SIMD state atomically w.r.t. compiler
-     * scheduling. Without this, the compiler could insert code between
-     * separate asm volatile blocks that clobbers v0-v3.
+     * scheduling. Without this, the compiler could insert code between separate
+     * asm volatile blocks that clobbers v0-v3.
      */
     __asm__ volatile(
         "mov %[v0lo], v0.d[0]\n\t"

--- a/tests/test-socket.c
+++ b/tests/test-socket.c
@@ -4,8 +4,8 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Verifies socket syscalls work by creating an AF_UNIX socketpair
- * and exchanging data. This avoids needing a network stack.
+ * Verifies socket syscalls work by creating an AF_UNIX socketpair and
+ * exchanging data. This avoids needing a network stack.
  *
  * Tests:
  * 1. socketpair(AF_UNIX, SOCK_STREAM) creates two connected fds
@@ -228,8 +228,8 @@ int main(void)
                 n = recvfrom(dsv[1], recv_buf, sizeof(recv_buf), 0,
                              (struct sockaddr *) &sa, &salen);
                 /* Linux returns salen=0 for unnamed AF_UNIX socketpair
-                 * endpoints (no source address). Accept both salen==0
-                 * and salen with AF_UNIX family filled in.
+                 * endpoints (no source address). Accept both salen==0 and salen
+                 * with AF_UNIX family filled in.
                  */
                 int addr_ok = (salen == 0) || (salen >= sizeof(sa.sun_family) &&
                                                sa.sun_family == AF_UNIX);

--- a/tests/test-stress.c
+++ b/tests/test-stress.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Exercises resource limits: max threads, mmap churn, FD exhaustion,
- * and rapid mprotect cycling. Verifies correct behavior at and beyond
- * capacity boundaries.
+ * Exercises resource limits: max threads, mmap churn, FD exhaustion, and rapid
+ * mprotect cycling. Verifies correct behavior at and beyond capacity
+ * boundaries.
  *
  * Syscalls exercised: clone(220), futex(98), mmap(222), munmap(215),
  *                     mprotect(226), pipe2(59), close(57), exit(93)
@@ -48,8 +48,8 @@ static void test_max_threads(void)
 
     int spawned = 0;
     for (int i = 0; i < STRESS_THREADS; i++) {
-        /* Store the index in a 16-byte aligned slot at the top of the
-         * child's stack. AArch64 requires SP to be 16-byte aligned.
+        /* Store the index in a 16-byte aligned slot at the top of the child's
+         * stack. AArch64 requires SP to be 16-byte aligned.
          */
         char *stack_top = thread_stacks[i] + sizeof(thread_stacks[i]);
         int *slot = (int *) (stack_top - 16);
@@ -216,8 +216,8 @@ static void test_fd_exhaustion(void)
         return;
     }
 
-    /* The test expects to have opened at least 500 FDs and eventually
-     * hit the limit (EMFILE).
+    /* The test expects to have opened at least 500 FDs and eventually hit the
+     * limit (EMFILE).
      */
     EXPECT_TRUE(opened >= 500 && got_emfile,
                 "too few FDs opened before exhaustion");

--- a/tests/test-syscall-fidelity.c
+++ b/tests/test-syscall-fidelity.c
@@ -3,13 +3,13 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Covers Linux syscalls whose semantics elfuse must emulate exactly:
- * fchmodat2 (SYS 452) including AT_SYMLINK_NOFOLLOW, getcpu (SYS 168),
- * openat2 (SYS 437) with each RESOLVE_* flag variant (BENEATH,
- * IN_ROOT, NO_SYMLINKS, NO_MAGICLINKS, NO_XDEV), O_PATH descriptor enforcement
- * for read/write/fstat, madvise corner cases (MADV_COLD acceptance and
- * MADV_DONTNEED across an unmapped hole), and the low-address mmap
- * hint preservation that ET_EXEC layout depends on.
+ * Covers Linux syscalls whose semantics elfuse must emulate exactly: fchmodat2
+ * (SYS 452) including AT_SYMLINK_NOFOLLOW, getcpu (SYS 168), openat2 (SYS 437)
+ * with each RESOLVE_* flag variant (BENEATH, IN_ROOT, NO_SYMLINKS,
+ * NO_MAGICLINKS, NO_XDEV), O_PATH descriptor enforcement for read/write/fstat,
+ * madvise corner cases (MADV_COLD acceptance and MADV_DONTNEED across an
+ * unmapped hole), and the low-address mmap hint preservation that ET_EXEC
+ * layout depends on.
  */
 
 #include <errno.h>
@@ -33,13 +33,12 @@
 
 int passes = 0, fails = 0;
 
-/* Some Linux fidelity tests probe semantics that depend on filesystem
- * support (e.g. changing a symlink's own mode via AT_SYMLINK_NOFOLLOW
- * fails with EOPNOTSUPP on most Linux filesystems). Counting those as
- * skips keeps the summary honest: the syscall path was reached and
- * answered correctly, but the kernel declined the specific request.
- * Hard-failing on EOPNOTSUPP would turn the regression into a false
- * negative on perfectly conforming kernels.
+/* Some Linux fidelity tests probe semantics that depend on filesystem support
+ * (e.g. changing a symlink's own mode via AT_SYMLINK_NOFOLLOW fails with
+ * EOPNOTSUPP on most Linux filesystems). Counting those as skips keeps the
+ * summary honest: the syscall path was reached and answered correctly, but the
+ * kernel declined the specific request. Hard-failing on EOPNOTSUPP would turn
+ * the regression into a false negative on perfectly conforming kernels.
  */
 static int syscall_skips = 0;
 #define SYSCALL_SKIP(reason)          \
@@ -121,9 +120,9 @@ static void test_fchmodat2_symlink_nofollow(void)
      * Most Linux filesystems (including tmpfs, ext4, btrfs without the
      * symlink-mode opt-in) reject this with EOPNOTSUPP because the on-disk
      * inode for a symlink has no separately writable mode bit. Treat that
-     * answer as an honest skip: the kernel reached fchmodat2_write and
-     * declined the specific request. Any other negative return is a real
-     * failure that the test should surface.
+     * answer as an honest skip: the kernel reached fchmodat2_write and declined
+     * the specific request. Any other negative return is a real failure that
+     * the test should surface.
      */
     long rc =
         syscall(SYS_fchmodat2, AT_FDCWD, linkpath, 0700, AT_SYMLINK_NOFOLLOW);
@@ -623,8 +622,8 @@ static void test_openat2_resolve_no_xdev_allows_same_mount(void)
         PASS();
         return;
     }
-    /* Acceptable if /etc/passwd doesn't exist on the host running the test,
-     * as long as the error is not EXDEV.
+    /* Acceptable if /etc/passwd doesn't exist on the host running the test, as
+     * long as the error is not EXDEV.
      */
     EXPECT_TRUE(errno != EXDEV, "should not return EXDEV for same-class path");
 }
@@ -809,11 +808,11 @@ static void test_openat2_resolve_no_xdev_rejects_relative_tmp(void)
 
 static void test_openat2_resolve_no_xdev_rejects_transient_proc(void)
 {
-    /* A naive endpoint-only check would accept /proc/self/../../tmp/foo
-     * because the lexical normalization collapses /proc/self/../.. to /
-     * and the final classifier sees only /tmp/foo. Linux walks the path
-     * component by component and catches the transient crossing into
-     * /proc. The component walker must do the same.
+    /* A naive endpoint-only check would accept /proc/self/../../tmp/foo because
+     * the lexical normalization collapses /proc/self/../.. to / and the final
+     * classifier sees only /tmp/foo. Linux walks the path component by
+     * component and catches the transient crossing into /proc. The component
+     * walker must do the same.
      */
     TEST("openat2 RESOLVE_NO_XDEV catches transient /proc visit");
     struct open_how how = {
@@ -889,11 +888,10 @@ static void test_openat2_resolve_no_xdev_rejects_symlink_to_proc(void)
 
 static void test_openat2_resolve_no_xdev_in_root_clamps_dotdot(void)
 {
-    /* IN_ROOT clamps ".." at the dirfd. The combined NO_XDEV precheck must
-     * use the same floor, otherwise a path like /../../tmp from a /proc/1
-     * dirfd lexically pops above /proc and the walker would falsely report
-     * EXDEV even though the actual resolution clamps and stays inside the
-     * proc class.
+    /* IN_ROOT clamps ".." at the dirfd. The combined NO_XDEV precheck must use
+     * the same floor, otherwise a path like /../../tmp from a /proc/1 dirfd
+     * lexically pops above /proc and the walker would falsely report EXDEV even
+     * though the actual resolution clamps and stays inside the proc class.
      */
     TEST("openat2 RESOLVE_IN_ROOT | NO_XDEV clamps .. at dirfd");
     int dirfd = open("/proc/self", O_RDONLY | O_DIRECTORY);
@@ -918,10 +916,10 @@ static void test_openat2_resolve_no_xdev_in_root_clamps_dotdot(void)
 static void test_openat2_resolve_no_xdev_rejects_proc_fd_magiclink(void)
 {
     /* /proc/self/fd/N is a magic link whose target lives in whatever mount
-     * holds the underlying fd. Following it out of procfs is a mount
-     * crossing under Linux NO_XDEV. Without this guard the post-open
-     * check sees proc_path stamped as /proc/self/fd/N and falsely
-     * agrees with the PROC start class.
+     * holds the underlying fd. Following it out of procfs is a mount crossing
+     * under Linux NO_XDEV. Without this guard the post-open check sees
+     * proc_path stamped as /proc/self/fd/N and falsely agrees with the PROC
+     * start class.
      */
     TEST("openat2 RESOLVE_NO_XDEV rejects /proc/self/fd magic link");
     int helper = open("/tmp", O_RDONLY | O_DIRECTORY);

--- a/tests/test-syscall-smoke.c
+++ b/tests/test-syscall-smoke.c
@@ -201,9 +201,9 @@ static void test_close_range_basic(void)
     }
 
     /* Probe before clearing pipes[] so the EXPECT_ERRNO actually tests
-     * close_range's effect, not close(-1). On success every fd in the
-     * range is closed, so leave pipes[] zeroed afterward to keep the
-     * cleanup loop from double-closing.
+     * close_range's effect, not close(-1). On success every fd in the range is
+     * closed, so leave pipes[] zeroed afterward to keep the cleanup loop from
+     * double-closing.
      */
     int probe_fd = pipes[1][0];
     memset(pipes, -1, sizeof(pipes));
@@ -448,8 +448,8 @@ static void test_waitid(void)
         PASS();
         return;
     }
-    /* waitid failed or returned the wrong siginfo; reap with waitpid so
-     * the child does not linger as a zombie and skew later tests.
+    /* waitid failed or returned the wrong siginfo; reap with waitpid so the
+     * child does not linger as a zombie and skew later tests.
      */
     int status;
     waitpid(pid, &status, 0);
@@ -575,9 +575,9 @@ static void test_accept4(void)
     }
 
     /* Gate the blocking accept4() on a poll(): if the child fails before
-     * connect(), no incoming connection will ever arrive and the parent
-     * would wedge the test until the driver timeout. The poll bounds the
-     * wait so we can detect that case and fail fast.
+     * connect(), no incoming connection will ever arrive and the parent would
+     * wedge the test until the driver timeout. The poll bounds the wait so we
+     * can detect that case and fail fast.
      */
     struct pollfd pfd = {.fd = listen_fd, .events = POLLIN};
     int pr = poll(&pfd, 1, 2000);

--- a/tests/test-sysfs-cpu.c
+++ b/tests/test-sysfs-cpu.c
@@ -25,8 +25,9 @@
 #include "test-harness.h"
 #include "test-util.h"
 
-/* Parse a "0\n" or "0-N\n" cpumask range file into the highest set CPU
- * index. Returns -1 on malformed input.
+/* Parse a "0\n" or "0-N\n" cpumask range file into the highest set CPU index.
+ *
+ * Returns -1 on malformed input.
  */
 static int parse_cpurange(const char *s, ssize_t len)
 {
@@ -54,8 +55,8 @@ static int parse_cpurange(const char *s, ssize_t len)
     return low;
 }
 
-/* Read a cpumask range file (online/possible/present) and return the
- * highest CPU index it advertises. -1 on read or parse failure.
+/* Read a cpumask range file (online/possible/present) and return the highest
+ * CPU index it advertises. -1 on read or parse failure.
  */
 static int read_cpurange(const char *path)
 {
@@ -143,9 +144,9 @@ int main(void)
             FAIL("opendir failed");
     }
 
-    /* The stub is read-only: O_WRONLY / O_RDWR / O_CREAT / O_TRUNC must
-     * fail with EACCES so a guest cannot mutate the synthetic tree (and
-     * cannot pivot a creation into the host scratch dir).
+    /* The stub is read-only: O_WRONLY / O_RDWR / O_CREAT / O_TRUNC must fail
+     * with EACCES so a guest cannot mutate the synthetic tree (and cannot pivot
+     * a creation into the host scratch dir).
      */
     TEST("EACCES on O_WRONLY of online");
     {
@@ -206,8 +207,8 @@ int main(void)
     }
 
     /* '..' in the suffix must not let the open/stat fall through onto an
-     * arbitrary host path. The stub keeps the tree closed against
-     * traversal regardless of where the scratch dir happens to live.
+     * arbitrary host path. The stub keeps the tree closed against traversal
+     * regardless of where the scratch dir happens to live.
      */
     TEST("EACCES on dotdot traversal in open");
     {

--- a/tests/test-thread.c
+++ b/tests/test-thread.c
@@ -4,9 +4,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests raw clone(CLONE_THREAD) with futex-based synchronization.
- * Uses inline syscall wrappers (no pthread) to directly exercise
- * elfuse's thread implementation.
+ * Tests raw clone(CLONE_THREAD) with futex-based synchronization. Uses inline
+ * syscall wrappers (no pthread) to directly exercise elfuse's thread
+ * implementation.
  */
 
 #include <stdbool.h>
@@ -29,8 +29,8 @@ int passes = 0, fails = 0;
 /* Shared variable written by child thread, read by parent */
 static volatile int shared_value = 0;
 
-/* Child TID: written by CLONE_PARENT_SETTID and cleared by
- * CLONE_CHILD_CLEARTID on thread exit
+/* Child TID: written by CLONE_PARENT_SETTID and cleared by CLONE_CHILD_CLEARTID
+ * on thread exit
  */
 static volatile int child_tid = 0;
 
@@ -40,9 +40,9 @@ static volatile int parked_state = 0;
 
 /* Child thread function */
 
-/* This is the entry point for the child thread. Since clone returns to the
- * same instruction, main branches on the return value and calls this only in
- * the child path.
+/* This is the entry point for the child thread. Since clone returns to the same
+ * instruction, main branches on the return value and calls this only in the
+ * child path.
  */
 
 static void child_work(void)
@@ -135,9 +135,8 @@ static void test_parent_settid(void)
         raw_futex_wait((int *) &child_tid, child_tid);
     }
 
-    /* If execution reaches this point, CHILD_CLEARTID cleared it and
-     * FUTEX_WAKE woke the parent.
-     * The original value was > 0 (written by PARENT_SETTID).
+    /* If execution reaches this point, CHILD_CLEARTID cleared it and FUTEX_WAKE
+     * woke the parent. The original value was > 0 (written by PARENT_SETTID).
      */
     PASS();
 }
@@ -163,8 +162,8 @@ static void test_multi_thread(void)
 
     int spawned = 0;
     for (int i = 0; i < N_THREADS; i++) {
-        /* Store the index in a 16-byte aligned slot at the top of the
-         * child's stack. AArch64 requires SP to be 16-byte aligned.
+        /* Store the index in a 16-byte aligned slot at the top of the child's
+         * stack. AArch64 requires SP to be 16-byte aligned.
          */
         char *stack_top = mt_stacks[i] + sizeof(mt_stacks[i]);
         int *slot = (int *) (stack_top - 16);

--- a/tests/test-tier-a.c
+++ b/tests/test-tier-a.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: SysV message queues, memory policy stubs, mlockall stubs,
- * prctl new options, /proc/self/task, PAC feature probe.
+ * Tests: SysV message queues, memory policy stubs, mlockall stubs, prctl new
+ * options, /proc/self/task, PAC feature probe.
  */
 
 #include <errno.h>
@@ -164,8 +164,8 @@ static void test_msgctl_rmid(void)
 
 /* Memory policy stubs. */
 
-/* get_mempolicy(2) and set_mempolicy(2) are Linux-specific.
- * Use raw syscall since glibc may not wrap them.
+/* get_mempolicy(2) and set_mempolicy(2) are Linux-specific. Use raw syscall
+ * since glibc may not wrap them.
  */
 #ifndef __NR_get_mempolicy
 #define __NR_get_mempolicy 236
@@ -451,12 +451,12 @@ static void test_pac_hwcap(void)
 
 /* AT_SECURE auxv probe. Bionic aborts when AT_SECURE is missing from the
  * auxiliary vector. elfuse never elevates privileges, so the value is 0.
- * getauxval() also returns 0 when an entry is not present, so distinguish
- * the two by walking /proc/self/auxv and looking for the AT_SECURE key.
+ * getauxval() also returns 0 when an entry is not present, so distinguish the
+ * two by walking /proc/self/auxv and looking for the AT_SECURE key.
  *
- * Read /proc/self/auxv with a loop: procfs is not required to return the
- * whole file in one read, and EINTR must be retried. AT_NULL must appear
- * in the accumulated buffer or the test cannot conclude.
+ * Read /proc/self/auxv with a loop: procfs is not required to return the whole
+ * file in one read, and EINTR must be retried. AT_NULL must appear in the
+ * accumulated buffer or the test cannot conclude.
  */
 static void test_at_secure_present(void)
 {

--- a/tests/test-timerfd.c
+++ b/tests/test-timerfd.c
@@ -149,9 +149,9 @@ int main(void)
             FAIL("timerfd_create failed");
     }
 
-    /* CLOCK_BOOTTIME backs foot's keyboard repeat timer; on macOS it
-     * resolves to CLOCK_MONOTONIC since no boottime equivalent exists.
-     * Paired with TFD_NONBLOCK to mirror foot's actual call.
+    /* CLOCK_BOOTTIME backs foot's keyboard repeat timer; on macOS it resolves
+     * to CLOCK_MONOTONIC since no boottime equivalent exists. Paired with
+     * TFD_NONBLOCK to mirror foot's actual call.
      */
     TEST("create accepts CLOCK_BOOTTIME with TFD_NONBLOCK");
     {
@@ -161,11 +161,11 @@ int main(void)
             close(fd);
     }
 
-    /* NONBLOCK shadow: the kqueue host fd cannot carry O_NONBLOCK, so the
-     * flag lives in fd_table[gfd].linux_flags. Arm with a 1s deadline so
-     * the read is non-trivially blocked, then verify EAGAIN comes from the
-     * NONBLOCK path; an unarmed timer would also return EAGAIN, so the arm
-     * step is what makes this a real probe of the shadow.
+    /* NONBLOCK shadow: the kqueue host fd cannot carry O_NONBLOCK, so the flag
+     * lives in fd_table[gfd].linux_flags. Arm with a 1s deadline so the read is
+     * non-trivially blocked, then verify EAGAIN comes from the NONBLOCK path;
+     * an unarmed timer would also return EAGAIN, so the arm step is what makes
+     * this a real probe of the shadow.
      */
     TEST("NONBLOCK: armed-but-unfired returns EAGAIN");
     {
@@ -185,10 +185,10 @@ int main(void)
             FAIL("timerfd_create");
     }
 
-    /* fcntl coherence: F_GETFL must surface O_RDWR plus the writable bits
-     * Linux honors on a timerfd (O_APPEND, O_NONBLOCK, O_NOATIME).
-     * F_SETFL persists the writable bits and silently drops everything
-     * else; O_DIRECT returns EINVAL.
+    /* fcntl coherence: F_GETFL must surface O_RDWR plus the writable bits Linux
+     * honors on a timerfd (O_APPEND, O_NONBLOCK, O_NOATIME). F_SETFL persists
+     * the writable bits and silently drops everything else; O_DIRECT returns
+     * EINVAL.
      */
     TEST("fcntl F_GETFL/F_SETFL match Linux setfl semantics");
     {
@@ -226,9 +226,9 @@ int main(void)
     }
 
     /* F_SETFD and F_SETFL touch the same linux_flags shadow but operate on
-     * disjoint bits. Toggling CLOEXEC via F_SETFD must not perturb the
-     * status bits surfaced by F_GETFL. Targets the new fd_lock-serialized
-     * RMW in both branches.
+     * disjoint bits. Toggling CLOEXEC via F_SETFD must not perturb the status
+     * bits surfaced by F_GETFL. Targets the new fd_lock-serialized RMW in both
+     * branches.
      */
     TEST("F_SETFD does not perturb F_GETFL status bits");
     {
@@ -252,11 +252,11 @@ int main(void)
             FAIL("timerfd_create");
     }
 
-    /* dup must carry the linux_flags shadow's NONBLOCK bit through; without
-     * the preserved-mask fix the new fd's F_GETFL would report blocking.
-     * (The timerfd slot table is keyed by guest_fd with no alias support,
-     * so read/settime through the dup return EBADF -- that pre-existing
-     * limitation is outside #82's scope.)
+    /* dup must carry the linux_flags shadow's NONBLOCK bit through; without the
+     * preserved-mask fix the new fd's F_GETFL would report blocking. (The
+     * timerfd slot table is keyed by guest_fd with no alias support, so
+     * read/settime through the dup return EBADF -- that pre-existing limitation
+     * is outside #82's scope.)
      */
     TEST("dup preserves O_NONBLOCK and O_RDWR in linux_flags");
     {

--- a/tests/test-tlbi-encoder-host.c
+++ b/tests/test-tlbi-encoder-host.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * The integration tests in tests/test-mprotect-mt.c exercise the operand
- * end-to-end inside a VM, but they happily pass on M4 even when the
- * encoder dropped the TG=01 bit (the M-series PE silently falls back to
- * TCR_EL1.TGn). This host-side test decodes the operand bit-by-bit and
- * asserts every field matches the ARM ARM DDI 0487J.a D8.7.6 layout, so a
- * future regression in the encoder surfaces as a build / CI failure
- * regardless of the running PE's tolerance for reserved encodings.
+ * end-to-end inside a VM, but they happily pass on M4 even when the encoder
+ * dropped the TG=01 bit (the M-series PE silently falls back to TCR_EL1.TGn).
+ * This host-side test decodes the operand bit-by-bit and asserts every field
+ * matches the ARM ARM DDI 0487J.a D8.7.6 layout, so a future regression in the
+ * encoder surfaces as a build / CI failure regardless of the running PE's
+ * tolerance for reserved encodings.
  *
  * Native macOS binary; no HVF entitlement needed (the encoder is pure C).
- * Symbols pulled from core/guest.h that the encoder does not actually
- * reference still need to link, so a stub cpu_tlbi_req / g_tlbi_range_*
- * definition lives below.
+ * Symbols pulled from core/guest.h that the encoder does not actually reference
+ * still need to link, so a stub cpu_tlbi_req / g_tlbi_range_* definition lives
+ * below.
  */
 
 #include <stdbool.h>
@@ -24,8 +24,9 @@
 
 #include "core/guest.h"
 
-/* Stubs for the extern symbols guest.h declares. The encoder under test
- * does not read them, but the linker needs definitions. */
+/* Stubs for the extern symbols guest.h declares. The encoder under test does
+ * not read them, but the linker needs definitions.
+ */
 _Thread_local tlbi_request_t cpu_tlbi_req;
 bool g_tlbi_range_supported;
 
@@ -43,10 +44,11 @@ static void check_field(const char *label, uint64_t got, uint64_t expect)
     }
 }
 
-/* Decompose the operand per ARM ARM D8.7.6 and compare each field against
- * the expected value. baseADDR is VA>>12 masked to 37 bits; TG must be 01
- * (4 KiB); SCALE must be 0; TTL must be 0; ASID must be 0. NUM derives
- * from the page count via the ceil(pages/2) - 1 SCALE=0 encoding. */
+/* Decompose the operand per ARM ARM D8.7.6 and compare each field against the
+ * expected value. baseADDR is VA>>12 masked to 37 bits; TG must be 01 (4 KiB);
+ * SCALE must be 0; TTL must be 0; ASID must be 0. NUM derives from the page
+ * count via the ceil(pages/2) - 1 SCALE=0 encoding.
+ */
 static void verify_operand(uint64_t start_va,
                            uint16_t pages,
                            uint64_t expect_num)
@@ -105,8 +107,9 @@ int main(void)
     verify_operand(0x10000000ULL, 63, 31);
     verify_operand(0x10000000ULL, 64, 31);
 
-    /* Boundary VAs. 4 KiB-aligned, low-VA, MMAP_BASE (8 GiB), high-VA
-     * just below the 48-bit BaseADDR truncation point. */
+    /* Boundary VAs. 4 KiB-aligned, low-VA, MMAP_BASE (8 GiB), high-VA just
+     * below the 48-bit BaseADDR truncation point.
+     */
     verify_operand(0x00000000ULL, 32, 15);         /* zero base */
     verify_operand(0x200000000ULL, 32, 15);        /* MMAP_BASE */
     verify_operand(0x800000000000ULL, 32, 15);     /* Rosetta image */
@@ -121,10 +124,10 @@ int main(void)
     verify_operand(0x10000000ULL, 1, 0);
     verify_operand(0x10000000ULL, UINT16_MAX, 31);
 
-    /* TG bit is the architectural lynchpin -- if the encoder ever drops
-     * it the integration tests on Apple Silicon would still pass. Pin a
-     * direct bit-46 inspection so a regression to TG=00 fails this test
-     * immediately. */
+    /* TG bit is the architectural lynchpin -- if the encoder ever drops it the
+     * integration tests on Apple Silicon would still pass. Pin a direct bit-46
+     * inspection so a regression to TG=00 fails this test immediately.
+     */
     uint64_t op = tlbi_rvae1is_operand(0x10000000ULL, 32);
     if (op & (1ULL << 46)) {
         passes++;

--- a/tests/test-vdso.c
+++ b/tests/test-vdso.c
@@ -12,11 +12,11 @@
  *   5. trampolines actually execute (call __kernel_clock_gettime and
  *      compare the result against a direct SVC clock_gettime)
  *
- * Static binary so the standard test driver runs it under elfuse with
- * no sysroot. The probe walks the vDSO's dynamic linker structure
- * itself rather than relying on dlsym (which is unavailable in static
- * builds anyway), so a regression in the elf layout fails this test
- * regardless of which libc would later consume it.
+ * Static binary so the standard test driver runs it under elfuse with no
+ * sysroot. The probe walks the vDSO's dynamic linker structure itself rather
+ * than relying on dlsym (which is unavailable in static builds anyway), so a
+ * regression in the elf layout fails this test regardless of which libc would
+ * later consume it.
  */
 
 #include <elf.h>
@@ -169,12 +169,12 @@ static void test_vdso(void)
     EXPECT(ehdr->e_machine == EM_AARCH64, "vDSO e_machine");
     EXPECT(ehdr->e_type == ET_DYN, "vDSO e_type");
 
-    /* NT_GNU_ABI_TAG note. glibc 2.41's vDSO probe expects a Linux ABI tag
-     * note alongside the dynamic symbol table; walk every PT_NOTE segment
-     * the EHDR advertises and confirm exactly one entry matches the
-     * (name="GNU", type=NT_GNU_ABI_TAG, desc[0]=Linux) shape with a
-     * minimum-kernel descriptor that is at least 2.6.39 (matching the
-     * LINUX_2.6.39 symbol version this vDSO exports).
+    /* NT_GNU_ABI_TAG note. glibc 2.41's vDSO probe expects a Linux ABI tag note
+     * alongside the dynamic symbol table; walk every PT_NOTE segment the EHDR
+     * advertises and confirm exactly one entry matches the (name="GNU",
+     * type=NT_GNU_ABI_TAG, desc[0]=Linux) shape with a minimum-kernel
+     * descriptor that is at least 2.6.39 (matching the LINUX_2.6.39 symbol
+     * version this vDSO exports).
      */
     const Elf64_Phdr *probe_phdr =
         (const Elf64_Phdr *) ((const uint8_t *) ehdr + ehdr->e_phoff);
@@ -241,8 +241,8 @@ static void test_vdso(void)
         }
     }
 
-    /* Probe gettimeofday before clock_gettime so the first vDSO-mediated
-     * time fallback must be able to seed the shared vvar anchor by itself.
+    /* Probe gettimeofday before clock_gettime so the first vDSO-mediated time
+     * fallback must be able to seed the shared vvar anchor by itself.
      */
     const Elf64_Sym *gtod =
         lookup_sym(ehdr, v.symtab, v.strtab, v.hash, "__kernel_gettimeofday");
@@ -256,8 +256,8 @@ static void test_vdso(void)
 
     /* Direct call into the vDSO trampoline. Must agree with SVC for both
      * CLOCK_MONOTONIC and CLOCK_REALTIME. The preceding gettimeofday probe
-     * seeded the shared CNTVCT anchor, so both clockids exercise the
-     * post-seed fast path.
+     * seeded the shared CNTVCT anchor, so both clockids exercise the post-seed
+     * fast path.
      */
     const Elf64_Sym *cg =
         lookup_sym(ehdr, v.symtab, v.strtab, v.hash, "__kernel_clock_gettime");
@@ -269,13 +269,12 @@ static void test_vdso(void)
             const char *label;
             int64_t tolerance_ns;
         } cases[] = {
-            /* CLOCK_MONOTONIC: tight tolerance, anchor-derived value
-             * cannot drift relative to the SVC reference beyond the gap
-             * between calls.
+            /* CLOCK_MONOTONIC: tight tolerance, anchor-derived value cannot
+             * drift relative to the SVC reference beyond the gap between calls.
              */
             {CLOCK_MONOTONIC, "MONOTONIC", 10000000},
-            /* CLOCK_REALTIME: tolerance loose enough to absorb host
-             * scheduling jitter between the two clock_gettime calls.
+            /* CLOCK_REALTIME: tolerance loose enough to absorb host scheduling
+             * jitter between the two clock_gettime calls.
              */
             {CLOCK_REALTIME, "REALTIME", 10000000},
         };
@@ -303,8 +302,8 @@ static void test_vdso(void)
         }
     }
 
-    /* clock_getres vDSO entry must match raw SVC for supported clockids.
-     * NULL res must succeed for valid clockids.
+    /* clock_getres vDSO entry must match raw SVC for supported clockids. NULL
+     * res must succeed for valid clockids.
      */
     typedef int (*clock_getres_fn)(clockid_t, struct timespec *);
     const Elf64_Sym *cr =
@@ -379,8 +378,8 @@ static void test_vdso(void)
         EXPECT(fn(NULL, NULL) == 0, "vDSO gettimeofday(NULL, NULL) returned 0");
     }
 
-    /* getcpu fast path: must always return cpu=0 / node=0 (elfuse models
-     * one online CPU and one NUMA node).
+    /* getcpu fast path: must always return cpu=0 / node=0 (elfuse models one
+     * online CPU and one NUMA node).
      */
     typedef int (*getcpu_fn)(unsigned *, unsigned *, void *);
     const Elf64_Sym *gc =

--- a/tests/test-x11.c
+++ b/tests/test-x11.c
@@ -4,15 +4,15 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Validates X11 socket transport by speaking raw X11 wire protocol
- * over AF_UNIX or TCP.  Zero external library dependencies; all X11
- * protocol structures are hand-coded.
+ * Validates X11 socket transport by speaking raw X11 wire protocol over AF_UNIX
+ * or TCP. Zero external library dependencies; all X11 protocol structures are
+ * hand-coded.
  *
  * Tests: DISPLAY env var parsing, Xauthority reading, X server socket
  *        connect, window creation + map, Expose event handling + draw.
  *
- * All X11-server-dependent tests skip gracefully when DISPLAY is
- * unset or the X server is unreachable (exit 0, 0 failures).
+ * All X11-server-dependent tests skip gracefully when DISPLAY is unset or the X
+ * server is unreachable (exit 0, 0 failures).
  *
  * Syscalls exercised: socket(198), connect(203), read(63), write(64),
  *                     ppoll(73), openat(56), close(57)
@@ -70,7 +70,7 @@ static inline int pad4(int n)
     return (n + 3) & ~3;
 }
 
-/* Read exactly n bytes from fd.  Retries on EINTR.
+/* Read exactly n bytes from fd. Retries on EINTR.
  * Returns 0 on success, -1 on failure/EOF.
  */
 static int read_exact(int fd, void *buf, int n)
@@ -99,8 +99,8 @@ typedef struct {
     int display_number, screen_number;
 } display_info_t;
 
-/* Parse X11 DISPLAY string into structured info.
- * Supports:  ":N", ":N.S", "host:N", "/path:N"
+/* Parse X11 DISPLAY string into structured info. Supports: ":N", ":N.S",
+ * "host:N", "/path:N"
  * Returns 0 on success, -1 on invalid format.
  */
 static int parse_display(const char *display, display_info_t *info)
@@ -126,10 +126,10 @@ static int parse_display(const char *display, display_info_t *info)
         snprintf(info->socket_path, sizeof(info->socket_path),
                  "/tmp/.X11-unix/X%d", info->display_number);
     } else if (display[0] == '/') {
-        /* "/path:N": XQuartz launchd or custom socket path.
-         * libxcb convention: the path before ':N' is the socket.
-         * Fallback: try the full DISPLAY string as the socket filename
-         * (some setups embed ':N' in the actual filename).
+        /* "/path:N": XQuartz launchd or custom socket path. libxcb convention:
+         * the path before ':N' is the socket. Fallback: try the full DISPLAY
+         * string as the socket filename (some setups embed ':N' in the actual
+         * filename).
          */
         info->type = DISPLAY_UNIX;
         if (host_len < (int) sizeof(info->socket_path)) {
@@ -182,8 +182,8 @@ static int xauth_skip(int fd, uint16_t n)
     return 0;
 }
 
-/* Find an Xauthority entry matching display_num.
- * Reads from XAUTHORITY env var or $HOME/.Xauthority.
+/* Find an Xauthority entry matching display_num. Reads from XAUTHORITY env var
+ * or $HOME/.Xauthority.
  * Returns 0 if found, -1 if not.
  */
 static int find_xauth(int display_num, xauth_t *auth)
@@ -288,8 +288,8 @@ static uint32_t x11_alloc_id(x11_conn_t *c)
     return c->id_base | (c->next_id & c->id_mask);
 }
 
-/* Connect to X server and perform protocol handshake.
- * On success, conn is populated and conn->fd is open.
+/* Connect to X server and perform protocol handshake. On success, conn is
+ * populated and conn->fd is open.
  * Returns 0 on success, -1 on failure.
  */
 static int x11_connect(const display_info_t *info,
@@ -392,9 +392,8 @@ static int x11_connect(const display_info_t *info,
     /* Parse fixed fields:
      *   +0: release_number(4)  +4: resource_id_base(4)
      *   +8: resource_id_mask(4) +12: motion_buf_size(4)
-     *  +16: vendor_length(2)   +18: max_request_length(2)
-     *  +20: num_screens(1)     +21: num_formats(1)
-     *  +22..+31: image_byte_order, etc.
+     * +16: vendor_length(2) +18: max_request_length(2) +20: num_screens(1) +21:
+     * num_formats(1) +22..+31: image_byte_order, etc.
      */
     conn->id_base = le32(data + 4);
     conn->id_mask = le32(data + 8);
@@ -455,8 +454,8 @@ static int x11_create_window(x11_conn_t *c,
                              uint32_t bg_pixel,
                              uint32_t event_mask)
 {
-    /* value_mask = CWBackPixel(0x02) | CWEventMask(0x800) = 0x0802
-     * 2 value words -> total length = (32 + 8) / 4 = 10 dwords
+    /* value_mask = CWBackPixel(0x02) | CWEventMask(0x800) = 0x0802 2 value
+     * words -> total length = (32 + 8) / 4 = 10 dwords
      */
     uint8_t req[40];
     req[0] = 1;             /* opcode: CreateWindow */
@@ -519,7 +518,7 @@ static int x11_destroy_window(x11_conn_t *c, uint32_t wid)
     return (write(c->fd, req, 8) == 8) ? 0 : -1;
 }
 
-/* Read one X11 event (32 bytes).  Handles variable-length replies and
+/* Read one X11 event (32 bytes). Handles variable-length replies and
  * GenericEvents by consuming their extra data transparently.
  * Returns the event code (2-34), 0 for Error, or -1 for read failure.
  */
@@ -588,8 +587,8 @@ int main(void)
     TEST("DISPLAY parse '/path/sock:0'");
     {
         display_info_t d;
-        /* Path does not exist on disk, so parse_display falls back to
-         * the full string as socket_path
+        /* Path does not exist on disk, so parse_display falls back to the full
+         * string as socket_path
          */
         if (parse_display("/path/to/sock:0", &d) == 0 &&
             d.type == DISPLAY_UNIX && d.display_number == 0)
@@ -656,8 +655,8 @@ int main(void)
         uint32_t events = (1u << 15) | (1u << 0);
         bool ok = false;
 
-        /* Use white_pixel/black_pixel for maximum visual compatibility
-         * (works on TrueColor, PseudoColor, and any other visual)
+        /* Use white_pixel/black_pixel for maximum visual compatibility (works
+         * on TrueColor, PseudoColor, and any other visual)
          */
         if (x11_create_window(&conn, wid, conn.root_window, 100, 100, 200, 200,
                               conn.white_pixel, events) < 0 ||

--- a/tests/test-xattr.c
+++ b/tests/test-xattr.c
@@ -3,8 +3,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Pins three properties of the elfuse xattr surface that the host
- * shim has to translate:
+ * Pins three properties of the elfuse xattr surface that the host shim has to
+ * translate:
  *
  *   1. lgetxattr returns the stored value on a regular file.
  *   2. lgetxattr on a symlink does not follow the link, so requesting
@@ -14,10 +14,9 @@
  *      ENOATTR(93) or its synonym ENODATA(96); both must translate to
  *      Linux ENODATA(61).
  *
- * Regression: an earlier revision lacked the ENOATTR translation
- * entry, so the default in linux_errno() fell through to EINVAL,
- * which masked real "attribute not present" outcomes and broke
- * fontconfig / glibc xattr probes.
+ * Regression: an earlier revision lacked the ENOATTR translation entry, so the
+ * default in linux_errno() fell through to EINVAL, which masked real "attribute
+ * not present" outcomes and broke fontconfig / glibc xattr probes.
  *
  * Syscalls exercised: setxattr(5), lsetxattr(6), getxattr(8),
  *                     lgetxattr(9)

--- a/tests/x86_64-glibc-dlopen.c
+++ b/tests/x86_64-glibc-dlopen.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * The hello/--list probes only exercise load-time PT_INTERP and ld.so
- * introspection. Runtime dlopen takes a different elfuse codepath:
- * a fresh anonymous-then-file mmap into the gap-finding allocator,
- * not the high-VA fixed-mmap replacement path the static probe
- * touches. The success line is the only signal; everything else is
- * stderr-only so the consumer regex stays trivial.
+ * introspection. Runtime dlopen takes a different elfuse codepath: a fresh
+ * anonymous-then-file mmap into the gap-finding allocator, not the high-VA
+ * fixed-mmap replacement path the static probe touches. The success line is the
+ * only signal; everything else is stderr-only so the consumer regex stays
+ * trivial.
  */
 
 #define _GNU_SOURCE
@@ -19,9 +19,9 @@
 
 static void emit(int fd, const char *s)
 {
-    /* warn_unused_result on glibc's write() prototype is not suppressed
-     * by (void) cast, so route the return through a sink variable that
-     * gets read once at function exit.
+    /* warn_unused_result on glibc's write() prototype is not suppressed by
+     * (void) cast, so route the return through a sink variable that gets read
+     * once at function exit.
      */
     ssize_t n = write(fd, s, strlen(s));
     if (n > 0)
@@ -39,9 +39,9 @@ int main(void)
     }
 
     /* dlsym -> function pointer cannot be expressed as a single ISO C
-     * conversion; the POSIX-2013 idiom is to copy the bits across a
-     * void* slot. The static_assert keeps the cast honest if a future
-     * platform ever changes pointer sizes.
+     * conversion; the POSIX-2013 idiom is to copy the bits across a void* slot.
+     * The static_assert keeps the cast honest if a future platform ever changes
+     * pointer sizes.
      */
     _Static_assert(sizeof(void *) == sizeof(double (*)(double)),
                    "void* and function pointer width mismatch");

--- a/tests/x86_64-glibc-gdtls-lib.c
+++ b/tests/x86_64-glibc-gdtls-lib.c
@@ -1,15 +1,14 @@
-/* x86_64-glibc-gdtls-lib.c - Shared object with a general-dynamic
- * thread-local variable, paired with x86_64-glibc-gdtls.c.
+/* x86_64-glibc-gdtls-lib.c - Shared object with a general-dynamic thread-local
+ * variable, paired with x86_64-glibc-gdtls.c.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The probe binary dlopens this .so at runtime. A dlopen-loaded .so
- * cannot use the initial-exec TLS model that the main executable's
- * __thread variables use; the compiler emits a general-dynamic access
- * sequence that calls __tls_get_addr() at runtime. This .so therefore
- * exercises a TLS lowering path the existing initial-exec probe in
- * glibc-tls cannot reach.
+ * The probe binary dlopens this .so at runtime. A dlopen-loaded .so cannot use
+ * the initial-exec TLS model that the main executable's __thread variables use;
+ * the compiler emits a general-dynamic access sequence that calls
+ * __tls_get_addr() at runtime. This .so therefore exercises a TLS lowering path
+ * the existing initial-exec probe in glibc-tls cannot reach.
  *
  * Build (on an x86_64 Linux host):
  *   gcc -O2 -fPIC -shared -o libgdtls.so x86_64-glibc-gdtls-lib.c
@@ -17,13 +16,12 @@
 
 #include <stdint.h>
 
-/* The general-dynamic TLS model is explicitly forced here. With just
- * 'static __thread' the compiler is free to pick local-dynamic for a
- * file-scope symbol inside a shared object, which would still call
- * __tls_get_addr but through a different relocation sequence. Dropping
- * 'static' makes the symbol externally visible (which prevents LD
- * relaxation) and the tls_model attribute pins the codegen so the
- * vendored .so cannot silently regress to LD when rebuilt with a
+/* The general-dynamic TLS model is explicitly forced here. With just 'static
+ * __thread' the compiler is free to pick local-dynamic for a file-scope symbol
+ * inside a shared object, which would still call __tls_get_addr but through a
+ * different relocation sequence. Dropping 'static' makes the symbol externally
+ * visible (which prevents LD relaxation) and the tls_model attribute pins the
+ * codegen so the vendored .so cannot silently regress to LD when rebuilt with a
  * different compiler.
  */
 __attribute__((tls_model("global-dynamic"))) __thread uint64_t gdtls_value =

--- a/tests/x86_64-glibc-gdtls.c
+++ b/tests/x86_64-glibc-gdtls.c
@@ -3,18 +3,18 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * dlopen() the companion shared library (libgdtls.so), pull its
- * gdtls_get / gdtls_set accessors via dlsym, exercise the __thread
- * variable across set/read/re-set/read. Because the library is loaded
- * after main() starts, its __thread storage uses the general-dynamic
- * model (calls into __tls_get_addr) rather than initial-exec; a broken
- * Rosetta lowering of that path surfaces as a value mismatch.
+ * dlopen() the companion shared library (libgdtls.so), pull its gdtls_get /
+ * gdtls_set accessors via dlsym, exercise the __thread variable across
+ * set/read/re-set/read. Because the library is loaded after main() starts, its
+ * __thread storage uses the general-dynamic model (calls into __tls_get_addr)
+ * rather than initial-exec; a broken Rosetta lowering of that path surfaces as
+ * a value mismatch.
  *
  * Build (on an x86_64 Linux host):
  *   gcc -O2 -ldl -o gdtls-probe x86_64-glibc-gdtls.c
  *
- * libgdtls.so must sit on the dynamic loader search path at runtime;
- * the test rootfs stages it under /lib/x86_64-linux-gnu/.
+ * libgdtls.so must sit on the dynamic loader search path at runtime; the test
+ * rootfs stages it under /lib/x86_64-linux-gnu/.
  */
 
 #define _GNU_SOURCE
@@ -53,8 +53,8 @@ int main(void)
     memcpy((void *) &get_fn, (const void *) &raw_get, sizeof(get_fn));
     memcpy((void *) &set_fn, (const void *) &raw_set, sizeof(set_fn));
 
-    /* Initial-state read goes through __tls_get_addr on the
-     * dlopened image's PT_TLS template.
+    /* Initial-state read goes through __tls_get_addr on the dlopened image's
+     * PT_TLS template.
      */
     if (get_fn() != 0x0123456789abcdefULL) {
         emit(STDERR_FILENO, "gdtls-initial-read-wrong");

--- a/tests/x86_64-glibc-pthread-tls.c
+++ b/tests/x86_64-glibc-pthread-tls.c
@@ -3,13 +3,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Each thread under pthread gets its own TLS block; on x86_64 the
- * FS-register points at a different address per thread. Rosetta has
- * to wire that per-thread FS to a per-thread TPIDR_EL0 when it lowers
- * the guest. The single-thread initial-exec probe (glibc-tls) only
- * exercises the main thread's setup; this probe asserts that a worker
- * thread sees its own isolated TLS slot and that the main thread's
- * slot is not clobbered by the worker.
+ * Each thread under pthread gets its own TLS block; on x86_64 the FS-register
+ * points at a different address per thread. Rosetta has to wire that per-thread
+ * FS to a per-thread TPIDR_EL0 when it lowers the guest. The single-thread
+ * initial-exec probe (glibc-tls) only exercises the main thread's setup; this
+ * probe asserts that a worker thread sees its own isolated TLS slot and that
+ * the main thread's slot is not clobbered by the worker.
  *
  * Build (on an x86_64 Linux host):
  *   gcc -O2 -pthread -o pthread-tls-probe x86_64-glibc-pthread-tls.c
@@ -48,9 +47,8 @@ static void *worker(void *arg)
 
 int main(void)
 {
-    /* Main thread's TLS slot starts at the default value. Write a
-     * different marker so we can prove the worker's write does not
-     * bleed across.
+    /* Main thread's TLS slot starts at the default value. Write a different
+     * marker so we can prove the worker's write does not bleed across.
      */
     if (per_thread_value != 0xa5a5a5a5a5a5a5a5ULL) {
         emit(STDERR_FILENO, "main-initial-wrong");
@@ -69,8 +67,8 @@ int main(void)
         return 3;
     }
 
-    /* Worker must have seen its own default (not main's overwritten
-     * marker), and its own write must have stayed in its slot.
+    /* Worker must have seen its own default (not main's overwritten marker),
+     * and its own write must have stayed in its slot.
      */
     if (wr.initial != 0xa5a5a5a5a5a5a5a5ULL) {
         emit(STDERR_FILENO, "worker-initial-not-isolated");
@@ -80,8 +78,8 @@ int main(void)
         emit(STDERR_FILENO, "worker-write-readback-wrong");
         return 5;
     }
-    /* Main's slot must still hold the value we wrote before pthread
-     * _create, untouched by the worker's write.
+    /* Main's slot must still hold the value we wrote before pthread _create,
+     * untouched by the worker's write.
      */
     if (per_thread_value != 0xdeadbeefdeadbeefULL) {
         emit(STDERR_FILENO, "main-slot-clobbered");

--- a/tests/x86_64-glibc-tls.c
+++ b/tests/x86_64-glibc-tls.c
@@ -3,32 +3,31 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * x86-64 reads thread-local storage through the FS segment register;
- * Rosetta has to translate those accesses into TPIDR_EL0-relative
- * loads when it lowers x86 to aarch64. The hello/dlopen probes never
- * touch FS-relative addressing, so this is the first elfuse probe
- * that actually exercises that translation. Two __thread variables
- * cover both the integer and pointer access shapes the compiler
- * emits; a value-mismatch failure here typically points at a broken
- * FS-to-TPIDR_EL0 plumbing inside the translator path, not at glibc
- * or elfuse mmap.
+ * x86-64 reads thread-local storage through the FS segment register; Rosetta
+ * has to translate those accesses into TPIDR_EL0-relative loads when it lowers
+ * x86 to aarch64. The hello/dlopen probes never touch FS-relative addressing,
+ * so this is the first elfuse probe that actually exercises that translation.
+ * Two __thread variables cover both the integer and pointer access shapes the
+ * compiler emits; a value-mismatch failure here typically points at a broken
+ * FS-to-TPIDR_EL0 plumbing inside the translator path, not at glibc or elfuse
+ * mmap.
  */
 
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 
-/* Initial-exec model: the variables live in the main executable, so
- * the compiler emits direct fs:offset loads. No libpthread needed.
+/* Initial-exec model: the variables live in the main executable, so the
+ * compiler emits direct fs:offset loads. No libpthread needed.
  */
 static __thread uint32_t tls_int = 0xdeadbeef;
 static __thread const char *tls_ptr = "tls-pointer-ok";
 
 static void emit(int fd, const char *s)
 {
-    /* warn_unused_result on glibc's write() prototype is not suppressed
-     * by (void) cast, so route the return through a sink variable that
-     * gets read once at function exit.
+    /* warn_unused_result on glibc's write() prototype is not suppressed by
+     * (void) cast, so route the return through a sink variable that gets read
+     * once at function exit.
      */
     ssize_t n = write(fd, s, strlen(s));
     if (n > 0)

--- a/tests/x86_64-stress.c
+++ b/tests/x86_64-stress.c
@@ -3,13 +3,13 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Exercises the high-VA mmap path in elfuse's sys_mmap_fixed_high_va by
- * issuing many small MAP_FIXED requests inside the same 2 MiB block. The
- * regression fixed in this branch was that gap-page invalidation after
- * each mmap could clobber neighbor mappings sharing the block. This
- * program installs N tiny mappings, fills each with a distinct sentinel,
- * then verifies every sentinel is still readable. If the freshness
- * detection regresses, sentinels read back as zero or fault.
+ * Exercises the high-VA mmap path in elfuse's sys_mmap_fixed_high_va by issuing
+ * many small MAP_FIXED requests inside the same 2 MiB block. The regression
+ * fixed in this branch was that gap-page invalidation after each mmap could
+ * clobber neighbor mappings sharing the block. This program installs N tiny
+ * mappings, fills each with a distinct sentinel, then verifies every sentinel
+ * is still readable. If the freshness detection regresses, sentinels read back
+ * as zero or fault.
  *
  * Build (on an x86_64-linux host): gcc -static -O2 -o x86_64-stress
  * x86_64-stress.c Run via elfuse: ./build/elfuse /path/to/x86_64-stress Exit
@@ -24,21 +24,21 @@
 #include <unistd.h>
 
 /* Pick a high VA inside the rosetta-mapped guest range that elfuse routes
- * through sys_mmap_fixed_high_va. 0xeffff7000000 sits in the same 2 MiB
- * block family as the addresses rosetta itself uses during bring-up.
+ * through sys_mmap_fixed_high_va. 0xeffff7000000 sits in the same 2 MiB block
+ * family as the addresses rosetta itself uses during bring-up.
  */
 #define HIGH_VA_BASE 0xeffff7000000ULL
 
-/* Number of 4 KiB pages. Sized so each lands in the same 2 MiB block as
- * the next, exercising the "pre-existing block" branch repeatedly. 64
- * pages * 4 KiB = 256 KiB, well inside one 2 MiB block.
+/* Number of 4 KiB pages. Sized so each lands in the same 2 MiB block as the
+ * next, exercising the "pre-existing block" branch repeatedly. 64 pages * 4 KiB
+ * = 256 KiB, well inside one 2 MiB block.
  */
 #define N_PAGES 64
 #define PAGE_BYTES 4096
 #define BLOCK_OFFSET PAGE_BYTES /* gap between successive mappings */
 
-/* Sentinel pattern derived from page index. Embedding the index makes
- * any cross-page corruption immediately visible.
+/* Sentinel pattern derived from page index. Embedding the index makes any
+ * cross-page corruption immediately visible.
  */
 static uint64_t sentinel_for(int i)
 {
@@ -50,10 +50,10 @@ int main(void)
     void *addrs[N_PAGES];
     int i;
 
-    /* Phase 1: install N small MAP_FIXED mappings, each in the same
-     * 2 MiB high-VA block. Each call goes through the high-VA helper;
-     * after the first, the L2 entry is already a table descriptor and
-     * the install path must avoid touching pre-existing neighbor PTEs.
+    /* Phase 1: install N small MAP_FIXED mappings, each in the same 2 MiB
+     * high-VA block. Each call goes through the high-VA helper; after the
+     * first, the L2 entry is already a table descriptor and the install path
+     * must avoid touching pre-existing neighbor PTEs.
      */
     for (i = 0; i < N_PAGES; i++) {
         uint64_t va = HIGH_VA_BASE + (uint64_t) i * BLOCK_OFFSET;
@@ -79,9 +79,8 @@ int main(void)
         *cell = sentinel_for(i);
     }
 
-    /* Phase 3: verify every sentinel survived. A freshness-detection
-     * regression typically zeros earlier mappings; the loop reports the
-     * first violator.
+    /* Phase 3: verify every sentinel survived. A freshness-detection regression
+     * typically zeros earlier mappings; the loop reports the first violator.
      */
     for (i = 0; i < N_PAGES; i++) {
         volatile uint64_t *cell = (uint64_t *) addrs[i];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reflowed comments across the codebase for consistency and fixed two runtime issues: MAP_SHARED overlays now span multiple HVF segments, and indefinite poll syscalls correctly re-block after spurious wakeups.

- Bug Fixes
  - MAP_SHARED overlays no longer fail with -EFAULT when a mapping crosses 2 MiB HVF segment boundaries. Added targeted split/collect/remap helpers to apply/remove overlays across multiple segments with safe rollback.
  - ppoll, pselect6, and epoll_pwait with infinite timeout now retry after draining the wakeup pipe, preventing spurious 0 returns and busy loops while preserving EINTR semantics.

- Refactors
  - Reflowed and clarified source comments (80-column wrap, consistent phrasing). No functional changes.

<sup>Written for commit fc2a9b080705341e54fd60d333f7db3730805bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

