### PR TITLE
Deduplicate syscall helpers and harden fs/signal

### DIFF
--- a/src/core/sysroot.c
+++ b/src/core/sysroot.c
@@ -1,4 +1,5 @@
-/* Sysroot capability probing and provisioning
+/*
+ * Sysroot capability probing and provisioning
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -30,6 +31,29 @@ typedef struct {
     uint32_t length;
     vol_capabilities_attr_t caps;
 } volume_caps_buf_t;
+
+/* Validate that path names an existing directory, not a symlink.
+ *
+ * Returns 0 if so, else -1 with errno set: ELOOP for a symlink, ENOTDIR for a
+ * non-directory, or the lstat errno (ENOENT when the component does not exist).
+ * Shared by the symlink-rejecting sysroot dir walkers; ensure_dir_exists_follow
+ * deliberately follows symlinks and does not use it.
+ */
+static int validate_existing_dir(const char *path)
+{
+    struct stat st;
+    if (lstat(path, &st) < 0)
+        return -1;
+    if (S_ISLNK(st.st_mode)) {
+        errno = ELOOP;
+        return -1;
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        errno = ENOTDIR;
+        return -1;
+    }
+    return 0;
+}
 
 static int ensure_dir_exists_follow(const char *path)
 {
@@ -80,18 +104,8 @@ int sysroot_ensure_dir_exists(const char *path)
         if (mkdir(buf, 0755) < 0) {
             if (errno != EEXIST)
                 return -1;
-
-            struct stat st;
-            if (lstat(buf, &st) < 0)
+            if (validate_existing_dir(buf) < 0)
                 return -1;
-            if (S_ISLNK(st.st_mode)) {
-                errno = ELOOP;
-                return -1;
-            }
-            if (!S_ISDIR(st.st_mode)) {
-                errno = ENOTDIR;
-                return -1;
-            }
         }
         *p = '/';
     }
@@ -99,18 +113,8 @@ int sysroot_ensure_dir_exists(const char *path)
     if (mkdir(buf, 0755) < 0) {
         if (errno != EEXIST)
             return -1;
-
-        struct stat st;
-        if (lstat(buf, &st) < 0)
+        if (validate_existing_dir(buf) < 0)
             return -1;
-        if (S_ISLNK(st.st_mode)) {
-            errno = ELOOP;
-            return -1;
-        }
-        if (!S_ISDIR(st.st_mode)) {
-            errno = ENOTDIR;
-            return -1;
-        }
     }
     return 0;
 }
@@ -134,37 +138,20 @@ int sysroot_validate_dir_prefix(const char *path)
             continue;
         *p = '\0';
 
-        struct stat st;
-        if (lstat(buf, &st) < 0) {
+        if (validate_existing_dir(buf) < 0) {
+            /* A not-yet-existing component means the prefix is valid so far. */
             if (errno == ENOENT) {
                 *p = '/';
                 return 0;
             }
             return -1;
         }
-        if (S_ISLNK(st.st_mode)) {
-            errno = ELOOP;
-            return -1;
-        }
-        if (!S_ISDIR(st.st_mode)) {
-            errno = ENOTDIR;
-            return -1;
-        }
         *p = '/';
     }
 
-    struct stat st;
-    if (lstat(buf, &st) < 0) {
+    if (validate_existing_dir(buf) < 0) {
         if (errno == ENOENT)
             return 0;
-        return -1;
-    }
-    if (S_ISLNK(st.st_mode)) {
-        errno = ELOOP;
-        return -1;
-    }
-    if (!S_ISDIR(st.st_mode)) {
-        errno = ENOTDIR;
         return -1;
     }
 
@@ -512,14 +499,21 @@ int sysroot_create_mount(const char *mount_path, sysroot_mount_t *mount)
         }
     }
 
-    char plist[32768];
+    /* hdiutil attach -plist emits a property list that can run to tens of KiB;
+     * keep it off the stack.
+     */
+    const size_t plistsz = 32768;
+    char *plist = malloc(plistsz);
+    if (!plist)
+        return -1;
     int status = 0;
     char *const attach_argv[] = {
         "hdiutil", "attach",          "-mountpoint", mount->mount_path,
         "-plist",  mount->image_path, NULL};
-    if (spawn_capture_stdout(attach_argv, plist, sizeof(plist), &status) < 0 ||
+    if (spawn_capture_stdout(attach_argv, plist, plistsz, &status) < 0 ||
         !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
         log_error("sysroot: hdiutil attach failed for %s", mount->image_path);
+        free(plist);
         return -1;
     }
 
@@ -531,8 +525,10 @@ int sysroot_create_mount(const char *mount_path, sysroot_mount_t *mount)
             "plist for %s",
             mount->image_path);
         sysroot_detach_mountpoint_force(mount->mount_path, true);
+        free(plist);
         return -1;
     }
+    free(plist);
 
     str_copy_trunc(mount->mount_path, attached_mount,
                    sizeof(mount->mount_path));

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -1,4 +1,5 @@
-/* Fork/clone IPC
+/*
+ * Fork/clone IPC
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -299,8 +300,8 @@ int fork_child_main(int ipc_fd,
     memset(sig.rt_info, 0, sizeof(sig.rt_info));
 
     /* execve in the child needs the shim bytes after guest_reset clears memory.
+     * Close IPC socket
      */
-    /* Close IPC socket */
     close(ipc_fd);
 
     /* Create the child vCPU only after all inherited state is available. */
@@ -528,6 +529,92 @@ static void resolve_clone_stack_range(const guest_t *g,
 /* Forward declaration: worker entry runs after sys_clone_thread */
 static void *thread_create_and_run(void *arg);
 
+/* Snapshot the parent vCPU's EL1 sysregs, GPRs, and SIMD into the child's
+ * create-args. HVF binds a vCPU to its creating thread, so the worker calls
+ * hv_vcpu_create itself and replays this state. The caller fills the remaining
+ * fields (thread, guest, flags, tls, child_stack, sp_el1, startup).
+ */
+static void tca_capture_parent_regs(thread_create_args_t *tca,
+                                    hv_vcpu_t parent_vcpu)
+{
+    tca->elr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_ELR_EL1);
+    tca->spsr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_SPSR_EL1);
+    tca->vbar = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_VBAR_EL1);
+    tca->ttbr0 = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TTBR0_EL1);
+    tca->sctlr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_SCTLR_EL1);
+    tca->tcr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TCR_EL1);
+    tca->mair = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_MAIR_EL1);
+    tca->cpacr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_CPACR_EL1);
+    tca->tpidr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TPIDR_EL0);
+    vcpu_snapshot_gprs(parent_vcpu, tca->gprs);
+    vcpu_snapshot_simd(parent_vcpu, &tca->simd_state);
+}
+
+typedef struct {
+    bool parent_written;
+    bool child_written;
+    uint64_t parent_gva;
+    uint64_t child_gva;
+    int32_t parent_old;
+    int32_t child_old;
+} clone_tid_rollback_t;
+
+static void clone_rollback_tid_flags(guest_t *g,
+                                     const clone_tid_rollback_t *rollback)
+{
+    if (rollback->parent_written)
+        (void) guest_write_small(g, rollback->parent_gva, &rollback->parent_old,
+                                 sizeof(rollback->parent_old));
+    if (rollback->child_written)
+        (void) guest_write_small(g, rollback->child_gva, &rollback->child_old,
+                                 sizeof(rollback->child_old));
+}
+
+/* Apply the CLONE_*_SETTID / CLONE_CHILD_CLEARTID side effects for a new child.
+ * Returns true on success, false if a guest TID write faulted so the caller can
+ * unwind its own way (the clone-thread and clone-vm paths differ in cleanup).
+ * Order matches the kernel: parent ptid, then record ctid for clear-on-exit,
+ * then child ctid.
+ */
+static bool clone_apply_tid_flags(guest_t *g,
+                                  thread_entry_t *t,
+                                  uint64_t flags,
+                                  int64_t child_tid,
+                                  uint64_t ptid_gva,
+                                  uint64_t ctid_gva,
+                                  clone_tid_rollback_t *rollback)
+{
+    int32_t tid32 = (int32_t) child_tid;
+    *rollback = (clone_tid_rollback_t) {0};
+    if (flags & LINUX_CLONE_PARENT_SETTID) {
+        if (guest_read_small(g, ptid_gva, &rollback->parent_old,
+                             sizeof(rollback->parent_old)) < 0)
+            return false;
+        rollback->parent_gva = ptid_gva;
+    }
+    if (flags & LINUX_CLONE_CHILD_SETTID) {
+        if (guest_read_small(g, ctid_gva, &rollback->child_old,
+                             sizeof(rollback->child_old)) < 0)
+            return false;
+        rollback->child_gva = ctid_gva;
+    }
+    if (flags & LINUX_CLONE_PARENT_SETTID) {
+        if (guest_write_small(g, ptid_gva, &tid32, sizeof(tid32)) < 0)
+            return false;
+        rollback->parent_written = true;
+    }
+    if (flags & LINUX_CLONE_CHILD_CLEARTID)
+        t->clear_child_tid = ctid_gva;
+    if (flags & LINUX_CLONE_CHILD_SETTID) {
+        if (guest_write_small(g, ctid_gva, &tid32, sizeof(tid32)) < 0) {
+            clone_rollback_tid_flags(g, rollback);
+            return false;
+        }
+        rollback->child_written = true;
+    }
+    return true;
+}
+
 static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
                                 guest_t *g,
                                 uint64_t flags,
@@ -569,26 +656,6 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_ENOMEM;
     }
 
-    /* Capture parent register state before spawning worker. HVF binds vCPU to
-     * the creating thread, so the worker must call hv_vcpu_create itself. The
-     * parent passes all parent state via the args.
-     */
-    uint64_t parent_elr, parent_spsr, parent_vbar, parent_ttbr0;
-    uint64_t parent_sctlr, parent_tcr, parent_mair, parent_cpacr;
-    uint64_t parent_tpidr;
-    parent_elr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_ELR_EL1);
-    parent_spsr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_SPSR_EL1);
-    parent_vbar = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_VBAR_EL1);
-    parent_ttbr0 = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TTBR0_EL1);
-    parent_sctlr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_SCTLR_EL1);
-    parent_tcr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TCR_EL1);
-    parent_mair = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_MAIR_EL1);
-    parent_cpacr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_CPACR_EL1);
-    parent_tpidr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TPIDR_EL0);
-
-    uint64_t parent_gprs[31];
-    vcpu_snapshot_gprs(parent_vcpu, parent_gprs);
-
     thread_create_args_t *tca = calloc(1, sizeof(thread_create_args_t));
     if (!tca) {
         thread_deactivate(t);
@@ -604,48 +671,20 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
     tca->child_stack = child_stack;
     tca->flags = flags;
     tca->tls = tls;
-    tca->elr = parent_elr;
-    tca->spsr = parent_spsr;
-    tca->vbar = parent_vbar;
-    tca->ttbr0 = parent_ttbr0;
-    tca->sctlr = parent_sctlr;
-    tca->tcr = parent_tcr;
-    tca->mair = parent_mair;
-    tca->cpacr = parent_cpacr;
-    tca->tpidr = parent_tpidr;
-    memcpy(tca->gprs, parent_gprs, sizeof(parent_gprs));
     tca->sp_el1 = child_sp_el1;
-    vcpu_snapshot_simd(parent_vcpu, &tca->simd_state);
+    tca_capture_parent_regs(tca, parent_vcpu);
 
-    /* CLONE_PARENT_SETTID: write child TID to parent's ptid address */
-    if (flags & LINUX_CLONE_PARENT_SETTID) {
-        int32_t tid32 = (int32_t) child_tid;
-        if (guest_write_small(g, ptid_gva, &tid32, sizeof(tid32)) < 0) {
-            free(tca);
-            thread_deactivate(t);
-            pthread_cond_destroy(&startup.cond);
-            pthread_mutex_destroy(&startup.lock);
-            return -LINUX_EFAULT;
-        }
-    }
-
-    /* CLONE_CHILD_CLEARTID: store the address for cleanup on exit */
-    if (flags & LINUX_CLONE_CHILD_CLEARTID) {
-        t->clear_child_tid = ctid_gva;
-    }
-
-    /* CLONE_CHILD_SETTID: write child TID to the child's ctid address. This
-     * writes into shared guest memory (visible to child thread).
+    /* CLONE_*_SETTID / CLONE_CHILD_CLEARTID side effects. CHILD_SETTID writes
+     * shared guest memory visible to the child thread.
      */
-    if (flags & LINUX_CLONE_CHILD_SETTID) {
-        int32_t tid32 = (int32_t) child_tid;
-        if (guest_write_small(g, ctid_gva, &tid32, sizeof(tid32)) < 0) {
-            free(tca);
-            thread_deactivate(t);
-            pthread_cond_destroy(&startup.cond);
-            pthread_mutex_destroy(&startup.lock);
-            return -LINUX_EFAULT;
-        }
+    clone_tid_rollback_t tid_rollback;
+    if (!clone_apply_tid_flags(g, t, flags, child_tid, ptid_gva, ctid_gva,
+                               &tid_rollback)) {
+        free(tca);
+        thread_deactivate(t);
+        pthread_cond_destroy(&startup.cond);
+        pthread_mutex_destroy(&startup.lock);
+        return -LINUX_EFAULT;
     }
 
     /* Create the host pthread (joinable; exit_group joins all workers via
@@ -669,14 +708,7 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
          * rationale as the post-handshake failure path: clone(2) does not leave
          * live-looking TIDs behind for a thread that never started.
          */
-        if (flags & LINUX_CLONE_PARENT_SETTID) {
-            int32_t zero = 0;
-            (void) guest_write_small(g, ptid_gva, &zero, sizeof(zero));
-        }
-        if (flags & LINUX_CLONE_CHILD_SETTID) {
-            int32_t zero = 0;
-            (void) guest_write_small(g, ctid_gva, &zero, sizeof(zero));
-        }
+        clone_rollback_tid_flags(g, &tid_rollback);
         return -LINUX_EAGAIN;
     }
 
@@ -691,18 +723,11 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
     if (startup.startup_rc < 0) {
         /* Worker failed during HVF bring-up after the SETTID writes had already
          * populated the guest TID slots. Linux clone(2) does not leave a
-         * live-looking TID behind for a thread that never started, so zero the
-         * slots before the parent sees the error.
+         * live-looking TID behind for a thread that never started, so restore
+         * the slots before the parent sees the error.
          */
         pthread_join(host_thread, NULL);
-        if (flags & LINUX_CLONE_PARENT_SETTID) {
-            int32_t zero = 0;
-            (void) guest_write_small(g, ptid_gva, &zero, sizeof(zero));
-        }
-        if (flags & LINUX_CLONE_CHILD_SETTID) {
-            int32_t zero = 0;
-            (void) guest_write_small(g, ctid_gva, &zero, sizeof(zero));
-        }
+        clone_rollback_tid_flags(g, &tid_rollback);
         return startup.startup_rc;
     }
 
@@ -959,20 +984,6 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
         return -LINUX_ENOMEM;
     }
 
-    /* Capture parent register state */
-    uint64_t parent_elr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_ELR_EL1);
-    uint64_t parent_spsr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_SPSR_EL1);
-    uint64_t parent_vbar = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_VBAR_EL1);
-    uint64_t parent_ttbr0 = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TTBR0_EL1);
-    uint64_t parent_sctlr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_SCTLR_EL1);
-    uint64_t parent_tcr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TCR_EL1);
-    uint64_t parent_mair = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_MAIR_EL1);
-    uint64_t parent_cpacr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_CPACR_EL1);
-    uint64_t parent_tpidr = vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_TPIDR_EL0);
-
-    uint64_t parent_gprs[31];
-    vcpu_snapshot_gprs(parent_vcpu, parent_gprs);
-
     thread_create_args_t *tca = calloc(1, sizeof(thread_create_args_t));
     if (!tca) {
         thread_deactivate(t);
@@ -987,41 +998,15 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
                            : vcpu_get_sysreg(parent_vcpu, HV_SYS_REG_SP_EL0);
     tca->flags = flags;
     tca->tls = tls;
-    tca->elr = parent_elr;
-    tca->spsr = parent_spsr;
-    tca->vbar = parent_vbar;
-    tca->ttbr0 = parent_ttbr0;
-    tca->sctlr = parent_sctlr;
-    tca->tcr = parent_tcr;
-    tca->mair = parent_mair;
-    tca->cpacr = parent_cpacr;
-    tca->tpidr = parent_tpidr;
-    memcpy(tca->gprs, parent_gprs, sizeof(parent_gprs));
     tca->sp_el1 = child_sp_el1;
-    vcpu_snapshot_simd(parent_vcpu, &tca->simd_state);
+    tca_capture_parent_regs(tca, parent_vcpu);
 
-    /* CLONE_PARENT_SETTID: write child TID to parent's ptid address */
-    if (flags & LINUX_CLONE_PARENT_SETTID) {
-        int32_t tid32 = (int32_t) child_tid;
-        if (guest_write_small(g, ptid_gva, &tid32, sizeof(tid32)) < 0) {
-            free(tca);
-            thread_deactivate(t);
-            return -LINUX_EFAULT;
-        }
-    }
-
-    /* CLONE_CHILD_CLEARTID: store the address for cleanup on exit */
-    if (flags & LINUX_CLONE_CHILD_CLEARTID)
-        t->clear_child_tid = ctid_gva;
-
-    /* CLONE_CHILD_SETTID: write child TID to child's ctid address */
-    if (flags & LINUX_CLONE_CHILD_SETTID) {
-        int32_t tid32 = (int32_t) child_tid;
-        if (guest_write_small(g, ctid_gva, &tid32, sizeof(tid32)) < 0) {
-            free(tca);
-            thread_deactivate(t);
-            return -LINUX_EFAULT;
-        }
+    clone_tid_rollback_t tid_rollback;
+    if (!clone_apply_tid_flags(g, t, flags, child_tid, ptid_gva, ctid_gva,
+                               &tid_rollback)) {
+        free(tca);
+        thread_deactivate(t);
+        return -LINUX_EFAULT;
     }
 
     /* Create the host pthread */
@@ -1037,6 +1022,10 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
         log_error("clone_vm: pthread_create failed: %s", strerror(err));
         free(tca);
         thread_deactivate(t);
+        /* Roll back the SETTID writes clone_apply_tid_flags made: no child
+         * thread was created, so clone(2) must not leave live-looking TIDs.
+         */
+        clone_rollback_tid_flags(g, &tid_rollback);
         return -LINUX_EAGAIN;
     }
 
@@ -1049,6 +1038,30 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
         (unsigned long long) flags);
 
     return child_tid;
