### PR TITLE
Defer sidecar walks to the sysroot host fallback

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -10,6 +10,7 @@
         test-matrix test-matrix-elfuse-aarch64 test-matrix-qemu-aarch64 \
         test-full test-multi-vcpu test-rwx test-sysroot-rename \
         test-case-collision test-case-collision-fallback test-getdents64-overlong \
+        test-sysroot-host-fallback \
         test-sysroot-create-paths test-fork-ipc-protocol-host test-identity-override-host \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-timeout-disable test-fuse-alpine \
@@ -57,6 +58,8 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 	@$(MAKE) --no-print-directory test-sysroot-procfs-exec
 	@printf "\n$(BLUE)━━━ getdents64 overlong-UTF-8 dirent skip ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-getdents64-overlong
+	@printf "\n$(BLUE)━━━ sysroot host-fallback validation ━━━$(RESET)\n"
+	@$(MAKE) --no-print-directory test-sysroot-host-fallback
 	@printf "\n$(BLUE)━━━ Alpine sysroot FUSE validation ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-fuse-alpine
 	@printf "\n$(BLUE)━━━ timeout=0 validation ━━━$(RESET)\n"
@@ -125,6 +128,29 @@ test-case-collision-fallback: $(ELFUSE_BIN) $(BUILD_DIR)/test-case-collision
 	@tmpdir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmpdir"' EXIT; \
 	$(ELFUSE_BIN) --sysroot "$$tmpdir" $(BUILD_DIR)/test-case-collision
+
+## Host paths outside the sysroot must stay reachable when the sysroot is
+## case-insensitive (sidecar active): the sidecar walk defers to the
+## resolver's host-literal fallback instead of vetoing it with ENOENT.
+## Regression test for the test-matrix "musl dyn" coreutils failures.
+test-sysroot-host-fallback: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-host-fallback
+	@set -e; \
+	tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	sysroot="$$tmpdir/sysroot"; \
+	hostdir="$$tmpdir/host-data"; \
+	mkdir -p "$$sysroot" "$$hostdir"; \
+	first=$${tmpdir#/}; first=$${first%%/*}; \
+	mkdir -p "$$sysroot/$$first"; \
+	printf 'host-visible\n' > "$$hostdir/hello.txt"; \
+	mirror="$$tmpdir/mirrored"; \
+	mkdir -p "$$mirror" "$$sysroot$$mirror"; \
+	printf 'host-final\n' > "$$mirror/final.txt"; \
+	printf 'host-loses\n' > "$$mirror/both.txt"; \
+	printf 'sysroot-wins\n' > "$$sysroot$$mirror/both.txt"; \
+	$(ELFUSE_BIN) --sysroot "$$sysroot" \
+	    $(BUILD_DIR)/test-sysroot-host-fallback \
+	    "$$hostdir" "$$mirror/final.txt" "$$mirror/both.txt"
 
 # Build APFS-side dirents whose UTF-8 byte length exceeds Linux
 # NAME_MAX (255). 89 copies of U+3042 (3-byte UTF-8) plus a 1-byte

--- a/src/syscall/sidecar.c
+++ b/src/syscall/sidecar.c
@@ -610,6 +610,18 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
     if (sidecar_open_base(dirfd, path, out, outsz, &cur_fd, &absolute) < 0)
         return -1;
 
+    /* Sidecar only speaks for entries that live inside the sysroot tree (or
+     * are reachable through an index mapping). The sysroot resolver
+     * (proc_resolve_sysroot_path_flags) falls back to the literal host path
+     * when the guest path does not exist under the sysroot; a walk that
+     * unconditionally re-anchored such paths at the sysroot would veto that
+     * fallback and break host-resource access (mktemp dirs, /etc/resolv.conf).
+     * Track whether any component actually consulted an index mapping: with a
+     * mapped prefix the sysroot view is authoritative and missing suffixes
+     * must surface as ENOENT against the translated path; without one, a walk
+     * that leaves the tree simply is not sidecar's business (return 0).
+     */
+    bool used_mapping = false;
     size_t out_len = strlen(out);
     const char *comp;
     size_t comp_len;
@@ -638,7 +650,12 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
                 int next_fd = openat(cur_fd, guest_comp,
                                      O_RDONLY | O_DIRECTORY | O_CLOEXEC);
                 if (next_fd < 0) {
+                    int saved_errno = errno;
                     close(cur_fd);
+                    if (!used_mapping &&
+                        (saved_errno == ENOENT || saved_errno == ENOTDIR))
+                        return 0;
+                    errno = saved_errno;
                     return -1;
                 }
                 close(cur_fd);
@@ -654,10 +671,12 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
         }
         const char *mapped = sidecar_lookup_guest(&index, guest_comp);
         char host_comp[NAME_MAX + 1];
