### PR TITLE
Enable address-wait fast path for FUTEX_WAIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,13 @@ $(BUILD_DIR)/test-pthread: tests/test-pthread.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
 
+# test-osync-requeue drives a raw FUTEX_REQUEUE against a plain-FUTEX_WAIT
+# waiter (musl unlock_requeue pattern) to guard the os_sync wake-at-source
+# degradation; needs -lpthread.
+$(BUILD_DIR)/test-osync-requeue: tests/test-osync-requeue.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
+
 # test-scm-creds blocks accept in a pthread while the listener option changes.
 $(BUILD_DIR)/test-scm-creds: tests/test-scm-creds.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"

--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -40,10 +40,12 @@
 
 /* macOS 14.4+ ships os_sync_{wait_on_address_with_timeout,wake_by_address_any}
  * with futex-style compare-and-wait semantics on process-private addresses.
- * elfuse still keeps plain FUTEX_WAIT on the bucket path because Darwin reports
- * the Linux -EAGAIN pre-block race as a successful wait, and that semantic gap
- * is observable to user space. FUTEX_WAIT_BITSET, PI variants, and futex_waitv
- * also stay on the bucket path: they need state the kernel API does not expose.
+ * elfuse routes plain FUTEX_WAIT / FUTEX_WAKE through this path. Darwin folds
+ * the Linux -EAGAIN pre-block race into a successful wait; futex_os_sync_wait
+ * closes that common gap with a compare-after-block re-check (word moved off
+ * the expected value on a rc>=0 return maps to -EAGAIN). FUTEX_WAIT_BITSET, PI
+ * variants, and futex_waitv stay on the bucket path: they need state the
+ * kernel API does not expose.
  *
  * SDK gate: probe the header via __has_include so older SDKs build clean.
  * Runtime gate: __builtin_available cached in futex_init().
@@ -96,10 +98,10 @@ static _Atomic int futex_interrupt_requested = 0;
 /* Address-wait helper state.
  *
  * os_sync_available is set in futex_init() when the runtime supports the
- * os_sync_wait_on_address family (macOS 14.4+). Plain FUTEX_WAIT remains on the
- * bucket path until Darwin can preserve Linux's -EAGAIN race semantics, so
- * os_sync_wait_enabled stays false for now and the wake-side helper stays
- * dormant too.
+ * os_sync_wait_on_address family (macOS 14.4+). os_sync_wait_enabled gates
+ * whether plain FUTEX_WAIT / FUTEX_WAKE use the address-wait path; it is set
+ * alongside os_sync_available now that futex_os_sync_wait's compare-after-block
+ * re-check preserves Linux's -EAGAIN race semantics.
  *
  * The wait quantum is capped at 100 ms so proc_exit_group_requested() and
  * futex_interrupt_pending() get noticed promptly without a process-wide
@@ -200,8 +202,29 @@ void futex_init(void)
         buckets[i].head = NULL;
     }
 #if ELFUSE_HAVE_OS_SYNC_WAIT_ON_ADDRESS
-    if (__builtin_available(macOS 14.4, *))
+    if (__builtin_available(macOS 14.4, *)) {
         os_sync_available = true;
+        /* Plain FUTEX_WAIT / FUTEX_WAKE take the Darwin address-wait path.
+         * Enable the gate only where the API is actually available so the two
+         * flags cannot disagree. The late-EAGAIN gap is bridged by the
+         * compare-after-block re-check in futex_os_sync_wait (a rc>=0 return
+         * with the word moved off expected maps to -EAGAIN, matching Linux for
+         * the pre-block race; the post-wake case is equally safe since a
+         * correct caller re-reads the word either way). FUTEX_REQUEUE of such a
+         * waiter cannot migrate a kernel os_sync waiter between addresses, so
+         * futex_requeue degrades the requeue portion into a wake at the source
+         * address; woken callers re-acquire what they need in userspace. glibc
+         * condvars are safe because broadcast/signal wake with FUTEX_WAKE, not
+         * requeue (2.25+ dropped the requeue optimization); musl's
+         * private-condvar barrier->mutex handoff tolerates wake-in-place,
+         * matching its own emscripten fallback. Only plain FUTEX_WAIT enqueues
+         * on the os_sync queue; FUTEX_WAIT_BITSET, PI waits, and futex_waitv
+         * stay on the bucket path. Every wake site drains both queues via
+         * futex_wake_topup_osync, so os_sync waiters are reached regardless of
+         * which wake op (FUTEX_WAKE, requeue, wake_op) fires.
+         */
+        os_sync_wait_enabled = true;
+    }
 #endif
 }
 
