### PR TITLE
Add bounded retry on stale-TLB data abort

### DIFF
--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1,4 +1,5 @@
-/* Process state and management
+/*
+ * Process state and management
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -941,11 +942,10 @@ void proc_request_hvc6_yield(void)
 }
 
 /* Global vCPU handle for the SIGALRM handler (unavoidable global state --
- * signal handlers cannot receive context parameters).
- */
-/* Written once by vcpu_run_loop before signal(SIGALRM), then only read by
- * alarm_handler / guest_signal_transport_handler. The write happens-before the
- * signal() call that installs the handlers, so no volatile needed.
+ * signal handlers cannot receive context parameters). Written once by
+ * vcpu_run_loop before signal(SIGALRM), then only read by alarm_handler /
+ * guest_signal_transport_handler. The write happens-before the signal() call
+ * that installs the handlers, so no volatile needed.
  */
 static hv_vcpu_t g_timeout_vcpu;
 static volatile sig_atomic_t g_timed_out, g_external_guest_signal;
@@ -1657,6 +1657,115 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                         }
                     }
 
+                    /* Bounded retry on a stale-TLB data / instruction abort.
+                     * Re-walk the live page tables for the faulting VA before
+                     * declaring SIGSEGV. guest_ptr_avail consults pt_gen, which
+                     * the mutating vCPU bumps under mmap_lock, so the walk
+                     * reflects the current mapping regardless of this vCPU's
+                     * cached (possibly stale) hardware TLB. A non-NULL result
+                     * means the live PT is valid and grants the faulting access
+                     * -- the signature of a stale TLB entry that a cross-vCPU
+                     * mprotect + TLBI failed to evict on this PE.
+                     *
+                     * On that signature, re-issue a selective TLBI for the
+                     * faulting page from this vCPU (same accumulator + emit
+                     * path the lazy-materialization branch uses) and return to
+                     * EL0 to retry the instruction. A genuinely stale entry
+                     * clears on the first retry, so the guest makes progress
+                     * and never re-enters here for that VA.
+                     *
+                     * The retry is bounded per vCPU and per (page, faulting
+                     * PC). If the same instruction keeps faulting on the same
+                     * page despite the re-issued TLBI, the entry is not
+                     * actually stale (a walker / hardware permission-model
+                     * disagreement, or an HVF TLBI that did not take): after
+                     * STALE_TLB_RETRY_MAX attempts, stop retrying and deliver
+                     * SIGSEGV so a genuine fault is never silently swallowed.
+                     * The per-vCPU slot resets when a different page or PC
+                     * faults or when the cap is hit, so a cap-out cannot poison
+                     * a later legitimate retry.
+                     */
+                    enum { STALE_TLB_RETRY_MAX = 16 };
+                    /* Only translation (fsc_type 0x01) and permission (0x03)
+                     * faults are stale-TLB plausible. Alignment,
+                     * external-abort, and access-flag classes cannot be cleared
+                     * by re-issuing TLBI, so do not spend the retry budget on
+                     * them. A translation fault reaches here only after the
+                     * lazy- materialization branch above already declined the
+                     * address, so a live PT that still grants access is a stale
+                     * negative (translation-fault) entry; a permission fault is
+                     * the classic stale entry left by a cross-vCPU mprotect.
+                     */
+                    bool stale_plausible =
+                        (fsc_type == 0x01 || fsc_type == 0x03);
+                    int want_perm =
+                        (fault_ec == 0x20)
+                            ? MEM_PERM_X
+                            : ((esr & (1u << 6)) ? MEM_PERM_W : MEM_PERM_R);
+                    uint64_t live_avail = 0;
+                    void *live_pt = NULL;
+                    if (stale_plausible) {
+                        pthread_mutex_lock(&mmap_lock);
+                        live_pt = guest_ptr_avail(g, far_addr, &live_avail,
+                                                  want_perm);
+                        pthread_mutex_unlock(&mmap_lock);
+                    }
+                    if (live_pt) {
+                        /* Bound per vCPU and per (page, faulting PC). A
+                         * genuinely stuck entry re-faults on the same
+                         * instruction at the same page, so keying the counter
+                         * on both distinguishes a non-recovering loop (cap it)
+                         * from separate successful recoveries -- a different
+                         * PC, or the same page reached from a different
+                         * instruction -- that must each get a fresh budget.
+                         */
+                        static _Thread_local uint64_t stale_page;
+                        static _Thread_local uint64_t stale_elr;
+                        static _Thread_local int stale_count;
+                        uint64_t page = far_addr & ~(GUEST_PAGE_SIZE - 1);
+                        if (page == stale_page && elr_addr == stale_elr) {
+                            stale_count++;
+                        } else {
+                            stale_page = page;
+                            stale_elr = elr_addr;
+                            stale_count = 1;
+                        }
+                        if (stale_count <= STALE_TLB_RETRY_MAX) {
+                            static _Thread_local bool stale_warned;
+                            if (!stale_warned) {
+                                stale_warned = true;
+                                log_warn(
+                                    "%s: EL0 %s fault at 0x%llx (ESR=0x%llx) "
+                                    "but "
+                                    "live PT grants access -- stale TLB; "
+                                    "re-issuing TLBI and retrying (cap %d)",
+                                    prefix,
+                                    (fault_ec == 0x20) ? "inst" : "data",
+                                    (unsigned long long) far_addr,
+                                    (unsigned long long) esr,
+                                    STALE_TLB_RETRY_MAX);
+                            }
+                            tlbi_request_clear();
+                            tlbi_request_range(page, page + GUEST_PAGE_SIZE);
+                            if (want_perm & MEM_PERM_X)
+                                tlbi_request_mark_icache();
+                            tlbi_request_emit_to_vcpu(vcpu);
+                            break;
+                        }
+                        /* Retry budget exhausted: the entry is not actually
+                         * stale. Reset the slot and fall through to SIGSEGV.
+                         */
+                        log_warn(
+                            "%s: stale-TLB retry cap (%d) hit at 0x%llx "
+                            "(ESR=0x%llx); delivering SIGSEGV",
+                            prefix, STALE_TLB_RETRY_MAX,
+                            (unsigned long long) far_addr,
+                            (unsigned long long) esr);
+                        stale_page = 0;
+                        stale_elr = 0;
+                        stale_count = 0;
+                    }
+
                     /* Real SIGSEGV. Permission faults (xFSC[5:2] == 0x3) map to
                      * SEGV_ACCERR; address size, translation, and access-flag
                      * faults map to SEGV_MAPERR for Linux.
@@ -1940,13 +2049,13 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                    (vexit->reason == HV_EXIT_REASON_UNKNOWN &&
                     (signal_pending() || proc_exit_group_requested() ||
                      (is_main && g_timed_out)))) {
-            /* Canceled by hv_vcpus_exit(). Can be: alarm timeout,
-             * exit_group from another thread, or signal preemption
-             * (signal_queue called hv_vcpus_exit to deliver a signal
-             * while the guest was in a tight loop).
+            /* Canceled by hv_vcpus_exit(). Can be: alarm timeout, exit_group
+             * from another thread, or signal preemption (signal_queue called
+             * hv_vcpus_exit to deliver a signal while the guest was in a tight
+             * loop).
              *
-             * HV_EXIT_REASON_UNKNOWN is the same event seen from the other
-             * side of a race: when a host signal (e.g. the SIGUSR2 used by the
+             * HV_EXIT_REASON_UNKNOWN is the same event seen from the other side
+             * of a race: when a host signal (e.g. the SIGUSR2 used by the
              * cross-process guest-signal transport) is delivered to this thread
              * while it is actively executing guest code inside hv_vcpu_run, the
              * run aborts with UNKNOWN instead of the clean CANCELED that

--- a/tests/fetch-fixtures.sh
+++ b/tests/fetch-fixtures.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# fetch-fixtures.sh -- Download Alpine packages and assemble a qemu/elfuse
-# test fixture tree under externals/test-fixtures/.
+# fetch-fixtures.sh -- Download Alpine packages and assemble a qemu/elfuse test
+# fixture tree under externals/test-fixtures/.
 #
-# Idempotent: re-runs are no-ops once everything is in place.  Re-execute
-# with FORCE=1 to rebuild from scratch.
+# Idempotent: re-runs are no-ops once everything is in place. Re-execute with
+# FORCE=1 to rebuild from scratch.
 #
 # Layout:
 #   externals/test-fixtures/
@@ -36,9 +36,9 @@ set -euo pipefail
 . "$(dirname "$0")/lib/bash-compat.sh"
 
 ALPINE_VERSION="${ALPINE_VERSION:-3.21}"
-# Empty by default -- the exact point release is resolved from the live
-# releases listing at fetch time (see resolve_minirootfs), then written back
-# here so the x86_64 path reuses the same patch. Set explicitly to pin one.
+# Empty by default -- the exact point release is resolved from the live releases
+# listing at fetch time (see resolve_minirootfs), then written back here so the
+# x86_64 path reuses the same patch. Set explicitly to pin one.
 ALPINE_PATCH="${ALPINE_PATCH:-}"
 ALPINE_ARCH="${ALPINE_ARCH:-aarch64}"
 
@@ -57,10 +57,10 @@ STATICBIN="${FIXTURES}/aarch64-musl/staticbin/bin"
 INITRAMFS="${FIXTURES}/initramfs.cpio.gz"
 
 # Required packages as "repo:name". Versions are NOT pinned here: Alpine's
-# mirror keeps only the latest build of each package, so any hard-coded
-# version 404s once a newer build supersedes it. resolve_versions() reads
-# each repo's live APKINDEX and fills PKG_RESOLVED with "repo:name:version"
-# tuples; the rest of the script and pkg_version go through that.
+# mirror keeps only the latest build of each package, so any hard-coded version
+# 404s once a newer build supersedes it. resolve_versions() reads each repo's
+# live APKINDEX and fills PKG_RESOLVED with "repo:name:version" tuples; the rest
+# of the script and pkg_version go through that.
 #
 # Tuples (not associative arrays) keep this working on bash 3.2 hosts (stock
 # macOS /bin/bash) -- see tests/lib/bash-compat.sh.
@@ -104,17 +104,18 @@ PKGS=(
     "main:tree"
 )
 
-# "repo:name:version" tuples, populated by resolve_versions() from live
-# APKINDEX data. Same shape the staging loops and pkg_version expect.
+# "repo:name:version" tuples, populated by resolve_versions() from live APKINDEX
+# data. Same shape the staging loops and pkg_version expect.
 PKG_RESOLVED=()
 
 # Set to 1 by main() when the resolved version set differs from versions.lock,
-# forcing a rebuild of the staged tree even without FORCE. Global so the
-# x86_64 path can honor it too.
+# forcing a rebuild of the staged tree even without FORCE. Global so the x86_64
+# path can honor it too.
 REBUILD=0
 
-# Look up a resolved package version by its "repo:name" prefix. Returns the
-# version on stdout and rc=0 on hit, rc=1 (silently) on miss so the
+# Look up a resolved package version by its "repo:name" prefix.
+#
+# Returns the version on stdout and rc=0 on hit, rc=1 (silently) on miss so the
 # old ${PKGS[key]:-} fallback callers keep working.
 pkg_version()
 {
@@ -133,9 +134,9 @@ pkg_version()
 
 # Subset whose binaries are exposed as standalone "static-bins" suite paths.
 # Most are dynamic but link only against musl/zlib/etc., already in rootfs/.
-# Applet list (hardcoded -- busybox 1.37 inventory).  Busybox does not have
-# b2sum / numfmt / base32; those tests fall through to the dynamic-coreutils
-# suite where the real coreutils binary is available.
+# Applet list (hardcoded -- busybox 1.37 inventory). Busybox does not have b2sum
+# / numfmt / base32; those tests fall through to the dynamic-coreutils suite
+# where the real coreutils binary is available.
 STATIC_APPLETS=(
     echo cat head tail wc sort tr seq expr factor base64 md5sum sha256sum
     cp touch ls stat basename dirname realpath df du
@@ -240,8 +241,8 @@ resolve_versions()
         log "resolve versions ($repo)"
         # Always try to refresh the index -- tracking the live mirror is the
         # point -- but fall back to a cached copy so warm re-runs work offline.
-        # APKINDEX records are blank-line separated; P: is the package name,
-        # V: its version. Flatten to "name version" lines.
+        # APKINDEX records are blank-line separated; P: is the package name, V:
+        # its version. Flatten to "name version" lines.
         if curl -fsSL --retry 3 -o "${idxtgz}.partial" "${base}/APKINDEX.tar.gz"; then
             mv "${idxtgz}.partial" "$idxtgz"
             tar xzOf "$idxtgz" APKINDEX 2> /dev/null | awk '
@@ -280,9 +281,9 @@ resolve_versions()
 }
 
 # Resolve the minirootfs point release. Alpine keeps only a handful of recent
-# releases under releases/, so honor an explicit ALPINE_PATCH but otherwise
-# pick the newest the mirror advertises and write it back to ALPINE_PATCH so
-# the x86_64 path reuses the same patch. Sets MINIROOTFS_TGZ.
+# releases under releases/, so honor an explicit ALPINE_PATCH but otherwise pick
+# the newest the mirror advertises and write it back to ALPINE_PATCH so the
+# x86_64 path reuses the same patch. Sets MINIROOTFS_TGZ.
 resolve_minirootfs()
 {
     if [ -z "$ALPINE_PATCH" ]; then
@@ -309,7 +310,7 @@ resolve_minirootfs()
 }
 
 # Strip Alpine apk metadata (.PKGINFO, .SIGN.*, .pre-install, etc.) when
-# extracting into a target tree.  These are not real files and pollute the
+# extracting into a target tree. These are not real files and pollute the
 # rootfs.
 extract_apk_to()
 {
@@ -337,12 +338,15 @@ main()
     resolve_minirootfs
 
     # If the resolved version set changed since the last run, the staged
-    # rootfs/kernel/initramfs are built from stale apks and must be rebuilt
-    # even without an explicit FORCE.
+    # rootfs/kernel/initramfs are built from stale apks and must be rebuilt even
+    # without an explicit FORCE.
     local entry manifest lockfile
-    manifest="$( { for entry in "${PKG_RESOLVED[@]}"; do
-        printf '%s\n' "$entry"
-    done | LC_ALL=C sort; printf 'minirootfs=%s\n' "$MINIROOTFS_TGZ"; } )"
+    manifest="$({
+        for entry in "${PKG_RESOLVED[@]}"; do
+            printf '%s\n' "$entry"
+        done | LC_ALL=C sort
+        printf 'minirootfs=%s\n' "$MINIROOTFS_TGZ"
+    })"
     lockfile="${FIXTURES}/versions.lock"
     if [ ! -f "$lockfile" ] || [ "$manifest" != "$(cat "$lockfile")" ]; then
         REBUILD=1
@@ -486,18 +490,17 @@ EOF
     fi
     ok "initramfs: $(du -h "$INITRAMFS" | cut -f1)"
 
-    # Stage the dynamic-bin aggregate directory.
-    # Single flat directory of *relative* symlinks pointing into the rootfs.
-    # Relative paths matter: this same tree is consumed by elfuse on macOS
-    # AND by qemu's guest kernel after a 9p mount, where any absolute host
-    # path would no longer resolve.
+    # Stage the dynamic-bin aggregate directory. Single flat directory of
+    # *relative* symlinks pointing into the rootfs. Relative paths matter: this
+    # same tree is consumed by elfuse on macOS AND by qemu's guest kernel after
+    # a 9p mount, where any absolute host path would no longer resolve.
     local dynbin="${FIXTURES}/aarch64-musl/dyn-bin"
     if [ ! -d "$dynbin" ] || [ "${FORCE:-0}" = "1" ] || [ "$REBUILD" = 1 ]; then
         log "stage dyn-bin aggregate"
         rm -rf "$dynbin"
         mkdir -p "$dynbin"
         # ${dynbin} is at <fixtures>/aarch64-musl/dyn-bin; rootfs is at
-        # <fixtures>/rootfs.  The relative path back is "../../rootfs/...".
+        # <fixtures>/rootfs. The relative path back is "../../rootfs/...".
         for sub in bin usr/bin; do
             [ -d "${ROOTFS}/${sub}" ] || continue
             for src in "${ROOTFS}/${sub}"/*; do
@@ -551,10 +554,10 @@ EOF
 }
 
 # Fetch just enough Alpine x86_64 packages to drive the elfuse-x86_64 test
-# matrix mode through rosetta. Userspace only: no kernel or initramfs is
-# built because elfuse runs x86_64 binaries directly. Pinned to the same
-# Alpine release as the aarch64 corpus so busybox / coreutils versions match
-# and the per-mode expected-count table stays consistent.
+# matrix mode through rosetta. Userspace only: no kernel or initramfs is built
+# because elfuse runs x86_64 binaries directly. Pinned to the same Alpine
+# release as the aarch64 corpus so busybox / coreutils versions match and the
+# per-mode expected-count table stays consistent.
 fetch_x86_64_userspace()
 {
     local x86_cache="${FIXTURES}/cache/x86_64"

--- a/tests/test-credentials.c
+++ b/tests/test-credentials.c
@@ -1,4 +1,5 @@
-/* Test emulated UID/GID, capabilities, priority, and affinity
+/*
+ * Test emulated UID/GID, capabilities, priority, and affinity
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -7,6 +8,9 @@
  *        getresuid, getresgid, capset, setpriority, getpriority,
  *        sched_setaffinity
  */
