### PR TITLE
Refactor process identity to support unified fakeroot mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,13 @@ $(BUILD_DIR)/test-fork-ipc-protocol-host: \
 	@echo "  LD      $@"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^
 
+## Build the identity override host test (native macOS binary)
+$(BUILD_DIR)/test-identity-override-host: \
+		$(BUILD_DIR)/test-identity-override-host.o \
+		$(BUILD_DIR)/syscall/proc-identity.o | $(BUILD_DIR)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(CFLAGS) -o $@ $^
+
 ## Build the proctitle argv-tail regression test (native macOS binary)
 # Links against the project-built proctitle.o so the exact in-tree code is
 # exercised; no HVF entitlement is needed because the test only manipulates

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -10,7 +10,7 @@
         test-matrix test-matrix-elfuse-aarch64 test-matrix-qemu-aarch64 \
         test-full test-multi-vcpu test-rwx test-sysroot-rename \
         test-case-collision test-case-collision-fallback test-getdents64-overlong \
-        test-sysroot-create-paths test-fork-ipc-protocol-host \
+        test-sysroot-create-paths test-fork-ipc-protocol-host test-identity-override-host \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-timeout-disable test-fuse-alpine \
         test-sysroot-nofollow test-sysroot-chdir perf
@@ -38,12 +38,15 @@ endef
 ## Run the unit test suite plus busybox applet validation
 check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 		$(BUILD_DIR)/test-tlbi-encoder-host \
-		$(BUILD_DIR)/test-fork-ipc-protocol-host
+		$(BUILD_DIR)/test-fork-ipc-protocol-host \
+		$(BUILD_DIR)/test-identity-override-host
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
 	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-tlbi-encoder-host
 	@printf "\n$(BLUE)━━━ fork IPC protocol identity unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-fork-ipc-protocol-host
+	@printf "\n$(BLUE)━━━ identity override unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-identity-override-host
 	@printf "\n$(BLUE)━━━ proctitle argv-tail regression ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-proctitle-host
 	@printf "\n$(BLUE)━━━ proctitle low-stack regression ━━━$(RESET)\n"

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -17,6 +17,7 @@
 
 #include "core/stack.h"
 #include "syscall/abi.h" /* GUEST_UID, GUEST_GID */
+#include "syscall/proc.h"
 
 /* Linux aarch64 HWCAP bits (from asm/hwcap.h). Only the bits the VZ-sanitized
  * ID registers actually advertise are listed here; HWCAP bits left out (e.g.,
@@ -284,10 +285,10 @@ uint64_t build_linux_stack(guest_t *g,
     AUX(AT_PHENT, elf_info->phentsize);
     AUX(AT_PHNUM, elf_info->phnum);
     AUX(AT_ENTRY, elf_info->entry + elf_load_base);
-    AUX(AT_UID, GUEST_UID);
-    AUX(AT_EUID, GUEST_UID);
-    AUX(AT_GID, GUEST_GID);
-    AUX(AT_EGID, GUEST_GID);
+    AUX(AT_UID, proc_get_uid());
+    AUX(AT_EUID, proc_get_euid());
+    AUX(AT_GID, proc_get_gid());
+    AUX(AT_EGID, proc_get_egid());
     /* Bionic's __libc_init_AT_SECURE aborts when AT_SECURE is absent. elfuse
      * never elevates privileges, so AT_SECURE is always 0.
      */

--- a/src/main.c
+++ b/src/main.c
@@ -201,6 +201,7 @@ int main(int argc, char **argv)
     const char *create_sysroot = NULL;
     int gdb_port = 0;
     bool gdb_stop_on_entry = false;