@@ -430,8 +453,27 @@ static int64_t futex_os_sync_wait(guest_t *g,
         int rc = os_sync_wait_on_address_with_timeout(
             host_addr, (uint64_t) expected, 4, OS_SYNC_WAIT_ON_ADDRESS_NONE,
             OS_CLOCK_MACH_ABSOLUTE_TIME, timeout_ns);
-        if (rc >= 0)
-            return 0;
+        if (rc >= 0) {
+            /* Compare-after-block re-check. Darwin folds two distinct Linux
+             * outcomes into a single rc>=0: a genuine wake, and the racy
+             * "value moved off expected between the pre-check and the
+             * in-kernel compare" case that Linux reports as -EAGAIN. Reload
+             * the word: value still == expected means a real (or spurious)
+             * wake -> return 0; value != expected means it moved, which is
+             * -EAGAIN under Linux for the pre-block race and is equally safe
+             * for the post-wake case, since a correct futex caller must
+             * re-read the word and re-test its condition on either return.
+             * This is not a perfect oracle: a value that moves off expected
+             * and back before the reload returns 0 where Linux returns
+             * -EAGAIN, a benign spurious wake the futex contract permits. No
+             * wake is lost: the kernel's atomic compare-and-block already
+             * guarantees a waiter enqueued at expected cannot miss an
+             * os_sync_wake_by_address, and any value change carries the state
+             * the caller re-reads.
+             */
+            uint32_t observed = __atomic_load_n(host_addr, __ATOMIC_SEQ_CST);
+            return observed == expected ? 0 : -LINUX_EAGAIN;
+        }
 
         int err = errno;
         if (err != ETIMEDOUT && err != EINTR && err != EFAULT && err != ENOMEM)
@@ -485,6 +527,32 @@ static uint32_t futex_os_sync_wake_n(const guest_t *g,
 }
 
 #endif /* ELFUSE_HAVE_OS_SYNC_WAIT_ON_ADDRESS */
+
+/* Top up a wake after the bucket walk. A plain FUTEX_WAIT enqueues on the
+ * kernel os_sync queue, not the hash bucket, so any site that wakes by walking
+ * the bucket must also drain the os_sync queue at the same address or it
+ * strands those waiters. woken is how many of target the bucket walk already
+ * satisfied at uaddr; this drains the shortfall and returns the new total.
+ * futex_os_sync_wake_n is a no-op when the address-wait path is disabled
+ * or when no kernel waiter sits at uaddr, so this is safe to call
+ * unconditionally. Call it AFTER dropping the bucket lock: os_sync_wake is a
+ * syscall and must not run under the leaf lock.
+ *
+ * Every bucket-walking wake site (futex_wake, futex_requeue, futex_wake_op)
+ * routes through here so the "drain both queues" invariant is one named step,
+ * not a rule each new caller has to remember. The int64_t return absorbs
+ * futex_os_sync_wake_n's uint32_t count without sign-extension.
+ */
+static int64_t futex_wake_topup_osync(const guest_t *g,
+                                      uint64_t uaddr,
+                                      int64_t woken,
+                                      uint64_t target)
+{
+    if ((uint64_t) woken >= target)
+        return woken;
+    uint64_t budget = target - (uint64_t) woken;
+    return woken + (int64_t) futex_os_sync_wake_n(g, uaddr, budget);
+}
 
 /* FUTEX_WAIT / FUTEX_WAIT_BITSET: atomically check word == val, then sleep. */
 static int64_t futex_wait(guest_t *g,
@@ -680,12 +748,7 @@ static int64_t futex_wake(const guest_t *g,
 
     pthread_mutex_unlock(&b->lock);
 
-    if ((uint32_t) woken < val) {
-        uint64_t budget = (uint64_t) val - (uint64_t) woken;
-        woken += (int) futex_os_sync_wake_n(g, uaddr, budget);
-    }
-
-    return woken;
+    return futex_wake_topup_osync(g, uaddr, woken, val);
 }
 
 /* FUTEX_REQUEUE / FUTEX_CMP_REQUEUE: wake val waiters at uaddr, then move up to
@@ -788,23 +851,16 @@ static int64_t futex_requeue(guest_t *g,
         pthread_mutex_unlock(&b_dst->lock);
     }
 
-    /* If the Darwin address-wait path is enabled again, drain the remaining
-     * wake + requeue budget against kernel-side waiters at uaddr. The kernel
-     * API has no facility for migrating waiters between addresses, so the
-     * requeue portion degrades into a wake at uaddr: waiters return to userland
-     * and either re-acquire what they actually need (typically the mutex
-     * pthread_cond_broadcast wanted to requeue onto) or re-wait. Widen the cap
-     * to uint64_t before adding so INT_MAX + INT_MAX fits, then clamp to
-     * UINT32_MAX inside futex_os_sync_wake_n; this preserves the INT_MAX "wake
-     * all" sentinel without overflowing the syscall return contract (woken +
-     * requeued must not exceed wake_count + requeue_count).
+    /* The kernel os_sync API cannot migrate waiters between addresses, so the
+     * requeue portion degrades into a wake at the source uaddr: os_sync waiters
+     * return to userland and re-acquire what they actually need (typically the
+     * mutex pthread_cond_broadcast wanted to requeue onto). Both the wake and
+     * requeue shortfalls therefore drain as wakes at uaddr; target is the full
+     * wake_count + requeue_count so the returned count stays within the Linux
+     * contract (woken + requeued must not exceed that sum).
      */
-    uint64_t remaining_wake = (uint64_t) wake_count - (uint64_t) woken;
-    uint64_t remaining_requeue = (uint64_t) requeue_count - (uint64_t) requeued;
-    uint64_t budget = remaining_wake + remaining_requeue;
-    woken += (int) futex_os_sync_wake_n(g, uaddr, budget);
-
-    return woken + requeued;
+    return futex_wake_topup_osync(g, uaddr, (int64_t) woken + requeued,
+                                  (uint64_t) wake_count + requeue_count);
 }
 
 /* FUTEX_WAKE_OP: atomically modify *uaddr2, wake val waiters at uaddr, then
@@ -978,20 +1034,14 @@ static int64_t futex_wake_op(guest_t *g,
         pthread_mutex_unlock(&b2->lock);
     }
 
-    /* If the Darwin address-wait path is enabled again, drain the remaining
-     * bucket budget against kernel-side waiters at each address. The uaddr2
-     * wake only fires when the predicate matched the old value of *uaddr2.
+    /* Drain the os_sync queue at each address for the bucket shortfall. The
+     * uaddr2 wake only fires when the predicate matched the old *uaddr2.
      */
-    if ((uint32_t) woken1 < val) {
-        uint64_t budget1 = (uint64_t) val - (uint64_t) woken1;
-        woken1 += (int) futex_os_sync_wake_n(g, uaddr, budget1);
-    }
-    if (cond_met && (uint32_t) woken2 < val2) {
-        uint64_t budget2 = (uint64_t) val2 - (uint64_t) woken2;
-        woken2 += (int) futex_os_sync_wake_n(g, uaddr2, budget2);
-    }
+    int64_t total1 = futex_wake_topup_osync(g, uaddr, woken1, val);
+    int64_t total2 =
+        cond_met ? futex_wake_topup_osync(g, uaddr2, woken2, val2) : woken2;
 
-    return woken1 + woken2;
+    return total1 + total2;
 }
 
 /* PI (Priority-Inheritance) futex.

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -197,6 +197,10 @@ _GUEST_EXTRA=""
 # runs are distinguishable in the merged output.
 _COREUTILS_SUFFIX=""
 
+# Guest path of the coreutils bindir for exec-child targets under --sysroot.
+# Empty means "use the host launch path" (native/static runs).
+_COREUTILS_GUEST_BINDIR=""
+
 run_elfuse_sysroot()
 {
     local bin="$1"
@@ -205,6 +209,40 @@ run_elfuse_sysroot()
     [ -n "$_SYSROOT" ] && sysroot_args="--sysroot $_SYSROOT"
     # shellcheck disable=SC2086
     timeout "$_ELFUSE_TIMEOUT" "$ELFUSE" $sysroot_args "$bin" $_GUEST_EXTRA "$@" 2> /dev/null
+}
+
+# Coreutils fixtures (hello.txt / lines.txt / unsorted.txt) live in the host
+# TEST_TMPDIR, which the static runs read directly. Under --sysroot the guest
+# view is chrooted to the sysroot, so a host-absolute path is redirected inside
+# it and the fixture is not found. For a sysroot run, copy the fixtures into a
+# scratch dir inside the sysroot and repoint TEST_TMPDIR at the guest-visible
+# path so run_coreutils_tests addresses them by a path that resolves under the
+# redirect. Reversed by unstage_sysroot_fixtures.
+_HOST_TMPDIR=""
+_STAGED_SYSROOT_DIR=""
+stage_sysroot_fixtures()
+{
+    local sysroot="$1"
+    local guest_rel="/tmp/matrix-coreutils.$$"
+    local host_dir="${sysroot}${guest_rel}"
+    mkdir -p "$host_dir"
+    # Copy the fixtures setup_fixtures already authored rather than re-creating
+    # their content here, so the two stay in sync from one definition.
+    cp "$TEST_TMPDIR/hello.txt" "$TEST_TMPDIR/unsorted.txt" \
+        "$TEST_TMPDIR/lines.txt" "$host_dir/"
+    _HOST_TMPDIR="$TEST_TMPDIR"
+    _STAGED_SYSROOT_DIR="$host_dir"
+    TEST_TMPDIR="$guest_rel"
+}
+
+unstage_sysroot_fixtures()
+{
+    if [ -n "$_STAGED_SYSROOT_DIR" ]; then
+        rm -rf "$_STAGED_SYSROOT_DIR"
+    fi
+    _STAGED_SYSROOT_DIR=""
+    TEST_TMPDIR="$_HOST_TMPDIR"
+    _HOST_TMPDIR=""
 }
 
 # Generic test helpers.
@@ -217,7 +255,7 @@ run_elfuse_sysroot()
 # cpuN count == online count) which a real kernel does not honor. All listed
 # tests still run in elfuse-aarch64 mode and in 'make check'; the qemu
 # reference run skips them.
-QEMU_SKIP="test-thread test-stress test-futex-pi test-io-opt test-sysfs-cpu"
+QEMU_SKIP="test-thread test-stress test-futex-pi test-osync-requeue test-io-opt test-sysfs-cpu"
 
 is_qemu_skipped()
 {
@@ -491,6 +529,7 @@ run_unit_tests()
     printf "\nThreading\n"
     test_check "$runner" "test-thread" "0 failed" "$bindir/test-thread"
     test_check "$runner" "test-pthread" "0 failed" "$bindir/test-pthread"
+    test_check "$runner" "test-osync-requeue" "0 failed" "$bindir/test-osync-requeue"
     test_check "$runner" "test-simd-clone" "0 failed" "$bindir/test-simd-clone"
     test_check "$runner" "test-stress" "0 failed" "$bindir/test-stress"
 
@@ -519,6 +558,11 @@ run_unit_tests()
 run_coreutils_tests()
 {
     local runner="$1" bindir="$2"
+    # Exec-child targets (env/nice/... run "<dir>/true") must resolve inside the
+    # guest. Native/static runs address them by the same host path they launch
+    # from; a --sysroot run overrides this with the binary's guest path via
+    # _COREUTILS_GUEST_BINDIR so the redirected execve finds the child.
+    local guest_bindir="${_COREUTILS_GUEST_BINDIR:-$bindir}"
 
     printf "Coreutils text%s\n" "$_COREUTILS_SUFFIX"
     test_check "$runner" "echo" "hello" "$bindir/echo" hello
@@ -557,10 +601,10 @@ run_coreutils_tests()
     test_rc "$runner" "true" 0 "$bindir/true"
     test_rc "$runner" "false" 1 "$bindir/false"
     test_rc "$runner" "sleep" 0 "$bindir/sleep" 0
-    test_rc "$runner" "env" 0 "$bindir/env" "$bindir/true"
-    test_rc "$runner" "nice" 0 "$bindir/nice" "$bindir/true"
-    test_rc "$runner" "nohup" 0 "$bindir/nohup" "$bindir/true"
-    test_rc "$runner" "timeout" 0 "$bindir/timeout" 5 "$bindir/true"
+    test_rc "$runner" "env" 0 "$bindir/env" "$guest_bindir/true"
+    test_rc "$runner" "nice" 0 "$bindir/nice" "$guest_bindir/true"
+    test_rc "$runner" "nohup" 0 "$bindir/nohup" "$guest_bindir/true"
+    test_rc "$runner" "timeout" 0 "$bindir/timeout" 5 "$guest_bindir/true"
 
     printf "\nCoreutils encoding%s\n" "$_COREUTILS_SUFFIX"
     # The if/then form contains require_binary's exit status so missing
@@ -797,7 +841,23 @@ run_suite()
     run_busybox_tests "$runner" "$GUEST_BUSYBOX"
 
     if [ -d "$GUEST_STATIC_BINS" ]; then
+        # run_elfuse auto-adds --sysroot for binaries under GUEST_SYSROOT or the
+        # dyn-bin dir (see its case), so tree/find/diff here run chrooted and
+        # must read the fixtures from inside the sysroot, same as the dynamic
+        # coreutils run. Stage them only for elfuse runs when that trigger applies.
+        local static_staged=0
+        if [ "$mode" = "elfuse-aarch64" ] && [ -n "${GUEST_SYSROOT:-}" ]; then
+            case "$GUEST_STATIC_BINS" in
+                "${GUEST_SYSROOT}"/* | "${FIXTURES}/aarch64-musl/dyn-bin"*)
+                    stage_sysroot_fixtures "$GUEST_SYSROOT"
+                    static_staged=1
+                    ;;
+            esac
+        fi
         run_static_tests "$runner" "$GUEST_STATIC_BINS"
+        if [ "$static_staged" = 1 ]; then
+            unstage_sysroot_fixtures
+        fi
     else
         skip_suite "static-bins" "no $GUEST_STATIC_BINS"
     fi
@@ -815,7 +875,17 @@ run_suite()
         else
             _COREUTILS_SUFFIX=" (musl dyn)"
             _SYSROOT="$GUEST_SYSROOT"
+            if [ "$mode" = "elfuse-aarch64" ]; then
+                # dyn-bin binaries symlink to the rootfs /bin multiplexer, so
+                # their guest path under --sysroot is /bin.
+                _COREUTILS_GUEST_BINDIR="/bin"
+                stage_sysroot_fixtures "$GUEST_SYSROOT"
+            fi
             run_coreutils_tests "$dyn_runner" "$GUEST_DYNAMIC_COREUTILS"
+            if [ "$mode" = "elfuse-aarch64" ]; then
+                unstage_sysroot_fixtures
+                _COREUTILS_GUEST_BINDIR=""
+            fi
             _COREUTILS_SUFFIX=""
         fi
     else
@@ -831,7 +901,15 @@ run_suite()
         else
             _COREUTILS_SUFFIX=" (glibc dyn)"
             _SYSROOT="$GUEST_GLIBC_SYSROOT"
+            if [ "$mode" = "elfuse-aarch64" ]; then
+                _COREUTILS_GUEST_BINDIR="/usr/bin"
+                stage_sysroot_fixtures "$GUEST_GLIBC_SYSROOT"
+            fi
             run_coreutils_tests "$dyn_runner" "$GUEST_GLIBC_DYNAMIC_COREUTILS"
+            if [ "$mode" = "elfuse-aarch64" ]; then
+                unstage_sysroot_fixtures
+                _COREUTILS_GUEST_BINDIR=""
+            fi
             _COREUTILS_SUFFIX=""
         fi
     else

--- a/tests/test-osync-requeue.c
+++ b/tests/test-osync-requeue.c
@@ -1,0 +1,110 @@
+/*
+ * Spike probe: does routing plain FUTEX_WAIT to the Darwin os_sync address-wait
+ * queue break FUTEX_REQUEUE of that waiter?
+ *
+ * musl's private condvar (pthread_cond_timedwait.c: lock()/unlock_requeue())
+ * parks waiters with a plain FUTEX_WAIT on a per-node "barrier" word, then its
+ * broadcast/handoff path uses FUTEX_REQUEUE to move those parked waiters from
+ * the barrier word onto the mutex word. If plain FUTEX_WAIT enqueues on the
+ * kernel os_sync queue while FUTEX_REQUEUE only walks the emulator's hash
+ * bucket, the requeue reaches nobody: the waiter is stranded until the 100 ms
+ * os_sync poll cap re-checks the (now changed) word and returns.
+ *
+ * This reproduces the pattern with raw syscalls (libc-agnostic) and measures
+ * the wake latency. A correct requeue path wakes the waiter in well under the
+ * poll cap; a stranded waiter only surfaces after ~100 ms.
+ */
+
+#include <errno.h>
+#include <linux/futex.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+static int futex(volatile int *u, int op, int val, void *to, int *u2, int v3)
+{
+    return (int) syscall(SYS_futex, u, op, val, to, u2, v3);
+}
+
+/* musl lock() barrier word: waiter blocks while *barrier == 2. */
+static volatile int barrier = 2;
+static volatile int mutex_word = 0;
+static volatile int waiter_returned = 0;
+static struct timespec t_wake;
+
+static void *waiter_fn(void *arg)
+{
+    (void) arg;
+    /* musl: do __wait(l,0,2,1); while (a_cas(l,0,2)); -- FUTEX_WAIT on barrier
+     * expecting 2, retry while the word is still 2.
+     */
+    while (__atomic_load_n(&barrier, __ATOMIC_SEQ_CST) == 2) {
+        int rc =
+            futex(&barrier, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, 2, NULL, NULL, 0);
+        (void) rc; /* EAGAIN / 0 both loop back to the compare */
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t_wake);
+    __atomic_store_n(&waiter_returned, 1, __ATOMIC_SEQ_CST);
+    return NULL;
+}
+
+static double ms_since(const struct timespec *a, const struct timespec *b)
+{
+    return (double) (b->tv_sec - a->tv_sec) * 1e3 +
+           (double) (b->tv_nsec - a->tv_nsec) / 1e6;
+}
+
+int main(void)
+{
+    pthread_t th;
+    if (pthread_create(&th, NULL, waiter_fn, NULL) != 0) {
+        printf(
+            "test-osync-requeue: 0 passed, 1 failed - FAIL "
+            "(pthread_create)\n");
+        return 1;
+    }
+
+    /* Let the waiter reach FUTEX_WAIT. Keep this well below the difference
+     * between the 100 ms os_sync poll cap (FUTEX_OS_SYNC_POLL_CAP_NS) and the
+     * pass threshold below, so a stranded waiter (regression: requeue no longer
+     * degrades to a wake at the source address) surfaces near the cap, far
+     * above the threshold, instead of landing on it.
+     */
+    usleep(10 * 1000);
+
+    struct timespec t0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+
+    /* musl unlock_requeue(): a_store(l,0); FUTEX_REQUEUE(l, 0, 1, r). Store
+     * barrier=0 first, then requeue one waiter from barrier to mutex.
+     */
+    __atomic_store_n(&barrier, 0, __ATOMIC_SEQ_CST);
+    int rq = futex(&barrier, FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG, 0, (void *) 1,
+                   (int *) &mutex_word, 0);
+    /* Then the mutex owner unlock wakes the (requeued) waiter on the mutex. */
+    int wk =
+        futex(&mutex_word, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 1, NULL, NULL, 0);
+
+    pthread_join(th, NULL);
+    double latency = ms_since(&t0, &t_wake);
+
+    printf("test-osync-requeue: musl-style requeue wake latency\n");
+    printf("  requeue rc=%d wake rc=%d\n", rq, wk);
+    printf("  wake latency: %.2f ms\n", latency);
+
+    /* A working requeue path wakes well under the 100 ms os_sync poll cap.
+     * Allow generous headroom for scheduler jitter; a stranded waiter only
+     * comes back on the ~100 ms timeout. Also require the requeue or wake to
+     * have reached the waiter (rq/wk > 0): if the waiter had not blocked yet,
+     * both reach nobody and the waiter exits fast on its own, which would
+     * otherwise show a false sub-threshold PASS.
+     */
+    int reached = (rq > 0) || (wk > 0);
+    int pass = reached && latency < 50.0;
+    printf("test-osync-requeue: %d passed, %d failed - %s\n", pass, !pass,
+           pass ? "PASS" : "FAIL");
+    return pass ? 0 : 1;
+}