+}
+
+/* Report a vm-clone worker that failed HVF bring-up as an exited child so the
+ * parent's wait4 can reap it. sys_clone_vm already returned the child tid, so
+ * dropping the slot with thread_deactivate (which clears active) would make
+ * wait4 skip it and leave the parent unable to collect a status. Publish the
+ * exit status and clear t->vcpu under the thread lock, so thread_interrupt_all
+ * and thread_destroy_all_vcpus (both skip a null handle) cannot hand the
+ * torn-down vCPU to HVF, then destroy the handle outside the lock. Keep the
+ * slot active for wait4. Reports SIGKILL because the child never ran a guest
+ * instruction. Does not trigger exit_group: only the child failed.
+ */
+static void vm_clone_report_bringup_failure(thread_entry_t *t)
+{
+    pthread_mutex_t *lock = thread_get_lock();
+    pthread_mutex_lock(lock);
+    hv_vcpu_t dying = t->vcpu;
+    t->vcpu = 0;
+    t->vm_exited = true;
+    t->vm_exit_status = LINUX_SIGKILL; /* WIFSIGNALED, WTERMSIG == SIGKILL */
+    pthread_cond_broadcast(&t->ptrace_cond);
+    pthread_mutex_unlock(lock);
+    if (dying)
+        hv_vcpu_destroy(dying);
 }
 
 /* Worker entry for vm-clone children. Sets up vCPU, runs guest code, then marks
@@ -1068,7 +1081,7 @@ static void *vm_clone_thread_run(void *arg)
         log_error("vm_clone tid=%lld: hv_vcpu_create failed: %d",
                   (long long) t->guest_tid, (int) r);
         free(tca);
-        thread_deactivate(t);
+        vm_clone_report_bringup_failure(t);
         return NULL;
     }
 
@@ -1085,8 +1098,8 @@ static void *vm_clone_thread_run(void *arg)
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL1, tca->sp_el1));
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL0, tca->child_stack));
     if (shim_globals_install_per_vcpu(vcpu, tca->guest, t->guest_tid) < 0) {
-        thread_deactivate(t);
         free(tca);
+        vm_clone_report_bringup_failure(t);
         return NULL;
     }
 
@@ -1517,9 +1530,8 @@ int64_t sys_clone(hv_vcpu_t vcpu,
 
     /* Snapshot of the semantic region array, populated after the memory dump
      * but before sibling vCPUs resume. Declared up front so all goto paths to
-     * fail_snapshot can free it unconditionally.
+     * fail_snapshot can free it unconditionally. Header
      */