-        if (mapped)
+        if (mapped) {
+            used_mapping = true;
             str_copy_trunc(host_comp, mapped, sizeof(host_comp));
-        else
+        } else {
             str_copy_trunc(host_comp, guest_comp, sizeof(host_comp));
+        }
 
         if (sidecar_append_component(out, outsz, &out_len, host_comp,
                                      absolute) < 0) {
@@ -670,14 +689,54 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
         const char *peek = scan;
         while (*peek == '/')
             peek++;
-        if (*peek == '\0')
+        if (*peek == '\0') {
+            /* Final component: an unmapped walk is the identity translation
+             * ${sysroot}${path}; claim it only if the entry actually exists
+             * there so the resolver's host-literal fallback stands otherwise.
+             */
+            if (!used_mapping) {
+                struct stat st;
+                if (fstatat(cur_fd, host_comp, &st, AT_SYMLINK_NOFOLLOW) < 0) {
+                    int saved_errno = errno;
+                    close(cur_fd);
+                    if (saved_errno == ENOENT || saved_errno == ENOTDIR)
+                        return 0;
+                    errno = saved_errno;
+                    return -1;
+                }
+            }
             break;
+        }
 
         int next_fd =
             openat(cur_fd, host_comp, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
         if (next_fd < 0) {
+            int saved_errno = errno;
             close(cur_fd);
-            return -1;
+            if (saved_errno != ENOENT && saved_errno != ENOTDIR) {
+                errno = saved_errno;
+                return -1;
+            }
+            if (!used_mapping)
+                return 0;
+            /* The walk left the sysroot beneath an index-mapped prefix. No
+             * index can exist under a missing directory, so the remaining
+             * components translate to themselves; the caller's syscall then
+             * reports ENOENT against the translated path.
+             */
+            while (sidecar_next_component(&scan, &comp, &comp_len)) {
+                char rest_comp[NAME_MAX + 1];
+                if (comp_len >= sizeof(rest_comp)) {
+                    errno = ENAMETOOLONG;
+                    return -1;
+                }
+                memcpy(rest_comp, comp, comp_len);
+                rest_comp[comp_len] = '\0';
+                if (sidecar_append_component(out, outsz, &out_len, rest_comp,
+                                             absolute) < 0)
+                    return -1;
+            }
+            return 1;
         }
         close(cur_fd);
         cur_fd = next_fd;
@@ -1155,6 +1214,12 @@ static int sidecar_generate_token(char token[SIDECAR_TOKEN_NAME_LEN + 1])
     return 0;
 }
 
+/* Open the parent directory sidecar would maintain an index in for `path`.
+ * Returns 0 with parent->dirfd open on success, -1 on error, and 1 when the
+ * parent resolves outside the sysroot: such paths follow the resolver's
+ * host-literal fallback (proc_resolve_sysroot_path_flags) and carry no index,
+ * so the mutation entry points hand them back as SIDECAR_NOT_HANDLED.
+ */
 static int sidecar_walk_parent_at(guest_fd_t dirfd,
                                   const char *path,
                                   sidecar_parent_t *parent)
@@ -1239,17 +1304,11 @@ static int sidecar_walk_parent_at(guest_fd_t dirfd,
             host_fd_ref_close(&ref);
         }
     } else if (path[0] == '/') {
-        char sysroot[LINUX_PATH_MAX];
-        if (!proc_sysroot_snapshot(sysroot, sizeof(sysroot))) {
-            errno = ENOENT;
-            return -1;
-        }
-        if (snprintf(host_parent, sizeof(host_parent), "%s/%s", sysroot,
-                     work) >= (int) sizeof(host_parent)) {
-            errno = ENAMETOOLONG;
-            return -1;
-        }
-        parent->dirfd = open(host_parent, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        /* The parent does not resolve inside the sysroot (or lives on a
+         * procemu-backed prefix): the operation belongs to the regular
+         * translation flow, not the sidecar index.
+         */
+        return 1;
     } else if (dirfd == LINUX_AT_FDCWD) {
         parent->dirfd = open(work, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
     } else {
@@ -1303,8 +1362,11 @@ int sidecar_openat(guest_fd_t dirfd,
         return (int) SIDECAR_NOT_HANDLED;
 
     sidecar_parent_t parent;
-    if (sidecar_walk_parent_at(dirfd, path, &parent) < 0)
+    int walk_rc = sidecar_walk_parent_at(dirfd, path, &parent);
+    if (walk_rc < 0)
         return -1;
+    if (walk_rc > 0)
+        return (int) SIDECAR_NOT_HANDLED;
     if (sidecar_name_reserved(parent.basename)) {
         sidecar_parent_close(&parent);
         errno = ENOENT;
@@ -1399,8 +1461,11 @@ int64_t sidecar_mkdirat(guest_fd_t dirfd, const char *path, mode_t mode)
         return SIDECAR_NOT_HANDLED;
 
     sidecar_parent_t parent;
-    if (sidecar_walk_parent_at(dirfd, path, &parent) < 0)
+    int walk_rc = sidecar_walk_parent_at(dirfd, path, &parent);
+    if (walk_rc < 0)
         return linux_errno();
+    if (walk_rc > 0)
+        return SIDECAR_NOT_HANDLED;
 
     int lock_fd = -1;
     if (sidecar_lock_index(parent.dirfd, &lock_fd) < 0) {
@@ -1476,8 +1541,11 @@ int64_t sidecar_unlinkat(guest_fd_t dirfd, const char *path, int flags)
         return SIDECAR_NOT_HANDLED;
 
     sidecar_parent_t parent;
-    if (sidecar_walk_parent_at(dirfd, path, &parent) < 0)
+    int walk_rc = sidecar_walk_parent_at(dirfd, path, &parent);
+    if (walk_rc < 0)
         return linux_errno();
+    if (walk_rc > 0)
+        return SIDECAR_NOT_HANDLED;
 
     int lock_fd = -1;
     if (sidecar_lock_index(parent.dirfd, &lock_fd) < 0) {
@@ -1564,13 +1632,17 @@ int64_t sidecar_unlinkat(guest_fd_t dirfd, const char *path, int flags)
     return rc;
 }
 
+/* Same contract as sidecar_walk_parent_at: 0 resolved, -1 error, 1 when the
+ * path lives outside the sysroot and the caller should not handle it.
+ */
 static int sidecar_resolve_existing_at(guest_fd_t dirfd,
                                        const char *path,
                                        sidecar_parent_t *parent,
                                        char host_name[NAME_MAX + 1])
 {
-    if (sidecar_walk_parent_at(dirfd, path, parent) < 0)
-        return -1;
+    int walk_rc = sidecar_walk_parent_at(dirfd, path, parent);
+    if (walk_rc != 0)
+        return walk_rc;
 
     sidecar_index_t index;
     if (sidecar_load_index(parent->dirfd, &index) < 0) {
@@ -1611,15 +1683,18 @@ int64_t sidecar_linkat(guest_fd_t olddirfd,
 
     sidecar_parent_t old_parent;
     char old_host[NAME_MAX + 1];
-    if (sidecar_resolve_existing_at(olddirfd, oldpath, &old_parent, old_host) <
-        0) {
+    int old_rc =
+        sidecar_resolve_existing_at(olddirfd, oldpath, &old_parent, old_host);
+    if (old_rc < 0)
         return linux_errno();
-    }
+    if (old_rc > 0)
+        return SIDECAR_NOT_HANDLED;
 
     sidecar_parent_t new_parent;
-    if (sidecar_walk_parent_at(newdirfd, newpath, &new_parent) < 0) {
+    int new_rc = sidecar_walk_parent_at(newdirfd, newpath, &new_parent);
+    if (new_rc != 0) {
         sidecar_parent_close(&old_parent);
-        return linux_errno();
+        return new_rc < 0 ? linux_errno() : SIDECAR_NOT_HANDLED;
     }
 
     int lock_fd = -1;
@@ -1810,13 +1885,17 @@ int64_t sidecar_renameat(guest_fd_t olddirfd,
     }
 
     sidecar_parent_t old_parent;
-    if (sidecar_walk_parent_at(olddirfd, oldpath, &old_parent) < 0)
+    int old_walk_rc = sidecar_walk_parent_at(olddirfd, oldpath, &old_parent);
+    if (old_walk_rc < 0)
         return linux_errno();
+    if (old_walk_rc > 0)
+        return SIDECAR_NOT_HANDLED;
 
     sidecar_parent_t new_parent;
-    if (sidecar_walk_parent_at(newdirfd, newpath, &new_parent) < 0) {
+    int new_walk_rc = sidecar_walk_parent_at(newdirfd, newpath, &new_parent);
+    if (new_walk_rc != 0) {
         sidecar_parent_close(&old_parent);
-        return linux_errno();
+        return new_walk_rc < 0 ? linux_errno() : SIDECAR_NOT_HANDLED;
     }
 
     if (!strcmp(old_parent.basename, new_parent.basename)) {

--- a/tests/test-sysroot-host-fallback.c
+++ b/tests/test-sysroot-host-fallback.c
@@ -1,0 +1,137 @@
+/* Host-literal fallback regression tests for case-insensitive sysroots
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * proc_resolve_sysroot_path_flags resolves absolute guest paths inside the
+ * sysroot when they exist there and otherwise falls back to the literal host
+ * path so guests can reach host resources (mktemp dirs, /etc/resolv.conf).
+ * On a case-insensitive sysroot the sidecar walk used to veto that fallback:
+ * it anchored every absolute path at the sysroot root and returned ENOENT as
+ * soon as a component was missing there, which broke every coreutils
+ * invocation against a host mktemp directory (test-matrix "musl dyn" suite).
+ *
+ * The harness (mk/tests.mk) runs this binary under --sysroot with a
+ * case-insensitive sysroot so the sidecar is active, and passes:
+ *   argv[1]  host directory whose intermediate components do not exist in
+ *            the sysroot; contains hello.txt ("host-visible\n")
+ *   argv[2]  host file whose parent chain is fully mirrored inside the
+ *            sysroot but whose final component exists only on the host
+ *            ("host-final\n")
+ *   argv[3]  file that exists both on the host ("host-loses\n") and in the
+ *            sysroot mirror ("sysroot-wins\n"); the sysroot copy must win
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+#include "test-util.h"
+
+int passes = 0, fails = 0;
+
+static int path_join(char *out, size_t outsz, const char *dir, const char *leaf)
+{
+    int n = snprintf(out, outsz, "%s/%s", dir, leaf);
+    return (n < 0 || (size_t) n >= outsz) ? -1 : 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 4) {
+        fprintf(stderr,
+                "usage: %s <host-dir> <host-final-file> <both-sides-file>\n",
+                argv[0]);
+        return 1;
+    }
+    const char *host_dir = argv[1];
+    const char *host_final = argv[2];
+    const char *both_sides = argv[3];
+    char path[4096];
+    char moved[4096];
+    char buf[64];
+
+    printf("test-sysroot-host-fallback: host paths outside the sysroot\n");
+
+    TEST("read through missing intermediates");
+    if (path_join(path, sizeof(path), host_dir, "hello.txt") < 0)
+        FAIL("path too long");
+    else if (read_file_nul(path, buf, sizeof(buf)) <= 0)
+        FAIL("open/read fell into the sysroot");
+    else if (strcmp(buf, "host-visible\n"))
+        FAIL("read wrong contents");
+    else
+        PASS();
+
+    TEST("stat host file");
+    {
+        struct stat st;
+        if (stat(path, &st) < 0 || !S_ISREG(st.st_mode))
+            FAIL("stat failed");
+        else
+            PASS();
+    }
+
+    TEST("create/write/read-back/unlink");
+    if (path_join(path, sizeof(path), host_dir, "created.txt") < 0) {
+        FAIL("path too long");
+    } else {
+        int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+        if (fd < 0 || write_fd_all(fd, "guest-wrote\n", 12) < 0)
+            FAIL("create/write failed");
+        else if (close(fd), read_file_nul(path, buf, sizeof(buf)) <= 0 ||
+                                strcmp(buf, "guest-wrote\n"))
+            FAIL("read-back mismatch");
+        else if (unlink(path) < 0)
+            FAIL("unlink failed");
+        else
+            PASS();
+    }
+
+    TEST("mkdir/rmdir host subdir");
+    if (path_join(path, sizeof(path), host_dir, "subdir") < 0)
+        FAIL("path too long");
+    else if (mkdir(path, 0755) < 0)
+        FAIL("mkdir failed");
+    else if (rmdir(path) < 0)
+        FAIL("rmdir failed");
+    else
+        PASS();
+
+    TEST("rename within host dir");
+    if (path_join(path, sizeof(path), host_dir, "hello.txt") < 0 ||
+        path_join(moved, sizeof(moved), host_dir, "moved.txt") < 0)
+        FAIL("path too long");
+    else if (rename(path, moved) < 0)
+        FAIL("rename failed");
+    else if (read_file_nul(moved, buf, sizeof(buf)) <= 0 ||
+             strcmp(buf, "host-visible\n"))
+        FAIL("moved file unreadable");
+    else if (rename(moved, path) < 0)
+        FAIL("rename back failed");
+    else
+        PASS();
+
+    TEST("missing final component falls back");
+    if (read_file_nul(host_final, buf, sizeof(buf)) <= 0)
+        FAIL("open/read fell into the sysroot");
+    else if (strcmp(buf, "host-final\n"))
+        FAIL("read wrong contents");
+    else
+        PASS();
+
+    TEST("sysroot copy still wins over host");
+    if (read_file_nul(both_sides, buf, sizeof(buf)) <= 0)
+        FAIL("read failed");
+    else if (strcmp(buf, "sysroot-wins\n"))
+        FAIL("host copy shadowed the sysroot");
+    else
+        PASS();
+
+    SUMMARY("test-sysroot-host-fallback");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Problem

On a case-insensitive sysroot (macOS default APFS, where the sidecar
case-folding layer is active), absolute guest paths that live outside the
sysroot became unreachable. `proc_resolve_sysroot_path_flags` documents the
contract: resolve inside the sysroot when the path exists there, otherwise
fall back to the literal host path so guests can still reach host resources
such as mktemp directories or `/etc/resolv.conf`. The sidecar walk vetoed
that fallback in two ways:

- `sidecar_translate_lookup_at` anchored every absolute path at the sysroot
  root and returned ENOENT as soon as an intermediate component was missing
  there; when only the final component was missing it still rewrote the path
  to `${sysroot}${path}`. Either way the resolver's host-literal decision was
  overridden.
- Mutating syscalls (`openat` with `O_CREAT`, `mkdirat`, `unlinkat`,
  `linkat`, `renameat`) hit the same wall through `sidecar_walk_parent_at`,
  which hard-anchored the parent directory at the sysroot.

### Symptom

All 27 failures in the test-matrix **"musl dyn"** coreutils suite on the
self-hosted runtime job (PR #91) and on any local run where the fixtures
live on a case-insensitive volume:

```
cat   [ FAIL ] (exit 1)   ... cat: /var/folders/.../hello.txt: No such file or directory
touch [ FAIL ] (got 1)    ... cannot touch '/var/folders/.../touched-1'
env   [ FAIL ] (got 127)  ... execve could not reach the host binary
```

Dynamic binaries run under `--sysroot`; macOS `mktemp -d` lives in
`/var/folders/...` and the sysroot only contains `/var`, so the walk
descended into `${sysroot}/var`, failed at `folders`, and turned the
documented fallback into ENOENT. Static coreutils run without `--sysroot`
and passed, which is why only the dynamic suite failed.

## Fix

Track whether the walk consulted an index mapping:

- A walk that leaves the sysroot tree **without** touching a mapping returns
  "no translation" (0), so the resolver's fallback decision stands.
- Beneath a **mapped** prefix the sysroot view stays authoritative: missing
  suffixes append literally and surface as ENOENT against the translated
  path (no index can exist under a missing directory).
- An unmapped final component is claimed only if it actually exists in the
  sysroot, restoring the fallback for paths like `/etc/resolv.conf` whose
  parent exists in the sysroot but whose leaf does not.

`sidecar_walk_parent_at` now reports a parent that resolves outside the
sysroot as a distinct verdict, and all mutation entry points hand such paths
back as `SIDECAR_NOT_HANDLED` to the regular translation flow.

## Validation

- `tests/test-matrix.sh elfuse-aarch64`: **168 passed, 0 failed** (was
  141/27); the remaining 4 skips are missing optional fixtures
  (base32/b2sum/numfmt applets, glibc dyn suite), unrelated to this bug.
- New regression test `test-sysroot-host-fallback` (wired into
  `make check`): 7 cases covering reads through missing intermediates,
  create/write/unlink, mkdir/rmdir, rename on host paths, the
  missing-final-component fallback, and sysroot-over-host precedence.
  Without the fix six of the seven cases fail with ENOENT.
- `make check`: all green (104 driver tests + host unit tests, 0 failed).
- `test-case-collision` and `test-case-collision-fallback` (12/12 both):
  the sidecar's collision compensation is unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers sidecar path walks to the resolver’s host-literal fallback on case-insensitive sysroots so absolute guest paths outside the sysroot remain reachable. Restores access to host resources (e.g., mktemp dirs, `/etc/resolv.conf`) and fixes the “musl dyn” coreutils failures.

- **Bug Fixes**
  - Lookup returns “no translation” if a walk leaves the sysroot without an index mapping; mapped prefixes stay authoritative and missing dirs surface ENOENT; unmapped final components are only claimed if they exist.
  - `sidecar_walk_parent_at` reports parents outside the sysroot; mutation syscalls (`openat`, `mkdirat`, `unlinkat`, `linkat`, `renameat`) return `SIDECAR_NOT_HANDLED` for the regular resolver.
  - Adds `test-sysroot-host-fallback` and wires it into `make check`; matrix now 168 passed, 0 failed (was 141/27).

<sup>Written for commit 1304c68a9d36317307bf172dced3b0725739cf85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