### PR DESCRIPTION
This routes plain FUTEX_WAIT / FUTEX_WAKE through Darwin's os_sync_wait_on_address (macOS 14.4+) instead of the pthread-condvar bucket path. Darwin folds Linux's pre-block value-change race into a successful wait; a compare-after-block re-check bridges the gap. On a rc>=0 return, reload the futex word and map a value that moved off the expected word to -EAGAIN, matching Linux for the pre-block race. A correct caller re-reads the word on either return, so the post-wake case is equally safe and no wake is lost: the kernel's atomic compare-and-block guarantees a waiter enqueued at the expected value cannot miss an os_sync_wake_by_address.

Consolidate the os_sync drain that every bucket-walking wake site needs into futex_wake_topup_osync, so the drain-both-queues invariant is one named step; the int64_t accumulator retires the earlier narrowing cast. FUTEX_REQUEUE of a plain-WAIT waiter cannot migrate a kernel waiter between addresses, so it degrades the requeue portion into a wake at the source address, which glibc (broadcast wakes with FUTEX_WAKE) and musl (barrier-to-mutex handoff tolerates wake-in-place) both accept.

Add tests/test-osync-requeue.c to guard the requeue degradation and register it in the matrix, skipped under qemu alongside the other timing-sensitive futex tests.