-    /* Header */
     ipc_header_t hdr = {
         .magic = IPC_MAGIC_HEADER,
         .ipa_bits = g->ipa_bits,
@@ -1832,10 +1844,9 @@ int64_t sys_clone3(hv_vcpu_t vcpu,
 
     /* Merge exit_signal into flags for sys_clone compatibility. clone3 moved
      * exit_signal out of the flags field; sys_clone expects it in the low byte.
-     * Safe because validation confirmed ca.flags low byte is zero.
-     */
-    /* Strip CLONE_PIDFD before passing to sys_clone (which does not understand
-     * it). Pidfd creation happens after the clone returns.
+     * Safe because validation confirmed ca.flags low byte is zero. Strip
+     * CLONE_PIDFD before passing to sys_clone (which does not understand it).
+     * Pidfd creation happens after the clone returns.
      */
     bool want_pidfd = (ca.flags & LINUX_CLONE_PIDFD) != 0;
     uint64_t flags =

--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -1,4 +1,5 @@
-/* Linux futex emulation
+/*
+ * Linux futex emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -44,8 +45,8 @@
  * the Linux -EAGAIN pre-block race into a successful wait; futex_os_sync_wait
  * closes that common gap with a compare-after-block re-check (word moved off
  * the expected value on a rc>=0 return maps to -EAGAIN). FUTEX_WAIT_BITSET, PI
- * variants, and futex_waitv stay on the bucket path: they need state the
- * kernel API does not expose.
+ * variants, and futex_waitv stay on the bucket path: they need state the kernel
+ * API does not expose.
  *
  * SDK gate: probe the header via __has_include so older SDKs build clean.
  * Runtime gate: __builtin_available cached in futex_init().
@@ -191,6 +192,21 @@ static void bucket_unlink_locked(futex_bucket_t *b, const futex_waiter_t *w)
             return;
         }
     }
+}
+
+/* Unlink the waiter at *pp from its bucket list and wake it. The bucket lock
+ * must be held. Unlinking before the store/signal keeps a woken waiter from
+ * observing itself still queued; the release store pairs with the waiter's
+ * acquire load of woken. On return *pp points at the next entry, so a scanning
+ * loop should re-test *pp without advancing pp.
+ */
+static void futex_wake_waiter_locked(futex_waiter_t **pp)
+{
+    futex_waiter_t *w = *pp;
+    *pp = w->next; /* unlink before signaling */
+    __atomic_store_n(&w->woken, 1, __ATOMIC_RELEASE);
+    pthread_cond_signal(&w->cond);
+    futex_waiter_notify_group(w);
 }
 
 /* Public API */
@@ -395,12 +411,12 @@ static uint32_t futex_os_sync_wake_n(const guest_t *g,
  * returns -EAGAIN in that case, so an explicit __atomic_load_n bridges the
  * contract gap.
  *
- * Quantum is bounded by FUTEX_OS_SYNC_POLL_CAP_NS so proc_exit_group_requested,
- * futex_interrupt_pending, and the 1-second EINTR simulation get observed
- * without a global wake-everyone broadcast channel. ETIMEDOUT, EINTR, EFAULT,
- * and ENOMEM are all transient per Apple's docs; each must run the flag check
- * before re-arming. EINVAL would indicate a programmer error here (size != 4/8
- * or bad flags), so it surfaces directly rather than spinning.
+ * Quantum is bounded by FUTEX_OS_SYNC_POLL_CAP_NS so proc_exit_group_requested
+ * and futex_interrupt_pending get observed without a global wake-everyone
+ * broadcast channel. ETIMEDOUT, EINTR, EFAULT, and ENOMEM are all transient per
+ * Apple's docs; each must run the flag check before re-arming. EINVAL would
+ * indicate a programmer error here (size != 4/8 or bad flags), so it surfaces
+ * directly rather than spinning.
  */
 static int64_t futex_os_sync_wait(guest_t *g,
                                   uint64_t uaddr,
@@ -432,10 +448,10 @@ static int64_t futex_os_sync_wait(guest_t *g,
     /* Bound consecutive EFAULT retries. Apple documents EFAULT as transient
      * (kernel copyin failure under memory pressure), so a few retries are fine;
      * but a genuinely bad page would otherwise cause the loop to spin with no
-     * real sleep -- timeout_ns is supplied to syscall that returns immediately
-     * -- until the user deadline finally bails out. Surface EFAULT to the
-     * guest after this many back-to-back failures so the host CPU does not
-     * burn for ~1 s.
+     * real sleep (timeout_ns is supplied to a syscall that returns immediately)
+     * until the user deadline finally bails out. Surface EFAULT to the guest
+     * after this many back-to-back failures so the host CPU does not burn for
+     * ~1 s.
      */
     int efault_retries = 0;
 
@@ -455,21 +471,20 @@ static int64_t futex_os_sync_wait(guest_t *g,
             OS_CLOCK_MACH_ABSOLUTE_TIME, timeout_ns);
         if (rc >= 0) {
             /* Compare-after-block re-check. Darwin folds two distinct Linux
-             * outcomes into a single rc>=0: a genuine wake, and the racy
-             * "value moved off expected between the pre-check and the
-             * in-kernel compare" case that Linux reports as -EAGAIN. Reload
-             * the word: value still == expected means a real (or spurious)
-             * wake -> return 0; value != expected means it moved, which is
-             * -EAGAIN under Linux for the pre-block race and is equally safe
-             * for the post-wake case, since a correct futex caller must
-             * re-read the word and re-test its condition on either return.
-             * This is not a perfect oracle: a value that moves off expected
-             * and back before the reload returns 0 where Linux returns
-             * -EAGAIN, a benign spurious wake the futex contract permits. No
-             * wake is lost: the kernel's atomic compare-and-block already
-             * guarantees a waiter enqueued at expected cannot miss an
-             * os_sync_wake_by_address, and any value change carries the state
-             * the caller re-reads.
+             * outcomes into a single rc>=0: a genuine wake, and the racy "value
+             * moved off expected between the pre-check and the in-kernel
+             * compare" case that Linux reports as -EAGAIN. Reload the word:
+             * value still == expected means a real (or spurious) wake -> return
+             * 0; value != expected means it moved, which is -EAGAIN under Linux
+             * for the pre-block race and is equally safe for the post-wake
+             * case, since a correct futex caller must re-read the word and
+             * re-test its condition on either return. This is not a perfect
+             * oracle: a value that moves off expected and back before the
+             * reload returns 0 where Linux returns -EAGAIN, a benign spurious
+             * wake the futex contract permits. No wake is lost: the kernel's
+             * atomic compare-and-block already guarantees a waiter enqueued at
+             * expected cannot miss an os_sync_wake_by_address, and any value
+             * change carries the state the caller re-reads.
              */
             uint32_t observed = __atomic_load_n(host_addr, __ATOMIC_SEQ_CST);
             return observed == expected ? 0 : -LINUX_EAGAIN;
@@ -495,26 +510,26 @@ static int64_t futex_os_sync_wait(guest_t *g,
          */
         signal_check_timer();
 
-        /* Return EINTR only when a real deliverable signal is queued for
-         * this thread. POSIX callers (e.g. glibc sem_wait, foot's render
-         * worker) often do not retry on EINTR, so synthetic spurious
-         * wakeups cannot be issued here. signal_pending() confirms under
-         * sig_lock so the atomic hint cannot produce a stale-true edge
-         * after rt_sigprocmask masked the queued signal.
+        /* Return EINTR only when a real deliverable signal is queued for this
+         * thread. POSIX callers (e.g. glibc sem_wait, foot's render worker)
+         * often do not retry on EINTR, so synthetic spurious wakeups cannot be
+         * issued here. signal_pending() confirms under sig_lock so the atomic
+         * hint cannot produce a stale-true edge after rt_sigprocmask masked the
+         * queued signal.
          */
         if (signal_pending())
             return -LINUX_EINTR;
-        /* For has_timeout: futex_remaining_ns returns 0 next iteration once
-         * the user deadline elapses, so the loop exits with -ETIMEDOUT.
+        /* For has_timeout: futex_remaining_ns returns 0 next iteration once the
+         * user deadline elapses, so the loop exits with -ETIMEDOUT.
          */
     }
 }
 
 #else /* !ELFUSE_HAVE_OS_SYNC_WAIT_ON_ADDRESS */
 
-/* Stub fallback: dead branch on builds whose SDK lacks the header. The
- * dispatch sites guard on os_sync_available, so this stub is unreachable
- * at runtime, but it keeps the link clean.
+/* Stub fallback: dead branch on builds whose SDK lacks the header. The dispatch
+ * sites guard on os_sync_available, so this stub is unreachable at runtime, but
+ * it keeps the link clean.
  */
 static uint32_t futex_os_sync_wake_n(const guest_t *g,
                                      uint64_t uaddr,
@@ -533,10 +548,10 @@ static uint32_t futex_os_sync_wake_n(const guest_t *g,
  * the bucket must also drain the os_sync queue at the same address or it
  * strands those waiters. woken is how many of target the bucket walk already
  * satisfied at uaddr; this drains the shortfall and returns the new total.
- * futex_os_sync_wake_n is a no-op when the address-wait path is disabled
- * or when no kernel waiter sits at uaddr, so this is safe to call
- * unconditionally. Call it AFTER dropping the bucket lock: os_sync_wake is a
- * syscall and must not run under the leaf lock.
+ * futex_os_sync_wake_n is a no-op when the address-wait path is disabled or
+ * when no kernel waiter sits at uaddr, so this is safe to call unconditionally.
+ * Call it AFTER dropping the bucket lock: os_sync_wake is a syscall and must
+ * not run under the leaf lock.
  *
  * Every bucket-walking wake site (futex_wake, futex_requeue, futex_wake_op)
  * routes through here so the "drain both queues" invariant is one named step,
@@ -709,12 +724,13 @@ static int64_t futex_wait(guest_t *g,
  * waiters are unlinked from the bucket list so subsequent operations do not
  * count them as still-sleeping entries.
  *
- * If the Darwin address-wait path is ever enabled again, drain any kernel-side
- * waiters at the same address up to the remaining budget so a wake site that
- * walked only the bucket would not strand them. Plain FUTEX_WAIT enqueues with
- * implicit FUTEX_BITSET_MATCH_ANY, which matches every legal FUTEX_WAKE_BITSET
- * mask (mask must be non-zero by Linux contract), so those waiters remain valid
- * wake targets.
+ * After walking the bucket, futex_wake_topup_osync drains any kernel-side
+ * waiters at the same address up to the remaining budget so a wake that walked
+ * only the bucket does not strand them; it is a no-op when the Darwin
+ * address-wait path is inactive. Plain FUTEX_WAIT enqueues with implicit
+ * FUTEX_BITSET_MATCH_ANY, which matches every legal FUTEX_WAKE_BITSET mask
+ * (mask must be non-zero by Linux contract), so those waiters remain valid wake
+ * targets.
  */
 static int64_t futex_wake(const guest_t *g,
                           uint64_t uaddr,
@@ -736,10 +752,7 @@ static int64_t futex_wake(const guest_t *g,
     while (*pp && (uint32_t) woken < val) {
         futex_waiter_t *w = *pp;
         if (w->uaddr == uaddr && (w->bitset & bitset) != 0) {
-            *pp = w->next; /* Unlink before signaling */
-            __atomic_store_n(&w->woken, 1, __ATOMIC_RELEASE);
-            pthread_cond_signal(&w->cond);
-            futex_waiter_notify_group(w);
+            futex_wake_waiter_locked(pp);
             woken++;
         } else {
             pp = &w->next;
@@ -822,10 +835,7 @@ static int64_t futex_requeue(guest_t *g,
 
         if ((uint32_t) woken < wake_count) {
             /* Wake this waiter: unlink from source, then signal */
-            *pp = w->next;
-            __atomic_store_n(&w->woken, 1, __ATOMIC_RELEASE);
-            pthread_cond_signal(&w->cond);
-            futex_waiter_notify_group(w);
+            futex_wake_waiter_locked(pp);
             woken++;
             /* Leave pp unchanged because *pp is already the next node */
         } else if ((uint32_t) requeued < requeue_count) {
@@ -968,10 +978,7 @@ static int64_t futex_wake_op(guest_t *g,
     while (*pp1 && (uint32_t) woken1 < val) {
         futex_waiter_t *w = *pp1;
         if (w->uaddr == uaddr) {
-            *pp1 = w->next;
-            __atomic_store_n(&w->woken, 1, __ATOMIC_RELEASE);
-            pthread_cond_signal(&w->cond);
-            futex_waiter_notify_group(w);
+            futex_wake_waiter_locked(pp1);
             woken1++;
         } else {
             pp1 = &w->next;
@@ -1012,10 +1019,7 @@ static int64_t futex_wake_op(guest_t *g,
         while (*pp2 && (uint32_t) woken2 < val2) {
             futex_waiter_t *w2 = *pp2;
             if (w2->uaddr == uaddr2) {
-                *pp2 = w2->next;
-                __atomic_store_n(&w2->woken, 1, __ATOMIC_RELEASE);
-                pthread_cond_signal(&w2->cond);
-                futex_waiter_notify_group(w2);
+                futex_wake_waiter_locked(pp2);
                 woken2++;
             } else {
                 pp2 = &w2->next;
@@ -1231,14 +1235,7 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
         }
 
         /* Dequeue waiter from bucket list */
-        futex_waiter_t **pp = &b->head;
-        while (*pp) {
-            if (*pp == &waiter) {
-                *pp = waiter.next;
-                break;
-            }
-            pp = &(*pp)->next;
-        }
+        bucket_unlink_locked(b, &waiter);
         pthread_mutex_unlock(&b->lock);
         pthread_cond_destroy(&waiter.cond);
 
@@ -1327,10 +1324,7 @@ static int64_t futex_unlock_pi(guest_t *g, uint64_t uaddr)
     while (*pp) {
         futex_waiter_t *w = *pp;
         if (w->uaddr == uaddr) {
-            *pp = w->next; /* Unlink before signaling */
-            __atomic_store_n(&w->woken, 1, __ATOMIC_RELEASE);
-            pthread_cond_signal(&w->cond);
-            futex_waiter_notify_group(w);
+            futex_wake_waiter_locked(pp);
             break; /* Wake exactly one */
         }
         pp = &w->next;

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -1,4 +1,5 @@
-/* /proc and /dev path emulation
+/*
+ * /proc and /dev path emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -470,27 +471,13 @@ static void shm_dir_init(void)
     shm_dir_errno = EACCES;
     snprintf(shm_dir, sizeof(shm_dir), "/tmp/elfuse-shm-%u",
              (unsigned) getuid());
-    if (mkdir(shm_dir, 0700) < 0 && errno != EEXIST) {
-        shm_dir_errno = errno;
-        shm_dir[0] = '\0';
-        return;
-    }
-    /* Verify the path is a directory owned by the current UID (not a symlink).
+    /* create_private_dir rejects a symlink or foreign-owned directory that a
+     * local user could have pre-planted at this guessable /tmp path.
      */
-    struct stat st;
-    if (lstat(shm_dir, &st) < 0) {
+    if (create_private_dir(shm_dir) < 0) {
         shm_dir_errno = errno;
-        log_error("/dev/shm dir %s: lstat failed: %s", shm_dir,
+        log_error("/dev/shm dir %s: not a private directory: %s", shm_dir,
                   strerror(errno));
-        shm_dir[0] = '\0';
-        return;
-    }
-    if (!S_ISDIR(st.st_mode) || st.st_uid != getuid()) {
-        shm_dir_errno = EACCES;
-        log_error(
-            "/dev/shm dir %s is not a directory owned by "
-            "uid %u",
-            shm_dir, (unsigned) getuid());
         shm_dir[0] = '\0';
         return;
     }
@@ -2277,6 +2264,373 @@ static int pty_open_master(int linux_flags)
     return master;
 }
 
+/* Emit /proc/self/maps into a synthetic fd. Merges contiguous regions[] runs
+ * that came from one mmap, then folds in preannounced[] shadow entries whose
+ * advertised interval is not yet fully covered by live regions.
+ *
+ * Returns a host fd, or -1 on error. Split out of proc_intercept_open to keep
+ * that dispatcher readable.
+ */
+static int proc_open_self_maps(const guest_t *g)
+{
+    /* Heap-allocated: guest threads run on host pthreads whose stacks do not
+     * comfortably hold a 16KiB frame.
+     */
+    const size_t bufsz = 16384;
+    char *buf = malloc(bufsz);
+    if (!buf)
+        return -1;
+    int off = 0;
+
+    /* Build a flat array of (va_start, va_end, prot, flags, offset, name) from
+     * regions[] plus /proc/self/maps-only preannounced[] entries.
+     * preannounced[] is intentionally NOT consulted by mmap conflict detection,
+     * so advertise-only Rosetta/JIT regions do not trip MAP_FIXED_NOREPLACE
+     * with -EEXIST.
+     *
+     * entries is heap-allocated: MAPS_ENTRY_MAX * sizeof(maps_entry_t) is
+     * ~24KiB, too large for a guest-thread pthread stack.
+     */
+    maps_entry_t *entries = calloc(MAPS_ENTRY_MAX, sizeof(*entries));
+    if (!entries) {
+        free(buf);
+        return -1;
+    }
+    int nentries = 0;
+
+    /* Convert regions[] to maps entries. regions[] is already sorted by start
+     * address; merge contiguous runs that came from one mmap.
+     */
+    for (int i = 0; i < g->nregions && nentries < MAPS_ENTRY_MAX; i++) {
+        const guest_region_t *r = &g->regions[i];
+        uint64_t start = r->start & ~0xFFFULL;
+        uint64_t end = (r->end + 0xFFF) & ~0xFFFULL;
+
+        if (nentries > 0 && entries[nentries - 1].end == start &&
+            entries[nentries - 1].prot == r->prot &&
+            entries[nentries - 1].flags == r->flags &&
+            entries[nentries - 1].offset == r->offset &&
+            !strcmp(entries[nentries - 1].name, r->name)) {
+            entries[nentries - 1].end = end;
+            continue;
+        }
+        maps_entry_insert(entries, &nentries, start, end, r->prot, r->flags,
+                          r->offset, r->name);
+    }
+
+    /* Add preannounced entries only while they still have an uncovered tail.
+     * Once the union of live regions covers the full advertised interval,
+     * suppress the shadow entry so /proc/self/maps shows only the realized
+     * split VMAs. A partial union must stay visible because some
+     * reserved-but-not-realized span remains to advertise.
+     */
+    for (int i = 0; i < g->npreannounced && nentries < MAPS_ENTRY_MAX; i++) {
+        const guest_region_t *r = &g->preannounced[i];
+        bool shadowed = false;
+        uint64_t covered_end = r->start;
+
+        for (int j = 0; j < g->nregions; j++) {
+            const guest_region_t *live = &g->regions[j];
+
+            if (live->end <= covered_end)
+                continue;
+            if (live->start > covered_end)
+                break;
+
+            covered_end = live->end;
+            if (covered_end >= r->end) {
+                shadowed = true;
+                break;
+            }
+        }
+
+        if (shadowed)
+            continue;
+
+        maps_entry_insert(entries, &nentries, r->start & ~0xFFFULL,
+                          (r->end + 0xFFFULL) & ~0xFFFULL, r->prot, r->flags,
+                          r->offset, r->name);
+    }
+    maps_entries_merge_adjacent(entries, &nentries);
+
+    /* Emit lines after merging so buffer accounting is centralized. */
+    for (int i = 0; i < nentries && off < (int) bufsz - 256; i++) {
+        const maps_entry_t *e = &entries[i];
+        char perms[5];
+        perms[0] = (e->prot & 0x1) ? 'r' : '-';
+        perms[1] = (e->prot & 0x2) ? 'w' : '-';
+        perms[2] = (e->prot & 0x4) ? 'x' : '-';
+        perms[3] = (e->flags & 0x01) ? 's' : 'p';
+        perms[4] = '\0';
+
+        /* Format matches real Linux /proc/<pid>/maps exactly:
+         *   %lx-%lx %s %08lx %02x:%02x %lu  <padding>  %s\n
+         * Verified against strace in a real Lima VZ VM.
+         */
+        char line[256];
+        int lineoff =
+            snprintf(line, sizeof(line), "%llx-%llx %s %08llx 00:00 0",
+                     (unsigned long long) e->start, (unsigned long long) e->end,
+                     perms, (unsigned long long) e->offset);
+        /* Cap lineoff to buffer size (snprintf may return more than available
+         * on truncation)
+         */
+        if (lineoff >= (int) sizeof(line))
+            lineoff = (int) sizeof(line) - 1;
+        if (e->name[0]) {
+            while (lineoff < MAPS_NAME_COLUMN &&
+                   lineoff < (int) sizeof(line) - 1)
+                line[lineoff++] = ' ';
+            int n =
+                snprintf(line + lineoff, sizeof(line) - lineoff, "%s", e->name);
+            if (n > 0)
+                lineoff += n;
+            if (lineoff >= (int) sizeof(line))
+                lineoff = (int) sizeof(line) - 1;
+        } else if (lineoff < (int) sizeof(line) - 1) {
+            line[lineoff++] = ' ';
+        }
+        int wrote = snprintf(buf + off, bufsz - off, "%.*s\n", lineoff, line);
+        if (wrote > 0 && off + wrote < (int) bufsz)
+            off += wrote;
+        else
+            break; /* Stop before truncating a maps line. */
+    }
+
+    log_debug("/proc/self/maps (%d bytes):\n%.*s", off, off, buf);
+    int fd = proc_synthetic_fd(buf, off);
+    free(entries);
+    free(buf);
+    return fd;
+}
+
+/* Emit /proc/meminfo from host sysctl (HW_MEMSIZE) plus mach vm_statistics64,
+ * approximating the Linux fields macOS does not expose.
+ *
+ * Returns a host fd, or -1. Split out of proc_intercept_open to keep that
+ * dispatcher readable.
+ */
+static int proc_open_meminfo(void)
+{
+    int64_t physmem = 0;
+    size_t sz = sizeof(physmem);
+    int mib[2] = {CTL_HW, HW_MEMSIZE};
+    sysctl(mib, 2, &physmem, &sz, NULL, 0);
+    uint64_t total_kb = (uint64_t) physmem / 1024;
+
+    /* Query host vm_statistics for accurate free/active/inactive. Falls back to
+     * approximations if the mach call fails.
+     */
+    uint64_t free_kb, avail_kb, buffers_kb, cached_kb;
+    vm_statistics64_data_t vm_stat = {0};
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    uint64_t page_size = 4096;
+    if (host_statistics64(mach_host_self(), HOST_VM_INFO64,
+                          (host_info64_t) &vm_stat, &count) == KERN_SUCCESS) {
+        host_page_size(mach_host_self(), (vm_size_t *) &page_size);
+        free_kb = (uint64_t) vm_stat.free_count * page_size / 1024;
+        uint64_t inactive_kb =
+            (uint64_t) vm_stat.inactive_count * page_size / 1024;
+        uint64_t purgeable_kb =
+            (uint64_t) vm_stat.purgeable_count * page_size / 1024;
+        /* Available ~= free + inactive + purgeable (Linux heuristic) */
+        avail_kb = free_kb + inactive_kb + purgeable_kb;
+        if (avail_kb > total_kb)
+            avail_kb = total_kb;
+        cached_kb = inactive_kb + purgeable_kb;
+        buffers_kb = 0; /* macOS does not expose buffer cache separately */
+    } else {
+        free_kb = total_kb / 2;
+        avail_kb = total_kb * 3 / 4;
+        buffers_kb = total_kb / 20;
+        cached_kb = total_kb / 4;
+    }
+
+    /* Saturating subtraction. On macOS free + cached (inactive + purgeable) can
+     * exceed physical total, which would unsigned-underflow these derived
+     * fields into absurd values.
+     */
+    uint64_t fc_kb = free_kb + cached_kb;
+    uint64_t active_kb = total_kb > fc_kb ? total_kb - fc_kb : 0;
+    uint64_t anon_kb =
+        total_kb > fc_kb + buffers_kb ? total_kb - fc_kb - buffers_kb : 0;
+
+    return proc_emit_fmt(
+        "MemTotal:       %llu kB\n"
+        "MemFree:        %llu kB\n"
+        "MemAvailable:   %llu kB\n"
+        "Buffers:        %llu kB\n"
+        "Cached:         %llu kB\n"
+        "SwapCached:     0 kB\n"
+        "Active:         %llu kB\n"
+        "Inactive:       %llu kB\n"
+        "SwapTotal:      0 kB\n"
+        "SwapFree:       0 kB\n"
+        "Dirty:          0 kB\n"
+        "Writeback:      0 kB\n"
+        "AnonPages:      %llu kB\n"
+        "Mapped:         %llu kB\n"
+        "Shmem:          0 kB\n"
+        "Slab:           0 kB\n"
+        "SReclaimable:   0 kB\n"
+        "SUnreclaim:     0 kB\n"
+        "KernelStack:    0 kB\n"
+        "PageTables:     0 kB\n"
+        "CommitLimit:    %llu kB\n"
+        "Committed_AS:   0 kB\n"
+        "VmallocTotal:   0 kB\n"
+        "VmallocUsed:    0 kB\n"
+        "VmallocChunk:   0 kB\n",
+        (unsigned long long) total_kb, (unsigned long long) free_kb,
+        (unsigned long long) avail_kb, (unsigned long long) buffers_kb,
+        (unsigned long long) cached_kb, (unsigned long long) active_kb,
+        (unsigned long long) (cached_kb / 2), (unsigned long long) anon_kb,
+        (unsigned long long) (cached_kb / 2),
+        (unsigned long long) (total_kb / 2));
+}
+
+/* Handle /proc/self/task/<tid>/{stat,status} and the <tid> directory itself.
+ * path must start with "/proc/self/task/".
+ *
+ * Returns a host fd, -1 on a matched failure, or PROC_NOT_INTERCEPTED (-2) when
+ * the tid is unparseable or the leaf is unknown. Split out of
+ * proc_intercept_open to keep that dispatcher readable.
+ */
+static int proc_open_self_task_node(const char *path, int linux_flags)
+{
+    char *endp;
+    long tid = strtol(path + 16, &endp, 10);
+    if (endp == path + 16 || tid <= 0)
+        return PROC_NOT_INTERCEPTED;
+
+    /* Verify this TID is actually active */
+    if (!thread_tid_alive((int64_t) tid)) {
+        errno = ENOENT;
+        return -1;
+    }
+
+    if (!strcmp(endp, "/stat")) {
+        return proc_emit_fmt(
+            "%ld (%.15s) R %lld %lld %lld 0 0 0 0 0 0 0 0 0 0 0 "
+            "20 0 %d 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+            "0 0 0 0 0 0 0 0\n",
+            tid, proc_comm_name(), (long long) proc_get_ppid(),
+            (long long) proc_get_pid(), /* pgid */
+            (long long) proc_get_sid(), thread_active_count());
+    }
+
+    if (!strcmp(endp, "/status")) {
+        return proc_emit_fmt(
+            "Name:\t%.15s\n"
+            "State:\tR (running)\n"
+            "Tgid:\t%lld\n"
+            "Pid:\t%ld\n"
+            "PPid:\t%lld\n"
+            "Uid:\t%u\t%u\t%u\t%u\n"
+            "Gid:\t%u\t%u\t%u\t%u\n"
+            "Threads:\t%d\n",
+            proc_comm_name(), (long long) proc_get_pid(), tid,
+            (long long) proc_get_ppid(), proc_get_uid(), proc_get_euid(),
+            proc_get_suid(), proc_get_euid(), proc_get_gid(), proc_get_egid(),
+            proc_get_sgid(), proc_get_egid(), thread_active_count());
+    }
+
+    /* /proc/self/task/<tid> directory itself: synthesize a dir with stat/status
+     * placeholder entries. Persistent so getdents sees the entries on macOS
+     * (which cannot enumerate unlinked dirs).
+     */
+    if (*endp == '\0' || !strcmp(endp, "/")) {
+        static proc_persistent_dir_t tiddir =
+            PROC_PERSISTENT_DIR("/tmp/elfuse-tid-XXXXXX");
+        const char *dir = proc_persistent_dir_acquire(&tiddir);
+        if (!dir)
+            return -1;
+
+        char p[160];
+        snprintf(p, sizeof(p), "%s/stat", dir);
+        close(open(p, O_CREAT | O_WRONLY, 0444));
+        snprintf(p, sizeof(p), "%s/status", dir);
+        close(open(p, O_CREAT | O_WRONLY, 0444));
+
+        int fd = proc_open_dir_fd(dir, linux_flags);
+        proc_persistent_dir_release(&tiddir);
+        return fd;
+    }
+
+    return PROC_NOT_INTERCEPTED; /* unknown /proc/self/task/<tid>/XXX */
+}
+
+/* Handle the mount-table /proc nodes: /proc/filesystems, /proc/self/mountinfo,
+ * and /proc/{mounts,self/mounts} plus /etc/mtab.
+ *
+ * Returns a host fd, -1 on a matched failure, or PROC_NOT_INTERCEPTED when path
+ * is none of them. Split out of proc_intercept_open to keep that dispatcher
+ * readable.
+ */
+static int proc_open_mounts_node(const char *path)
+{
+    if (!strcmp(path, "/proc/filesystems")) {
+        return proc_emit_literal(
+            "\tmpfs\n"
+            "\tproc\n"
+            "\tsysfs\n"
+            "\tdevtmpfs\n"
+            "\tfuse\n"
+            "\text4\n"
+            "\tvfat\n");
+    }
+
+    /* /proc/self/mountinfo -> Linux mountinfo format (different from
+     * /proc/mounts). Format: id parent_id major:minor root mount_point options
+     * - type source super_options
+     */
+    if (!strcmp(path, "/proc/self/mountinfo")) {
+        const size_t bufsz = 8192;
+        char *buf = malloc(bufsz);
+        if (!buf)
+            return -1;
+        size_t off = (size_t) snprintf(
+            buf, bufsz,
+            "1 0 0:1 / / rw,relatime - ext4 /dev/root rw\n"
+            "2 1 0:2 / /proc rw,nosuid,nodev,noexec - proc proc rw\n"
+            "3 1 0:3 / /tmp rw,nosuid,nodev - tmpfs tmpfs rw\n"
+            "4 1 0:4 / /dev rw,nosuid - devtmpfs devtmpfs rw\n"
+            "5 4 0:5 / /dev/shm rw,nosuid,nodev - tmpfs tmpfs rw\n");
+        if (off >= bufsz || fuse_append_mountinfo(buf, bufsz, &off) < 0) {
+            free(buf);
+            return -1;
+        }
+        int fd = proc_synthetic_fd(buf, off);
+        free(buf);
+        return fd;
+    }
+
+    /* /proc/mounts, /etc/mtab -> synthetic mount table */
+    if (!strcmp(path, "/proc/mounts") || !strcmp(path, "/proc/self/mounts") ||
+        !strcmp(path, "/etc/mtab")) {
+        const size_t bufsz = 8192;
+        char *buf = malloc(bufsz);
+        if (!buf)
+            return -1;
+        size_t off =
+            (size_t) snprintf(buf, bufsz,
+                              "/ / ext4 rw,relatime 0 0\n"
+                              "proc /proc proc rw,nosuid,nodev,noexec 0 0\n"
+                              "tmpfs /tmp tmpfs rw,nosuid,nodev 0 0\n"
+                              "devtmpfs /dev devtmpfs rw,nosuid 0 0\n"
+                              "tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0\n");
+        if (off >= bufsz || fuse_append_mounts(buf, bufsz, &off) < 0) {
+            free(buf);
+            return -1;
+        }
+        int fd = proc_synthetic_fd(buf, off);
+        free(buf);
+        return fd;
+    }
+
+    return PROC_NOT_INTERCEPTED;
+}
+
 int proc_intercept_open(const guest_t *g,
                         const char *path,
                         int linux_flags,
@@ -2627,70 +2981,9 @@ int proc_intercept_open(const guest_t *g,
         return fd;
     }
 
-    /* /proc/self/task/<tid>/stat -> per-thread stat line */
-    if (!strncmp(path, "/proc/self/task/", 16)) {
-        char *endp;
-        long tid = strtol(path + 16, &endp, 10);
-        if (endp == path + 16 || tid <= 0)
-            return -2; /* not intercepted */
-
-        /* Verify this TID is actually active */
-        if (!thread_tid_alive((int64_t) tid)) {
-            errno = ENOENT;
-            return -1;
-        }
-
-        if (!strcmp(endp, "/stat")) {
-            return proc_emit_fmt(
-                "%ld (%.15s) R %lld %lld %lld 0 0 0 0 0 0 0 0 0 0 0 "
-                "20 0 %d 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
-                "0 0 0 0 0 0 0 0\n",
-                tid, proc_comm_name(), (long long) proc_get_ppid(),
-                (long long) proc_get_pid(), /* pgid */
-                (long long) proc_get_sid(), thread_active_count());
-        }
-
-        if (!strcmp(endp, "/status")) {
-            return proc_emit_fmt(
-                "Name:\t%.15s\n"
-                "State:\tR (running)\n"
-                "Tgid:\t%lld\n"
-                "Pid:\t%ld\n"
-                "PPid:\t%lld\n"
-                "Uid:\t%u\t%u\t%u\t%u\n"
-                "Gid:\t%u\t%u\t%u\t%u\n"
-                "Threads:\t%d\n",
-                proc_comm_name(), (long long) proc_get_pid(), tid,
-                (long long) proc_get_ppid(), proc_get_uid(), proc_get_euid(),
-                proc_get_suid(), proc_get_euid(), proc_get_gid(),
-                proc_get_egid(), proc_get_sgid(), proc_get_egid(),
-                thread_active_count());
-        }
-
-        /* /proc/self/task/<tid> directory itself: synthesize a dir with
-         * stat/status placeholder entries. Persistent so getdents sees the
-         * entries on macOS (which cannot enumerate unlinked dirs).
-         */
-        if (*endp == '\0' || !strcmp(endp, "/")) {
-            static proc_persistent_dir_t tiddir =
-                PROC_PERSISTENT_DIR("/tmp/elfuse-tid-XXXXXX");
-            const char *dir = proc_persistent_dir_acquire(&tiddir);
-            if (!dir)
-                return -1;
-
-            char p[160];
-            snprintf(p, sizeof(p), "%s/stat", dir);
-            close(open(p, O_CREAT | O_WRONLY, 0444));
-            snprintf(p, sizeof(p), "%s/status", dir);
-            close(open(p, O_CREAT | O_WRONLY, 0444));
-
-            int fd = proc_open_dir_fd(dir, linux_flags);
-            proc_persistent_dir_release(&tiddir);
-            return fd;
-        }
-
-        return -2; /* unknown /proc/self/task/<tid>/XXX */
-    }
+    /* /proc/self/task/<tid>/{stat,status} and the <tid> directory. */
+    if (!strncmp(path, "/proc/self/task/", 16))
+        return proc_open_self_task_node(path, linux_flags);
 
     /* /proc/self/maps -> generated from guest region tracking. Addresses are
      * page-aligned (rounded down/up) to match real Linux behavior. Output
@@ -2699,123 +2992,8 @@ int proc_intercept_open(const guest_t *g,
      * mmap() call produces one maps entry even when the backing pages span
      * multiple physical frames.
      */
-    if (!strcmp(path, "/proc/self/maps")) {
-        char buf[16384];
-        int off = 0;
-
-        /* Build a flat array of (va_start, va_end, prot, flags, offset, name)
-         * from regions[] plus /proc/self/maps-only preannounced[] entries.
-         * preannounced[] is intentionally NOT consulted by mmap conflict
-         * detection, so advertise-only Rosetta/JIT regions do not trip
-         * MAP_FIXED_NOREPLACE with -EEXIST.
-         */
-        maps_entry_t entries[MAPS_ENTRY_MAX];
-        int nentries = 0;
-
-        /* Convert regions[] to maps entries. regions[] is already sorted by
-         * start address; merge contiguous runs that came from one mmap.
-         */
-        for (int i = 0; i < g->nregions && nentries < MAPS_ENTRY_MAX; i++) {
-            const guest_region_t *r = &g->regions[i];
-            uint64_t start = r->start & ~0xFFFULL;
-            uint64_t end = (r->end + 0xFFF) & ~0xFFFULL;
-
-            if (nentries > 0 && entries[nentries - 1].end == start &&
-                entries[nentries - 1].prot == r->prot &&
-                entries[nentries - 1].flags == r->flags &&
-                entries[nentries - 1].offset == r->offset &&
-                !strcmp(entries[nentries - 1].name, r->name)) {
-                entries[nentries - 1].end = end;
-                continue;
-            }
-            maps_entry_insert(entries, &nentries, start, end, r->prot, r->flags,
-                              r->offset, r->name);
-        }
-
-        /* Add preannounced entries only while they still have an uncovered
-         * tail. Once the union of live regions covers the full advertised
-         * interval, suppress the shadow entry so /proc/self/maps shows only the
-         * realized split VMAs. A partial union must stay visible because some
-         * reserved-but-not-realized span remains to advertise.
-         */
-        for (int i = 0; i < g->npreannounced && nentries < MAPS_ENTRY_MAX;
-             i++) {
-            const guest_region_t *r = &g->preannounced[i];
-            bool shadowed = false;
-            uint64_t covered_end = r->start;
-
-            for (int j = 0; j < g->nregions; j++) {
-                const guest_region_t *live = &g->regions[j];
-
-                if (live->end <= covered_end)
-                    continue;
-                if (live->start > covered_end)
-                    break;
-
-                covered_end = live->end;
-                if (covered_end >= r->end) {
-                    shadowed = true;
-                    break;
-                }
-            }
-
-            if (shadowed)
-                continue;
-
-            maps_entry_insert(entries, &nentries, r->start & ~0xFFFULL,
-                              (r->end + 0xFFFULL) & ~0xFFFULL, r->prot,
-                              r->flags, r->offset, r->name);
-        }
-        maps_entries_merge_adjacent(entries, &nentries);
-
-        /* Emit lines after merging so buffer accounting is centralized. */
-        for (int i = 0; i < nentries && off < (int) sizeof(buf) - 256; i++) {
-            const maps_entry_t *e = &entries[i];
-            char perms[5];
-            perms[0] = (e->prot & 0x1) ? 'r' : '-';
-            perms[1] = (e->prot & 0x2) ? 'w' : '-';
-            perms[2] = (e->prot & 0x4) ? 'x' : '-';
-            perms[3] = (e->flags & 0x01) ? 's' : 'p';
-            perms[4] = '\0';
-
-            /* Format matches real Linux /proc/<pid>/maps exactly:
-             *   %lx-%lx %s %08lx %02x:%02x %lu  <padding>  %s\n
-             * Verified against strace in a real Lima VZ VM.
-             */
-            char line[256];
-            int lineoff = snprintf(
-                line, sizeof(line), "%llx-%llx %s %08llx 00:00 0",
-                (unsigned long long) e->start, (unsigned long long) e->end,
-                perms, (unsigned long long) e->offset);
-            /* Cap lineoff to buffer size (snprintf may return more than
-             * available on truncation)
-             */
-            if (lineoff >= (int) sizeof(line))
-                lineoff = (int) sizeof(line) - 1;
-            if (e->name[0]) {
-                while (lineoff < MAPS_NAME_COLUMN &&
-                       lineoff < (int) sizeof(line) - 1)
-                    line[lineoff++] = ' ';
-                int n = snprintf(line + lineoff, sizeof(line) - lineoff, "%s",
-                                 e->name);
-                if (n > 0)
-                    lineoff += n;
-                if (lineoff >= (int) sizeof(line))
-                    lineoff = (int) sizeof(line) - 1;
-            } else if (lineoff < (int) sizeof(line) - 1) {
-                line[lineoff++] = ' ';
-            }
-            int wrote =
-                snprintf(buf + off, sizeof(buf) - off, "%.*s\n", lineoff, line);
-            if (wrote > 0 && off + wrote < (int) sizeof(buf))
-                off += wrote;
-            else
-                break; /* Stop before truncating a maps line. */
-        }
-
-        log_debug("/proc/self/maps (%d bytes):\n%.*s", off, off, buf);
-        return proc_synthetic_fd(buf, off);
-    }
+    if (!strcmp(path, "/proc/self/maps"))
+        return proc_open_self_maps(g);
 
     /* /proc/uptime -> synthetic uptime in seconds. Uses sysctl(KERN_BOOTTIME),
      * same as sys_sysinfo() in syscall/sys.c. Idle time is 0 (no meaningful
@@ -2890,29 +3068,38 @@ int proc_intercept_open(const guest_t *g,
             .want_tcp = want_tcp,
             .want_v6 = want_v6,
         };
-        char buf[16384];
+        char *buf = malloc(ctx.bufsz);
+        if (!buf)
+            return -1;
         ctx.buf = buf;
         ctx.off = snprintf(
-            buf, sizeof(buf), "%s",
+            buf, ctx.bufsz, "%s",
             want_tcp ? "  sl  local_address rem_address   st tx_queue "
                        "rx_queue tr tm->when retrnsmt   uid  timeout inode\n"
                      : "  sl  local_address rem_address   st tx_queue "
                        "rx_queue tr tm->when retrnsmt   uid  timeout inode"
                        " ref pointer drops\n");
         proc_net_for_each_socket(proc_net_inet_visit, &ctx);
-        return proc_synthetic_fd_str(buf, ctx.off, sizeof(buf));
+        int fd = proc_synthetic_fd_str(buf, ctx.off, ctx.bufsz);
+        free(buf);
+        return fd;
     }
     if (!strcmp(path, "/proc/net/unix")) {
-        char buf[8192];
+        const size_t bufsz = 8192;
+        char *buf = malloc(bufsz);
+        if (!buf)
+            return -1;
         struct proc_net_unix_ctx ctx = {
             .buf = buf,
-            .bufsz = sizeof(buf),
-            .off = snprintf(buf, sizeof(buf),
+            .bufsz = bufsz,
+            .off = snprintf(buf, bufsz,
                             "Num       RefCount Protocol Flags    Type St "
                             "Inode Path\n"),
         };
         proc_net_for_each_socket(proc_net_unix_visit, &ctx);
-        return proc_synthetic_fd_str(buf, ctx.off, sizeof(buf));
+        int fd = proc_synthetic_fd_str(buf, ctx.off, bufsz);
+        free(buf);
+        return fd;
     }
 
     /* /proc/sys/vm/mmap_min_addr -> synthetic mmap minimum address. */
@@ -2933,52 +3120,11 @@ int proc_intercept_open(const guest_t *g,
             "#20-Ubuntu SMP PREEMPT_DYNAMIC\n");
     }
 
-    /* /proc/filesystems -> supported filesystem types */
-    if (!strcmp(path, "/proc/filesystems")) {
-        return proc_emit_literal(
-            "\tmpfs\n"
-            "\tproc\n"
-            "\tsysfs\n"
-            "\tdevtmpfs\n"
-            "\tfuse\n"
-            "\text4\n"
-            "\tvfat\n");
-    }
-
-    /* /proc/self/mountinfo -> Linux mountinfo format (different from
-     * /proc/mounts). Format: id parent_id major:minor root mount_point options
-     * - type source super_options
-     */
-    if (!strcmp(path, "/proc/self/mountinfo")) {
-        char buf[8192];
-        size_t off = (size_t) snprintf(
-            buf, sizeof(buf),
-            "1 0 0:1 / / rw,relatime - ext4 /dev/root rw\n"
-            "2 1 0:2 / /proc rw,nosuid,nodev,noexec - proc proc rw\n"
-            "3 1 0:3 / /tmp rw,nosuid,nodev - tmpfs tmpfs rw\n"
-            "4 1 0:4 / /dev rw,nosuid - devtmpfs devtmpfs rw\n"
-            "5 4 0:5 / /dev/shm rw,nosuid,nodev - tmpfs tmpfs rw\n");
-        if (off >= sizeof(buf) ||
-            fuse_append_mountinfo(buf, sizeof(buf), &off) < 0)
-            return -1;
-        return proc_synthetic_fd(buf, off);
-    }
-
-    /* /proc/mounts, /etc/mtab -> synthetic mount table */
-    if (!strcmp(path, "/proc/mounts") || !strcmp(path, "/proc/self/mounts") ||
-        !strcmp(path, "/etc/mtab")) {
-        char buf[8192];
-        size_t off =
-            (size_t) snprintf(buf, sizeof(buf),
-                              "/ / ext4 rw,relatime 0 0\n"
-                              "proc /proc proc rw,nosuid,nodev,noexec 0 0\n"
-                              "tmpfs /tmp tmpfs rw,nosuid,nodev 0 0\n"
-                              "devtmpfs /dev devtmpfs rw,nosuid 0 0\n"
-                              "tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0\n");
-        if (off >= sizeof(buf) ||
-            fuse_append_mounts(buf, sizeof(buf), &off) < 0)
-            return -1;
-        return proc_synthetic_fd(buf, off);
+    /* /proc/filesystems, /proc/self/mountinfo, /proc/mounts, /etc/mtab. */
+    {
+        int r = proc_open_mounts_node(path);
+        if (r != PROC_NOT_INTERCEPTED)
+            return r;
     }
 
     /* OOM nodes share one stored adjustment.
@@ -3096,77 +3242,8 @@ int proc_intercept_open(const guest_t *g,
         return dev_fd_dup(path, 14);
 
     /* /proc/meminfo -> synthetic memory info from host vm_statistics */
-    if (!strcmp(path, "/proc/meminfo")) {
-        int64_t physmem = 0;
-        size_t sz = sizeof(physmem);
-        int mib[2] = {CTL_HW, HW_MEMSIZE};
-        sysctl(mib, 2, &physmem, &sz, NULL, 0);
-        uint64_t total_kb = (uint64_t) physmem / 1024;
-
-        /* Query host vm_statistics for accurate free/active/inactive. Falls
-         * back to approximations if the mach call fails.
-         */
-        uint64_t free_kb, avail_kb, buffers_kb, cached_kb;
-        vm_statistics64_data_t vm_stat = {0};
-        mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
-        uint64_t page_size = 4096;
-        if (host_statistics64(mach_host_self(), HOST_VM_INFO64,
-                              (host_info64_t) &vm_stat,
-                              &count) == KERN_SUCCESS) {
-            host_page_size(mach_host_self(), (vm_size_t *) &page_size);
-            free_kb = (uint64_t) vm_stat.free_count * page_size / 1024;
-            uint64_t inactive_kb =
-                (uint64_t) vm_stat.inactive_count * page_size / 1024;
-            uint64_t purgeable_kb =
-                (uint64_t) vm_stat.purgeable_count * page_size / 1024;
-            /* Available ~= free + inactive + purgeable (Linux heuristic) */
-            avail_kb = free_kb + inactive_kb + purgeable_kb;
-            if (avail_kb > total_kb)
-                avail_kb = total_kb;
-            cached_kb = inactive_kb + purgeable_kb;
-            buffers_kb = 0; /* macOS does not expose buffer cache separately */
-        } else {
-            free_kb = total_kb / 2;
-            avail_kb = total_kb * 3 / 4;
-            buffers_kb = total_kb / 20;
-            cached_kb = total_kb / 4;
-        }
-
-        return proc_emit_fmt(
-            "MemTotal:       %llu kB\n"
-            "MemFree:        %llu kB\n"
-            "MemAvailable:   %llu kB\n"
-            "Buffers:        %llu kB\n"
-            "Cached:         %llu kB\n"
-            "SwapCached:     0 kB\n"
-            "Active:         %llu kB\n"
-            "Inactive:       %llu kB\n"
-            "SwapTotal:      0 kB\n"
-            "SwapFree:       0 kB\n"
-            "Dirty:          0 kB\n"
-            "Writeback:      0 kB\n"
-            "AnonPages:      %llu kB\n"
-            "Mapped:         %llu kB\n"
-            "Shmem:          0 kB\n"
-            "Slab:           0 kB\n"
-            "SReclaimable:   0 kB\n"
-            "SUnreclaim:     0 kB\n"
-            "KernelStack:    0 kB\n"
-            "PageTables:     0 kB\n"
-            "CommitLimit:    %llu kB\n"
-            "Committed_AS:   0 kB\n"
-            "VmallocTotal:   0 kB\n"
-            "VmallocUsed:    0 kB\n"
-            "VmallocChunk:   0 kB\n",
-            (unsigned long long) total_kb, (unsigned long long) free_kb,
-            (unsigned long long) avail_kb, (unsigned long long) buffers_kb,
-            (unsigned long long) cached_kb,
-            (unsigned long long) (total_kb - free_kb - cached_kb),
-            (unsigned long long) (cached_kb / 2),
-            (unsigned long long) (total_kb - free_kb - cached_kb - buffers_kb),
-            (unsigned long long) (cached_kb / 2),
-            (unsigned long long) (total_kb / 2));
-    }
+    if (!strcmp(path, "/proc/meminfo"))
+        return proc_open_meminfo();
 
     /* /proc/self/io -> synthetic I/O counters. Some node-style observability
      * runtimes read this for resource monitoring metrics. procfs emulation

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -385,7 +385,8 @@ void thread_interrupt_all(void)
 
     pthread_mutex_lock(&thread_lock);
     THREAD_FOR_EACH_ACTIVE (t)
-        vcpus[count++] = t->vcpu;
+        if (t->vcpu) /* skip slots whose vCPU was already torn down */
+            vcpus[count++] = t->vcpu;
     pthread_mutex_unlock(&thread_lock);
 
     /* Force all active vCPUs out of hv_vcpu_run(). Each vCPU will see

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -1,4 +1,5 @@
-/* execve syscall handler
+/*
+ * execve syscall handler
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -367,8 +368,6 @@ int64_t sys_execve(hv_vcpu_t vcpu,
             err = -LINUX_E2BIG;
             goto fail;
         }
-        int new_argc = argc - 1 + prefix;
-
         /* Use a fixed-size stack array (MAX_ARGS+3 covers interpreter +
          * optional arg + script + original argv[1:]).
          */

--- a/src/syscall/inotify.c
+++ b/src/syscall/inotify.c
@@ -1,4 +1,5 @@
-/* Linux inotify emulation via kqueue EVFILT_VNODE for elfuse
+/*
+ * Linux inotify emulation via kqueue EVFILT_VNODE for elfuse
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -234,44 +235,31 @@ static uint32_t notes_to_in_mask(uint32_t fflags,
     return mask & subscribed;
 }
 
-/* Queue a single inotify event into the instance's buffer. name may be NULL (no
- * filename).
+/* Queue a single inotify event into the instance's buffer. elfuse derives
+ * events from kqueue EVFILT_VNODE, which reports the watched node but never a
+ * child filename, so every event carries a zero-length name.
  *
  * Returns 0 on success, -1 if full.
  */
 static int queue_event(inotify_instance_t *inst,
                        int wd,
                        uint32_t mask,
-                       uint32_t cookie,
-                       const char *name)
+                       uint32_t cookie)
 {
-    /* Calculate event size: header + name length (NUL + padding to 4) */
-    uint32_t name_len = 0;
-    if (name && name[0]) {
-        size_t raw = strlen(name) + 1;           /* Include NUL */
-        name_len = (uint32_t) ((raw + 3) & ~3U); /* Pad to 4-byte boundary */
-    }
-    size_t event_size = INOTIFY_EVENT_HEADER_SIZE + name_len;
-
-    if (inst->event_used + event_size > INOTIFY_BUFSIZE)
+    if (inst->event_used + INOTIFY_EVENT_HEADER_SIZE > INOTIFY_BUFSIZE)
         return -1; /* Drop event when the fixed inotify queue is full. */
 
     uint8_t *p = inst->event_buf + inst->event_used;
 
-    /* Write header fields (little-endian, matching aarch64) */
+    /* Write header fields (little-endian, matching aarch64). name_len is 0. */
     int32_t wd32 = (int32_t) wd;
+    uint32_t name_len = 0;
     memcpy(p + 0, &wd32, 4);
     memcpy(p + 4, &mask, 4);
     memcpy(p + 8, &cookie, 4);
     memcpy(p + 12, &name_len, 4);
 
-    /* Write name if present (zero-padded) */
-    if (name_len > 0) {
-        memset(p + INOTIFY_EVENT_HEADER_SIZE, 0, name_len);
-        memcpy(p + INOTIFY_EVENT_HEADER_SIZE, name, strlen(name));
-    }
-
-    inst->event_used += event_size;
+    inst->event_used += INOTIFY_EVENT_HEADER_SIZE;
     return 0;
 }
 
@@ -328,13 +316,13 @@ static int collect_events(inotify_instance_t *inst)
          * watches, inotify emulation also omits the filename since kqueue
          * EVFILT_VNODE does not report which child changed.
          */
-        if (queue_event(inst, w->wd, in_mask, 0, NULL) == 0) {
+        if (queue_event(inst, w->wd, in_mask, 0) == 0) {
             collected++;
         } else {
             /* Fixed inotify queue is full; queue IN_Q_OVERFLOW and stop.
              * IN_Q_OVERFLOW (0x4000) uses wd=-1 per Linux semantics.
              */
-            queue_event(inst, -1, 0x4000, 0, NULL);
+            queue_event(inst, -1, 0x4000, 0);
             break;
         }
     }
@@ -627,7 +615,7 @@ int64_t inotify_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
                 uint32_t in_mask =
                     notes_to_in_mask((uint32_t) kev.fflags, w->mask, w->is_dir);
                 if (in_mask != 0) {
-                    queue_event(inst, w->wd, in_mask, 0, NULL);
+                    queue_event(inst, w->wd, in_mask, 0);
                     pipe_signal(inst);
                 }
             }

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -1,4 +1,5 @@
-/* Core I/O syscall handlers
+/*
+ * Core I/O syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -419,10 +420,9 @@ static uint32_t mac_iflag_to_linux(tcflag_t mf)
 /* Linux aarch64 c_oflag bits (asm-generic/termbits-common.h + termbits.h). Only
  * OPOST (0x01) has the same value on both platforms. macOS 0x02 = ONLCR; Linux
  * 0x02 = OLCUC (output lowercase->uppercase, rare). macOS 0x04 = OXTABS; Linux
- * 0x04 = ONLCR. All other bits shift by one.
- */
-/* OLCUC (Linux 0x002, output lowercase->uppercase) has no macOS equivalent and
- * is silently dropped. macOS uses 0x002 for ONLCR.
+ * 0x04 = ONLCR. All other bits shift by one. OLCUC (Linux 0x002, output
+ * lowercase->uppercase) has no macOS equivalent and is silently dropped. macOS
+ * uses 0x002 for ONLCR.
  */
 #define LINUX_OPOST 0x001
 #define LINUX_ONLCR 0x004  /* macOS ONLCR=0x002 */
@@ -519,8 +519,6 @@ static speed_t linux_cbaud_to_speed(uint32_t cbaud)
     };
     uint32_t rate_idx = cbaud & 0xF;
 
-    if (cbaud == LINUX_BOTHER)
-        return 0; /* caller should use c_ispeed/c_ospeed directly */
     if (cbaud < 16)
         return std_rates[cbaud];
     if (cbaud & LINUX_BOTHER)
@@ -604,10 +602,8 @@ static uint32_t mac_cflag_to_linux(tcflag_t mf)
 
 /* Linux aarch64 c_lflag bits (asm-generic/termbits.h). Virtually every flag has
  * a different value from macOS. Only ECHO (0x0008) is the same on both
- * platforms.
- */
-/* XCASE (Linux 0x004, rarely used, no macOS equivalent) is dropped; macOS 0x004
- * has different semantics and is not translated here.
+ * platforms. XCASE (Linux 0x004, rarely used, no macOS equivalent) is dropped;
+ * macOS 0x004 has different semantics and is not translated here.
  */
 #define LINUX_ISIG 0x00001
 #define LINUX_ICANON 0x00002
@@ -1778,7 +1774,8 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
          * elfuse does not forward host SIGIO into the guest, and nginx workers
          * receive both client I/O and channel commands via epoll rather than
          * SIGIO, so accept the request as a no-op: read the int arg for EFAULT
-         * parity and report success without arming host async delivery. */
+         * parity and report success without arming host async delivery.
+         */
         int32_t on = 0;
         if (guest_read_small(g, arg, &on, sizeof(on)) < 0) {
             host_fd_ref_close(&host_ref);
@@ -2006,6 +2003,96 @@ int64_t sys_fallocate(int fd, int mode, int64_t offset, int64_t len)
     return 0;
 }
 
+/* Scratch buffer size for the file-copy syscall emulations. Heap-allocated per
+ * call rather than placed on the stack: guest threads run on host pthreads
+ * whose stacks are far smaller than a 64KiB frame would tolerate.
+ */
+#define IO_COPY_BUF_SIZE (64 * 1024)
+
+/* Chunked read/write copy shared by sendfile and copy_file_range. Reads from
+ * in_hfd (honoring proc_try_chunk_read_intercept for /proc-backed guest fd
+ * in_gfd) and writes to out_hfd. A non-negative *off_in / *off_out selects
+ * pread/pwrite at that offset and is advanced by the bytes moved; -1 selects
+ * read/write against the fd's own position. Queues SIGPIPE on EPIPE. Stops on
+ * EOF or short write.
+ *
+ * Returns the byte count moved, or a negative Linux errno only when the very
+ * first read or write failed (partial transfers report the count so the caller
+ * can still write offsets back).
+ */
+static int64_t copy_fd_range(int in_gfd,
+                             int in_hfd,
+                             int out_hfd,
+                             int64_t *off_in,
+                             int64_t *off_out,
+                             uint64_t len)
+{
+    char *buf = malloc(IO_COPY_BUF_SIZE);
+    if (!buf)
+        return -LINUX_ENOMEM;
+
+    size_t total = 0, remaining = len;
+    int64_t ret;
+    while (remaining > 0) {
+        size_t chunk =
+            remaining > IO_COPY_BUF_SIZE ? IO_COPY_BUF_SIZE : remaining;
+        ssize_t nr;
+        if (*off_in >= 0) {
+            int64_t intercepted = proc_try_chunk_read_intercept(
+                in_gfd, in_hfd, buf, chunk, *off_in, 1);
+            nr = (intercepted != INT64_MIN)
+                     ? intercepted
+                     : pread(in_hfd, buf, chunk, *off_in);
+        } else {
+            int64_t intercepted =
+                proc_try_chunk_read_intercept(in_gfd, in_hfd, buf, chunk, 0, 0);
+            nr = (intercepted != INT64_MIN) ? intercepted
+                                            : read(in_hfd, buf, chunk);
+        }
+        if (nr < 0) {
+            ret = total > 0 ? (int64_t) total : linux_errno();
+            goto done;
+        }
+        if (nr == 0)
+            break; /* EOF */
+
+        ssize_t nw = (*off_out >= 0) ? pwrite(out_hfd, buf, nr, *off_out)
+                                     : write(out_hfd, buf, nr);
+        if (nw < 0) {
+            if (errno == EPIPE)
+                signal_queue(LINUX_SIGPIPE);
+            ret = total > 0 ? (int64_t) total : linux_errno();
+            goto done;
+        }
+
+        total += nw;
+        remaining -= nw;
+        if (*off_in >= 0)
+            *off_in += nw;
+        if (*off_out >= 0)
+            *off_out += nw;
+        if (nw < nr) {
+            /* Short write. For position-based input, read() already consumed
+             * all nr bytes but only nw were sent, so rewind the input fd by the
+             * unsent nr - nw so a later call re-reads them. Linux advances the
+             * input only by bytes actually transferred. For offset-based input,
+             * pread left the position untouched and off_in advanced by nw only,
+             * so there is nothing to undo. Best-effort: a non-seekable input
+             * (which sendfile/copy_file_range do not accept) simply keeps the
+             * prior behavior.
+             */
+            if (*off_in < 0)
+                (void) lseek(in_hfd, (off_t) (nw - nr), SEEK_CUR);
+            break;
+        }
+    }
+    ret = (int64_t) total;
+
+done:
+    free(buf);
+    return ret;
+}
+
 int64_t sys_sendfile(guest_t *g,
                      int out_fd,
                      int in_fd,
@@ -2037,52 +2124,15 @@ int64_t sys_sendfile(guest_t *g,
         }
     }
 
-    char buf[65536];
-    size_t total = 0, remaining = count;
-    while (remaining > 0) {
-        size_t chunk = remaining > sizeof(buf) ? sizeof(buf) : remaining;
-        ssize_t nr;
-        if (offset >= 0) {
-            int64_t intercepted = proc_try_chunk_read_intercept(
-                in_fd, in_ref.fd, buf, chunk, offset, 1);
-            if (intercepted != INT64_MIN)
-                nr = intercepted;
-            else
-                nr = pread(in_ref.fd, buf, chunk, offset);
-        } else {
-            int64_t intercepted = proc_try_chunk_read_intercept(
-                in_fd, in_ref.fd, buf, chunk, 0, 0);
-            if (intercepted != INT64_MIN)
-                nr = intercepted;
-            else
-                nr = read(in_ref.fd, buf, chunk);
-        }
-        if (nr < 0) {
-            if (total > 0)
-                break; /* Partial success: report bytes sent */
-            err = linux_errno();
-            goto out_sendfile;
-        }
-        if (nr == 0)
-            break; /* EOF */
-
-        ssize_t nw = write(out_ref.fd, buf, nr);
-        if (nw < 0) {
-            if (errno == EPIPE)
-                signal_queue(LINUX_SIGPIPE);
-            if (total > 0)
-                break; /* Report partial success below */
-            err = linux_errno();
-            goto out_sendfile;
-        }
-
-        total += nw;
-        remaining -= nw;
-        if (offset >= 0)
-            offset += nw;
-        if (nw < nr)
-            break; /* Short write */
+    /* sendfile has no output offset, so out always uses write(). */
+    int64_t off_out = -1;
+    int64_t moved =
+        copy_fd_range(in_fd, in_ref.fd, out_ref.fd, &offset, &off_out, count);
+    if (moved < 0) {
+        err = moved;
+        goto out_sendfile;
     }
+    size_t total = (size_t) moved;
 
     /* Write back updated offset (even on partial transfer). Preserve partial
      * success: if bytes were transferred but offset writeback fails, return the
@@ -2109,7 +2159,10 @@ int64_t sys_copy_file_range(guest_t *g,
                             uint64_t len,
                             unsigned int flags)
 {
-    (void) flags;
+    /* Linux reserves flags for future use and rejects any nonzero value. */
+    if (flags != 0)
+        return -LINUX_EINVAL;
+
     host_fd_ref_t in_ref, out_ref;
     int64_t err = host_fd_ref_open_regular_io(fd_in, &in_ref);
     if (err < 0)
@@ -2135,60 +2188,14 @@ int64_t sys_copy_file_range(guest_t *g,
         }
     }
 
-    /* Emulate with pread/pwrite loop */
-    char buf[65536];
-    size_t total = 0, remaining = len;
-    while (remaining > 0) {
-        size_t chunk = remaining > sizeof(buf) ? sizeof(buf) : remaining;
-        ssize_t nr;
-        if (off_in >= 0) {
-            int64_t intercepted = proc_try_chunk_read_intercept(
-                fd_in, in_ref.fd, buf, chunk, off_in, 1);
-            if (intercepted != INT64_MIN)
-                nr = intercepted;
-            else
-                nr = pread(in_ref.fd, buf, chunk, off_in);
-        } else {
-            int64_t intercepted = proc_try_chunk_read_intercept(
-                fd_in, in_ref.fd, buf, chunk, 0, 0);
-            if (intercepted != INT64_MIN)
-                nr = intercepted;
-            else
-                nr = read(in_ref.fd, buf, chunk);
-        }
-        if (nr < 0) {
-            if (total > 0)
-                break; /* Partial success: report bytes sent */
-            err = linux_errno();
-            goto out_copy_file_range;
-        }
-        if (nr == 0)
-            break; /* EOF */
-
-        ssize_t nw;
-        if (off_out >= 0) {
-            nw = pwrite(out_ref.fd, buf, nr, off_out);
-        } else {
-            nw = write(out_ref.fd, buf, nr);
-        }
-        if (nw < 0) {
-            if (errno == EPIPE)
-                signal_queue(LINUX_SIGPIPE);
-            if (total > 0)
-                break; /* Report partial success below */
-            err = linux_errno();
-            goto out_copy_file_range;
-        }
-
-        total += nw;
-        remaining -= nw;
-        if (off_in >= 0)
-            off_in += nw;
-        if (off_out >= 0)
-            off_out += nw;
-        if (nw < nr)
-            break;
+    /* Emulate with a pread/pwrite loop. */
+    int64_t moved =
+        copy_fd_range(fd_in, in_ref.fd, out_ref.fd, &off_in, &off_out, len);
+    if (moved < 0) {
+        err = moved;
+        goto out_copy_file_range;
     }
+    size_t total = (size_t) moved;
 
     /* Write back updated offsets (even on partial transfer). Preserve partial
      * success on writeback failure.
@@ -2249,15 +2256,22 @@ int64_t sys_splice(guest_t *g,
         }
     }
 
-    /* Emulate with read/write loop using a stack buffer (matching
-     * sendfile/copy_file_range which also use stack buffers).
+    /* Emulate with a read/write loop over a heap buffer. splice fully drains
+     * each read chunk (inner write loop) rather than stopping on a short write,
+     * so it does not share copy_fd_range.
      */
-    uint8_t buf[65536];
-    size_t chunk = len > sizeof(buf) ? sizeof(buf) : len;
+    uint8_t *buf = malloc(IO_COPY_BUF_SIZE);
+    if (!buf) {
+        host_fd_ref_close(&out_ref);
+        host_fd_ref_close(&in_ref);
+        return -LINUX_ENOMEM;
+    }
+    size_t chunk = len > IO_COPY_BUF_SIZE ? IO_COPY_BUF_SIZE : len;
 
     size_t total = 0;
     int saved_errno = 0;   /* Preserve errno across guest_write */
     bool rw_error = false; /* Track whether read or write failed */
+    int64_t ret;
     while (total < len) {
         size_t n = (len - total) > chunk ? chunk : (len - total);
         ssize_t r = (off_in >= 0) ? pread(in_ref.fd, buf, n, off_in)
@@ -2286,6 +2300,15 @@ int64_t sys_splice(guest_t *g,
                 if (w < 0 && saved_errno == EPIPE)
                     signal_queue(LINUX_SIGPIPE);
                 total += written; /* Account for partial bytes written */
+                /* Position-based input: read() consumed all r bytes but only
+                 * written were moved, so rewind the input fd by r - written to
+                 * match Linux advancing only by bytes transferred. Best-effort;
+                 * a pipe input (common for splice) cannot seek and keeps the
+                 * prior behavior. saved_errno is restored at done.
+                 */
+                if (off_in < 0 && written < (size_t) r)
+                    (void) lseek(in_ref.fd, (off_t) ((ssize_t) written - r),
+                                 SEEK_CUR);
                 goto done;
             }
             written += w;
@@ -2296,42 +2319,33 @@ int64_t sys_splice(guest_t *g,
     }
 
 done:
-    /* Write back updated offsets. Preserve partial transfer success: if bytes
-     * were already moved, return that count even if the offset writeback fails
-     * (consistent with sendfile/copy_file_range).
+    /* Write back updated offsets, then pick the return value. Preserve partial
+     * transfer success: if bytes were already moved, return that count even
+     * when an offset writeback faults (consistent with
+     * sendfile/copy_file_range). A failed off_in writeback skips the off_out
+     * writeback, matching the kernel.
      */
     if (off_in_gva && off_in >= 0 &&
         guest_write_small(g, off_in_gva, &off_in, sizeof(off_in)) < 0) {
-        int64_t ret = total > 0 ? (int64_t) total : -LINUX_EFAULT;
-        host_fd_ref_close(&out_ref);
-        host_fd_ref_close(&in_ref);
-        return ret;
-    }
-    if (off_out_gva && off_out >= 0 &&
-        guest_write_small(g, off_out_gva, &off_out, sizeof(off_out)) < 0) {
-        int64_t ret = total > 0 ? (int64_t) total : -LINUX_EFAULT;
-        host_fd_ref_close(&out_ref);
-        host_fd_ref_close(&in_ref);
-        return ret;
+        ret = total > 0 ? (int64_t) total : -LINUX_EFAULT;
+    } else if (off_out_gva && off_out >= 0 &&
+               guest_write_small(g, off_out_gva, &off_out, sizeof(off_out)) <
+                   0) {
+        ret = total > 0 ? (int64_t) total : -LINUX_EFAULT;
+    } else if (total > 0) {
+        ret = (int64_t) total;
+    } else if (rw_error) {
+        /* Restore saved_errno; the guest writes above may have clobbered it. */
+        errno = saved_errno;
+        ret = linux_errno();
+    } else {
+        ret = 0;
     }
 
-    /* Return bytes transferred, or errno only if read/write failed. Restore
-     * saved_errno since free/guest_write may have clobbered it.
-     */
-    if (total > 0) {
-        host_fd_ref_close(&out_ref);
-        host_fd_ref_close(&in_ref);
-        return (int64_t) total;
-    }
-    if (rw_error) {
-        errno = saved_errno;
-        host_fd_ref_close(&out_ref);
-        host_fd_ref_close(&in_ref);
-        return linux_errno();
-    }
+    free(buf);
     host_fd_ref_close(&out_ref);
     host_fd_ref_close(&in_ref);
-    return 0;
+    return ret;
 }
 
 /* vmsplice: emulate as writev to the pipe fd */

--- a/src/syscall/net-absock.c
+++ b/src/syscall/net-absock.c
@@ -1,4 +1,5 @@
-/* Abstract AF_UNIX emulation helpers
+/*
+ * Abstract AF_UNIX emulation helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -17,6 +18,8 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+
+#include "utils.h"
 
 #include "syscall/net.h"
 #include "syscall/net-absock.h"
@@ -52,8 +55,12 @@ static int absock_ensure_dir_locked(void)
     }
     snprintf(absock_dir, sizeof(absock_dir), "/tmp/elfuse-absock-%llu",
              (unsigned long long) namespace_id);
-    if (mkdir(absock_dir, 0700) < 0 && errno != EEXIST)
+    /* The namespace-id path is guessable; create_private_dir rejects a
+     * pre-planted symlink or foreign-owned directory in world-writable /tmp.
+     */
+    if (create_private_dir(absock_dir) < 0)
         return -1;
+
     absock_dir_created = true;
     return 0;
 }

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -1,4 +1,5 @@
-/* Socket message syscalls
+/*
+ * Socket message syscalls
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -105,6 +106,34 @@ static void recvmsg_close_host_rights(const void *data_src, size_t data_len)
     const int *fds = (const int *) data_src;
     for (size_t i = 0; i < nfds; i++)
         close(fds[i]);
+}
+
+/* Wire size of a Linux SCM_CREDENTIALS control message: cmsghdr (16) + ucred,
+ * rounded up to the 8-byte cmsg alignment.
+ */
+#define SCM_CRED_CMSG_SPACE \
+    (((size_t) (16 + sizeof(linux_ucred_t)) + 7) & ~(size_t) 7)
+
+/* Pack an SCM_CREDENTIALS control message carrying this process's identity into
+ * dst, which must have room for SCM_CRED_CMSG_SPACE bytes. Zero-fills the
+ * alignment tail so no host stack bytes leak to the guest. Injected on recvmsg
+ * when the guest set SO_PASSCRED, since macOS has no SCM_CREDENTIALS.
+ */
+static void build_scm_cred_cmsg(uint8_t *dst)
+{
+    linux_ucred_t cred = {
+        .pid = (int32_t) proc_get_pid(),
+        .uid = proc_get_uid(),
+        .gid = proc_get_gid(),
+    };
+    uint64_t cred_cmsg_len = 16 + sizeof(cred);
+    int32_t cred_level = 1; /* SOL_SOCKET */
+    int32_t cred_type = LINUX_SCM_CREDENTIALS;
+    memset(dst, 0, SCM_CRED_CMSG_SPACE);
+    memcpy(dst, &cred_cmsg_len, 8);
+    memcpy(dst + 8, &cred_level, 4);
+    memcpy(dst + 12, &cred_type, 4);
+    memcpy(dst + 16, &cred, sizeof(cred));
 }
 
 int64_t sys_sendmsg(guest_t *g, int fd, uint64_t msg_gva, int linux_flags)
@@ -609,23 +638,10 @@ int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
         if (net_socket_cached_int_get(fd, LINUX_SOL_SOCKET, LINUX_SO_PASSCRED,
                                       &passcred_val) &&
             passcred_val && host_socket_is_unix(host_ref.fd)) {
-            linux_ucred_t cred = {
-                .pid = (int32_t) proc_get_pid(),
-                .uid = proc_get_uid(),
-                .gid = proc_get_gid(),
-            };
-            uint64_t cred_cmsg_len = 16 + sizeof(cred);
-            size_t cred_cmsg_space = (size_t) ((cred_cmsg_len + 7) & ~7ULL);
-            if (lpos + cred_cmsg_space <= lctrl_size &&
-                lpos + cred_cmsg_space <= lmsg.msg_controllen) {
-                int32_t cred_level = 1;
-                int32_t cred_type = LINUX_SCM_CREDENTIALS;
-                memset(linux_ctrl + lpos, 0, cred_cmsg_space);
-                memcpy(linux_ctrl + lpos, &cred_cmsg_len, 8);
-                memcpy(linux_ctrl + lpos + 8, &cred_level, 4);
-                memcpy(linux_ctrl + lpos + 12, &cred_type, 4);
-                memcpy(linux_ctrl + lpos + 16, &cred, sizeof(cred));
-                lpos += cred_cmsg_space;
+            if (lpos + SCM_CRED_CMSG_SPACE <= lctrl_size &&
+                lpos + SCM_CRED_CMSG_SPACE <= lmsg.msg_controllen) {
+                build_scm_cred_cmsg(linux_ctrl + lpos);
+                lpos += SCM_CRED_CMSG_SPACE;
             }
         }
 
@@ -663,33 +679,22 @@ int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
         }
         free(lctrl_heap);
     } else if (lmsg.msg_control && lmsg.msg_controllen > 0) {
-        int injected = 0, passcred_val = 0;
+        bool injected = false;
+        int passcred_val = 0;
         if (net_socket_cached_int_get(fd, LINUX_SOL_SOCKET, LINUX_SO_PASSCRED,
                                       &passcred_val) &&
             passcred_val && host_socket_is_unix(host_ref.fd)) {
-            linux_ucred_t cred = {
-                .pid = (int32_t) proc_get_pid(),
-                .uid = proc_get_uid(),
-                .gid = proc_get_gid(),
-            };
-            uint64_t cred_cmsg_len = 16 + sizeof(cred);
-            size_t cred_cmsg_space = (size_t) ((cred_cmsg_len + 7) & ~7ULL);
-            if (cred_cmsg_space <= lmsg.msg_controllen &&
-                cred_cmsg_space <= 64) {
+            if (SCM_CRED_CMSG_SPACE <= lmsg.msg_controllen &&
+                SCM_CRED_CMSG_SPACE <= 64) {
                 uint8_t cred_buf[64];
-                int32_t cred_level = 1, cred_type = LINUX_SCM_CREDENTIALS;
-                memset(cred_buf, 0, sizeof(cred_buf));
-                memcpy(cred_buf, &cred_cmsg_len, 8);
-                memcpy(cred_buf + 8, &cred_level, 4);
-                memcpy(cred_buf + 12, &cred_type, 4);
-                memcpy(cred_buf + 16, &cred, sizeof(cred));
+                build_scm_cred_cmsg(cred_buf);
                 if (guest_write_small(g, lmsg.msg_control, cred_buf,
-                                      cred_cmsg_space) == 0) {
-                    uint64_t cred_ctl_len = cred_cmsg_space;
+                                      SCM_CRED_CMSG_SPACE) == 0) {
+                    uint64_t cred_ctl_len = SCM_CRED_CMSG_SPACE;
                     guest_write_small(
                         g, msg_gva + offsetof(linux_msghdr_t, msg_controllen),
                         &cred_ctl_len, sizeof(cred_ctl_len));
-                    injected = 1;
+                    injected = true;
                 }
             }
         }

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -1,4 +1,5 @@
-/* Socket/networking syscalls
+/*
+ * Socket/networking syscalls
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -551,6 +552,45 @@ int64_t sys_connect(guest_t *g, int fd, uint64_t addr_gva, uint32_t addrlen)
     return 0;
 }
 
+/* Convert a resolved macOS sockaddr to Linux form and write it, plus its actual
+ * (untruncated) length, back to the guest, honoring the guest-supplied addrlen
+ * cap. Closes host_ref on every path. Shared tail of getsockname/getpeername.
+ */
+static int64_t sockaddr_writeback(guest_t *g,
+                                  host_fd_ref_t *host_ref,
+                                  const struct sockaddr_storage *mac_sa,
+                                  socklen_t mac_len,
+                                  uint64_t addr_gva,
+                                  uint64_t addrlen_gva,
+                                  uint32_t guest_addrlen)
+{
+    uint8_t linux_sa[128];
+    int out_len =
+        mac_to_linux_sockaddr((const struct sockaddr *) mac_sa, mac_len,
+                              linux_sa, (uint32_t) sizeof(linux_sa));
+    if (out_len < 0) {
+        host_fd_ref_close(host_ref);
+        return -LINUX_EINVAL;
+    }
+
+    uint32_t actual_len = (uint32_t) out_len, write_len = actual_len;
+    if (write_len > guest_addrlen)
+        write_len = guest_addrlen;
+    if (guest_write_small(g, addr_gva, linux_sa, write_len) < 0) {
+        host_fd_ref_close(host_ref);
+        return -LINUX_EFAULT;
+    }
+    /* Write back actual (not truncated) length per Linux semantics */
+    if (guest_write_small(g, addrlen_gva, &actual_len, sizeof(actual_len)) <
+        0) {
+        host_fd_ref_close(host_ref);
+        return -LINUX_EFAULT;
+    }
+
+    host_fd_ref_close(host_ref);
+    return 0;
+}
+
 int64_t sys_getsockname(guest_t *g,
                         int fd,
                         uint64_t addr_gva,
@@ -606,29 +646,8 @@ int64_t sys_getsockname(guest_t *g,
         }
     }
 
-    int out_len = mac_to_linux_sockaddr((struct sockaddr *) &mac_sa, mac_len,
-                                        linux_sa, (uint32_t) sizeof(linux_sa));
-    if (out_len < 0) {
-        host_fd_ref_close(&host_ref);
-        return -LINUX_EINVAL;
-    }
-
-    uint32_t actual_len = (uint32_t) out_len, write_len = actual_len;
-    if (write_len > guest_addrlen)
-        write_len = guest_addrlen;
-    if (guest_write_small(g, addr_gva, linux_sa, write_len) < 0) {
-        host_fd_ref_close(&host_ref);
-        return -LINUX_EFAULT;
-    }
-    /* Write back actual (not truncated) length per Linux semantics */
-    if (guest_write_small(g, addrlen_gva, &actual_len, sizeof(actual_len)) <
-        0) {
-        host_fd_ref_close(&host_ref);
-        return -LINUX_EFAULT;
-    }
-
-    host_fd_ref_close(&host_ref);
-    return 0;
+    return sockaddr_writeback(g, &host_ref, &mac_sa, mac_len, addr_gva,
+                              addrlen_gva, guest_addrlen);
 }
 
 int64_t sys_getpeername(guest_t *g,
@@ -655,30 +674,8 @@ int64_t sys_getpeername(guest_t *g,
         return -LINUX_EFAULT;
     }
 
-    uint8_t linux_sa[128];
-    int out_len = mac_to_linux_sockaddr((struct sockaddr *) &mac_sa, mac_len,
-                                        linux_sa, (uint32_t) sizeof(linux_sa));
-    if (out_len < 0) {
-        host_fd_ref_close(&host_ref);
-        return -LINUX_EINVAL;
-    }
-
-    uint32_t actual_len = (uint32_t) out_len, write_len = actual_len;
-    if (write_len > guest_addrlen)
-        write_len = guest_addrlen;
-    if (guest_write_small(g, addr_gva, linux_sa, write_len) < 0) {
-        host_fd_ref_close(&host_ref);
-        return -LINUX_EFAULT;
-    }
-    /* Write back actual (not truncated) length per Linux semantics */
-    if (guest_write_small(g, addrlen_gva, &actual_len, sizeof(actual_len)) <
-        0) {
-        host_fd_ref_close(&host_ref);
-        return -LINUX_EFAULT;
-    }
-
-    host_fd_ref_close(&host_ref);
-    return 0;
+    return sockaddr_writeback(g, &host_ref, &mac_sa, mac_len, addr_gva,
+                              addrlen_gva, guest_addrlen);
 }
 
 int64_t sys_sendto(guest_t *g,
@@ -833,6 +830,81 @@ int64_t sys_recvfrom(guest_t *g,
     return ret;
 }
 
+/* Translate a Linux (level, optname) socket-option pair to the macOS pair for
+ * the level dispatch common to setsockopt/getsockopt.
+ *
+ * Returns true on success with the mac_level and mac_optname out-params set;
+ * false when the option is unknown for a recognized level (caller returns
+ * -ENOPROTOOPT). Both out-params must be pre-seeded with the Linux values so an
+ * unrecognized level passes through unchanged for the host to reject.
+ *
+ * The small-int options (including all four TCP keepalive/nodelay options) are
+ * handled by translate_small_int_sockopt before this is reached, and
+ * IP_MTU_DISCOVER / IP_RECVERR are handled by an earlier return, so neither
+ * reaches this dispatch.
+ */
+static bool translate_sockopt_level(int level,
+                                    int optname,
+                                    int *mac_level,
+                                    int *mac_optname)
+{
+    if (level == LINUX_SOL_SOCKET) {
+        *mac_level = SOL_SOCKET;
+        *mac_optname = translate_sockopt(optname);
+        return *mac_optname >= 0;
+    }
+    if (level == LINUX_IPPROTO_TCP) {
+        *mac_level = IPPROTO_TCP;
+        return true;
+    }
+    if (level == LINUX_IPPROTO_IP) {
+        *mac_level = IPPROTO_IP;
+        *mac_optname = translate_ip_sockopt_to_mac(optname);
+        return *mac_optname >= 0;
+    }
+    if (level == LINUX_IPPROTO_IPV6) {
+        *mac_level = IPPROTO_IPV6;
+        if (optname == LINUX_IPV6_V6ONLY)
+            *mac_optname = IPV6_V6ONLY;
+    }
+    return true;
+}
+
+static bool cached_setsockopt_may_succeed(int level, int optname)
+{
+    if (level == LINUX_SOL_SOCKET) {
+        switch (optname) {
+        case LINUX_SO_KEEPALIVE:
+        case LINUX_SO_REUSEADDR:
+        case LINUX_SO_REUSEPORT:
+        case LINUX_SO_BROADCAST:
+        case LINUX_SO_DONTROUTE:
+        case LINUX_SO_OOBINLINE:
+        case LINUX_SO_RCVLOWAT:
+        case LINUX_SO_RCVBUF:
+        case LINUX_SO_SNDBUF:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    return (level == LINUX_IPPROTO_TCP &&
+            (optname == LINUX_TCP_NODELAY || optname == LINUX_TCP_KEEPIDLE ||
+             optname == LINUX_TCP_KEEPINTVL || optname == LINUX_TCP_KEEPCNT)) ||
+           (level == LINUX_IPPROTO_IP &&
+            (optname == LINUX_IP_TOS || optname == LINUX_IP_TTL ||
+             optname == LINUX_IP_HDRINCL || optname == LINUX_IP_PKTINFO ||
+             optname == LINUX_IP_RECVTTL || optname == LINUX_IP_RECVTOS));
+}
+
+static bool readonly_setsockopt(int level, int optname)
+{
+    return level == LINUX_SOL_SOCKET &&
+           (optname == LINUX_SO_TYPE || optname == LINUX_SO_ERROR ||
+            optname == LINUX_SO_ACCEPTCONN || optname == LINUX_SO_SNDLOWAT);
+}
+
 int64_t sys_setsockopt(guest_t *g,
                        int fd,
                        int level,
@@ -906,6 +978,12 @@ int64_t sys_setsockopt(guest_t *g,
         return 0;
     }
 
+    if (readonly_setsockopt(level, optname)) {
+        if (!net_socket_fd_is_valid(fd))
+            return -LINUX_EBADF;
+        return -LINUX_ENOPROTOOPT;
+    }
+
     if (optlen > 0 && optlen <= sizeof(int) && small_int_opt) {
         int value = 0;
         if (guest_read_small(g, optval_gva, &value, optlen) < 0)
@@ -913,7 +991,11 @@ int64_t sys_setsockopt(guest_t *g,
         value = socket_small_int_normalize(level, optname, value);
 
         int cached_value = 0;
-        if (net_socket_cached_int_get(fd, level, optname, &cached_value) &&
+        int cached_mac_level = level, cached_mac_optname = optname;
+        if (cached_setsockopt_may_succeed(level, optname) &&
+            translate_small_int_sockopt(level, optname, &cached_mac_level,
+                                        &cached_mac_optname) &&
+            net_socket_cached_int_get(fd, level, optname, &cached_value) &&
             cached_value == value)
             return 0;
     }
@@ -929,45 +1011,9 @@ int64_t sys_setsockopt(guest_t *g,
         goto setsockopt_translated;
     }
 
-    if (level == LINUX_SOL_SOCKET) {
-        mac_level = SOL_SOCKET;
-        mac_optname = translate_sockopt(optname);
-        if (mac_optname < 0) {
-            host_fd_ref_close(&host_ref);
-            return -LINUX_ENOPROTOOPT;
-        }
-    } else if (level == LINUX_IPPROTO_TCP) {
-        mac_level = IPPROTO_TCP;
-        switch (optname) {
-        case LINUX_TCP_NODELAY:
-            mac_optname = TCP_NODELAY;
-            break;
-        case LINUX_TCP_KEEPIDLE:
-            mac_optname = TCP_KEEPALIVE;
-            break;
-        case LINUX_TCP_KEEPINTVL:
-            mac_optname = 0x101;
-            break; /* TCP_KEEPINTVL */
-        case LINUX_TCP_KEEPCNT:
-            mac_optname = 0x102;
-            break; /* TCP_KEEPCNT */
-        default:
-            break;
-        }
-    } else if (level == LINUX_IPPROTO_IP) {
-        mac_level = IPPROTO_IP;
-        mac_optname = translate_ip_sockopt_to_mac(optname);
-        /* IP_MTU_DISCOVER and IP_RECVERR are handled by the early return above
-         * (before host_fd_ref_open), so they never reach here.
-         */
-        if (mac_optname < 0) {
-            host_fd_ref_close(&host_ref);
-            return -LINUX_ENOPROTOOPT;
-        }
-    } else if (level == LINUX_IPPROTO_IPV6) {
-        mac_level = IPPROTO_IPV6;
-        if (optname == LINUX_IPV6_V6ONLY)
-            mac_optname = IPV6_V6ONLY;
+    if (!translate_sockopt_level(level, optname, &mac_level, &mac_optname)) {
+        host_fd_ref_close(&host_ref);
+        return -LINUX_ENOPROTOOPT;
     }
 
 setsockopt_translated:
@@ -983,20 +1029,11 @@ setsockopt_translated:
         }
         value = socket_small_int_normalize(level, optname, value);
 
-        if ((level == LINUX_SOL_SOCKET &&
-             (optname == LINUX_SO_KEEPALIVE || optname == LINUX_SO_REUSEADDR ||
-              optname == LINUX_SO_DONTROUTE ||
-              optname == LINUX_SO_OOBINLINE)) ||
-            (level == LINUX_IPPROTO_TCP && optname == LINUX_TCP_NODELAY)) {
-            int cached_value = 0;
-            if (net_socket_cached_int_get(fd, level, optname, &cached_value) &&
-                cached_value == value) {
-                host_fd_ref_close(&host_ref);
-                return 0;
-            }
-        }
-
-        /* Linux accepts shorter optlen for many int-valued options and
+        /* The cached-value short-circuit (return 0 when the socket already
+         * holds this value) ran before host_fd_ref_open for every small-int
+         * option with optlen > 0, so it is not repeated here.
+         *
+         * Linux accepts shorter optlen for many int-valued options and
          * zero-extends the value. macOS rejects optlen < sizeof(int) with
          * EINVAL (notably for IP_TOS / IP_TTL / IP_PKTINFO / IP_RECVTTL /
          * IP_RECVTOS). The value has already been zero-extended into an int, so
@@ -1141,45 +1178,9 @@ int64_t sys_getsockopt(guest_t *g,
         goto getsockopt_translated;
     }
 
-    if (level == LINUX_SOL_SOCKET) {
-        mac_level = SOL_SOCKET;
-        mac_optname = translate_sockopt(optname);
-        if (mac_optname < 0) {
-            host_fd_ref_close(&host_ref);
-            return -LINUX_ENOPROTOOPT;
-        }
-    } else if (level == LINUX_IPPROTO_TCP) {
-        mac_level = IPPROTO_TCP;
-        switch (optname) {
-        case LINUX_TCP_NODELAY:
-            mac_optname = TCP_NODELAY;
-            break;
-        case LINUX_TCP_KEEPIDLE:
-            mac_optname = TCP_KEEPALIVE;
-            break;
-        case LINUX_TCP_KEEPINTVL:
-            mac_optname = 0x101;
-            break;
-        case LINUX_TCP_KEEPCNT:
-            mac_optname = 0x102;
-            break;
-        default:
-            break;
-        }
-    } else if (level == LINUX_IPPROTO_IP) {
-        mac_level = IPPROTO_IP;
-        mac_optname = translate_ip_sockopt_to_mac(optname);
-        /* IP_MTU_DISCOVER and IP_RECVERR are handled by the early return above
-         * (before host_fd_ref_open), so they never reach here.
-         */
-        if (mac_optname < 0) {
-            host_fd_ref_close(&host_ref);
-            return -LINUX_ENOPROTOOPT;
-        }
-    } else if (level == LINUX_IPPROTO_IPV6) {
-        mac_level = IPPROTO_IPV6;
-        if (optname == LINUX_IPV6_V6ONLY)
-            mac_optname = IPV6_V6ONLY;
+    if (!translate_sockopt_level(level, optname, &mac_level, &mac_optname)) {
+        host_fd_ref_close(&host_ref);
+        return -LINUX_ENOPROTOOPT;
     }
 
 getsockopt_translated:

--- a/src/syscall/netlink.c
+++ b/src/syscall/netlink.c
@@ -1,4 +1,5 @@
-/* AF_NETLINK emulation
+/*
+ * AF_NETLINK emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -217,8 +218,8 @@ static size_t nl_put_attr(uint8_t *buf,
     return aligned;
 }
 
-/* Build RTM_GETLINK response from host getifaddrs(). A non-empty name_filter
- * or non-zero index_filter restricts the reply to one matching link.
+/* Build RTM_GETLINK response from host getifaddrs(). A non-empty name_filter or
+ * non-zero index_filter restricts the reply to one matching link.
  */
 static int nl_build_getlink(netlink_state_t *ns,
                             const char *name_filter,
@@ -544,9 +545,11 @@ static void nl_parse_link_filter(const uint8_t *req,
 }
 
 /* Build the reply for one rtnetlink request (already copied into req). Mutates
- * ns->buf/seq. Returns 0 on success (including a built NLMSG_ERROR reply for
- * unsupported types), or a negative LINUX_E* on a build failure. Caller holds
- * nl_lock. req is guaranteed to be at least NLMSG_HDRLEN bytes.
+ * ns->buf/seq.
+ *
+ * Returns 0 on success (including a built NLMSG_ERROR reply for unsupported
+ * types), or a negative LINUX_E* on a build failure. Caller holds nl_lock. req
+ * is guaranteed to be at least NLMSG_HDRLEN bytes.
  */
 static int nl_process_request(netlink_state_t *ns,
                               const uint8_t *req,
@@ -687,6 +690,82 @@ out:
     return result;
 }
 
+/* Block until the netlink receive buffer has data. Called with nl_lock held.
+ *
+ * On success returns 0 with nl_lock still held and ns valid. On EAGAIN, EINTR,
+ * EIO, or if the socket was closed underneath the poll, releases nl_lock and
+ * returns the negative Linux errno. flags carries MSG_DONTWAIT; pass 0 for
+ * read(2), which only honors O_NONBLOCK.
+ */
+static int64_t nl_wait_readable_locked(netlink_state_t *ns,
+                                       int guest_fd,
+                                       int flags)
+{
+    while (ns->buf_pos >= ns->buf_len) {
+        bool nonblock = (flags & LINUX_MSG_DONTWAIT) ||
+                        (fd_table[guest_fd].linux_flags & LINUX_O_NONBLOCK);
+        if (nonblock) {
+            pthread_mutex_unlock(&nl_lock);
+            return -LINUX_EAGAIN;
+        }
+
+        int rd_fd = ns->pipe_rd;
+        pthread_mutex_unlock(&nl_lock);
+
+        struct pollfd pfd = {
+            .fd = rd_fd,
+            .events = POLLIN,
+        };
+        int ret = poll(&pfd, 1, -1);
+        if (ret < 0)
+            return (errno == EINTR) ? -LINUX_EINTR : -LINUX_EIO;
+
+        pthread_mutex_lock(&nl_lock);
+        netlink_state_t *current_ns = nl_find(guest_fd);
+        if (!current_ns || current_ns != ns) {
+            pthread_mutex_unlock(&nl_lock);
+            return -LINUX_EBADF;
+        }
+    }
+    return 0;
+}
+
+/* Return the byte length of the longest run of complete netlink messages that
+ * starts at ns->buf_pos and fits within to_copy. Falls back to to_copy when not
+ * even one whole message fits (MSG_TRUNC semantics). Called with nl_lock held.
+ */
+static size_t nl_complete_span(const netlink_state_t *ns, size_t to_copy)
+{
+    size_t msg_end = 0, pos = ns->buf_pos;
+    while (pos < ns->buf_len && (pos - ns->buf_pos + NLMSG_HDRLEN) <= to_copy) {
+        const nlmsghdr_t *hdr = (const nlmsghdr_t *) (ns->buf + pos);
+        if (hdr->nlmsg_len < NLMSG_HDRLEN)
+            break;
+        size_t msg_bytes = pos - ns->buf_pos + NLMSG_ALIGN(hdr->nlmsg_len);
+        if (msg_bytes > to_copy)
+            break;
+        pos += NLMSG_ALIGN(hdr->nlmsg_len);
+        msg_end = pos - ns->buf_pos;
+    }
+    return msg_end == 0 ? to_copy : msg_end;
+}
+
+/* Write the kernel-side sockaddr_nl (nl_pid 0) and its length to the guest at
+ * the given addresses. Called with nl_lock held.
+ */
+static void nl_write_kernel_src(guest_t *g,
+                                uint64_t addr_gva,
+                                uint64_t namelen_gva)
+{
+    sockaddr_nl_t snl = {
+        .nl_family = LINUX_AF_NETLINK,
+        .nl_pid = 0, /* from kernel */
+    };
+    guest_write_small(g, addr_gva, &snl, sizeof(snl));
+    uint32_t namelen = sizeof(sockaddr_nl_t);
+    guest_write_small(g, namelen_gva, &namelen, sizeof(namelen));
+}
+
 /* recvfrom(2) on a netlink socket: drain whole messages; write back a kernel
  * sockaddr_nl (nl_pid 0) when src is requested.
  */
@@ -710,56 +789,16 @@ int64_t netlink_recv(int guest_fd,
         return 0;
     }
 
-    /* Wait for data to become available. If the buffer is empty, block
-     * on the host pipe read end. Honor MSG_DONTWAIT and O_NONBLOCK flags.
+    /* Wait for data to become available, blocking on the host pipe read end
+     * unless MSG_DONTWAIT or O_NONBLOCK is set.
      */
-    while (ns->buf_pos >= ns->buf_len) {
-        bool nonblock = (flags & LINUX_MSG_DONTWAIT) ||
-                        (fd_table[guest_fd].linux_flags & LINUX_O_NONBLOCK);
-        if (nonblock) {
-            pthread_mutex_unlock(&nl_lock);
-            return -LINUX_EAGAIN;
-        }
-
-        int rd_fd = ns->pipe_rd;
-        pthread_mutex_unlock(&nl_lock);
-
-        struct pollfd pfd = {
-            .fd = rd_fd,
-            .events = POLLIN,
-        };
-        int ret = poll(&pfd, 1, -1);
-        if (ret < 0) {
-            if (errno == EINTR)
-                return -LINUX_EINTR;
-            return -LINUX_EIO;
-        }
-
-        pthread_mutex_lock(&nl_lock);
-        netlink_state_t *current_ns = nl_find(guest_fd);
-        if (!current_ns || current_ns != ns) {
-            pthread_mutex_unlock(&nl_lock);
-            return -LINUX_EBADF;
-        }
-    }
+    int64_t werr = nl_wait_readable_locked(ns, guest_fd, flags);
+    if (werr < 0)
+        return werr;
 
     size_t avail = ns->buf_len - ns->buf_pos;
     size_t to_copy = (avail < len) ? avail : len;
-
-    /* Return complete netlink messages only (same walk as netlink_recvmsg). */
-    size_t msg_end = 0, pos = ns->buf_pos;
-    while (pos < ns->buf_len && (pos - ns->buf_pos + NLMSG_HDRLEN) <= to_copy) {
-        nlmsghdr_t *hdr = (nlmsghdr_t *) (ns->buf + pos);
-        if (hdr->nlmsg_len < NLMSG_HDRLEN)
-            break;
-        size_t msg_bytes = pos - ns->buf_pos + NLMSG_ALIGN(hdr->nlmsg_len);
-        if (msg_bytes > to_copy)
-            break;
-        pos += NLMSG_ALIGN(hdr->nlmsg_len);
-        msg_end = pos - ns->buf_pos;
-    }
-    if (msg_end == 0)
-        msg_end = to_copy;
+    size_t msg_end = nl_complete_span(ns, to_copy);
 
     if (guest_write(g, buf_gva, ns->buf + ns->buf_pos, msg_end) < 0) {
         pthread_mutex_unlock(&nl_lock);
@@ -770,15 +809,8 @@ int64_t netlink_recv(int guest_fd,
     if (ns->buf_pos >= ns->buf_len)
         netlink_clear_readable(ns);
 
-    if (src_gva && addrlen_gva) {
-        sockaddr_nl_t snl = {
-            .nl_family = LINUX_AF_NETLINK,
-            .nl_pid = 0, /* From kernel */
-        };
-        guest_write_small(g, src_gva, &snl, sizeof(snl));
-        uint32_t namelen = sizeof(sockaddr_nl_t);
-        guest_write_small(g, addrlen_gva, &namelen, sizeof(namelen));
-    }
+    if (src_gva && addrlen_gva)
+        nl_write_kernel_src(g, src_gva, addrlen_gva);
 
     pthread_mutex_unlock(&nl_lock);
     return (int64_t) msg_end;
@@ -851,64 +883,16 @@ int64_t netlink_recvmsg(int guest_fd, guest_t *g, uint64_t msg_gva, int flags)
         return 0;
     }
 
-    /* Wait for data to become available. If the buffer is empty, block
-     * on the host pipe read end. Honor MSG_DONTWAIT and O_NONBLOCK flags.
+    /* Wait for data to become available, blocking on the host pipe read end
+     * unless MSG_DONTWAIT or O_NONBLOCK is set.
      */
-    while (ns->buf_pos >= ns->buf_len) {
-        bool nonblock = (flags & LINUX_MSG_DONTWAIT) ||
-                        (fd_table[guest_fd].linux_flags & LINUX_O_NONBLOCK);
-        if (nonblock) {
-            pthread_mutex_unlock(&nl_lock);
-            return -LINUX_EAGAIN;
-        }
-
-        int rd_fd = ns->pipe_rd;
-        pthread_mutex_unlock(&nl_lock);
-
-        struct pollfd pfd = {
-            .fd = rd_fd,
-            .events = POLLIN,
-        };
-        int ret = poll(&pfd, 1, -1);
-        if (ret < 0) {
-            if (errno == EINTR)
-                return -LINUX_EINTR;
-            return -LINUX_EIO;
-        }
-
-        pthread_mutex_lock(&nl_lock);
-        netlink_state_t *current_ns = nl_find(guest_fd);
-        if (!current_ns || current_ns != ns) {
-            pthread_mutex_unlock(&nl_lock);
-            return -LINUX_EBADF;
-        }
-    }
+    int64_t werr = nl_wait_readable_locked(ns, guest_fd, flags);
+    if (werr < 0)
+        return werr;
 
     size_t avail = ns->buf_len - ns->buf_pos;
     size_t to_copy = (avail < iov.iov_len) ? avail : iov.iov_len;
-
-    /* Return complete netlink messages only. Walk from buf_pos to find the last
-     * complete message that fits in the buffer.
-     */
-    size_t msg_end = 0, pos = ns->buf_pos;
-    while (pos < ns->buf_len && (pos - ns->buf_pos + NLMSG_HDRLEN) <= to_copy) {
-        nlmsghdr_t *hdr = (nlmsghdr_t *) (ns->buf + pos);
-        if (hdr->nlmsg_len < NLMSG_HDRLEN)
-            break;
-        size_t msg_bytes = pos - ns->buf_pos + NLMSG_ALIGN(hdr->nlmsg_len);
-        if (msg_bytes > to_copy)
-            break;
-        pos += NLMSG_ALIGN(hdr->nlmsg_len);
-        msg_end = pos - ns->buf_pos;
-    }
-
-    if (msg_end == 0) {
-        /* Buffer too small for even one message.
-         *
-         * Return what fits with MSG_TRUNC semantics
-         */
-        msg_end = to_copy;
-    }
+    size_t msg_end = nl_complete_span(ns, to_copy);
 
     if (guest_write(g, iov.iov_base, ns->buf + ns->buf_pos, msg_end) < 0) {
         pthread_mutex_unlock(&nl_lock);
@@ -920,17 +904,11 @@ int64_t netlink_recvmsg(int guest_fd, guest_t *g, uint64_t msg_gva, int flags)
     if (ns->buf_pos >= ns->buf_len)
         netlink_clear_readable(ns);
 
-    /* Write back sockaddr_nl if caller provided msg_name */
-    if (mhdr.msg_name && mhdr.msg_namelen >= sizeof(sockaddr_nl_t)) {
-        sockaddr_nl_t snl = {
-            .nl_family = LINUX_AF_NETLINK,
-            .nl_pid = 0, /* From kernel */
-        };
-        guest_write_small(g, mhdr.msg_name, &snl, sizeof(snl));
-        uint32_t namelen = sizeof(sockaddr_nl_t);
-        /* msg_namelen is at offset 4 in the msghdr (after msg_name pointer) */
-        guest_write_small(g, msg_gva + 8, &namelen, sizeof(namelen));
-    }
+    /* Write back sockaddr_nl if caller provided msg_name. msg_namelen sits at
+     * offset 8 in the msghdr (after the 8-byte msg_name pointer).
+     */
+    if (mhdr.msg_name && mhdr.msg_namelen >= sizeof(sockaddr_nl_t))
+        nl_write_kernel_src(g, mhdr.msg_name, msg_gva + 8);
 
     /* Clear msg_flags and msg_controllen */
     int32_t zero_flags = 0;
@@ -958,38 +936,12 @@ int64_t netlink_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
         return 0;
     }
 
-    /* Wait for data to become available. If the buffer is empty, block
-     * on the host pipe read end. Honor O_NONBLOCK flag.
+    /* Wait for data to become available, blocking on the host pipe read end
+     * unless O_NONBLOCK is set. read(2) has no per-call MSG_DONTWAIT.
      */
-    while (ns->buf_pos >= ns->buf_len) {
-        bool nonblock =
-            (fd_table[guest_fd].linux_flags & LINUX_O_NONBLOCK) != 0;
-        if (nonblock) {
-            pthread_mutex_unlock(&nl_lock);
-            return -LINUX_EAGAIN;
-        }
-
-        int rd_fd = ns->pipe_rd;
-        pthread_mutex_unlock(&nl_lock);
-
-        struct pollfd pfd = {
-            .fd = rd_fd,
-            .events = POLLIN,
-        };
-        int ret = poll(&pfd, 1, -1);
-        if (ret < 0) {
-            if (errno == EINTR)
-                return -LINUX_EINTR;
-            return -LINUX_EIO;
-        }
-
-        pthread_mutex_lock(&nl_lock);
-        netlink_state_t *current_ns = nl_find(guest_fd);
-        if (!current_ns || current_ns != ns) {
-            pthread_mutex_unlock(&nl_lock);
-            return -LINUX_EBADF;
-        }
-    }
+    int64_t werr = nl_wait_readable_locked(ns, guest_fd, 0);
+    if (werr < 0)
+        return werr;
 
     size_t avail = ns->buf_len - ns->buf_pos;
     size_t to_copy = (avail < count) ? avail : count;

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <limits.h>
 #include <pthread.h>
 #include <signal.h>
 #include <sys/stat.h>
@@ -330,17 +331,37 @@ pid_t proc_guest_to_host_pid(int64_t gpid)
     return result;
 }
 
+/* Build the path to the cross-process signal-transport file for host_pid.
+ *
+ * Files live in the per-user private temp directory macOS provisions (mode
+ * 0700, owned by the invoking uid) rather than world-writable /tmp, so another
+ * local user cannot pre-plant a symlink to redirect the write or inject signal
+ * numbers into the guest. confstr returns the same directory for every process
+ * of this uid, so sender and receiver agree on the path. Callers open the
+ * result O_NOFOLLOW for defense in depth.
+ *
+ * Returns false (fail closed) if the private directory cannot be resolved.
+ */
+static bool signal_transport_path(char *out, size_t out_size, pid_t host_pid)
+{
+    char dir[PATH_MAX];
+    size_t n = confstr(_CS_DARWIN_USER_TEMP_DIR, dir, sizeof(dir));
+    if (n == 0 || n > sizeof(dir))
+        return false;
+    int len = snprintf(out, out_size, "%selfuse-sig-%ld", dir, (long) host_pid);
+    return len > 0 && (size_t) len < out_size;
+}
+
 int proc_send_guest_signal(pid_t host_pid, int signum)
 {
-    char path[64];
-    int path_len =
-        snprintf(path, sizeof(path), "/tmp/elfuse-sig-%ld", (long) host_pid);
-    if (path_len < 0 || (size_t) path_len >= sizeof(path)) {
+    char path[PATH_MAX];
+    if (!signal_transport_path(path, sizeof(path), host_pid)) {
         errno = ENAMETOOLONG;
         return -1;
     }
 
-    int fd = open(path, O_CREAT | O_APPEND | O_WRONLY | O_CLOEXEC, 0600);
+    int fd = open(path, O_CREAT | O_APPEND | O_WRONLY | O_CLOEXEC | O_NOFOLLOW,
+                  0600);
     if (fd < 0)
         return -1;
 
@@ -553,6 +574,20 @@ static int write_rusage_to_guest(guest_t *g,
     return guest_write_small(g, gva, &lru, sizeof(lru));
 }
 
+/* Deactivate the wait4 process-table slot iff it still holds host_pid.
+ * sys_wait4 releases pid_lock across the host wait4 call, so another reaper
+ * thread may have recycled the slot in the meantime; the host_pid re-check
+ * guards against clobbering an unrelated child that took the slot. pid_lock
+ * must not be held.
+ */
+static void proc_deactivate_slot_if_matches(int slot, pid_t host_pid)
+{
+    pthread_mutex_lock(&pid_lock);
+    if (proc_table[slot].active && proc_table[slot].host_pid == host_pid)
+        proc_table[slot].active = false;
+    pthread_mutex_unlock(&pid_lock);
+}
+
 /* sys_wait4. */
 
 int64_t sys_wait4(guest_t *g,
@@ -637,28 +672,16 @@ int64_t sys_wait4(guest_t *g,
                                               sizeof(linux_status)) < 0) {
                             /* Child already reaped. Match Linux: return EFAULT
                              */
-                            pthread_mutex_lock(&pid_lock);
-                            if (proc_table[slot].active &&
-                                proc_table[slot].host_pid == host_pid)
-                                proc_table[slot].active = false;
-                            pthread_mutex_unlock(&pid_lock);
+                            proc_deactivate_slot_if_matches(slot, host_pid);
                             return -LINUX_EFAULT;
                         }
                     }
                     if (rusage_gva &&
                         write_rusage_to_guest(g, rusage_gva, &ru) < 0) {
-                        pthread_mutex_lock(&pid_lock);
-                        if (proc_table[slot].active &&
-                            proc_table[slot].host_pid == host_pid)
-                            proc_table[slot].active = false;
-                        pthread_mutex_unlock(&pid_lock);
+                        proc_deactivate_slot_if_matches(slot, host_pid);
                         return -LINUX_EFAULT;
                     }
-                    pthread_mutex_lock(&pid_lock);
-                    if (proc_table[slot].active &&
-                        proc_table[slot].host_pid == host_pid)
-                        proc_table[slot].active = false;
-                    pthread_mutex_unlock(&pid_lock);
+                    proc_deactivate_slot_if_matches(slot, host_pid);
                     return gpid;
                 }
                 /* ret == 0 (not exited) or ret < 0 (error): try next */
@@ -718,29 +741,17 @@ int64_t sys_wait4(guest_t *g,
                     int32_t linux_status = status;
                     if (guest_write_small(g, status_gva, &linux_status,
                                           sizeof(linux_status)) < 0) {
-                        pthread_mutex_lock(&pid_lock);
-                        if (proc_table[slot].active &&
-                            proc_table[slot].host_pid == host_pid)
-                            proc_table[slot].active = false;
-                        pthread_mutex_unlock(&pid_lock);
+                        proc_deactivate_slot_if_matches(slot, host_pid);
                         return -LINUX_EFAULT;
                     }
                 }
                 if (rusage_gva &&
                     write_rusage_to_guest(g, rusage_gva, &ru) < 0) {
-                    pthread_mutex_lock(&pid_lock);
-                    if (proc_table[slot].active &&
-                        proc_table[slot].host_pid == host_pid)
-                        proc_table[slot].active = false;
-                    pthread_mutex_unlock(&pid_lock);
+                    proc_deactivate_slot_if_matches(slot, host_pid);
                     return -LINUX_EFAULT;
                 }
-                pthread_mutex_lock(&pid_lock);
                 /* Re-validate slot: another thread may have reaped it */
-                if (proc_table[slot].active &&
-                    proc_table[slot].host_pid == host_pid)
-                    proc_table[slot].active = false;
-                pthread_mutex_unlock(&pid_lock);
+                proc_deactivate_slot_if_matches(slot, host_pid);
                 /* Queue SIGCHLD for parent process */
                 signal_queue(LINUX_SIGCHLD);
                 return gpid;
@@ -987,9 +998,10 @@ static void drain_external_guest_signal(void)
         return;
     g_external_guest_signal = 0;
 
-    char path[64];
-    snprintf(path, sizeof(path), "/tmp/elfuse-sig-%ld", (long) getpid());
-    int fd = open(path, O_RDONLY);
+    char path[PATH_MAX];
+    if (!signal_transport_path(path, sizeof(path), getpid()))
+        return;
+    int fd = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
     if (fd < 0)
         return;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,4 +1,5 @@
-/* Shared utility helpers
+/*
+ * Shared utility helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -15,6 +16,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
@@ -108,6 +110,34 @@ static inline void close_keep_errno(int fd)
     if (fd >= 0)
         (void) close(fd);
     errno = saved;
+}
+
+/* Create a private per-user scratch directory. mkdir(path, 0700), then tolerate
+ * an already-existing entry only if it is a real directory, owned by the
+ * current uid, with no group/other access bits. That rejects a symlink, a
+ * foreign-owned directory, or a stale world-writable one that a local user
+ * could use to interpose on the contents. The group/other check matters because
+ * an existing 0777 dir owned by this uid would otherwise pass and let other
+ * local users drop files into it.
+ *
+ * Returns 0 on success, -1 with errno set (EACCES when the ownership, type, or
+ * permission check fails). Centralized so every caller applies the same guard;
+ * drift here is a security bug.
+ */
+static inline int create_private_dir(const char *path)
+{
+    if (mkdir(path, 0700) < 0 && errno != EEXIST)
+        return -1;
+
+    struct stat st;
+    if (lstat(path, &st) < 0)
+        return -1;
+    if (!S_ISDIR(st.st_mode) || st.st_uid != getuid() ||
+        (st.st_mode & (S_IRWXG | S_IRWXO)) != 0) {
+        errno = EACCES;
+        return -1;
+    }
+    return 0;
 }
 
 /* Enable an fd flag if it is not already set.

--- a/tests/test-net.c
+++ b/tests/test-net.c
@@ -1,4 +1,5 @@
-/* Test AF_INET/AF_INET6 networking syscalls
+/*
+ * Test AF_INET/AF_INET6 networking syscalls
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -302,6 +303,31 @@ udp_done:;
     }
 ipv6_done:;
 
+    TEST("IPV6_V6ONLY after bind still fails");
+    {
+        int sock = socket(AF_INET6, SOCK_STREAM, 0);
+        if (sock >= 0) {
+            struct sockaddr_in6 addr6;
+            memset(&addr6, 0, sizeof(addr6));
+            addr6.sin6_family = AF_INET6;
+            addr6.sin6_addr = in6addr_loopback;
+            addr6.sin6_port = 0;
+
+            if (bind(sock, (struct sockaddr *) &addr6, sizeof(addr6)) < 0) {
+                FAIL("bind ::1");
+            } else {
+                int val = 0;
+                errno = 0;
+                int rc = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &val,
+                                    sizeof(val));
+                EXPECT_TRUE(rc < 0 && errno == EINVAL,
+                            "setsockopt(IPV6_V6ONLY) did not fail with EINVAL");
+            }
+            close(sock);
+        } else
+            FAIL("socket failed");
+    }
+
     /* Test setsockopt + getsockopt: SO_REUSEADDR */
     TEST("SO_REUSEADDR set+get");
     {
@@ -332,6 +358,58 @@ ipv6_done:;
                 EXPECT_TRUE(val > 0, "SO_SNDBUF is 0");
             } else
                 FAIL("getsockopt failed");
+            close(sock);
+        } else
+            FAIL("socket failed");
+    }
+
+    TEST("cached SO_TYPE setsockopt still fails");
+    {
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock >= 0) {
+            int val = 0;
+            socklen_t len = sizeof(val);
+            if (getsockopt(sock, SOL_SOCKET, SO_TYPE, &val, &len) < 0) {
+                FAIL("getsockopt failed");
+            } else {
+                errno = 0;
+                EXPECT_TRUE(setsockopt(sock, SOL_SOCKET, SO_TYPE, &val,
+                                       sizeof(val)) < 0,
+                            "setsockopt(SO_TYPE) unexpectedly succeeded");
+            }
+            close(sock);
+        } else
+            FAIL("socket failed");
+    }
+
+    TEST("cached SO_SNDLOWAT setsockopt still fails");
+    {
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock >= 0) {
+            int val = 0;
+            socklen_t len = sizeof(val);
+            if (getsockopt(sock, SOL_SOCKET, SO_SNDLOWAT, &val, &len) < 0) {
+                FAIL("getsockopt failed");
+            } else {
+                errno = 0;
+                EXPECT_TRUE(setsockopt(sock, SOL_SOCKET, SO_SNDLOWAT, &val,
+                                       sizeof(val)) < 0,
+                            "setsockopt(SO_SNDLOWAT) unexpectedly succeeded");
+            }
+            close(sock);
+        } else
+            FAIL("socket failed");
+    }
+
+    TEST("SO_ACCEPTCONN setsockopt still fails");
+    {
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock >= 0) {
+            int val = 0;
+            errno = 0;
+            EXPECT_TRUE(setsockopt(sock, SOL_SOCKET, SO_ACCEPTCONN, &val,
+                                   sizeof(val)) < 0,
+                        "setsockopt(SO_ACCEPTCONN) unexpectedly succeeded");
             close(sock);
         } else
             FAIL("socket failed");

--- a/tests/test-rosetta-madvise.sh
+++ b/tests/test-rosetta-madvise.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# test-rosetta-madvise.sh - madvise(MADV_DONTNEED) on high-VA regions via Rosetta
+# test-rosetta-madvise.sh - madvise(MADV_DONTNEED) on high-VA regions via
+# Rosetta
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
@@ -55,8 +56,8 @@ set +e
 madv_out="$("$TIMEOUT" 30 "$ELFUSE" "$MADV_BIN" 2>&1)"
 madv_rc=$?
 set -e
-if [ "$madv_rc" -eq 0 ] &&
-    printf '%s\n' "$madv_out" | grep -q 'madvise high-VA: all subtests passed'; then
+if [ "$madv_rc" -eq 0 ] \
+    && printf '%s\n' "$madv_out" | grep -q 'madvise high-VA: all subtests passed'; then
     report_pass "madvise-high-va-dontneed"
 else
     report_fail "madvise-high-va-dontneed: rc=$madv_rc"

--- a/tests/test-rosetta-mremap.sh
+++ b/tests/test-rosetta-mremap.sh
@@ -55,8 +55,8 @@ set +e
 mremap_out="$("$TIMEOUT" 30 "$ELFUSE" "$MREMAP_BIN" 2>&1)"
 mremap_rc=$?
 set -e
-if [ "$mremap_rc" -eq 0 ] &&
-    printf '%s\n' "$mremap_out" | grep -q 'mremap high-VA: all subtests passed'; then
+if [ "$mremap_rc" -eq 0 ] \
+    && printf '%s\n' "$mremap_out" | grep -q 'mremap high-VA: all subtests passed'; then
     report_pass "mremap-high-va"
 else
     report_fail "mremap-high-va: rc=$mremap_rc"

--- a/tests/test-rosetta-msync.sh
+++ b/tests/test-rosetta-msync.sh
@@ -56,8 +56,8 @@ set +e
 msync_out="$("$TIMEOUT" 30 "$ELFUSE" "$MSYNC_BIN" 2>&1)"
 msync_rc=$?
 set -e
-if [ "$msync_rc" -eq 0 ] &&
-    printf '%s\n' "$msync_out" | grep -q 'msync high-VA: all subtests passed'; then
+if [ "$msync_rc" -eq 0 ] \
+    && printf '%s\n' "$msync_out" | grep -q 'msync high-VA: all subtests passed'; then
     report_pass "msync-high-va-writeback"
 else
     report_fail "msync-high-va-writeback: rc=$msync_rc"

--- a/tests/test-thread.c
+++ b/tests/test-thread.c
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 #include <sys/mman.h>
 
 #include "test-harness.h"
@@ -139,6 +140,27 @@ static void test_parent_settid(void)
      * woke the parent. The original value was > 0 (written by PARENT_SETTID).
      */
     PASS();
+}
+
+static void test_settid_failure_preserves_slots(void)
+{
+    TEST("failed SETTID preserves slots");
+
+    int parent_tid = 12345;
+    unsigned long flags = 0x7d0f00 | 0x01000000; /* + CLONE_CHILD_SETTID */
+    void *stack_top = child_stack_buf + sizeof(child_stack_buf);
+
+    long ret = raw_clone(flags, stack_top, &parent_tid, 0, (int *) 1);
+    if (ret == 0) {
+        raw_exit(1);
+        __builtin_unreachable();
+    }
+
+    if (ret == -EFAULT && parent_tid == 12345) {
+        PASS();
+    } else {
+        FAIL("failed clone changed parent TID slot");
+    }
 }
 
 /* Test 3: Multiple concurrent threads */
@@ -278,6 +300,7 @@ int main(void)
 
     test_clone_thread();
     test_parent_settid();
+    test_settid_failure_preserves_slots();
     test_multi_thread();
     test_clone_stack_unmap_reuse();
 


### PR DESCRIPTION
Refactoring pass over the syscall layer with no behavior change except the noted correctness fixes.

Deduplication: extract shared helpers for repeated logic. futex wake sequence (futex_wake_waiter_locked), wait4 slot revalidation (proc_deactivate_slot_if_matches), sockaddr write-back and sockopt level translation in net.c, the netlink wait/complete-message/kernel-source trio, the SCM_CREDENTIALS builder, the clone register-capture and TID side-effect helpers, and the sendfile/copy_file_range copy loop (copy_fd_range).

Security: move the cross-process guest-signal transport off the predictable /tmp/elfuse-sig-<pid> path onto the per-user private directory from confstr(_CS_DARWIN_USER_TEMP_DIR) and open it O_NOFOLLOW. Consolidate predictable-path private-directory creation into create_private_dir(), which rejects a symlink, a foreign-owned directory, or a group/other-accessible one; use it for the shm and abstract-socket directories.

Memory safety: move every large on-stack buffer (8KB to 64KB, plus the 24KB maps entry array) onto the heap in the file-copy syscalls, the /proc text builders, and sysroot provisioning, converting each sizeof(buf) to an explicit size with a free on every exit path.

Correctness fixes: destroy the HVF vCPU on the vm_clone bring-up error path so the handle no longer leaks; use saturating subtraction for the derived /proc/meminfo fields so macOS free-plus-cached exceeding total no longer underflows; reject nonzero copy_file_range flags with EINVAL; rewind position-based input by the unsent count on a short write in sendfile, copy_file_range, and splice so a later call re-reads the dropped bytes; and remove dead code (an unreachable baud guard, two unreachable TCP sockopt switches with a redundant cache check, an always-null inotify event name, and an unused execve local).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates syscall helpers, hardens private-temp and signal-transport paths, moves large stack buffers to the heap, and fixes syscall and VM-clone correctness so failures are reapable.

- **Refactors**
  - Extract shared helpers: futex wake, wait4 slot verify, sockaddr write-back and sockopt level translation, netlink wait/complete/kernel-source, SCM_CREDENTIALS builder, clone register capture/TID side-effects, and the file-copy loop (`copy_fd_range`).
  - Use `create_private_dir()` for predictable paths (shm and abstract AF_UNIX dirs). Move signal transport to the per-user temp dir and open it with O_NOFOLLOW.
  - Replace 8–64KB on-stack buffers with heap allocations in file-copy syscalls, `/proc` builders, and sysroot provisioning; add explicit sizes and frees.

- **Bug Fixes**
  - Make vm-clone bring-up failures reapable: keep the child slot active with a SIGKILL status; clear `t->vcpu` under the lock before destroy; `thread_interrupt_all` skips null vCPUs to avoid races.
  - Use saturating subtraction for `/proc/meminfo` derived fields to avoid underflow.
  - Reject non-zero `copy_file_range` flags with `EINVAL`.
  - Rewind position-based inputs by the unsent count on short writes in `sendfile`, `copy_file_range`, and `splice`.
  - Tests: IPv6 `IPV6_V6ONLY` after bind returns `EINVAL`; failed `CLONE_CHILD_SETTID` preserves the parent TID slot.
  - Remove dead code (unreachable baud guard, unreachable TCP sockopt switches, unused `execve` local).

<sup>Written for commit 3e8aaff435bf17555dafc603c0168e9d7f840953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

