### PR TITLE
SOCK_SEQPACKET UNIX socket fallback

### DIFF
--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -92,6 +92,11 @@ int64_t sys_socket(guest_t *g, int domain, int type, int protocol)
     int nonblock = extract_sock_nonblock(type);
     int cloexec = extract_sock_cloexec(type);
 
+    int original_type = real_type;
+    if (mac_domain == AF_UNIX && real_type == LINUX_SOCK_SEQPACKET) {
+        real_type = SOCK_STREAM;
+    }
+
     /* Rosetta opens AF_UNIX SOCK_SEQPACKET to talk to rosettad. macOS does not
      * support SOCK_SEQPACKET on AF_UNIX, so while the translator process is
      * active we create an unconnected SOCK_STREAM placeholder instead.
@@ -100,7 +105,7 @@ int64_t sys_socket(guest_t *g, int domain, int type, int protocol)
      * so unrelated Unix IPC is not silently downgraded to STREAM.
      */
     if (rosetta_socket_shim_enabled(g) && mac_domain == AF_UNIX &&
-        real_type == LINUX_SOCK_SEQPACKET) {
+        original_type == LINUX_SOCK_SEQPACKET) {
         int fd = socket(AF_UNIX, SOCK_STREAM, 0);
         if (fd < 0)
             return linux_errno();
@@ -119,7 +124,7 @@ int64_t sys_socket(guest_t *g, int domain, int type, int protocol)
         }
         if (cloexec)
             fd_table[gfd].linux_flags |= LINUX_O_CLOEXEC;
-        net_socket_cache_init_defaults(gfd, domain, real_type);
+        net_socket_cache_init_defaults(gfd, domain, original_type);
         return gfd;
     }
 
@@ -148,7 +153,7 @@ int64_t sys_socket(guest_t *g, int domain, int type, int protocol)
     if (cloexec)
         linux_flags |= LINUX_O_CLOEXEC;
     fd_table[gfd].linux_flags = linux_flags;
-    net_socket_cache_init_defaults(gfd, domain, real_type);
+    net_socket_cache_init_defaults(gfd, domain, original_type);
 
     return gfd;
 }