Fix the elfuse-aarch64 matrix dynamic-coreutils and static-bins suites, which ran dyn-bin binaries under --sysroot but staged fixtures and exec-child targets by host path, unreachable through the sysroot chroot. Stage fixtures inside the sysroot and address exec children by guest path. Gate the staging to elfuse-aarch64 so qemu-aarch64, which runs the binaries natively with a VM-side TEST_TMPDIR, is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the address-wait fast path for plain FUTEX_WAIT/FUTEX_WAKE using Darwin `os_sync_wait_on_address` (macOS 14.4+), preserving Linux -EAGAIN race semantics with a compare-after-block re-check. Adds a unified wake drain and a guard test for FUTEX_REQUEUE behavior; fixes sysroot test paths in the matrix.

- **New Features**
  - Enable `os_sync_wait_on_address` for plain FUTEX_WAIT/FUTEX_WAKE when available.
  - Preserve Linux -EAGAIN semantics with a post-block compare; no wake loss.
  - Add `futex_wake_topup_osync` to drain kernel waiters after bucket-based wakes (wake, requeue, wake_op); FUTEX_REQUEUE degrades to wake-at-source (glibc/musl-safe).
  - New `tests/test-osync-requeue.c` to validate the requeue behavior.

- **Bug Fixes**
  - Fix `elfuse-aarch64` matrix runs: stage coreutils fixtures inside `--sysroot` and run exec-children via guest paths; introduce `_COREUTILS_GUEST_BINDIR`.
  - Gate staging to elfuse runs and unstage after; `qemu-aarch64` stays unchanged.
  - Add build target for the new test with `-lpthread` and skip it under qemu due to timing sensitivity.

<sup>Written for commit 4c5334656a173a9b5639cc0d31a3147abf613d7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