+    bool fakeroot = false;
     int arg_start = 1;
 
     /* 'elfuse rosettad translate <in> <out>' runs the real Apple rosettad
@@ -232,7 +233,7 @@ int main(int argc, char **argv)
             printf(
                 "usage: elfuse [--verbose] [--timeout N] [--sysroot PATH]\n"
                 "              [--create-sysroot PATH]\n"
-                "              [--no-rosetta]\n"
+                "              [--no-rosetta] [--fakeroot]\n"
                 "              [--gdb PORT] [--gdb-stop-on-entry]\n"
                 "              <elf-path> [args...]\n"
                 "\n"
@@ -249,6 +250,8 @@ int main(int argc, char **argv)
                 "  --no-rosetta            Disable x86_64-via-Rosetta "
                 "(architecture is auto-detected from the ELF header; "
                 "on by default)\n"
+                "  --fakeroot              Enable fakeroot mode (sets guest "
+                "UID/GID to 0 and provides full caps)\n"
                 "  --gdb PORT              Listen for GDB Remote Serial "
                 "Protocol on PORT\n"
                 "  --gdb-stop-on-entry     Halt before the first guest "
@@ -301,6 +304,9 @@ int main(int argc, char **argv)
         } else if (!strcmp(argv[arg_start], "--no-rosetta")) {
             rosetta_enabled = false;
             arg_start++;
+        } else if (!strcmp(argv[arg_start], "--fakeroot")) {
+            fakeroot = true;
+            arg_start++;
         } else if (!strcmp(argv[arg_start], "--gdb") && arg_start + 1 < argc) {
             if (parse_int_arg(argv[arg_start + 1], 1, 65535, &gdb_port) < 0) {
                 log_error("invalid GDB port: %s", argv[arg_start + 1]);
@@ -320,7 +326,7 @@ int main(int argc, char **argv)
             log_error(
                 "usage: elfuse [--verbose] [--timeout N] "
                 "[--sysroot PATH] [--create-sysroot PATH] [--no-rosetta] "
-                "[--gdb PORT] "
+                "[--fakeroot] [--gdb PORT] "
                 "[--gdb-stop-on-entry] <elf-path> [args...]");
             return 1;
         }
@@ -345,6 +351,13 @@ int main(int argc, char **argv)
     }
     proc_set_rosetta_enabled(rosetta_enabled);
 
+    if (!fakeroot) {
+        const char *fakeroot_env = getenv("ELFUSE_FAKEROOT");
+        if (fakeroot_env && strcmp(fakeroot_env, "1") == 0)
+            fakeroot = true;
+    }
+    proc_set_fakeroot_enabled(fakeroot);
+
     /* Fork-child mode: receive VM state over IPC and run */
     if (fork_child_fd >= 0)
         return fork_child_main(fork_child_fd, vfork_notify_fd, verbose,
@@ -354,7 +367,7 @@ int main(int argc, char **argv)
         log_error(
             "usage: elfuse [--verbose] [--timeout N] "
             "[--sysroot PATH] [--create-sysroot PATH] [--no-rosetta] "
-            "<elf-path> [args...]");
+            "[--fakeroot] <elf-path> [args...]");
         return 1;
     }
 

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -1321,7 +1321,7 @@ int64_t sys_clone(hv_vcpu_t vcpu,
 
     /* argv is intentionally minimal; guest argv is restored later from IPC. */
     char notify_fd_str[32];
-    char *child_argv[8];
+    char *child_argv[16];
     int ci = 0;
     child_argv[ci++] = self_path;
     if (verbose)
@@ -1333,6 +1333,8 @@ int64_t sys_clone(hv_vcpu_t vcpu,
      */
     if (!proc_rosetta_enabled())
         child_argv[ci++] = "--no-rosetta";
+    if (proc_fakeroot_enabled())
+        child_argv[ci++] = "--fakeroot";
     child_argv[ci++] = "--fork-child";
     child_argv[ci++] = fd_str;
     if (is_vfork) {

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -2547,17 +2547,18 @@ int proc_intercept_open(const guest_t *g,
             "Tgid:\t%lld\n"
             "Pid:\t%lld\n"
             "PPid:\t%lld\n"
-            "Uid:\t%d\t%d\t%d\t%d\n"
-            "Gid:\t%d\t%d\t%d\t%d\n"
+            "Uid:\t%u\t%u\t%u\t%u\n"
+            "Gid:\t%u\t%u\t%u\t%u\n"
             "VmPeak:\t%llu kB\n"
             "VmSize:\t%llu kB\n"
             "VmRSS:\t%llu kB\n"
             "Threads:\t%d\n",
             name, (long long) proc_get_pid(), (long long) proc_get_pid(),
-            (long long) proc_get_ppid(), GUEST_UID, GUEST_UID, GUEST_UID,
-            GUEST_UID, GUEST_GID, GUEST_GID, GUEST_GID, GUEST_GID,
-            (unsigned long long) vm_size_kb, (unsigned long long) vm_size_kb,
-            (unsigned long long) vm_rss_kb, threads);
+            (long long) proc_get_ppid(), proc_get_uid(), proc_get_euid(),
+            proc_get_suid(), proc_get_euid(), proc_get_gid(), proc_get_egid(),
+            proc_get_sgid(), proc_get_egid(), (unsigned long long) vm_size_kb,
+            (unsigned long long) vm_size_kb, (unsigned long long) vm_rss_kb,
+            threads);
     }
 
     /* /proc/self/limits -> resource limits from prlimit64 cache */
@@ -2656,12 +2657,13 @@ int proc_intercept_open(const guest_t *g,
                 "Tgid:\t%lld\n"
                 "Pid:\t%ld\n"
                 "PPid:\t%lld\n"
-                "Uid:\t%d\t%d\t%d\t%d\n"
-                "Gid:\t%d\t%d\t%d\t%d\n"
+                "Uid:\t%u\t%u\t%u\t%u\n"
+                "Gid:\t%u\t%u\t%u\t%u\n"
                 "Threads:\t%d\n",
                 proc_comm_name(), (long long) proc_get_pid(), tid,
-                (long long) proc_get_ppid(), GUEST_UID, GUEST_UID, GUEST_UID,
-                GUEST_UID, GUEST_GID, GUEST_GID, GUEST_GID, GUEST_GID,
+                (long long) proc_get_ppid(), proc_get_uid(), proc_get_euid(),
+                proc_get_suid(), proc_get_euid(), proc_get_gid(),
+                proc_get_egid(), proc_get_sgid(), proc_get_egid(),
                 thread_active_count());
         }
 