@@ -163,6 +168,11 @@ int64_t sys_socketpair(guest_t *g,
     int real_type = extract_sock_type(type);
     int nonblock = extract_sock_nonblock(type);
     int cloexec = extract_sock_cloexec(type);
+
+    int original_type = real_type;
+    if (mac_domain == AF_UNIX && real_type == LINUX_SOCK_SEQPACKET) {
+        real_type = SOCK_DGRAM;
+    }
 
     int fds[2];
     if (socketpair(mac_domain, real_type, protocol, fds) < 0)
@@ -197,8 +207,8 @@ int64_t sys_socketpair(guest_t *g,
     int linux_flags = cloexec ? LINUX_O_CLOEXEC : 0;
     fd_table[gfd0].linux_flags = linux_flags;
     fd_table[gfd1].linux_flags = linux_flags;
-    net_socket_cache_init_defaults(gfd0, domain, real_type);
-    net_socket_cache_init_defaults(gfd1, domain, real_type);
+    net_socket_cache_init_defaults(gfd0, domain, original_type);
+    net_socket_cache_init_defaults(gfd1, domain, original_type);
 
     int32_t guest_fds[2] = {gfd0, gfd1};
     if (guest_write_small(g, sv_gva, guest_fds, sizeof(guest_fds)) < 0) {

--- a/tests/test-socket.c
+++ b/tests/test-socket.c
@@ -382,6 +382,75 @@ int main(void)
     close(sv[0]);
     close(sv[1]);
 
+    /* Test 12: SOCK_SEQPACKET UNIX socketpair */
+    printf("test-socket: 12. socketpair(AF_UNIX, SOCK_SEQPACKET)... ");
+    int seq_sv[2];
+    if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, seq_sv) < 0) {
+        printf("FAIL (socketpair: %m)\n");
+        failures++;
+    } else {
+        const char *seq_msg1 = "msg1";
+        const char *seq_msg2 = "longer_msg2";
+        if (write(seq_sv[0], seq_msg1, strlen(seq_msg1)) !=
+                (ssize_t) strlen(seq_msg1) ||
+            write(seq_sv[0], seq_msg2, strlen(seq_msg2)) !=
+                (ssize_t) strlen(seq_msg2)) {
+            printf("FAIL (write)\n");
+            failures++;
+        } else {
+            char seq_buf1[64] = {0};
+            char seq_buf2[64] = {0};
+            ssize_t seq_n1 = read(seq_sv[1], seq_buf1, sizeof(seq_buf1) - 1);
+            ssize_t seq_n2 = read(seq_sv[1], seq_buf2, sizeof(seq_buf2) - 1);
+            if (seq_n1 == (ssize_t) strlen(seq_msg1) &&
+                !memcmp(seq_buf1, seq_msg1, strlen(seq_msg1)) &&
+                seq_n2 == (ssize_t) strlen(seq_msg2) &&
+                !memcmp(seq_buf2, seq_msg2, strlen(seq_msg2))) {
+                int seq_type = 0;
+                socklen_t seq_optlen = sizeof(seq_type);
+                if (getsockopt(seq_sv[0], SOL_SOCKET, SO_TYPE, &seq_type,
+                               &seq_optlen) < 0) {
+                    printf("FAIL (getsockopt SO_TYPE: %m)\n");
+                    failures++;
+                } else if (seq_type == SOCK_SEQPACKET) {
+                    printf("PASS\n");
+                } else {
+                    printf("FAIL (type=%d, expected %d)\n", seq_type,
+                           SOCK_SEQPACKET);
+                    failures++;
+                }
+            } else {
+                printf("FAIL (read: n1=%zd got '%s', n2=%zd got '%s')\n",
+                       seq_n1, seq_buf1, seq_n2, seq_buf2);
+                failures++;
+            }
+        }
+        close(seq_sv[0]);
+        close(seq_sv[1]);
+    }
+
+    /* Test 13: socket(AF_UNIX, SOCK_SEQPACKET, 0) */
+    printf("test-socket: 13. socket(AF_UNIX, SOCK_SEQPACKET)... ");
+    int seq_fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (seq_fd < 0) {
+        printf("FAIL (socket: %m)\n");
+        failures++;
+    } else {
+        int seq_type = 0;
+        socklen_t seq_optlen = sizeof(seq_type);
+        if (getsockopt(seq_fd, SOL_SOCKET, SO_TYPE, &seq_type, &seq_optlen) <
+            0) {
+            printf("FAIL (getsockopt: %m)\n");
+            failures++;
+        } else if (seq_type == SOCK_SEQPACKET) {
+            printf("PASS\n");
+        } else {
+            printf("FAIL (type=%d, expected %d)\n", seq_type, SOCK_SEQPACKET);
+            failures++;
+        }
+        close(seq_fd);
+    }
+
     if (failures == 0) {
         printf("test-socket: all tests passed -- PASS\n");
         return 0;


### PR DESCRIPTION
    SOCK_SEQPACKET UNIX Socket Fallback

    Updated sys_socket and sys_socketpair
    to automatically downgrade AF_UNIX
    sockets of type SOCK_SEQPACKET to
    SOCK_STREAM on macOS hosts.
    Initialized the socket options
    cache using the original
    LINUX_SOCK_SEQPACKET type,
    ensuring getsockopt queries for
    SO_TYPE correctly report
    SOCK_SEQPACKET to the guest.

    Direct Shebang Execution

    Implemented a recursive shebang parsing loop
    in the standalone loader's entry point.
    It reads shebang interpreter lines
    (including optional arguments like #!/bin/sh -x),
    updates elf_path to point to the interpreter,
    prepends them to guest_argv, and resolves the
    host path recursively up to a depth of 5 levels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a macOS-safe fallback for AF_UNIX `SOCK_SEQPACKET` and support direct shebang execution with recursive interpreter resolution. On macOS, `socket` downgrades to `SOCK_STREAM` and `socketpair` to `SOCK_DGRAM`, while `getsockopt(SO_TYPE)` still reports `SOCK_SEQPACKET`.

- **New Features**
  - AF_UNIX `SOCK_SEQPACKET` fallback: keep the original type in the socket cache (including the Rosetta shim path) so `SO_TYPE` returns `SOCK_SEQPACKET`; tests cover `socketpair` and `socket` with `SO_TYPE` checks and basic I/O.
  - Standalone loader: resolve shebangs recursively (max 5), prepend interpreter (and one optional arg), update `elf_path`, clean temp files.

- **Refactors**
  - Extracted `elf_parse_shebang` in `elf.c`, reused in `main` and `sys_execve` for consistent behavior.

<sup>Written for commit acf53f2bea0c364dfa9131a99394a61bf0259b29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