+
+#include <sys/types.h> /* gid_t */
+#include <unistd.h>    /* getgroups */
 
 #include "test-harness.h"
 #include "raw-syscall.h"


### PR DESCRIPTION
The EL0 data/instruction abort handler in vcpu_run_loop re-walks the live page tables via guest_ptr_avail before declaring SIGSEGV. The walker keys on pt_gen, bumped by the mutating vCPU under mmap_lock, so it reflects the current mapping regardless of this vCPU's cached hardware TLB. When the live mapping grants the faulting access, the fault came from a stale TLB entry a cross-vCPU mprotect plus TLBI failed to evict on this PE.

On that signature the handler re-issues a selective TLBI for the faulting page (the per-vCPU cpu_tlbi_req accumulator plus tlbi_request_emit_to_vcpu path the lazy-materialization branch uses) and returns to EL0 to retry the instruction. Only translation and permission fault classes are eligible; alignment, external-abort, and access-flag classes fall straight through. The retry is bounded per vCPU and per (page, faulting PC) to 16 attempts, then delivers SIGSEGV so a genuine fault is never swallowed.

Defensive hardening against an HVF or broadcast-TLBI coherence gap; no reproducer. Verified the retry never fires on genuine faults: an unmapped write and a write to a read-only page both deliver SIGSEGV with zero retries.

The getgroups check used gid_t and getgroups without including sys/types.h and unistd.h, so the test failed to compile and aborted make check before the suite finished.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded retry for suspected stale-TLB EL0 data/instruction aborts in `vcpu_run_loop`, issuing a targeted TLBI and retry before delivering SIGSEGV. Also fixes a missing test include so the suite compiles cleanly.

- **New Features**
  - Re-walks live page tables; if access is allowed, treats the fault as a stale TLB, issues a selective TLBI for the page, and retries at EL0.
  - Applies only to translation and permission faults; others bypass retry.
  - Caps retries to 16 per vCPU per (page, faulting PC); on cap hit, resets state and signals SIGSEGV.

- **Bug Fixes**
  - Include `<sys/types.h>` and `<unistd.h>` in `tests/test-credentials.c` for `gid_t`/`getgroups`, fixing a build failure.

<sup>Written for commit 77e7925811c0062453f90f7819aa2f3ed63ecc16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