--- a/src/syscall/proc-identity.c
+++ b/src/syscall/proc-identity.c
@@ -6,6 +6,8 @@
 
 #include <stdatomic.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
 #include <pthread.h>
 
 #include "syscall/abi.h"
@@ -24,16 +26,37 @@ static _Atomic int64_t guest_sid = 1, guest_pgid = 1;
 static _Atomic int64_t guest_fg_pgrp = 1;
 static _Atomic int32_t guest_has_ctty = 1;
 
+static _Atomic bool fakeroot_enabled = false;
+
+void proc_set_fakeroot_enabled(bool enabled)
+{
+    atomic_store(&fakeroot_enabled, enabled);
+}
+
+bool proc_fakeroot_enabled(void)
+{
+    return atomic_load(&fakeroot_enabled);
+}
+
 void proc_identity_init(void)
 {
     guest_pid = 1;
     parent_pid = 0;
-    emu_uid = GUEST_UID;
-    emu_euid = GUEST_UID;
-    emu_suid = GUEST_UID;
-    emu_gid = GUEST_GID;
-    emu_egid = GUEST_GID;
-    emu_sgid = GUEST_GID;
+
+    uint32_t uid = GUEST_UID;
+    uint32_t gid = GUEST_GID;
+
+    if (proc_fakeroot_enabled()) {
+        uid = 0;
+        gid = 0;
+    }
+
+    emu_uid = uid;
+    emu_euid = uid;
+    emu_suid = uid;
+    emu_gid = gid;
+    emu_egid = gid;
+    emu_sgid = gid;
     emu_nice = 0;
     guest_sid = 1;
     guest_pgid = 1;

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -98,6 +98,10 @@ bool proc_rosetta_enabled(void);
 void proc_set_rosetta_active(bool active);
 bool proc_rosetta_active(void);
 
+/* Process-wide feature gate for fakeroot mode. */
+void proc_set_fakeroot_enabled(bool enabled);
+bool proc_fakeroot_enabled(void);
+
 /* Store the guest command line for /proc/self/cmdline emulation. argv is a
  * NULL-terminated array of strings.
  */

--- a/src/syscall/sys.c
+++ b/src/syscall/sys.c
@@ -487,6 +487,15 @@ int64_t sys_sched_rr_get_interval(guest_t *g, int pid, uint64_t ts_gva)
 
 int64_t sys_getgroups(guest_t *g, int size, uint64_t list_gva)
 {
+    if (proc_fakeroot_enabled() && proc_get_euid() == 0) {
+        if (size == 0)
+            return 1;
+        uint32_t zero_group = 0;
+        if (guest_write_small(g, list_gva, &zero_group, sizeof(zero_group)) < 0)
+            return -LINUX_EFAULT;
+        return 1;
+    }
+
     int ngroups = get_cached_linux_groups();
     if (ngroups < 0)
         return linux_errno();

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -1316,6 +1316,15 @@ static int64_t sc_capget(guest_t *g,
     }
     if (x1) {
         uint32_t data[6] = {0};
+        if (proc_fakeroot_enabled() && proc_get_euid() == 0) {
+            uint32_t high_mask = (1U << (LINUX_CAP_LAST_CAP - 32 + 1)) - 1;
+            data[0] = 0xffffffff; /* effective low */
+            data[1] = high_mask;  /* effective high */
+            data[2] = 0xffffffff; /* permitted low */
+            data[3] = high_mask;  /* permitted high */
+            data[4] = 0xffffffff; /* inheritable low */
+            data[5] = high_mask;  /* inheritable high */
+        }
         if (guest_write_small(g, x1, data, sizeof(data)) < 0)
             return -LINUX_EFAULT;
     }

--- a/tests/test-credentials.c
+++ b/tests/test-credentials.c
@@ -35,15 +35,18 @@ int main(void)
 
     printf("test-credentials: UID/GID, capabilities, priority, affinity\n");
 
-    /* Baseline: UID/GID should be 1000 */
-    TEST("getuid == 1000");
-    EXPECT_TRUE(raw_syscall0(__NR_getuid) == 1000, "unexpected uid");
+    long uid = raw_syscall0(__NR_getuid);
+    long expected_id = (uid == 0) ? 0 : 1000;
 
-    TEST("geteuid == 1000");
-    EXPECT_TRUE(raw_syscall0(__NR_geteuid) == 1000, "unexpected euid");
+    /* Baseline: UID/GID should match expected_id */
+    TEST("getuid matches expected");
+    EXPECT_TRUE(raw_syscall0(__NR_getuid) == expected_id, "unexpected uid");
 
-    TEST("getgid == 1000");
-    EXPECT_TRUE(raw_syscall0(__NR_getgid) == 1000, "unexpected gid");
+    TEST("geteuid matches expected");
+    EXPECT_TRUE(raw_syscall0(__NR_geteuid) == expected_id, "unexpected euid");
+
+    TEST("getgid matches expected");
+    EXPECT_TRUE(raw_syscall0(__NR_getgid) == expected_id, "unexpected gid");
 
     /* getresuid returns coherent triple */
     TEST("getresuid coherent");
@@ -51,25 +54,26 @@ int main(void)
         unsigned int ruid = 0, euid = 0, suid = 0;
         long rc = raw_syscall3(__NR_getresuid, (long) &ruid, (long) &euid,
                                (long) &suid);
-        EXPECT_TRUE(rc == 0 && ruid == 1000 && euid == 1000 && suid == 1000,
+        EXPECT_TRUE(rc == 0 && ruid == expected_id && euid == expected_id &&
+                        suid == expected_id,
                     "getresuid mismatch");
     }
 
-    /* setuid: can set euid to current ruid (1000), no-op but must succeed */
-    TEST("setuid(1000) succeeds");
-    EXPECT_TRUE(raw_syscall1(__NR_setuid, 1000) == 0, "setuid(1000) failed");
+    /* setuid: can set euid to current ruid, no-op but must succeed */
+    TEST("setuid(expected) succeeds");
+    EXPECT_TRUE(raw_syscall1(__NR_setuid, expected_id) == 0, "setuid failed");
 
     /* setuid: setting to arbitrary value must fail with -EPERM */
-    TEST("setuid(0) returns -EPERM");
+    TEST("setuid(other) returns -EPERM");
     {
-        long rc = raw_syscall1(__NR_setuid, 0);
+        long rc = raw_syscall1(__NR_setuid, expected_id == 0 ? 1000 : 0);
         if (rc == -1) /* -EPERM */
             PASS();
         else
             FAIL("expected -EPERM");
     }
 
-    /* setresuid: swap euid to 1000 (already 1000, but tests the path) */
+    /* setresuid: swap euid (no-op but must succeed) */
     TEST("setresuid(-1,-1,-1) no-op");
     {
         long rc = raw_syscall3(__NR_setresuid, (long) (unsigned) -1,
@@ -78,10 +82,11 @@ int main(void)
     }
 
     /* setresuid: set euid to a value not in {ruid, euid, suid} */
-    TEST("setresuid(-1,42,-1) returns -EPERM");
+    TEST("setresuid(-1,other,-1) returns -EPERM");
     {
-        long rc = raw_syscall3(__NR_setresuid, (long) (unsigned) -1, 42,
-                               (long) (unsigned) -1);
+        long rc =
+            raw_syscall3(__NR_setresuid, (long) (unsigned) -1,
+                         expected_id == 0 ? 1000 : 42, (long) (unsigned) -1);
         if (rc == -1) /* -EPERM */
             PASS();
         else
@@ -89,15 +94,17 @@ int main(void)
     }
 
     /* setreuid: ruid can only be set to current ruid or euid */
-    TEST("setreuid(1000,-1) succeeds");
+    TEST("setreuid(expected,-1) succeeds");
     {
-        long rc = raw_syscall2(__NR_setreuid, 1000, (long) (unsigned) -1);
+        long rc =
+            raw_syscall2(__NR_setreuid, expected_id, (long) (unsigned) -1);
         EXPECT_TRUE(rc == 0, "setreuid(ruid,-1) failed");
     }
 
-    TEST("setreuid(42,-1) returns -EPERM");
+    TEST("setreuid(other,-1) returns -EPERM");
     {
-        long rc = raw_syscall2(__NR_setreuid, 42, (long) (unsigned) -1);
+        long rc = raw_syscall2(__NR_setreuid, expected_id == 0 ? 1000 : 42,
+                               (long) (unsigned) -1);
         if (rc == -1) /* -EPERM */
             PASS();
         else
@@ -110,49 +117,53 @@ int main(void)
         unsigned int rgid = 0, egid = 0, sgid = 0;
         long rc = raw_syscall3(__NR_getresgid, (long) &rgid, (long) &egid,
                                (long) &sgid);
-        EXPECT_TRUE(rc == 0 && rgid == 1000 && egid == 1000 && sgid == 1000,
+        EXPECT_TRUE(rc == 0 && rgid == expected_id && egid == expected_id &&
+                        sgid == expected_id,
                     "getresgid mismatch");
     }
 
     /* setgid: same constraints as setuid */
-    TEST("setgid(1000) succeeds");
-    EXPECT_TRUE(raw_syscall1(__NR_setgid, 1000) == 0, "setgid(1000) failed");
+    TEST("setgid(expected) succeeds");
+    EXPECT_TRUE(raw_syscall1(__NR_setgid, expected_id) == 0, "setgid failed");
 
-    TEST("setgid(0) returns -EPERM");
-    EXPECT_TRUE(raw_syscall1(__NR_setgid, 0) == -1, "expected -EPERM");
+    TEST("setgid(other) returns -EPERM");
+    EXPECT_TRUE(raw_syscall1(__NR_setgid, expected_id == 0 ? 1000 : 0) == -1,
+                "expected -EPERM");
 
     /* setfsuid / setfsgid: Linux contract is to return the previous fsuid /
-     * fsgid. elfuse reports the current euid / egid (1000) on every call, with
-     * no state mutation, which is what procps relies on when it brackets /proc
-     * reads with setfsuid(uid) / setfsuid(0).
+     * fsgid.
      */
-    TEST("setfsuid(0) returns 1000");
-    EXPECT_TRUE(raw_syscall1(__NR_setfsuid, 0) == 1000,
-                "setfsuid(0) did not return current euid");
+    TEST("setfsuid(other) returns expected_id");
+    EXPECT_TRUE(
+        raw_syscall1(__NR_setfsuid, expected_id == 0 ? 1000 : 0) == expected_id,
+        "setfsuid did not return current euid");
 
-    TEST("setfsuid(1000) returns 1000");
-    EXPECT_TRUE(raw_syscall1(__NR_setfsuid, 1000) == 1000,
-                "setfsuid(1000) did not return current euid");
+    TEST("setfsuid(expected_id) returns expected_id");
+    EXPECT_TRUE(raw_syscall1(__NR_setfsuid, expected_id) == expected_id,
+                "setfsuid did not return current euid");
 
-    TEST("setfsgid(0) returns 1000");
-    EXPECT_TRUE(raw_syscall1(__NR_setfsgid, 0) == 1000,
-                "setfsgid(0) did not return current egid");
+    TEST("setfsgid(other) returns expected_id");
+    EXPECT_TRUE(
+        raw_syscall1(__NR_setfsgid, expected_id == 0 ? 1000 : 0) == expected_id,
+        "setfsgid did not return current egid");
 
-    TEST("setfsgid(1000) returns 1000");
-    EXPECT_TRUE(raw_syscall1(__NR_setfsgid, 1000) == 1000,
-                "setfsgid(1000) did not return current egid");
+    TEST("setfsgid(expected_id) returns expected_id");
+    EXPECT_TRUE(raw_syscall1(__NR_setfsgid, expected_id) == expected_id,
+                "setfsgid did not return current egid");
 
     /* setfsuid(-1) / setfsgid(-1) is the canonical glibc "read fsuid without
      * changing it" idiom: -1 is never a valid uid, so the kernel only reports
      * the current fsuid.
      */
     TEST("setfsuid(-1) reports current fsuid");
-    EXPECT_TRUE(raw_syscall1(__NR_setfsuid, (long) (unsigned) -1) == 1000,
-                "setfsuid(-1) did not report current euid");
+    EXPECT_TRUE(
+        raw_syscall1(__NR_setfsuid, (long) (unsigned) -1) == expected_id,
+        "setfsuid(-1) did not report current euid");
 
     TEST("setfsgid(-1) reports current fsgid");
-    EXPECT_TRUE(raw_syscall1(__NR_setfsgid, (long) (unsigned) -1) == 1000,
-                "setfsgid(-1) did not report current egid");
+    EXPECT_TRUE(
+        raw_syscall1(__NR_setfsgid, (long) (unsigned) -1) == expected_id,
+        "setfsgid(-1) did not report current egid");
 
     /* capset: unprivileged process cannot set capabilities */
     TEST("capset returns -EPERM");
@@ -165,6 +176,19 @@ int main(void)
             PASS();
         else
             FAIL("expected -EPERM");
+    }
+
+    /* getgroups supplementary groups check */
+    TEST("getgroups returns expected groups");
+    {
+        gid_t list[64];
+        int ngroups = getgroups(64, list);
+        if (expected_id == 0) {
+            EXPECT_TRUE(ngroups == 1 && list[0] == 0,
+                        "fakeroot getgroups mismatch");
+        } else {
+            EXPECT_TRUE(ngroups >= 0, "getgroups failed");
+        }
     }
 
     /* setpriority/getpriority coherence */

--- a/tests/test-identity-override-host.c
+++ b/tests/test-identity-override-host.c
@@ -1,0 +1,82 @@
+/* Host-side unit test for ELFUSE_FAKEROOT environment overrides.
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "syscall/proc.h"
+#include "syscall/proc-identity.h"
+#include "syscall/abi.h"
+
+/* Mock shim_globals_publish_pgsid to avoid linking the entire guest shim
+ * subsystem */
+void shim_globals_publish_pgsid(guest_t *g, int64_t pgid, int64_t sid);
+void shim_globals_publish_pgsid(guest_t *g, int64_t pgid, int64_t sid)
+{
+    (void) g;
+    (void) pgid;
+    (void) sid;
+}
+
+int main(void)
+{
+    /* Test 1: Fallback case (fakeroot disabled) */
+    unsetenv("ELFUSE_FAKEROOT");
+    proc_set_fakeroot_enabled(false);
+    proc_identity_init();
+
+    assert(proc_get_uid() == GUEST_UID);
+    assert(proc_get_euid() == GUEST_UID);
+    assert(proc_get_suid() == GUEST_UID);
+    assert(proc_get_gid() == GUEST_GID);
+    assert(proc_get_egid() == GUEST_GID);
+    assert(proc_get_sgid() == GUEST_GID);
+    assert(proc_fakeroot_enabled() == false);
+
+    /* Test 2: Enable via API */
+    proc_set_fakeroot_enabled(true);
+    proc_identity_init();
+
+    assert(proc_get_uid() == 0);
+    assert(proc_get_euid() == 0);
+    assert(proc_get_suid() == 0);
+    assert(proc_get_gid() == 0);
+    assert(proc_get_egid() == 0);
+    assert(proc_get_sgid() == 0);
+    assert(proc_fakeroot_enabled() == true);
+
+    /* Test 3: Enable via Env Var (ELFUSE_FAKEROOT=1) */
+    proc_set_fakeroot_enabled(false);
+    setenv("ELFUSE_FAKEROOT", "1", 1);
+
+    bool fakeroot = false;
+    const char *fakeroot_env = getenv("ELFUSE_FAKEROOT");
+    if (fakeroot_env && strcmp(fakeroot_env, "1") == 0)
+        fakeroot = true;
+    proc_set_fakeroot_enabled(fakeroot);
+    proc_identity_init();
+
+    assert(proc_get_uid() == 0);
+    assert(proc_get_gid() == 0);
+    assert(proc_fakeroot_enabled() == true);
+
+    /* Test 4: Env Var other than 1 should not enable fakeroot */
+    setenv("ELFUSE_FAKEROOT", "0", 1);
+    fakeroot = false;
+    fakeroot_env = getenv("ELFUSE_FAKEROOT");
+    if (fakeroot_env && strcmp(fakeroot_env, "1") == 0)
+        fakeroot = true;
+    proc_set_fakeroot_enabled(fakeroot);
+    proc_identity_init();
+    assert(proc_get_uid() == GUEST_UID);
+    assert(proc_get_gid() == GUEST_GID);
+    assert(proc_fakeroot_enabled() == false);
+
+    printf("test-identity-override-host: PASS\n");
+    return 0;
+}

--- a/tests/test-syscall-smoke.c
+++ b/tests/test-syscall-smoke.c
@@ -495,7 +495,17 @@ static void test_process_query_stubs(void)
     long tid = syscall(SYS_set_tid_address, &clear_tid);
     long caps = syscall(SYS_capget, &hdr, data);
     long pers = syscall(SYS_personality, 0xffffffffu);
-    if (tid > 0 && caps == 0 && pers >= 0)
+    bool caps_ok = false;
+    if (caps == 0) {
+        if (getuid() == 0) {
+            /* Under fakeroot, effective and permitted should be non-zero (full
+             * caps) */
+            caps_ok = (data[0].effective != 0);
+        } else {
+            caps_ok = (data[0].effective == 0);
+        }
+    }
+    if (tid > 0 && caps_ok && pers >= 0)
         PASS();
     else
         FAIL("process query stubs");


### PR DESCRIPTION
Refactor process identity to support unified fakeroot mode

Replace the raw numeric UID/GID overrides (ELFUSE_GUEST_UID and
ELFUSE_GUEST_GID) with a unified --fakeroot CLI switch and
ELFUSE_FAKEROOT=1 environment variable.

This change aligns the process identity surface with the existing
fakeroot-style chown-overlay. When fakeroot mode is enabled:
- The emulated process UID, EUID, SUID, GID, EGID, and SGID are set
  to 0 (root).
- sc_capget() returns full capability sets, with the high capability
  word masked to LINUX_CAP_LAST_CAP to prevent impossible capabilities.
- sys_getgroups() returns a single supplementary group (GID 0).

Fakeroot mode defaults to false (disabled). In this default state, the
guest process runs with an unprivileged emulated identity (UID/GID 1000).

Limitations of fakeroot mode:
- It only emulates root status on the guest-identity surface (getuid,
  geteuid, capget, getgroups, etc.) and virtual file attributes inside
  the guest (chown-overlay).
- It does NOT grant real host-level root privileges, nor does it bypass
  macOS sandboxing, file system permissions, or other host-level security
  constraints.

Also increase child_argv size in forkipc.c to 16 to prevent overflow
when propagating optional flags, and update host and guest tests to
adapt to the fakeroot behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a unified fakeroot mode that emulates root identity and capabilities, replacing numeric UID/GID overrides. This lets package managers and other root-checking tools run without host sudo.

- **New Features**
  - `--fakeroot` flag and `ELFUSE_FAKEROOT=1` env enable root emulation (default off).
  - When enabled: all UIDs/GIDs are 0; `capget` reports full sets (masked to `LINUX_CAP_LAST_CAP`); `getgroups` returns `[0]`.
  - Fork/clone children inherit `--fakeroot`.

- **Refactors**
  - Removed `ELFUSE_GUEST_UID`/`ELFUSE_GUEST_GID`; AUX vector and `/proc/*/status` now read from `proc_get_*`.
  - Increased fork child argv capacity to 16 to safely propagate optional flags.
  - Tests updated; added `test-identity-override-host` and hooked into `make check`.

<sup>Written for commit 4a5626ee8136a5518509be8f8d1185502832d0c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



