### PR TITLE
Correct stale comments

### DIFF
--- a/src/core/bootstrap.c
+++ b/src/core/bootstrap.c
@@ -1,4 +1,5 @@
-/* Guest bootstrap helpers
+/*
+ * Guest bootstrap helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/core/bootstrap.h
+++ b/src/core/bootstrap.h
@@ -1,4 +1,5 @@
-/* Guest bootstrap helpers
+/*
+ * Guest bootstrap helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/core/elf.c
+++ b/src/core/elf.c
@@ -1,4 +1,5 @@
-/* ELF64 parser and loader
+/*
+ * ELF64 parser and loader
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/core/elf.h
+++ b/src/core/elf.h
@@ -1,4 +1,5 @@
-/* ELF64 parser and loader
+/*
+ * ELF64 parser and loader
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -136,13 +137,13 @@ void elf_resolve_interp(const char *sysroot,
                         char *out,
                         size_t out_sz);
 
-/* Read, probe, and parse a shebang script header from host_path.
- * Writes interpreter path to interp_out and the single optional argument
- * (if present) to arg_out. arg_out will be set to an empty string if there
- * is no optional argument.
+/* Read, probe, and parse a shebang script header from host_path. Writes
+ * interpreter path to interp_out and the single optional argument (if present)
+ * to arg_out. arg_out will be set to an empty string if there is no optional
+ * argument.
  *
- * Supports LF (\n), CRLF (\r\n), and CR (\r) line endings. If the shebang
- * line is not terminated within the 511-byte buffer limit, returns -ENOEXEC.
+ * Supports LF (\n), CRLF (\r\n), and CR (\r) line endings. If the shebang line
+ * is not terminated within the 511-byte buffer limit, returns -ENOEXEC.
  *
  * Returns:
  *   1 if a shebang script was successfully parsed

--- a/src/core/guest.c
+++ b/src/core/guest.c
@@ -1,4 +1,5 @@
-/* Guest memory management
+/*
+ * Guest memory management
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -1842,8 +1843,9 @@ static void try_merge_left(guest_t *g, int i)
 {
     if (i <= 0 || i >= g->nregions)
         return;
-    /* nregions is bounded by GUEST_MAX_REGIONS so i is in range. */
-    /* cppcheck-suppress arrayIndexOutOfBoundsCond */
+    /* cppcheck-suppress arrayIndexOutOfBoundsCond
+     * nregions is bounded by GUEST_MAX_REGIONS so i is in range.
+     */
     if (!regions_mergeable(&g->regions[i - 1], &g->regions[i]))
         return;
 
@@ -2725,15 +2727,14 @@ int guest_extend_page_tables(guest_t *g,
         /* Only map if not already mapped. A negative TLB entry from a prior
          * translation fault is possible only for VAs that were unmapped at the
          * time of the fault, so the TLBI is only needed for blocks actually
-         * installed by this call.
-         */
-        /* At L2 a valid descriptor is either a 2 MiB block (bits[1:0] = 01) or
-         * a table descriptor pointing to an L3 page table (bits[1:0] = 11).
-         * Both indicate the slot is already mapped at some granule, so the
-         * extend has nothing to install; skip without flushing. The previous "&
-         * PT_BLOCK" test relied on PT_BLOCK == PT_VALID == bit 0 to cover both
-         * cases by coincidence -- write it as an explicit PT_VALID test so the
-         * intent survives a future descriptor-bit renumbering.
+         * installed by this call. At L2 a valid descriptor is either a 2 MiB
+         * block (bits[1:0] = 01) or a table descriptor pointing to an L3 page
+         * table (bits[1:0] = 11). Both indicate the slot is already mapped at
+         * some granule, so the extend has nothing to install; skip without
+         * flushing. The previous "& PT_BLOCK" test relied on PT_BLOCK ==
+         * PT_VALID == bit 0 to cover both cases by coincidence -- write it as
+         * an explicit PT_VALID test so the intent survives a future
+         * descriptor-bit renumbering.
          */
         if (l2[l2_idx] & PT_VALID)
             continue;

--- a/src/core/guest.h
+++ b/src/core/guest.h
@@ -1,4 +1,5 @@
-/* Guest memory management
+/*
+ * Guest memory management
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -144,8 +145,7 @@
 #define KBUF_SIZE 0x10000000ULL /* 256 MiB */
 #define KBUF_USER_VA (KBUF_VA_BASE & 0x0000FFFFFFFFFFFFULL) /* TTBR0 mirror */
 
-/* Page table attributes. */
-/* Memory region permission flags */
+/* Page table attributes. Memory region permission flags */
 #define MEM_PERM_R (1 << 0)
 #define MEM_PERM_W (1 << 1)
 #define MEM_PERM_X (1 << 2)
@@ -522,8 +522,7 @@ typedef struct {
      */
     _Atomic uint64_t pt_gen;
 
-    /*
-     * Optional HVC 6 embedder extension hook.
+    /* Optional HVC 6 embedder extension hook.
      *
      * Native AArch64 guests reach this through HVC 6. When the build enables
      * ELFUSE_NR_EMBEDDER_HVC6, translated Rosetta guests may reach the same

--- a/src/core/rosetta.c
+++ b/src/core/rosetta.c
@@ -1,4 +1,5 @@
-/* x86_64-via-Apple-Rosetta translator setup.
+/*
+ * x86_64-via-Apple-Rosetta translator setup.
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/core/rosetta.h
+++ b/src/core/rosetta.h
@@ -1,4 +1,5 @@
-/* x86_64-via-Apple-Rosetta translator setup for elfuse.
+/*
+ * x86_64-via-Apple-Rosetta translator setup for elfuse.
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/core/shim-globals.c
+++ b/src/core/shim-globals.c
@@ -1,4 +1,5 @@
-/* EL1 shim globals -- host publisher.
+/*
+ * EL1 shim globals -- host publisher.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -28,17 +29,16 @@
 #include "syscall/signal.h"
 
 #ifndef HV_SYS_REG_TPIDR_EL1
-/* Older SDKs (e.g., the Nix-pinned apple-sdk-14.4) may lack the
- * enumerator. The encoding is stable: op0=3, op1=0, CRn=13, CRm=0,
- * op2=4 -> 0xc684. Mirrors the existing ACTLR_EL1 workaround in
- * src/syscall/syscall.c.
+/* Older SDKs (e.g., the Nix-pinned apple-sdk-14.4) may lack the enumerator. The
+ * encoding is stable: op0=3, op1=0, CRn=13, CRm=0, op2=4 -> 0xc684. Mirrors the
+ * existing ACTLR_EL1 workaround in src/syscall/syscall.c.
  */
 #define HV_SYS_REG_TPIDR_EL1 ((hv_sys_reg_t) 0xc684)
 #endif
 
 #ifndef HV_SYS_REG_CONTEXTIDR_EL1
-/* op0=3, op1=0, CRn=13, CRm=0, op2=1 -> 0xc681. Same SDK-fallback
- * pattern as TPIDR_EL1.
+/* op0=3, op1=0, CRn=13, CRm=0, op2=1 -> 0xc681. Same SDK-fallback pattern as
+ * TPIDR_EL1.
  */
 #define HV_SYS_REG_CONTEXTIDR_EL1 ((hv_sys_reg_t) 0xc681)
 #endif

--- a/src/core/shim-globals.h
+++ b/src/core/shim-globals.h
@@ -1,4 +1,5 @@
-/* EL1 shim globals (identity cache + attention flag)
+/*
+ * EL1 shim globals (identity cache + attention flag)
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -15,14 +16,15 @@
  *   - sys_munmap and sys_mprotect reject infra ranges
  *   - sys_mremap (all variants) and sys_madvise reject infra ranges
  *
- * Not yet defended: direct EL0 store to the cache GVA. The shim_data block is
- * mapped PT_AP_RW_EL0 (RW at both ELs), and /proc/self/maps exposes
- * [shim-data]. A guest that knows the layout can store the cache base into a
- * register and write spoofed values directly. This is documented as out of
- * scope; closing it requires a new AP[2:1]=00 permission level (RW at EL1, no
- * EL0 access) which is a separate hardening item. The elfuse threat model
- * treats the guest as the user's own binary, not adversarial, so direct-write
- * spoofing is a defense-in-depth gap rather than an active vulnerability.
+ * Direct EL0 store to the cache GVA is defended: the shim_data block is mapped
+ * AP[2:1]=00 (RW at EL1, no EL0 access), so a guest EL0 dereference of the
+ * cache base faults to the SIGSEGV path rather than spoofing values.
+ * gva_translate_perm refuses MEM_PERM_EL1_ONLY descriptors on EL0-behalf walks,
+ * and the EL1 shim retains full RW. /proc/self/maps still lists [shim-data] but
+ * reports it PROT_NONE (region tracking is independent of EL0 access), so the
+ * layout is disclosed without granting a usable mapping. The elfuse threat
+ * model treats the guest as the user's own binary, not adversarial; this
+ * mapping closes the direct-write spoofing gap as defense in depth.
  *
  * The shim addresses the cache via TPIDR_EL1, which the host sets at every vCPU
  * init point (bootstrap, fork-child, CLONE_THREAD, exec re-init). TPIDR_EL1 is

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -1,4 +1,5 @@
-/* Linux initial stack builder
+/*
+ * Linux initial stack builder
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/core/stack.h
+++ b/src/core/stack.h
@@ -1,4 +1,5 @@
-/* Linux initial stack builder
+/*
+ * Linux initial stack builder
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/core/startup-trace.h
+++ b/src/core/startup-trace.h
@@ -1,4 +1,5 @@
-/* Startup tracing helpers
+/*
+ * Startup tracing helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -32,9 +33,9 @@
 #include <time.h>
 
 /* File-scope cache (one copy per translation unit including this header).
- * pthread_once serializes concurrent first callers and supplies the
- * memory ordering that makes the cached value safely visible to all
- * subsequent readers without explicit atomics.
+ * pthread_once serializes concurrent first callers and supplies the memory
+ * ordering that makes the cached value safely visible to all subsequent readers
+ * without explicit atomics.
  */
 static pthread_once_t startup_trace_once = PTHREAD_ONCE_INIT;
 static bool startup_trace_value;
@@ -62,10 +63,9 @@ static inline void startup_trace_resolve(void)
     const char *v = getenv("ELFUSE_STARTUP_TRACE");
     if (!v || !v[0] || !strcmp(v, "0"))
         return;
-    /* The legacy "1" knob enables steps. Recognize it both as the whole
-     * value and as a token so compound forms like "1,syscalls" still
-     * keep the step trace on alongside the histogram, instead of
-     * silently dropping it.
+    /* The legacy "1" knob enables steps. Recognize it both as the whole value
+     * and as a token so compound forms like "1,syscalls" still keep the step
+     * trace on alongside the histogram, instead of silently dropping it.
      */
     if (!strcmp(v, "1") || startup_trace_env_has(v, "1") ||
         startup_trace_env_has(v, "steps") || startup_trace_env_has(v, "all"))

--- a/src/core/sysroot.h
+++ b/src/core/sysroot.h
@@ -1,4 +1,5 @@
-/* Sysroot capability probing and provisioning
+/*
+ * Sysroot capability probing and provisioning
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/core/vdso.c
+++ b/src/core/vdso.c
@@ -1,4 +1,5 @@
-/* vDSO ELF image
+/*
+ * vDSO ELF image
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -22,7 +23,7 @@
  * below) keeps concurrent publishers and readers race-free.
  *
  * Anchor-age cap: the time trampolines refuse to interpolate once (cntvct -
- * anchor_cntvct) exceeds 2**31 cycles (~89 s at 24 MHz). That forces an SVC
+ * anchor_cntvct) exceeds 2**22 cycles (~0.175 s at 24 MHz). That forces an SVC
  * fallback the host can use to re-anchor against fresh macOS clocks, bounding
  * any drift relative to a fresh REALTIME SVC after an NTP step or long sleep.
  * The host SVC path also computes a predicted REALTIME from the anchor and
@@ -687,13 +688,13 @@ static void emit_clock_gettime_trampoline(uint32_t *code,
     code[20] = enc_lsr_x_imm(7, 6, VDSO_ANCHOR_AGE_SHIFT);
     /* lsr x7, x6, #ANCHOR_AGE_SHIFT */
     code[21] = enc_cbnz_x(7, svc_fallback_off - 0x54);
-    /* cbnz x7, svc_fallback (age cap) */
-    /* delta_ns = (delta * 699050666) >> 24. 699050666 is floor((1e9 << 24) /
-     * 24e6), the mult+shift form Linux's arm64 vDSO uses for CNTFRQ = 24 MHz;
-     * an LSR (~1 cycle) in place of any 64-bit UDIV (~10-22 cycles on Apple
-     * Silicon). Rounding down keeps the trampoline tick slightly slower than
-     * the host so the next reseed never steps time backwards. The age cap
-     * bounds delta < 2^22, so delta * 699050666 < 2^52 -- no overflow.
+    /* cbnz x7, svc_fallback (age cap) delta_ns = (delta * 699050666) >> 24.
+     * 699050666 is floor((1e9 << 24) / 24e6), the mult+shift form Linux's arm64
+     * vDSO uses for CNTFRQ = 24 MHz; an LSR (~1 cycle) in place of any 64-bit
+     * UDIV (~10-22 cycles on Apple Silicon). Rounding down keeps the trampoline
+     * tick slightly slower than the host so the next reseed never steps time
+     * backwards. The age cap bounds delta < 2^22, so delta * 699050666 < 2^52
+     * -- no overflow.
      */
     code[22] = enc_movz_x(7, 0xAAAA);
     code[23] = enc_movk_x_lsl16(7, 0x29AA); /* w7 = 699050666     */

--- a/src/core/vdso.h
+++ b/src/core/vdso.h
@@ -1,4 +1,5 @@
-/* Minimal vDSO (Virtual Dynamic Shared Object)
+/*
+ * Minimal vDSO (Virtual Dynamic Shared Object)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/debug/crashreport.c
+++ b/src/debug/crashreport.c
@@ -1,4 +1,5 @@
-/* Structured crash report for GitHub issue filing
+/*
+ * Structured crash report for GitHub issue filing
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/debug/crashreport.h
+++ b/src/debug/crashreport.h
@@ -1,4 +1,5 @@
-/* Structured crash report for GitHub issue filing
+/*
+ * Structured crash report for GitHub issue filing
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/debug/gdbstub-reg.c
+++ b/src/debug/gdbstub-reg.c
@@ -1,4 +1,5 @@
-/* GDB register snapshot helpers
+/*
+ * GDB register snapshot helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -96,6 +97,13 @@ void gdb_restore_vcpu(thread_entry_t *t, int tde_stop)
     t->gdb_regs_dirty = false;
 }
 
+/* Return the snapshot offset and byte size for a GDB register number via
+ * @out_off and @out_size.
+ *
+ * Returns 0 on success, -1 for an invalid register. The two regular families
+ * (X0-X30, V0-V31) use closed-form math; the five irregular slots live in a
+ * sparse table so each one is a data entry instead of a switch case.
+ */
 int gdb_reg_offset(uint64_t regnum, int *out_off, int *out_size)
 {
     if (regnum < 31) {

--- a/src/debug/gdbstub-reg.h
+++ b/src/debug/gdbstub-reg.h
@@ -1,4 +1,5 @@
-/* GDB register snapshot helpers
+/*
+ * GDB register snapshot helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/debug/gdbstub-rsp.c
+++ b/src/debug/gdbstub-rsp.c
@@ -1,4 +1,5 @@
-/* GDB RSP transport and hex helpers
+/*
+ * GDB RSP transport and hex helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -140,6 +141,14 @@ void gdb_rsp_set_noack(gdb_rsp_ctx_t *ctx, bool enabled)
     ctx->no_ack_mode = enabled;
 }
 
+/* Read one RSP packet from the client into @buf. Strips $...# framing and
+ * verifies the checksum, sending + acknowledgment on success. Returns packet
+ * length, 0 on EOF, -1 on error. Also handles bare 0x03 (Ctrl+C) by returning
+ * "\x03" as a 1-byte packet.
+ *
+ * Uses a static read buffer to batch socket reads instead of reading one byte
+ * at a time. Packets exceeding @bufsz are rejected with E00.
+ */
 int gdb_rsp_recv(gdb_rsp_ctx_t *ctx, int fd, char *buf, size_t bufsz)
 {
     if (bufsz == 0) {

--- a/src/debug/gdbstub-rsp.h
+++ b/src/debug/gdbstub-rsp.h
@@ -1,4 +1,5 @@
-/* GDB RSP transport and hex helpers
+/*
+ * GDB RSP transport and hex helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -1,4 +1,5 @@
-/* GDB Remote Serial Protocol stub for guest debugging
+/*
+ * GDB Remote Serial Protocol stub for guest debugging
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -193,14 +194,6 @@ static int rsp_reply_error(int errnum)
     return rsp_reply(buf);
 }
 
-/* Read one RSP packet from the client. Strips $...# framing and verifies
- * checksum. Sends + acknowledgment on success.
- * Returns packet length, 0 on EOF, -1 on error. Also handles bare 0x03 (Ctrl+C)
- * by returning "\x03" as a 1-byte packet.
- *
- * Uses a static read buffer to batch socket reads instead of reading one byte
- * at a time. Packets exceeding bufsz are rejected with E00.
- */
 /* Breakpoint / watchpoint management. */
 
 /* BAS (Byte Address Select) for a watchpoint of given length aligned to the
@@ -416,12 +409,9 @@ static void build_stop_reply(char *buf, size_t bufsz)
 
 /* Packet handlers. */
 
-/* Return the snapshot offset and byte size for a GDB register number.
- * Returns 0 on success, -1 for invalid register. The two regular families
- * (X0-X30, V0-V31) use closed-form math; the five irregular slots live in a
- * sparse table so each one is a data entry instead of a switch case.
+/* Handle 'g': read all registers from the snapshot for current_g_tid and reply
+ * with the full register hex dump.
  */
-/* Handle 'g': read all registers from snapshot for current_g_tid. */
 static void handle_read_regs(void)
 {
     const thread_entry_t *t = find_thread_for_tid(gdb.current_g_tid);
@@ -670,8 +660,8 @@ static void handle_breakpoint(const char *pkt, int insert)
     case 0:
         /* Software breakpoint: for MVP, treat as hardware breakpoint since
          * hardware support is available and this avoids I-cache issues
+         * fallthrough
          */
-        /* fallthrough */
     case 1:
         /* Hardware breakpoint */
         if (insert)

--- a/src/debug/gdbstub.h
+++ b/src/debug/gdbstub.h
@@ -1,4 +1,5 @@
-/* GDB Remote Serial Protocol stub for guest debugging
+/*
+ * GDB Remote Serial Protocol stub for guest debugging
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -53,7 +54,9 @@ int gdb_stub_is_active(void);
  * vCPU. The vCPU is already stopped (hv_vcpu_run returned). This blocks the
  * calling thread until GDB resumes it.
  *
- * ec: exception class from syndrome (0x30=hw bp, 0x32=step, 0x34=wp)
+ * @stop_reason: GDB_STOP_* cause code (1=breakpoint, 2=watchpoint, 3=step,
+ *   4=signal, 5=entry).
+ * @stop_addr: faulting breakpoint/watchpoint address (0 when none applies).
  * Returns: 0 to continue, 1 to single-step next instruction.
  */
 int gdb_stub_handle_stop(int stop_reason, uint64_t stop_addr);

--- a/src/debug/log.c
+++ b/src/debug/log.c
@@ -1,4 +1,5 @@
-/* Level-based diagnostic logging
+/*
+ * Level-based diagnostic logging
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/debug/log.h
+++ b/src/debug/log.h
@@ -1,4 +1,5 @@
-/* Level-based diagnostic logging
+/*
+ * Level-based diagnostic logging
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/debug/syscall-hist.c
+++ b/src/debug/syscall-hist.c
@@ -1,4 +1,5 @@
-/* Dynamic-linker startup syscall histogram
+/*
+ * Dynamic-linker startup syscall histogram
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/debug/syscall-hist.h
+++ b/src/debug/syscall-hist.h
@@ -1,4 +1,5 @@
-/* Dynamic-linker startup syscall histogram
+/*
+ * Dynamic-linker startup syscall histogram
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -28,13 +29,17 @@
 void syscall_hist_init(void);
 
 /* Fast probe used by syscall_dispatch to decide whether to grab a start
- * timestamp. Returns false after syscall_hist_freeze() so the recording
- * stops cleanly at the first execve.
+ * timestamp.
+ *
+ * Returns false after syscall_hist_freeze() so the recording stops cleanly at
+ * the first execve.
  */
 bool syscall_hist_enabled(void);
 
-/* Monotonic timestamp source. Returns 0 when the histogram is disabled so
- * the caller can short-circuit without a branch on the env-var cache.
+/* Monotonic timestamp source.
+ *
+ * Returns 0 when the histogram is disabled so the caller can short-circuit
+ * without a branch on the env-var cache.
  */
 uint64_t syscall_hist_now_ns(void);
 
@@ -45,23 +50,23 @@ uint64_t syscall_hist_now_ns(void);
 void syscall_hist_record(int nr, uint64_t ns);
 
 /* Stop recording but keep the captured data ready to dump. Called from the
- * successful-execve path so steady-state syscall traffic does not pollute
- * the startup picture. The reason string survives until syscall_hist_dump
- * runs and appears in the dump header.
+ * successful-execve path so steady-state syscall traffic does not pollute the
+ * startup picture. The reason string survives until syscall_hist_dump runs and
+ * appears in the dump header.
  */
 void syscall_hist_freeze(const char *reason);
 
-/* Force-disable the histogram in this process even if ELFUSE_STARTUP_TRACE
- * is set. Used by fork-child bring-up: the child resumes from a parent
- * snapshot, so its first syscalls are steady-state, not dynamic-linker
- * bring-up. Without this, the inherited env var would trigger lazy init in
- * the child and pollute the parent's dump if both share stderr.
+/* Force-disable the histogram in this process even if ELFUSE_STARTUP_TRACE is
+ * set. Used by fork-child bring-up: the child resumes from a parent snapshot,
+ * so its first syscalls are steady-state, not dynamic-linker bring-up. Without
+ * this, the inherited env var would trigger lazy init in the child and pollute
+ * the parent's dump if both share stderr.
  */
 void syscall_hist_disable(void);
 
 /* Emit a human-readable summary to stderr, sorted by total ns descending.
- * Idempotent: subsequent calls are no-ops. Safe to call from cleanup paths
- * that may run more than once.
+ * Idempotent: subsequent calls are no-ops. Safe to call from cleanup paths that
+ * may run more than once.
  */
 void syscall_hist_dump(void);
 

--- a/src/hvutil.h
+++ b/src/hvutil.h
@@ -1,4 +1,5 @@
-/* Shared Hypervisor.framework utility macros and constants
+/*
+ * Shared Hypervisor.framework utility macros and constants
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
-/* Run aarch64-linux ELF binaries on macOS Apple Silicon
+/*
+ * Run aarch64-linux ELF binaries on macOS Apple Silicon
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -1,4 +1,5 @@
-/* Fork IPC state serialization
+/*
+ * Fork IPC state serialization
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/fork-state.h
+++ b/src/runtime/fork-state.h
@@ -1,4 +1,5 @@
-/* Fork IPC state serialization
+/*
+ * Fork IPC state serialization
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/forkipc.h
+++ b/src/runtime/forkipc.h
@@ -1,4 +1,5 @@
-/* Fork/clone IPC
+/*
+ * Fork/clone IPC
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -85,7 +85,8 @@ static _Atomic int futex_interrupt_requested = 0;
 #define FUTEX_BITSET_MATCH_ANY 0xFFFFFFFFU
 
 /* PI futex word layout (bits):
- *   0-30: TID of lock holder (0 = unlocked)
+ *   0-29: TID of lock holder (0 = unlocked)
+ *   30:   FUTEX_OWNER_DIED (set by robust_list_walk on thread exit)
  *   31:   FUTEX_WAITERS (at least one thread is blocked)
  *
  * Linux kernel: FUTEX_WAITERS=0x80000000 (bit 31), FUTEX_OWNER_DIED=0x40000000
@@ -1051,7 +1052,8 @@ static int64_t futex_wake_op(guest_t *g,
 /* PI (Priority-Inheritance) futex.
  *
  * PI futexes use the futex word itself as an atomic lock:
- *   bits 0-30 = owner TID (FUTEX_TID_MASK), bit 31 = FUTEX_WAITERS
+ *   bits 0-29 = owner TID (FUTEX_TID_MASK), bit 30 = FUTEX_OWNER_DIED,
+ *   bit 31 = FUTEX_WAITERS
  *
  * Futex emulation does not implement real priority inheritance (boosting the
  * holder's priority to the highest waiter's), but it implements the locking
@@ -1063,7 +1065,7 @@ static int64_t futex_wake_op(guest_t *g,
 
 /* FUTEX_LOCK_PI: Block until the lock at uaddr can be acquired.
  *
- * The PI futex word stores the owner TID in bits 0-30 and a WAITERS flag in bit
+ * The PI futex word stores the owner TID in bits 0-29 and a WAITERS flag in bit
  * 31. The kernel emulation sets FUTEX_WAITERS when a thread blocks, so the
  * current owner knows to call FUTEX_UNLOCK_PI instead of releasing the word
  * with the uncontended userspace CAS(TID->0) path.

--- a/src/runtime/futex.h
+++ b/src/runtime/futex.h
@@ -1,4 +1,5 @@
-/* Linux futex emulation
+/*
+ * Linux futex emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/runtime/procemu.h
+++ b/src/runtime/procemu.h
@@ -1,4 +1,5 @@
-/* /proc and /dev path emulation
+/*
+ * /proc and /dev path emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/runtime/proctitle.c
+++ b/src/runtime/proctitle.c
@@ -1,4 +1,5 @@
-/* Process-title helpers
+/*
+ * Process-title helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -1,4 +1,5 @@
-/* Per-thread state for Linux threading support
+/*
+ * Per-thread state for Linux threading support
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -197,8 +198,8 @@ void thread_deactivate(thread_entry_t *t)
     /* If this is a VM-clone child, mark it as exited and wake the tracer/parent
      * so wait4 can collect the exit status. Must happen BEFORE destroying the
      * condvars, since broadcasting a destroyed condvar is undefined behavior.
+     * Guard against double-deactivation: if already inactive, skip.
      */
-    /* Guard against double-deactivation: if already inactive, skip. */
     if (!t->active) {
         pthread_mutex_unlock(&thread_lock);
         return;

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -1,4 +1,5 @@
-/* Per-thread state for Linux threading support
+/*
+ * Per-thread state for Linux threading support
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -1,4 +1,5 @@
-/* Linux aarch64 syscall dispatch
+/*
+ * Linux aarch64 syscall dispatch
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -13,8 +14,7 @@
 #include "core/guest.h"
 #include "core/elf.h"
 
-/* Linux aarch64 syscall numbers. */
-/* Sorted numerically for easy lookup. Reference:
+/* Linux aarch64 syscall numbers. Sorted numerically for easy lookup. Reference:
  * include/uapi/asm-generic/unistd.h in Linux source.
  */
 #define SYS_io_destroy 1
@@ -345,7 +345,7 @@ typedef struct {
 /* Linux ioctl constants. Linux and macOS use different ioctl numbers for the
  * same operations. Linux terminal ioctls use 0x54xx (from
  * asm-generic/ioctls.h). macOS equivalents are in <sys/ioctl.h> and
- * <sys/ttycom.h>. Translation is done in syscall_io.c:sys_ioctl().
+ * <sys/ttycom.h>. Translation is done in io.c:sys_ioctl().
  */
 #define LINUX_TCGETS 0x5401     /* -> macOS TIOCGETA (tcgetattr) */
 #define LINUX_TCSETS 0x5402     /* -> macOS TIOCSETA (tcsetattr TCSANOW) */
@@ -583,10 +583,9 @@ typedef struct {
     uint64_t rlim_cur, rlim_max;
 } linux_rlimit64_t;
 
-/* Linux struct utmpx (aarch64 LP64). */
-/* Matches musl's struct utmpx layout. Used for /var/run/utmp synthesis. On
- * LP64: short=2, int=4, long=8, sizeof(struct timeval)=16.
- * sizeof(linux_utmpx_t) == 400 (396 data + 4 trailing padding).
+/* Linux struct utmpx (aarch64 LP64). Matches musl's struct utmpx layout. Used
+ * for /var/run/utmp synthesis. On LP64: short=2, int=4, long=8, sizeof(struct
+ * timeval)=16. sizeof(linux_utmpx_t) == 400 (396 data + 4 trailing padding).
  */
 #define LINUX_UT_LINESIZE 32
 #define LINUX_UT_NAMESIZE 32

--- a/src/syscall/chown-overlay.c
+++ b/src/syscall/chown-overlay.c
@@ -1,4 +1,5 @@
-/* Virtual chown overlay (fakeroot-style)
+/*
+ * Virtual chown overlay (fakeroot-style)
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/chown-overlay.h
+++ b/src/syscall/chown-overlay.h
@@ -1,4 +1,5 @@
-/* Virtual chown overlay (fakeroot-style)
+/*
+ * Virtual chown overlay (fakeroot-style)
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/exec.h
+++ b/src/syscall/exec.h
@@ -1,4 +1,5 @@
-/* execve syscall handler
+/*
+ * execve syscall handler
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/fd.c
+++ b/src/syscall/fd.c
@@ -1,4 +1,5 @@
-/* Special FD types (eventfd, signalfd, timerfd)
+/*
+ * Special FD types (eventfd, signalfd, timerfd)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/fd.h
+++ b/src/syscall/fd.h
@@ -1,4 +1,5 @@
-/* Special FD types (eventfd, signalfd, timerfd)
+/*
+ * Special FD types (eventfd, signalfd, timerfd)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -1,4 +1,5 @@
-/* FD table: bitmap allocator, alloc/close/snapshot helpers
+/*
+ * FD table: bitmap allocator, alloc/close/snapshot helpers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -34,9 +35,9 @@ pthread_mutex_t fd_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 3 */
 fd_entry_t fd_table[FD_TABLE_SIZE];
 static uint64_t fd_next_generation = 1;
 
-/* RLIMIT_NOFILE tracking. */
-/* Guest-side soft limit for RLIMIT_NOFILE. fd_alloc checks this. Default
- * matches typical Linux default (1024). Updated by prlimit64.
+/* RLIMIT_NOFILE tracking. Guest-side soft limit for RLIMIT_NOFILE. fd_alloc
+ * checks this. Default matches typical Linux default (1024). Updated by
+ * prlimit64.
  */
 static _Atomic int rlimit_nofile_cur = FD_TABLE_SIZE;
 

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -1,4 +1,5 @@
-/* Filesystem stat/statx/statfs handlers
+/*
+ * Filesystem stat/statx/statfs handlers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/fs-xattr.c
+++ b/src/syscall/fs-xattr.c
@@ -1,4 +1,5 @@
-/* Extended attribute syscall handlers
+/*
+ * Extended attribute syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -1,4 +1,5 @@
-/* Filesystem syscall handlers
+/*
+ * Filesystem syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -1123,13 +1124,14 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
          * elfuse does not deliver host SIGIO into the guest (see LINUX_FIOASYNC
          * in sys_ioctl), so no owner is tracked: accept the request as a no-op.
          * F_SETOWN's arg is the owner pid passed by value, so there is no user
-         * pointer to validate. */
+         * pointer to validate.
+         */
         return 0;
     case 15: { /* F_SETOWN_EX */
-        /* Same no-op owner semantics as F_SETOWN, but the arg is a
-         * struct f_owner_ex { int type; int pid; } pointer that Linux reads
-         * before applying. Read it through so a bad guest pointer faults with
-         * EFAULT rather than silently succeeding; the value is then discarded.
+        /* Same no-op owner semantics as F_SETOWN, but the arg is a struct
+         * f_owner_ex { int type; int pid; } pointer that Linux reads before
+         * applying. Read it through so a bad guest pointer faults with EFAULT
+         * rather than silently succeeding; the value is then discarded.
          */
         int32_t owner_ex[2];
         if (guest_read_small(g, arg, owner_ex, sizeof(owner_ex)) < 0)
@@ -1144,7 +1146,8 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
          * answer coherently with the F_SETOWN no-op above rather than EINVAL
          * (which would make F_GETOWN fail under glibc). Report "owned by no
          * specific process": struct f_owner_ex { int type; int pid; } with
-         * type=F_OWNER_PID(1), pid=0. */
+         * type=F_OWNER_PID(1), pid=0.
+         */
         int32_t owner_ex[2] = {1 /* F_OWNER_PID */, 0 /* pid */};
         if (guest_write_small(g, arg, owner_ex, sizeof(owner_ex)) < 0)
             return -LINUX_EFAULT;
@@ -1700,10 +1703,10 @@ int64_t sys_renameat2(guest_t *g,
         return -LINUX_EBADF;
     }
 
-    /* Apply sysroot resolution for absolute paths */
-    /* RENAME_NOREPLACE: fail if destination exists. macOS renamex_np supports
-     * RENAME_EXCL for the same semantics. Only supported for AT_FDCWD paths
-     * (renamex_np does not take dirfd arguments).
+    /* Apply sysroot resolution for absolute paths RENAME_NOREPLACE: fail if
+     * destination exists. macOS renamex_np supports RENAME_EXCL for the same
+     * semantics. Only supported for AT_FDCWD paths (renamex_np does not take
+     * dirfd arguments).
      */
     if (flags & LINUX_RENAME_NOREPLACE) {
         if (olddirfd == LINUX_AT_FDCWD && newdirfd == LINUX_AT_FDCWD) {
@@ -1796,7 +1799,9 @@ int64_t sys_mknodat(guest_t *g, int dirfd, uint64_t path_gva, int mode, int dev)
     if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
         return -LINUX_EBADF;
 
-    /* Only support FIFO creation; other node types need root */
+    /* FIFO via mkfifoat and regular files via openat are supported; device
+     * nodes need root
+     */
     if (S_ISFIFO(mode)) {
         if (mkfifoat(dir_ref.fd, tx.host_path, mode & 0777) < 0) {
             host_fd_ref_close(&dir_ref);

--- a/src/syscall/fs.h
+++ b/src/syscall/fs.h
@@ -1,4 +1,5 @@
-/* Filesystem syscall handlers
+/*
+ * Filesystem syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -198,7 +198,7 @@ typedef struct {
 #define FUSE_MAX_PENDING 128
 /* Per-session capacity for held lookup references. Sized for recursive
  * directory walks (ls -R style) without pushing the per-session struct into
- * multi-page territory; sizeof(struct) at the chosen cap stays under 80 KiB.
+ * multi-page territory; node_refs at this cap is ~96 KiB, kept off the stack.
  * Beyond this, fuse_lookup_locked() emits a compensating FORGET to keep the
  * daemon balanced instead of leaking a reference.
  */
@@ -1929,11 +1929,11 @@ typedef struct {
 } fuse_file_snap_t;
 
 /* Acquire exclusive offset-affecting access to a FUSE file, bump the file and
- * session refcounts, and snapshot the identity into snap. Stream reads (and
- * readdir) pass serialize=true so concurrent read() calls on the same fd are
+ * session refcounts, and snapshot the identity into @snap. Stream reads (and
+ * readdir) pass @serialize=true so concurrent read() calls on the same fd are
  * serialized via io_in_progress, matching Linux f_pos_lock semantics.
  * pread/getattr-style operations that do not touch the stream offset pass
- * serialize=false.
+ * @serialize=false.
  *
  * Returns 0 on success or a negative Linux errno.
  */
@@ -2018,9 +2018,9 @@ int fuse_materialize_fd(int fd, char *out_path, size_t outsz)
 }
 
 /* Read up to count bytes from a FUSE-backed file or directory at offset. Writes
- * the daemon's reply into the guest buffer at buf_gva. Updates the stream
- * offset on success when advance_offset is true and the fd still references the
- * same (session, mount_id, nodeid) identity (post-close races leave offsets
+ * the daemon's reply into the guest buffer at @buf_gva. Updates the stream
+ * offset on success when @advance_offset is true and the fd still references
+ * the same (session, mount_id, nodeid) identity (post-close races leave offsets
  * untouched).
  */
 static int64_t fuse_read_common(guest_t *g,

--- a/src/syscall/fuse.h
+++ b/src/syscall/fuse.h
@@ -60,9 +60,9 @@ bool fuse_fd_refuse_mmap(int fd);
 
 /* Move the per-fd offset for a FUSE-backed regular file.
  *
- * Returns the new offset on success or a negative Linux errno. /dev/fuse and
- * FUSE-backed directories return -ESPIPE/-EINVAL to match Linux semantics for
- * fds that do not support absolute seeking.
+ * Returns the new offset on success or a negative Linux errno. /dev/fuse
+ * returns -ESPIPE (stream-like, no absolute position); FUSE-backed regular
+ * files and directories are seekable.
  */
 int64_t fuse_lseek_fd(int fd, int64_t offset, int whence);
 int64_t fuse_fchdir(int fd);

--- a/src/syscall/inotify.h
+++ b/src/syscall/inotify.h
@@ -1,4 +1,5 @@
-/* Linux inotify emulation via kqueue EVFILT_VNODE for elfuse
+/*
+ * Linux inotify emulation via kqueue EVFILT_VNODE for elfuse
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -1,4 +1,5 @@
-/* Shared helpers for syscall modules
+/*
+ * Shared helpers for syscall modules
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -118,8 +118,8 @@ static void termios_copy_cc_to_linux(uint8_t linux_cc[19], const cc_t mac_cc[])
 {
     for (int i = 0; i < 19; i++) {
         int mac_idx = linux_mac_cc[i];
-        /* cppcheck-suppress negativeIndex RANGE_CHECK guards mac_idx >= 0
-         * before the array access.
+        /* cppcheck-suppress negativeIndex
+         * RANGE_CHECK guards mac_idx >= 0 before the array access.
          */
         linux_cc[i] = RANGE_CHECK(mac_idx, 0, NCCS) ? mac_cc[mac_idx] : 0;
     }
@@ -702,7 +702,7 @@ static uint32_t mac_lflag_to_linux(tcflag_t mf)
  * fd_lock for thread safety.
  *
  * Returns -LINUX_EBADF for path-only or closed fds, -LINUX_EPERM for
- * write-sealed fds (when check_seal is set), or 0 on success.
+ * write-sealed fds (when check_write_seal is set), or 0 on success.
  */
 static int64_t host_fd_ref_open_checked(int guest_fd,
                                         host_fd_ref_t *ref,

--- a/src/syscall/io.h
+++ b/src/syscall/io.h
@@ -1,4 +1,5 @@
-/* Core I/O syscall handlers
+/*
+ * Core I/O syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -1,4 +1,5 @@
-/* Guest memory syscalls
+/*
+ * Guest memory syscalls
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -207,9 +208,9 @@ static void mark_overlay_metadata_range(guest_t *g,
 }
 
 /* Mark the region spanning exactly [start, end) as backed by a fd that lost
- * write access, so sys_mprotect rejects a later PROT_WRITE upgrade. Exact
- * match (not overlap) because callers use this right after installing a
- * single freshly-added region.
+ * write access, so sys_mprotect rejects a later PROT_WRITE upgrade. Exact match
+ * (not overlap) because callers use this right after installing a single
+ * freshly-added region.
  */
 static void mark_region_backing_ro(guest_t *g, uint64_t start, uint64_t end)
 {
@@ -363,10 +364,10 @@ static uint64_t find_free_gap(guest_t *g,
      * mmap MAP_FIXED (Apple Silicon enforces 16 KiB host pages). Round to the
      * host page even when the current call requested a larger align (e.g.
      * BLOCK_2MIB for MAP_SHARED file-backed): a subsequent MAP_PRIVATE 4 KiB
-     * allocation should still be able to occupy the trailing space inside the
-     * 2 MiB block. find_free_gap_inner re-applies the caller's align on its
-     * next entry, so a subsequent MAP_SHARED allocation skips past the small
-     * tenant and lands on the next 2 MiB boundary anyway.
+     * allocation should still be able to occupy the trailing space inside the 2
+     * MiB block. find_free_gap_inner re-applies the caller's align on its next
+     * entry, so a subsequent MAP_SHARED allocation skips past the small tenant
+     * and lands on the next 2 MiB boundary anyway.
      */
     size_t hps = host_page_size_cached();
 
@@ -1000,12 +1001,13 @@ static int hvf_apply_file_overlay_quiesced(guest_t *g,
                                            off_t file_off);
 static int hvf_remove_file_overlay(guest_t *g, uint64_t ipa, uint64_t len);
 
-/* Copy [file_off, file_off+len) of fd into the guest page backing GPA `gpa`.
+/* Copy [@file_off, @file_off+@len) of @fd into the guest page backing GPA @gpa.
  * The destination is resolved through host_ptr_for_gpa so both primary-window
  * pages (gpa < guest_size -> host_base + gpa) and high-VA pages backed by a
  * named mapping or overflow segment land on their real host buffer. Callers
  * that stay in the primary window pass a low IPA offset, which equals its own
- * GPA there, so their behaviour is unchanged. */
+ * GPA there, so their behaviour is unchanged.
+ */
 static int read_file_range_to_guest(guest_t *g,
                                     uint64_t gpa,
                                     int fd,
@@ -1894,10 +1896,11 @@ int64_t sys_mmap(guest_t *g,
     if (is_noreserve)
         track_flags |= LINUX_MAP_NORESERVE;
 
-    /* The memory syscall layer handles all mmap variants. For file-backed
-     * MAP_SHARED, it falls back to MAP_PRIVATE semantics (copy-on-write). All
-     * threads share the same guest_t address space (CLONE_VM semantics), so
-     * MAP_SHARED and MAP_PRIVATE are equivalent within the guest.
+    /* The memory syscall layer handles all mmap variants. Aligned file-backed
+     * MAP_SHARED installs a live host overlay so guest writes reach the backing
+     * file and peer mappings; cases the overlay cannot serve fall back to a
+     * private pread snapshot. All threads share the same guest_t address space
+     * (CLONE_VM semantics).
      */
 
     /* Linux rejects zero-length mmap */
@@ -1956,8 +1959,8 @@ int64_t sys_mmap(guest_t *g,
          * that later teardown paths could not manage and let overflow-backed
          * aliases corrupt the fork snapshot high-water mark. Fail closed until
          * the region metadata and teardown paths are made VA-aware end-to-end.
+         * MAP_FIXED: addr is IPA-based, convert to offset
          */
-        /* MAP_FIXED: addr is IPA-based, convert to offset */
         uint64_t off = addr - g->ipa_base;
         /* Use subtraction-based check to avoid off+length overflow. Stays
          * primary-buffer-only for the low-VA path because the body below issues
@@ -2458,14 +2461,13 @@ int64_t sys_mmap(guest_t *g,
          * offset alignment matter for MAP_FIXED on macOS Apple Silicon (16 KiB
          * host pages). The "extra" trailing bytes inside the host page are
          * never reachable by the guest because the gap-finder advances the hint
-         * to the next host-page boundary after each allocation.
-         */
-        /* MAP_SHARED | PROT_WRITE against a backing fd opened without write
-         * access must fail EACCES, matching Linux. The alignment-mismatch and
-         * read-only-fd cases below both fall through to the pread snapshot
-         * path, which always succeeds -- without this check a writable shared
-         * mapping request on a read-only fd would be silently downgraded to a
-         * private snapshot instead of being rejected.
+         * to the next host-page boundary after each allocation. MAP_SHARED |
+         * PROT_WRITE against a backing fd opened without write access must fail
+         * EACCES, matching Linux. The alignment-mismatch and read-only-fd cases
+         * below both fall through to the pread snapshot path, which always
+         * succeeds -- without this check a writable shared mapping request on a
+         * read-only fd would be silently downgraded to a private snapshot
+         * instead of being rejected.
          */
         if ((flags & LINUX_MAP_SHARED) && (prot & LINUX_PROT_WRITE) &&
             !overlay_fd_writable(host_backing_fd)) {
@@ -2717,7 +2719,8 @@ int64_t sys_mremap(guest_t *g,
         if (cleanup_err < 0)
             return cleanup_err;
         /* Zero the trimmed region on its real backing (high-VA tails live at
-         * gpa_base, not host_base + tail_off). */
+         * gpa_base, not host_base + tail_off).
+         */
         memset(host_ptr_for_gpa(g, src_gpa_base + (tail_off - src_start)), 0,
                tail_end - tail_off);
         guest_region_remove(g, tail_off, tail_end);
@@ -2922,7 +2925,8 @@ int64_t sys_mremap(guest_t *g,
             /* Read the source through its GPA (identity for primary sources,
              * overflow/mapping backing for high-VA). The destination is always
              * a fresh primary-window range, so it never overlaps the source and
-             * the copy direction does not matter. */
+             * the copy direction does not matter.
+             */
             memmove((uint8_t *) g->host_base + new_off,
                     host_ptr_for_gpa(g, src_gpa_base + (old_off - src_start)),
                     copy_len);
@@ -3082,8 +3086,8 @@ int64_t sys_mremap(guest_t *g,
 
         uint64_t new_off;
         /* mremap moves the data via read_file_range_to_guest and does not
-         * reinstall a file overlay at the destination, so 2 MiB alignment
-         * would not narrow segment-table growth. Stay at host-page alignment.
+         * reinstall a file overlay at the destination, so 2 MiB alignment would
+         * not narrow segment-table growth. Stay at host-page alignment.
          */
         size_t mremap_align = host_page_size_cached();
         if (needs_exec && !(prot & LINUX_PROT_WRITE))
@@ -3163,7 +3167,8 @@ int64_t sys_mremap(guest_t *g,
         } else {
             /* Read the source through its GPA so high-VA sources copy from
              * their real backing (identity for primary: == host_base +
-             * old_off). The destination is a fresh primary-window gap. */
+             * old_off). The destination is a fresh primary-window gap.
+             */
             memcpy((uint8_t *) g->host_base + new_off,
                    host_ptr_for_gpa(g, src_gpa_base + (old_off - src_start)),
                    old_size);
@@ -3247,17 +3252,17 @@ int64_t sys_madvise(guest_t *g, uint64_t addr, uint64_t length, int advice)
     /* Range must lie within the guest IPA window. Linux returns -ENOMEM (not
      * -EINVAL) for addresses outside the process address space; see madvise(2):
      * "Addresses in the specified range are not currently mapped, or are
-     * outside the address space of the process." Stays primary-only because
-     * MADV_DONTNEED zeroes via raw host_base+off and the slab restore path
-     * likewise assumes primary backing. The region-aware variant will consume
-     * guest_is_valid_range once the body is updated.
+     * outside the address space of the process." The body accepts both the
+     * primary IPA window and high-VA mmap regions (gpa_base != start),
+     * resolving host pointers through host_ptr_for_gpa.
      */
     uint64_t off = addr - g->ipa_base;
     /* Accept ranges in the primary IPA window, and also high-VA mmap regions
      * (gpa_base != start) that the tracker records as mapped. Rosetta's own
      * slab/JIT and guest JITs (e.g. V8) decommit pages in the high-VA window
      * via mprotect(PROT_NONE)+madvise(MADV_DONTNEED); rejecting those with
-     * ENOMEM trips the guest's CHECK_EQ(0, ret) on the madvise return. */
+     * ENOMEM trips the guest's CHECK_EQ(0, ret) on the madvise return.
+     */
     bool in_primary = (off <= g->guest_size && length <= g->guest_size - off);
     if (!in_primary && !madvise_range_mapped(g, off, length))
         return -LINUX_ENOMEM;
@@ -3314,7 +3319,8 @@ int64_t sys_madvise(guest_t *g, uint64_t addr, uint64_t length, int advice)
             /* High-VA regions back their pages at gpa_base, not at the VA;
              * resolve the host pointer through the GPA so the reset hits the
              * real backing (host_ptr_for_gpa also follows live overlays). For
-             * identity regions gpa_base == start, so this is unchanged. */
+             * identity regions gpa_base == start, so this is unchanged.
+             */
             uint64_t rgpa = r->gpa_base + (zstart - r->start);
             memset(host_ptr_for_gpa(g, rgpa), 0, zend - zstart);
             if (!(r->flags & LINUX_MAP_ANONYMOUS)) {
@@ -3729,7 +3735,8 @@ static int64_t sync_shared_aliases_range(guest_t *g,
             /* Resolve the guest bytes through the region's GPA so high-VA
              * shared mappings (gpa_base != start) read from their real backing
              * rather than host_base + start. For identity regions gpa_base ==
-             * start, so this is unchanged. */
+             * start, so this is unchanged.
+             */
             const uint8_t *guest = host_ptr_for_gpa(
                 g, src->gpa_base + (wfile_start - src->offset));
             if (!guest)
@@ -3776,7 +3783,8 @@ static int64_t refresh_shared_region_range(guest_t *g,
     uint64_t len = rfile_end - rfile_start, file_off = rfile_start;
     /* Resolve through the region's GPA so high-VA shared mappings refresh their
      * real backing rather than host_base + start. Identity regions have
-     * gpa_base == start, so this is unchanged. */
+     * gpa_base == start, so this is unchanged.
+     */
     uint8_t *buf = host_ptr_for_gpa(g, r->gpa_base + (rfile_start - r->offset));
     if (!buf)
         return -LINUX_EFAULT;

--- a/src/syscall/mem.h
+++ b/src/syscall/mem.h
@@ -1,4 +1,5 @@
-/* Guest memory syscall interface
+/*
+ * Guest memory syscall interface
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/net-abi.c
+++ b/src/syscall/net-abi.c
@@ -1,4 +1,5 @@
-/* Socket ABI translation helpers
+/*
+ * Socket ABI translation helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/net-abi.h
+++ b/src/syscall/net-abi.h
@@ -1,4 +1,5 @@
-/* Socket ABI translation helpers
+/*
+ * Socket ABI translation helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/net-absock.h
+++ b/src/syscall/net-absock.h
@@ -1,4 +1,5 @@
-/* Abstract AF_UNIX emulation helpers
+/*
+ * Abstract AF_UNIX emulation helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/net-sockopt.c
+++ b/src/syscall/net-sockopt.c
@@ -1,4 +1,5 @@
-/* Socket option cache helpers
+/*
+ * Socket option cache helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/net-sockopt.h
+++ b/src/syscall/net-sockopt.h
@@ -1,4 +1,5 @@
-/* Socket option cache helpers
+/*
+ * Socket option cache helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/net.h
+++ b/src/syscall/net.h
@@ -1,4 +1,5 @@
-/* Socket/networking syscalls
+/*
+ * Socket/networking syscalls
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -1,4 +1,5 @@
-/* Shared guest/host path handling
+/*
+ * Shared guest/host path handling
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -1,4 +1,5 @@
-/* Shared guest/host path handling
+/*
+ * Shared guest/host path handling
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1,4 +1,5 @@
-/* Poll/select/epoll syscall handlers
+/*
+ * Poll/select/epoll syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -671,8 +672,8 @@ pselect_cleanup:
  *
  * Limitations:
  *   - EPOLLEXCLUSIVE not supported (rare, for load balancing)
- *   - epoll_data is stored in a per-process registration table indexed by guest
- *     fd (one epoll registration per fd)
+ *   - epoll_data is stored per epoll instance (fd_table[epfd].dir), indexed by
+ *     guest fd; each instance keeps its own table
  */
 
 /* Linux EPOLL constants */

--- a/src/syscall/poll.h
+++ b/src/syscall/poll.h
@@ -1,4 +1,5 @@
-/* Poll/select/epoll syscall handlers
+/*
+ * Poll/select/epoll syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/proc-identity.c
+++ b/src/syscall/proc-identity.c
@@ -1,4 +1,5 @@
-/* Process identity and session state
+/*
+ * Process identity and session state
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/proc-identity.h
+++ b/src/syscall/proc-identity.h
@@ -1,4 +1,5 @@
-/* Process identity state internals
+/*
+ * Process identity state internals
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/proc-pidfd.c
+++ b/src/syscall/proc-pidfd.c
@@ -1,4 +1,5 @@
-/* pidfd helpers
+/*
+ * pidfd helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/proc-pidfd.h
+++ b/src/syscall/proc-pidfd.h
@@ -1,4 +1,5 @@
-/* pidfd helpers
+/*
+ * pidfd helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -1,4 +1,5 @@
-/* Process metadata state helpers
+/*
+ * Process metadata state helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -441,9 +442,9 @@ bool proc_sysroot_casefold_enabled(void)
     return enabled;
 }
 
-/* Confirm resolved_path canonicalizes inside sysroot. This is a check-then-use
- * sequence: callers issue the actual syscall after this returns, so a symlink
- * swapped in between will not be re-validated. openat2
+/* Confirm @resolved_path canonicalizes inside @sysroot. This is a
+ * check-then-use sequence: callers issue the actual syscall after this returns,
+ * so a symlink swapped in between will not be re-validated. openat2
  * RESOLVE_{BENEATH,IN_ROOT} close that race for callers willing to opt in. For
  * the legacy *at() surface this is best-effort defense at the boundary; the
  * guest is in the host user's trust domain.

--- a/src/syscall/proc-state.h
+++ b/src/syscall/proc-state.h
@@ -1,4 +1,5 @@
-/* Process metadata state helpers
+/*
+ * Process metadata state helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -331,7 +331,7 @@ pid_t proc_guest_to_host_pid(int64_t gpid)
     return result;
 }
 
-/* Build the path to the cross-process signal-transport file for host_pid.
+/* Build the path to the cross-process signal-transport file for @host_pid.
  *
  * Files live in the per-user private temp directory macOS provisions (mode
  * 0700, owned by the invoking uid) rather than world-writable /tmp, so another
@@ -574,9 +574,9 @@ static int write_rusage_to_guest(guest_t *g,
     return guest_write_small(g, gva, &lru, sizeof(lru));
 }
 
-/* Deactivate the wait4 process-table slot iff it still holds host_pid.
+/* Deactivate the wait4 process-table slot iff it still holds @host_pid.
  * sys_wait4 releases pid_lock across the host wait4 call, so another reaper
- * thread may have recycled the slot in the meantime; the host_pid re-check
+ * thread may have recycled the slot in the meantime; the @host_pid re-check
  * guards against clobbering an unrelated child that took the slot. pid_lock
  * must not be held.
  */

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -1,4 +1,5 @@
-/* Process state and management
+/*
+ * Process state and management
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -175,10 +176,10 @@ uint32_t proc_get_gid(void);
 uint32_t proc_get_egid(void);
 uint32_t proc_get_sgid(void);
 
-/* Linux setuid semantics for non-root processes: setuid(uid) : set euid; if uid
- * == ruid or suid, also set ruid+suid setreuid(r,e) : swap real/effective
- * within {ruid, euid, suid} setresuid(r,e,s) : set any combination within
- * {ruid, euid, suid}
+/* Linux setuid semantics for non-root processes: setuid(@uid) : set euid only
+ * (non-root cannot change ruid/suid) setreuid(r,e) : swap real/effective within
+ * {ruid, euid, suid} setresuid(r,e,s) : set any combination within {ruid, euid,
+ * suid}
  * Returns 0 on success, -EPERM if transition is not allowed.
  */
 int64_t proc_sys_setuid(uint32_t uid);

--- a/src/syscall/sidecar.c
+++ b/src/syscall/sidecar.c
@@ -1,4 +1,5 @@
-/* Case-folding fallback VFS helpers
+/*
+ * Case-folding fallback VFS helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -242,10 +243,10 @@ static void sidecar_index_free(sidecar_index_t *index)
     index->count = 0;
 }
 
-/* Deep-copy src into dst so the caller can mutate dst freely and still recover
- * src for rollback.
+/* Deep-copy @src into @dst so the caller can mutate @dst freely and still
+ * recover @src for rollback.
  *
- * Returns 0 on success, -1 with errno on alloc failure (dst is left empty in
+ * Returns 0 on success, -1 with errno on alloc failure (@dst is left empty in
  * that case).
  */
 static int sidecar_index_clone(const sidecar_index_t *src, sidecar_index_t *dst)
@@ -610,16 +611,16 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
     if (sidecar_open_base(dirfd, path, out, outsz, &cur_fd, &absolute) < 0)
         return -1;
 
-    /* Sidecar only speaks for entries that live inside the sysroot tree (or
-     * are reachable through an index mapping). The sysroot resolver
+    /* Sidecar only speaks for entries that live inside the sysroot tree (or are
+     * reachable through an index mapping). The sysroot resolver
      * (proc_resolve_sysroot_path_flags) falls back to the literal host path
      * when the guest path does not exist under the sysroot; a walk that
      * unconditionally re-anchored such paths at the sysroot would veto that
      * fallback and break host-resource access (mktemp dirs, /etc/resolv.conf).
      * Track whether any component actually consulted an index mapping: with a
-     * mapped prefix the sysroot view is authoritative and missing suffixes
-     * must surface as ENOENT against the translated path; without one, a walk
-     * that leaves the tree simply is not sidecar's business (return 0).
+     * mapped prefix the sysroot view is authoritative and missing suffixes must
+     * surface as ENOENT against the translated path; without one, a walk that
+     * leaves the tree simply is not sidecar's business (return 0).
      */
     bool used_mapping = false;
     size_t out_len = strlen(out);
@@ -1049,9 +1050,10 @@ static int sidecar_write_all(int fd, const char *buf, size_t len)
     return 0;
 }
 
-/* Serialize the index into a malloc'd buffer. *out_len receives the byte count.
+/* Serialize the index into a malloc'd buffer. *@out_len receives the byte
+ * count.
  *
- * Returns 0 on success, -1 with errno on error; *out is NULL on failure.
+ * Returns 0 on success, -1 with errno on error; *@out is NULL on failure.
  */
 static int sidecar_serialize_index(const sidecar_index_t *index,
                                    char **out,
@@ -1214,7 +1216,7 @@ static int sidecar_generate_token(char token[SIDECAR_TOKEN_NAME_LEN + 1])
     return 0;
 }
 
-/* Open the parent directory sidecar would maintain an index in for `path`.
+/* Open the parent directory sidecar would maintain an index in for @path.
  * Returns 0 with parent->dirfd open on success, -1 on error, and 1 when the
  * parent resolves outside the sysroot: such paths follow the resolver's
  * host-literal fallback (proc_resolve_sysroot_path_flags) and carry no index,

--- a/src/syscall/sidecar.h
+++ b/src/syscall/sidecar.h
@@ -1,4 +1,5 @@
-/* Case-folding fallback VFS helpers
+/*
+ * Case-folding fallback VFS helpers
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -1,4 +1,5 @@
-/* Signal delivery
+/*
+ * Signal delivery
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -98,8 +99,7 @@ static guest_itimer_t guest_itimer;      /* ITIMER_REAL -> SIGALRM */
 static guest_itimer_t guest_itimer_virt; /* ITIMER_VIRTUAL -> SIGVTALRM */
 static guest_itimer_t guest_itimer_prof; /* ITIMER_PROF -> SIGPROF */
 
-/* Default disposition table. */
-/* Index 0 unused (signals are 1-based). */
+/* Default disposition table. Index 0 unused (signals are 1-based). */
 static const sig_disposition_t default_dispositions[LINUX_NSIG + 1] = {
     [0] = SIG_DISP_IGN, /* Invalid signal 0 */
     [LINUX_SIGHUP] = SIG_DISP_TERM,
@@ -1266,7 +1266,7 @@ int64_t signal_sigaltstack(guest_t *g, uint64_t ss_gva, uint64_t old_ss_gva)
  *   1. FPSIMD context (always present)
  *   2. ESR context (present for synchronous faults: BRK, segfault, etc.)
  *   3. Terminator (magic=0, size=0)
- * The esr parameter is the raw ESR_EL1 value; if non-zero, the ESR context
+ * The @esr parameter is the raw ESR_EL1 value; if non-zero, the ESR context
  * block is included.
  */
 static void build_sigcontext_reserved(uint8_t *reserved,
@@ -1563,10 +1563,10 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     /* SPSR_EL1: EL0t (user mode) */
     hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1, 0);
 
-    /* EL0-preemption delivery: the resume runs from HV_REG_PC, not via an
-     * ERET that consumes ELR_EL1, so redirect the live PC/PSTATE directly.
-     * The ELR_EL1/SPSR_EL1 writes above still cover the rt_sigreturn path,
-     * which unwinds back to EL0 through the shim ERET.
+    /* EL0-preemption delivery: the resume runs from HV_REG_PC, not via an ERET
+     * that consumes ELR_EL1, so redirect the live PC/PSTATE directly. The
+     * ELR_EL1/SPSR_EL1 writes above still cover the rt_sigreturn path, which
+     * unwinds back to EL0 through the shim ERET.
      */
     if (el0_preempt) {
         hv_vcpu_set_reg(vcpu, HV_REG_PC, act->sa_handler);
@@ -1613,9 +1613,9 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     /* If delivery happens while returning from the syscall HVC path, the shim
      * still has the interrupted syscall frame on its EL1 stack. Tell it to drop
      * that frame so the handler PC/SP/LR/args installed above are not
-     * overwritten before ERET. Fault/BRK delivery paths ignore this marker.
-     * The EL0-preemption path resumes straight into the handler at EL0 with
-     * no shim frame to drop, so the marker is neither needed nor consulted.
+     * overwritten before ERET. Fault/BRK delivery paths ignore this marker. The
+     * EL0-preemption path resumes straight into the handler at EL0 with no shim
+     * frame to drop, so the marker is neither needed nor consulted.
      */
     if (!el0_preempt)
         hv_vcpu_set_reg(vcpu, HV_REG_X8, 2);

--- a/src/syscall/signal.h
+++ b/src/syscall/signal.h
@@ -1,4 +1,5 @@
-/* Signal delivery
+/*
+ * Signal delivery
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -119,8 +120,7 @@ typedef struct {
 #define LINUX_SEGV_MAPERR 1 /* Address not mapped to object */
 #define LINUX_SEGV_ACCERR 2 /* Invalid permissions for mapped object */
 
-/* Linux sigcontext (aarch64). */
-/* From arch/arm64/include/uapi/asm/sigcontext.h */
+/* Linux sigcontext (aarch64). From arch/arm64/include/uapi/asm/sigcontext.h */
 typedef struct {
     uint64_t fault_address;
     uint64_t regs[31]; /* X0-X30 */
@@ -153,15 +153,15 @@ typedef struct {
     linux_sigcontext_t uc_mcontext;
 } linux_ucontext_t;
 
-/* Linux rt_sigframe (pushed onto guest stack). */
-/* From arch/arm64/kernel/signal.c: this is what setup_rt_frame() builds. */
+/* Linux rt_sigframe (pushed onto guest stack). From arch/arm64/kernel/signal.c:
+ * this is what setup_rt_frame() builds.
+ */
 typedef struct {
     linux_siginfo_t info;
     linux_ucontext_t uc;
 } linux_rt_sigframe_t;
 
-/* RT signal queue. */
-/* Maximum queued instances per RT signal. POSIX says at least
+/* RT signal queue. Maximum queued instances per RT signal. POSIX says at least
  * _POSIX_SIGQUEUE_MAX (32); Linux defaults to ~1024 per user.
  */
 #define RT_SIGQUEUE_MAX 32
@@ -235,7 +235,7 @@ void signal_queue_info(int signum,
  * populates si_code, si_addr, fault_address, and ESR context from these values
  * instead of using the default SI_USER/si_pid fields. Consumed (cleared) after
  * one delivery. Used for synchronous faults: BRK->SIGTRAP, SIGSEGV, etc. The
- * esr parameter is the raw ESR_EL1 value; if non-zero, an esr_context block is
+ * @esr parameter is the raw ESR_EL1 value; if non-zero, an esr_context block is
  * appended to __reserved after FPSIMD.
  */
 void signal_set_fault_info(int si_code, uint64_t addr, uint64_t esr);

--- a/src/syscall/sys.c
+++ b/src/syscall/sys.c
@@ -1,4 +1,5 @@
-/* System info and identity syscall handlers
+/*
+ * System info and identity syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/sys.h
+++ b/src/syscall/sys.h
@@ -1,4 +1,5 @@
-/* System info and identity syscall handlers
+/*
+ * System info and identity syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -1,4 +1,5 @@
-/* Linux aarch64 syscall dispatch
+/*
+ * Linux aarch64 syscall dispatch
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -417,12 +418,10 @@ SC_FORWARD(sc_futex, sys_futex(g, x0, (int) x1, (uint32_t) x2, x3, x4, (uint32_t
  * dups outside any guest lock so a slow disk cannot stall concurrent mmap/fd
  * operations on other threads. fsync on non-regular fds returns EINVAL on
  * macOS, which is benign and ignored. Always returns 0 to mirror sync(2)'s
- * "void" spirit.
- */
-/* Inline fallback: under malloc failure the bulk-dup path cannot proceed, so
- * iterate one fd at a time, dupping under the matching lock and fsync outside
- * it. Slower (acquires/releases fd_lock per regular fd) but keeps sync(2)
- * honest under memory pressure instead of silently no-opping.
+ * "void" spirit. Inline fallback: under malloc failure the bulk-dup path cannot
+ * proceed, so iterate one fd at a time, dupping under the matching lock and
+ * fsync outside it. Slower (acquires/releases fd_lock per regular fd) but keeps
+ * sync(2) honest under memory pressure instead of silently no-opping.
  */
 static void sc_sync_fdtable_inline(void)
 {
@@ -1276,8 +1275,7 @@ static int64_t sc_sync_file_range(guest_t *g,
         return -LINUX_EINVAL;
     }
 
-    /*
-     * If the flags only ask to initiate asynchronous write-out without waiting
+    /* If the flags only ask to initiate asynchronous write-out without waiting
      * (i.e. SYNC_FILE_RANGE_WRITE (2)), we return 0 immediately to avoid
      * blocking. The host OS's background page-out daemon will handle flushing
      * dirty buffers. WAIT_BEFORE (1) and WAIT_AFTER (4) require blocking until
@@ -1322,9 +1320,10 @@ static int64_t sc_syncfs(guest_t *g,
         return err;
     host_fd_ref_close(&host_ref);
 
-    /* macOS does not have syncfs. We fall back to sync() which synchronizes
-     * all mounted filesystems, satisfying the filesystem-level consistency
-     * guarantee of syncfs. */
+    /* macOS does not have syncfs. We fall back to sync() which synchronizes all
+     * mounted filesystems, satisfying the filesystem-level consistency
+     * guarantee of syncfs.
+     */
     sync();
     return 0;
 }
@@ -2064,8 +2063,7 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
 slow_path:
     entry = RANGE_CHECK(nr, 0, SC_TABLE_SIZE) ? &syscall_table[nr] : NULL;
 
-/*
- * Private embedder pseudo-syscall for translated guests.
+/* Private embedder pseudo-syscall for translated guests.
  *
  * This is not a Linux syscall number. Translated x86_64 guests cannot issue
  * native AArch64 HVC instructions, so elfuse uses this private build-selected

--- a/src/syscall/sysvipc.c
+++ b/src/syscall/sysvipc.c
@@ -1,4 +1,5 @@
-/* System V IPC syscall handlers
+/*
+ * System V IPC syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/sysvipc.h
+++ b/src/syscall/sysvipc.h
@@ -1,4 +1,5 @@
-/* System V IPC syscall handlers
+/*
+ * System V IPC syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/time.c
+++ b/src/syscall/time.c
@@ -1,4 +1,5 @@
-/* Time and timer syscall handlers
+/*
+ * Time and timer syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/time.h
+++ b/src/syscall/time.h
@@ -1,4 +1,5 @@
-/* Time and timer syscall handlers
+/*
+ * Time and timer syscall handlers
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/src/syscall/translate.c
+++ b/src/syscall/translate.c
@@ -1,4 +1,5 @@
-/* Linux errno and flag translation (macOS <-> Linux)
+/*
+ * Linux errno and flag translation (macOS <-> Linux)
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/bench-futex-pingpong.c
+++ b/tests/bench-futex-pingpong.c
@@ -1,4 +1,5 @@
-/* Futex ping-pong microbenchmark
+/*
+ * Futex ping-pong microbenchmark
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/bench-hot-guard.c
+++ b/tests/bench-hot-guard.c
@@ -1,4 +1,5 @@
-/* Hot-syscall guardrail bench
+/*
+ * Hot-syscall guardrail bench
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -12,7 +13,7 @@
  *
  * Built twice from this single source:
  *   build/bench-hot-guard       -- static glibc. Compiled without
- *       -DGUARD_USE_LIBC_CG: `clock_gettime` calls the vDSO trampoline
+ *       -DGUARD_USE_LIBC_CG: clock_gettime calls the vDSO trampoline
  *       directly via its function-pointer address resolved through
  *       AT_SYSINFO_EHDR. Static glibc never initializes
  *       dl_sysinfo_dso, so its libc clock_gettime wrapper falls back
@@ -21,7 +22,7 @@
  *       have nothing to do with the vDSO. Direct call isolates the
  *       trampoline.
  *   build/bench-hot-guard-glibc -- dynamic glibc. Compiled with
- *       -DGUARD_USE_LIBC_CG so `clock_gettime` invokes the libc
+ *       -DGUARD_USE_LIBC_CG so clock_gettime invokes the libc
  *       wrapper, which on glibc 2.41 + a correctly-stamped vDSO
  *       (NT_GNU_ABI_TAG present, LINUX_2.6.39 versioning) routes the
  *       call through the same trampoline. The guardrail's 50 ns
@@ -154,16 +155,16 @@ static long bench_clock_gettime(void *ctx)
 {
     cg_ctx_t *c = ctx;
 #ifdef GUARD_USE_LIBC_CG
-    /* Dynamic glibc build: exercise the libc wrapper so the
-     * NT_GNU_ABI_TAG / LINUX_2.6.39 vDSO routing is validated end to
-     * end. If glibc falls back to SVC (broken note / version regress)
-     * this measurement jumps to ~2000 ns and the guardrail fails.
+    /* Dynamic glibc build: exercise the libc wrapper so the NT_GNU_ABI_TAG /
+     * LINUX_2.6.39 vDSO routing is validated end to end. If glibc falls back to
+     * SVC (broken note / version regress) this measurement jumps to ~2000 ns
+     * and the guardrail fails.
      */
     (void) c->fn;
     return clock_gettime(CLOCK_MONOTONIC, &c->ts);
 #else
-    /* Static build (no dl_sysinfo_dso): call the trampoline directly
-     * via the resolved function pointer.
+    /* Static build (no dl_sysinfo_dso): call the trampoline directly via the
+     * resolved function pointer.
      */
     return c->fn(CLOCK_MONOTONIC, &c->ts);
 #endif

--- a/tests/bench-hot-syscalls.c
+++ b/tests/bench-hot-syscalls.c
@@ -1,4 +1,5 @@
-/* Guest microbenchmark for hot Linux syscalls.
+/*
+ * Guest microbenchmark for hot Linux syscalls.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/bench-vdso.c
+++ b/tests/bench-vdso.c
@@ -1,4 +1,5 @@
-/* vDSO fast-path microbenchmark
+/*
+ * vDSO fast-path microbenchmark
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/echo-test.c
+++ b/tests/echo-test.c
@@ -1,4 +1,5 @@
-/* echo arguments
+/*
+ * echo arguments
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/hello-dynamic.c
+++ b/tests/hello-dynamic.c
@@ -1,4 +1,5 @@
-/* Dynamically-linked test program --sysroot
+/*
+ * Dynamically-linked test program --sysroot
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/hello-musl.c
+++ b/tests/hello-musl.c
@@ -1,4 +1,5 @@
-/* musl printf/puts hello world
+/*
+ * musl printf/puts hello world
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/hello-write.c
+++ b/tests/hello-write.c
@@ -1,4 +1,5 @@
-/* direct write(2) hello world
+/*
+ * direct write(2) hello world
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/hvf-test.h
+++ b/tests/hvf-test.h
@@ -1,4 +1,5 @@
-/* Shared helpers for native HVF tests
+/*
+ * Shared helpers for native HVF tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/raw-syscall.h
+++ b/tests/raw-syscall.h
@@ -1,4 +1,5 @@
-/* Portable inline syscall wrappers for aarch64 and x86_64
+/*
+ * Portable inline syscall wrappers for aarch64 and x86_64
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-abstract-socket.c
+++ b/tests/test-abstract-socket.c
@@ -1,4 +1,5 @@
-/* Test abstract Unix socket namespace emulation
+/*
+ * Test abstract Unix socket namespace emulation
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-ancillary.c
+++ b/tests/test-ancillary.c
@@ -1,4 +1,5 @@
-/* Test ancillary data: SCM_RIGHTS and MSG_CTRUNC
+/*
+ * Test ancillary data: SCM_RIGHTS and MSG_CTRUNC
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-argc.c
+++ b/tests/test-argc.c
@@ -1,4 +1,5 @@
-/* verify argc/argv correctness
+/*
+ * verify argc/argv correctness
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-case-collision.c
+++ b/tests/test-case-collision.c
@@ -1,4 +1,5 @@
-/* Case-collision regression tests
+/*
+ * Case-collision regression tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-cat.c
+++ b/tests/test-cat.c
@@ -1,4 +1,5 @@
-/* minimal cat(1) implementation
+/*
+ * minimal cat(1) implementation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-chown-overlay.c
+++ b/tests/test-chown-overlay.c
@@ -1,12 +1,13 @@
-/* Virtual chown overlay round-trip tests
+/*
+ * Virtual chown overlay round-trip tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * An emulated-root guest expects chown(2)/fchown(2)/fchownat(2) to succeed
- * even when rootless macOS cannot satisfy the change, and the follow-up
- * stat(2)/statx(2)/fstat(2) must observe the intended owner/group rather
- * than the host's real owner.
+ * An emulated-root guest expects chown(2)/fchown(2)/fchownat(2) to succeed even
+ * when rootless macOS cannot satisfy the change, and the follow-up
+ * stat(2)/statx(2)/fstat(2) must observe the intended owner/group rather than
+ * the host's real owner.
  *
  * Exercises the round-trip across the chown family, the -1 sentinel,
  * AT_SYMLINK_NOFOLLOW on a symlink, the regression guard for non-EPERM
@@ -99,8 +100,8 @@ static void test_chown_then_stat(void)
 
 static void test_chown_minus_one_keeps_gid(void)
 {
-    /* The earlier test already set (1000, 1001). chown(uid, -1) must
-     * change uid only and keep the prior gid override visible to stat.
+    /* The earlier test already set (1000, 1001). chown(uid, -1) must change uid
+     * only and keep the prior gid override visible to stat.
      */
     TEST("chown(uid,-1) keeps prior gid override");
     if (chown(tmp_file, 2000, (gid_t) -1) != 0) {
@@ -199,8 +200,8 @@ static void test_open_removed_dir_keeps_overlay_until_last_close(void)
 static void test_lchown_on_symlink(void)
 {
     TEST("lchown(link) leaves target unchanged");
-    /* Reset target ownership through the existing path so test ordering
-     * does not leak overrides from earlier asserts.
+    /* Reset target ownership through the existing path so test ordering does
+     * not leak overrides from earlier asserts.
      */
     if (chown(tmp_target, 100, 100) != 0) {
         FAIL("chown target");

--- a/tests/test-cloexec.c
+++ b/tests/test-cloexec.c
@@ -1,4 +1,5 @@
-/* Test O_CLOEXEC behavior across fork and exec
+/*
+ * Test O_CLOEXEC behavior across fork and exec
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-clone-childtid.c
+++ b/tests/test-clone-childtid.c
@@ -1,14 +1,15 @@
-/* Test CLONE_CHILD_SETTID / CLONE_CHILD_CLEARTID on the fork (posix_spawn) path
+/*
+ * Test CLONE_CHILD_SETTID / CLONE_CHILD_CLEARTID on the fork (posix_spawn) path
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * Issue #99: glibc's fork wrapper clones with CLONE_CHILD_SETTID |
- * CLONE_CHILD_CLEARTID | SIGCHLD. The child's TID must be written into the
- * ctid address so glibc's TCB caches the right value. This calls clone()
- * directly with those exact flags (no CLONE_VM/THREAD/VFORK, so elfuse takes
- * the fork helper-process path) and checks the child observes its own TID at
- * the ctid slot -- glibc-version-independent, unlike the canary symptom.
+ * CLONE_CHILD_CLEARTID | SIGCHLD. The child's TID must be written into the ctid
+ * address so glibc's TCB caches the right value. This calls clone() directly
+ * with those exact flags (no CLONE_VM/THREAD/VFORK, so elfuse takes the fork
+ * helper-process path) and checks the child observes its own TID at the ctid
+ * slot -- glibc-version-independent, unlike the canary symptom.
  *
  * Raw syscall throughout: glibc's own clone wrapper does not expose the ctid
  * arg, and we want to exercise elfuse's handling rather than libc's.

--- a/tests/test-clone3.c
+++ b/tests/test-clone3.c
@@ -1,4 +1,5 @@
-/* Test clone3 syscall in elfuse
+/*
+ * Test clone3 syscall in elfuse
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-complex.c
+++ b/tests/test-complex.c
@@ -1,4 +1,5 @@
-/* exercise multiple syscalls
+/*
+ * exercise multiple syscalls
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-comprehensive.c
+++ b/tests/test-comprehensive.c
@@ -1,4 +1,5 @@
-/* exercises all major elfuse subsystems
+/*
+ * exercises all major elfuse subsystems
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-cow-fork.c
+++ b/tests/test-cow-fork.c
@@ -1,4 +1,5 @@
-/* CoW fork memory isolation tests
+/*
+ * CoW fork memory isolation tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-cross-fork-mapshared.c
+++ b/tests/test-cross-fork-mapshared.c
@@ -1,4 +1,5 @@
-/* Cross-fork MAP_SHARED coherence tests
+/*
+ * Cross-fork MAP_SHARED coherence tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-epoll-aba.c
+++ b/tests/test-epoll-aba.c
@@ -1,4 +1,5 @@
-/* epoll_ctl close+reopen ABA regression test
+/*
+ * epoll_ctl close+reopen ABA regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-epoll-edge.c
+++ b/tests/test-epoll-edge.c
@@ -1,4 +1,5 @@
-/* Test EPOLLET edge-trigger fidelity (kqueue EV_CLEAR backend)
+/*
+ * Test EPOLLET edge-trigger fidelity (kqueue EV_CLEAR backend)
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-epoll-mt.c
+++ b/tests/test-epoll-mt.c
@@ -1,4 +1,5 @@
-/* Multi-threaded epoll registration regression test
+/*
+ * Multi-threaded epoll registration regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -53,7 +54,7 @@ static int sibling_fn(void *arg)
     return 0;
 }
 
-/* Register host_fd for EPOLLIN on epfd, make it readable via make_ready(), and
+/* Register fd for EPOLLIN on epfd, make it readable via make_ready(), and
  * assert epoll_pwait() observes the edge within the timeout.
  *
  * Returns 1 on success.

--- a/tests/test-epoll.c
+++ b/tests/test-epoll.c
@@ -1,4 +1,5 @@
-/* Test epoll emulation (kqueue backend)
+/*
+ * Test epoll emulation (kqueue backend)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-eventfd-dup.c
+++ b/tests/test-eventfd-dup.c
@@ -1,4 +1,5 @@
-/* test-eventfd-dup.c -- dup of eventfd shares state (Linux contract)
+/*
+ * test-eventfd-dup.c -- dup of eventfd shares state (Linux contract)
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-eventfd.c
+++ b/tests/test-eventfd.c
@@ -1,4 +1,5 @@
-/* Test eventfd2 syscall emulation
+/*
+ * Test eventfd2 syscall emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-exec.c
+++ b/tests/test-exec.c
@@ -1,4 +1,5 @@
-/* Test execve() syscall
+/*
+ * Test execve() syscall
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -22,8 +23,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* argv[1] = path to binary to exec argv[2..] = arguments to pass to it
-     */
+    /* argv[1] = path to binary to exec argv[2..] = arguments to pass to it */
     char *new_argv[64];
     int n = 0;
     for (int i = 1; i < argc && n < 63; i++) {

--- a/tests/test-fd-family.c
+++ b/tests/test-fd-family.c
@@ -1,4 +1,5 @@
-/* fd-family tests
+/*
+ * fd-family tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-fd-lifecycle.c
+++ b/tests/test-fd-lifecycle.c
@@ -1,4 +1,5 @@
-/* fd metadata lifecycle regression tests
+/*
+ * fd metadata lifecycle regression tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-fd-race.c
+++ b/tests/test-fd-race.c
@@ -1,4 +1,5 @@
-/* FD table concurrency stress test
+/*
+ * FD table concurrency stress test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-file-ops.c
+++ b/tests/test-file-ops.c
@@ -1,4 +1,5 @@
-/* Test file manipulation syscalls (Batch 1)
+/*
+ * Test file manipulation syscalls (Batch 1)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-fileio.c
+++ b/tests/test-fileio.c
@@ -1,4 +1,5 @@
-/* file I/O test
+/*
+ * file I/O test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-flock.c
+++ b/tests/test-flock.c
@@ -1,4 +1,5 @@
-/* Test POSIX advisory record locking via fcntl(F_SETLK/F_GETLK/F_SETLKW)
+/*
+ * Test POSIX advisory record locking via fcntl(F_SETLK/F_GETLK/F_SETLKW)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-fork-exec.c
+++ b/tests/test-fork-exec.c
@@ -1,4 +1,5 @@
-/* Fork edge case tests
+/*
+ * Fork edge case tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-fork-ipc-protocol-host.c
+++ b/tests/test-fork-ipc-protocol-host.c
@@ -1,11 +1,12 @@
-/* Native-host unit test for fork IPC protocol identity.
+/*
+ * Native-host unit test for fork IPC protocol identity.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The fork child is spawned from elfuse_path, so a long-running parent can
- * handshake with a newer on-disk child after an upgrade. The first header
- * word is therefore the protocol identity, not just a frame delimiter.
+ * handshake with a newer on-disk child after an upgrade. The first header word
+ * is therefore the protocol identity, not just a frame delimiter.
  */
 
 #include <stdbool.h>
@@ -41,8 +42,8 @@ _Static_assert(_Generic(((ipc_header_t *) 0)->has_shm, bool: 1, default: 0),
 _Static_assert(_Generic(((ipc_header_t *) 0)->is_rosetta, bool: 1, default: 0),
                "is_rosetta must remain a bool field");
 /* The wire is private to one build (FORK_IPC_PROTOCOL_MAGIC bumps on every
- * incompatible layout change), but parent and child still need to agree on
- * the width of the bool flags they exchange. Pin the assumption so a future
+ * incompatible layout change), but parent and child still need to agree on the
+ * width of the bool flags they exchange. Pin the assumption so a future
  * toolchain that widens _Bool fails the build instead of silently desyncing.
  */
 _Static_assert(sizeof(bool) == 1,

--- a/tests/test-fork-lowbase.c
+++ b/tests/test-fork-lowbase.c
@@ -1,4 +1,5 @@
-/* Low-base nested fork regression test
+/*
+ * Low-base nested fork regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-fork-synthetic-fd.c
+++ b/tests/test-fork-synthetic-fd.c
@@ -1,4 +1,5 @@
-/* test-fork-synthetic-fd.c -- fork inheritance contract for synthetic fds
+/*
+ * test-fork-synthetic-fd.c -- fork inheritance contract for synthetic fds
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-fork.c
+++ b/tests/test-fork.c
@@ -1,4 +1,5 @@
-/* Test fork()/waitpid() via clone syscall
+/*
+ * Test fork()/waitpid() semantics
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-futex-pi.c
+++ b/tests/test-futex-pi.c
@@ -1,4 +1,5 @@
-/* PI futex and EINTR regression tests
+/*
+ * PI futex and EINTR regression tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -145,7 +146,8 @@ static void test_pi_dead_owner(void)
     /* Clone a child thread that acquires the PI lock and exits.
      * CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD |
      * CLONE_SYSVSEM | CLONE_SETTLS | CLONE_PARENT_SETTID |
-     * CLONE_CHILD_CLEARTID
+     * CLONE_CHILD_CLEARTID | CLONE_DETACHED (0x7d0f00; DETACHED is a legacy
+     * no-op on modern Linux)
      */
     void *stack_top = child_stack_buf + sizeof(child_stack_buf);
     int child_tid_val = 0;

--- a/tests/test-futex-waitv.c
+++ b/tests/test-futex-waitv.c
@@ -1,4 +1,5 @@
-/* futex_waitv (SYS 449) regression
+/*
+ * futex_waitv (SYS 449) regression
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-getdents64-overlong.c
+++ b/tests/test-getdents64-overlong.c
@@ -1,20 +1,20 @@
-/* getdents64 overlong-UTF-8 dirent skip regression
+/*
+ * getdents64 overlong-UTF-8 dirent skip regression
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * macOS APFS lets filenames exceed Linux NAME_MAX (255 bytes) on the
- * UTF-8 byte axis: ~90 CJK codepoints already crosses the cap while
- * staying under APFS's per-component character limit. The guest
- * cannot create such a name through Linux syscalls (NAME_MAX is
- * enforced at openat), so the surrounding harness builds the fixture
- * host-side and passes the directory path as argv[1].
+ * macOS APFS lets filenames exceed Linux NAME_MAX (255 bytes) on the UTF-8 byte
+ * axis: ~90 CJK codepoints already crosses the cap while staying under APFS's
+ * per-component character limit. The guest cannot create such a name through
+ * Linux syscalls (NAME_MAX is enforced at openat), so the surrounding harness
+ * builds the fixture host-side and passes the directory path as argv[1].
  *
- * Pre-fix behavior: sys_getdents64 aborted the whole stream with
- * ENAMETOOLONG the first time path_translate_dirent_name reported an
- * oversize entry, truncating ls / find / coreutils listings.
- * Post-fix: the overlong entry is skipped and the rest of the stream
- * is delivered, matching what real Linux does on the same input.
+ * Pre-fix behavior: sys_getdents64 aborted the whole stream with ENAMETOOLONG
+ * the first time path_translate_dirent_name reported an oversize entry,
+ * truncating ls / find / coreutils listings. Post-fix: the overlong entry is
+ * skipped and the rest of the stream is delivered, matching what real Linux
+ * does on the same input.
  */
 
 #include <dirent.h>
@@ -49,13 +49,12 @@ static const char EXPECTED_NAME[] = "expected.txt";
  * Returns -errno on the first non-EOF failure so the caller can tell a
  * mid-stream ENAMETOOLONG from an empty directory.
  *
- * The buffer is sized just past a single small dirent so each call
- * returns at most one entry. With multiple overlong files in the
- * fixture, this guarantees at least one call starts fresh (guest_pos
- * == 0) on an overlong entry, which is the exact condition under
- * which the pre-fix code returns -ENAMETOOLONG to userspace and
- * truncates the listing for ls / find. Larger buffers can mask the
- * bug because APFS hash order may bury every overlong after a
+ * The buffer is sized just past a single small dirent so each call returns at
+ * most one entry. With multiple overlong files in the fixture, this guarantees
+ * at least one call starts fresh (guest_pos == 0) on an overlong entry, which
+ * is the exact condition under which the pre-fix code returns -ENAMETOOLONG to
+ * userspace and truncates the listing for ls / find. Larger buffers can mask
+ * the bug because APFS hash order may bury every overlong after a
  * partial-return point.
  */
 static int scan_directory(const char *path,
@@ -69,13 +68,12 @@ static int scan_directory(const char *path,
     if (fd < 0)
         return -errno;
 
-    /* 64 bytes caps each call at one entry for the visible names
-     * (reclen 24 for ".", 24 for "..", 32 for "expected.txt"; ". + .."
-     * could pack into 48, but five overlong files outnumber three
-     * visible normals so at least one call still starts fresh on an
-     * overlong entry with guest_pos == 0 -- the exact condition under
-     * which pre-fix sys_getdents64 returned -ENAMETOOLONG to userspace
-     * and truncated the listing).
+    /* 64 bytes caps each call at one entry for the visible names (reclen 24 for
+     * ".", 24 for "..", 32 for "expected.txt"; ". + .." could pack into 48, but
+     * five overlong files outnumber three visible normals so at least one call
+     * still starts fresh on an overlong entry with guest_pos == 0 -- the exact
+     * condition under which pre-fix sys_getdents64 returned -ENAMETOOLONG to
+     * userspace and truncated the listing).
      */
     char buf[64];
     for (;;) {
@@ -88,9 +86,9 @@ static int scan_directory(const char *path,
         if (n == 0)
             break;
 
-        /* Validate the binary ABI strictly: an unterminated d_name or a
-         * forged d_reclen could otherwise let strcmp walk off the buffer.
-         * Header is 19 bytes; max valid record fits in n-off.
+        /* Validate the binary ABI strictly: an unterminated d_name or a forged
+         * d_reclen could otherwise let strcmp walk off the buffer. Header is 19
+         * bytes; max valid record fits in n-off.
          */
         for (long off = 0; off < n;) {
             linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
@@ -152,8 +150,8 @@ int main(int argc, char **argv)
     }
 
     TEST("listing has only the normal entry");
-    /* The overlong file is present on disk but must be silently
-     * skipped, so the visible-entry count is exactly 1.
+    /* The overlong file is present on disk but must be silently skipped, so the
+     * visible-entry count is exactly 1.
      */
     if (rc < 0) {
         errno = -rc;

--- a/tests/test-guard-page.c
+++ b/tests/test-guard-page.c
@@ -1,10 +1,11 @@
-/* Stack guard page and mmap edge case tests
+/*
+ * mmap PROT_NONE and mmap edge case tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: stack guard page (PROT_NONE), large mmap allocations,
+ * Tests: mmap PROT_NONE, large mmap allocations,
  *        MAP_FIXED overlap, mprotect transitions.
  *
  * Syscalls exercised: mmap(222), munmap(215), mprotect(226)

--- a/tests/test-harness.h
+++ b/tests/test-harness.h
@@ -1,4 +1,5 @@
-/* Shared test macros for unit tests
+/*
+ * Shared test macros for unit tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-identity-override-host.c
+++ b/tests/test-identity-override-host.c
@@ -1,4 +1,5 @@
-/* Host-side unit test for ELFUSE_FAKEROOT environment overrides.
+/*
+ * Host-side unit test for ELFUSE_FAKEROOT environment overrides.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -14,7 +15,8 @@
 #include "syscall/abi.h"
 
 /* Mock shim_globals_publish_pgsid to avoid linking the entire guest shim
- * subsystem */
+ * subsystem
+ */
 void shim_globals_publish_pgsid(guest_t *g, int64_t pgid, int64_t sid);
 void shim_globals_publish_pgsid(guest_t *g, int64_t pgid, int64_t sid)
 {

--- a/tests/test-inotify.c
+++ b/tests/test-inotify.c
@@ -1,4 +1,5 @@
-/* inotify emulation tests
+/*
+ * inotify emulation tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-io-opt.c
+++ b/tests/test-io-opt.c
@@ -1,4 +1,5 @@
-/* Test I/O optimization syscalls (Batch 3)
+/*
+ * Test I/O optimization syscalls (Batch 3)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-ioctl-cloexec.c
+++ b/tests/test-ioctl-cloexec.c
@@ -1,4 +1,5 @@
-/* FIOCLEX/FIONCLEX ioctl close-on-exec regression test
+/*
+ * FIOCLEX/FIONCLEX ioctl close-on-exec regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-ioctl-fioasync.c
+++ b/tests/test-ioctl-fioasync.c
@@ -1,4 +1,5 @@
-/* FIOASYNC ioctl + F_SETOWN/F_GETOWN fcntl regression test
+/*
+ * FIOASYNC ioctl + F_SETOWN/F_GETOWN fcntl regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -38,7 +39,8 @@
 #endif
 
 /* struct f_owner_ex is _GNU_SOURCE-gated; declare a layout-compatible struct
- * locally so the test does not depend on glibc feature macros. */
+ * locally so the test does not depend on glibc feature macros.
+ */
 struct elfuse_f_owner_ex {
     int type;
     int pid;
@@ -60,8 +62,9 @@ static void check_async_owner(int fd, const char *what)
     TEST(label);
     EXPECT_EQ(fcntl(fd, F_SETOWN, getpid()), 0, "F_SETOWN rejected");
 
-    /* F_SETOWN_EX takes a struct f_owner_ex* and is the variant glibc uses
-     * when targeting a thread/pgrp; a valid pointer is accepted as a no-op. */
+    /* F_SETOWN_EX takes a struct f_owner_ex* and is the variant glibc uses when
+     * targeting a thread/pgrp; a valid pointer is accepted as a no-op.
+     */
     struct elfuse_f_owner_ex owner = {F_OWNER_PID, getpid()};
     snprintf(label, sizeof(label), "%s: fcntl(F_SETOWN_EX) valid -> 0", what);
     TEST(label);
@@ -69,7 +72,8 @@ static void check_async_owner(int fd, const char *what)
 
     /* F_GETOWN reports the owner; elfuse tracks none, so 0 (no error). glibc
      * may probe F_GETOWN_EX first and fall back to plain F_GETOWN on EINVAL --
-     * either way the visible result must not be a failure. */
+     * either way the visible result must not be a failure.
+     */
     snprintf(label, sizeof(label), "%s: fcntl(F_GETOWN) -> not an error", what);
     TEST(label);
     EXPECT_TRUE(fcntl(fd, F_GETOWN) >= 0, "F_GETOWN returned an error");
@@ -86,7 +90,8 @@ int main(void)
 
     /* nginx's channel is an AF_UNIX SOCK_STREAM socketpair; FIOASYNC/F_SETOWN
      * are applied to channel[0] (nginx also marks it non-blocking via FIONBIO
-     * first, which this test omits to stay focused on the calls added here). */
+     * first, which this test omits to stay focused on the calls added here).
+     */
     int sp[2];
     TEST("socketpair(AF_UNIX, SOCK_STREAM)");
     EXPECT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sp), 0, "socketpair failed");

--- a/tests/test-large-io-boundary.c
+++ b/tests/test-large-io-boundary.c
@@ -1,4 +1,5 @@
-/* large I/O across guest page-table boundaries
+/*
+ * large I/O across guest page-table boundaries
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-lowbase-mem.c
+++ b/tests/test-lowbase-mem.c
@@ -1,4 +1,5 @@
-/* Low-linked ET_EXEC memory-syscall regression test
+/*
+ * Low-linked ET_EXEC memory-syscall regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-ls.c
+++ b/tests/test-ls.c
@@ -1,4 +1,5 @@
-/* directory listing test
+/*
+ * directory listing test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-madvise.c
+++ b/tests/test-madvise.c
@@ -1,4 +1,5 @@
-/* MADV_DONTNEED and madvise parity tests
+/*
+ * MADV_DONTNEED and madvise parity tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-malloc.c
+++ b/tests/test-malloc.c
@@ -1,4 +1,5 @@
-/* dynamic memory allocation test
+/*
+ * dynamic memory allocation test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-membarrier.c
+++ b/tests/test-membarrier.c
@@ -1,4 +1,5 @@
-/* Test membarrier syscall
+/*
+ * Test membarrier syscall
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-mmap-hint.c
+++ b/tests/test-mmap-hint.c
@@ -1,4 +1,5 @@
-/* Low-address mmap hint regression test
+/*
+ * Low-address mmap hint regression test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-mmap-shared-ro.c
+++ b/tests/test-mmap-shared-ro.c
@@ -1,17 +1,18 @@
-/* Read-only MAP_SHARED file overlay tests
+/*
+ * Read-only MAP_SHARED file overlay tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * Regression lock-in for the file-overlay path in src/syscall/mem.c.
  *
- * A MAP_SHARED, PROT_READ mapping of a file opened O_RDONLY is extremely
- * common -- the JVM maps its ~135 MiB lib/modules image this way, and so do
- * loaders that map read-only data segments. The original overlay code always
- * mmap'd the host page PROT_READ|PROT_WRITE and mapped the HVF segment RWX,
- * which fails twice for a read-only fd: the host mmap returns EACCES (writable
- * mapping of an O_RDONLY fd) and, even forced to PROT_READ, hv_vm_map then
- * fails because a MAP_SHARED-of-O_RDONLY region has macOS max_protection=READ.
+ * A MAP_SHARED, PROT_READ mapping of a file opened O_RDONLY is extremely common
+ * -- the JVM maps its ~135 MiB lib/modules image this way, and so do loaders
+ * that map read-only data segments. The original overlay code always mmap'd the
+ * host page PROT_READ|PROT_WRITE and mapped the HVF segment RWX, which fails
+ * twice for a read-only fd: the host mmap returns EACCES (writable mapping of
+ * an O_RDONLY fd) and, even forced to PROT_READ, hv_vm_map then fails because a
+ * MAP_SHARED-of-O_RDONLY region has macOS max_protection=READ.
  *
  * Syscalls exercised: openat, ftruncate/pwrite, mmap, munmap, pread64
  */
@@ -29,10 +30,11 @@
 int passes = 0, fails = 0;
 
 /* Several guest pages so the overlay spans more than one host page and the
- * containing 2 MiB segment is split and remapped over a realistic range.
- * 768 pages (3 MiB) crosses a 2 MiB boundary so hvf_segment_split's
- * multi-block path is exercised, matching how JVM's ~135 MiB lib/modules
- * image crosses many segments. */
+ * containing 2 MiB segment is split and remapped over a realistic range. 768
+ * pages (3 MiB) crosses a 2 MiB boundary so hvf_segment_split's multi-block
+ * path is exercised, matching how JVM's ~135 MiB lib/modules image crosses many
+ * segments.
+ */
 #define NPAGES 768
 #define PGSZ ((size_t) 4096)
 #define FILE_LEN (NPAGES * PGSZ)
@@ -43,8 +45,11 @@ static unsigned char page_marker(int page)
     return (unsigned char) (0x40 + (page % 64));
 }
 
-/* Create a file seeded with a per-page marker pattern, then close it. Returns
- * the path in `out` (caller-sized buffer). Returns 0 on success, -1 on error.
+/* Create a file seeded with a per-page marker pattern, then close it.
+ *
+ * Returns the path in @out (caller-sized buffer).
+ *
+ * Returns 0 on success, -1 on error.
  */
 static int make_seed_file(char *out, size_t out_sz)
 {
@@ -67,7 +72,8 @@ static int make_seed_file(char *out, size_t out_sz)
 }
 
 /* The headline case: O_RDONLY fd + MAP_SHARED + PROT_READ must map and expose
- * the full file contents. This is exactly the JVM lib/modules pattern. */
+ * the full file contents. This is exactly the JVM lib/modules pattern.
+ */
 static void test_rdonly_shared_read(const char *path)
 {
     TEST("MAP_SHARED PROT_READ on O_RDONLY fd maps");
@@ -104,8 +110,9 @@ static void test_rdonly_shared_read(const char *path)
     close(fd);
 }
 
-/* The same content must be readable back-to-back through a fresh mapping, and
- * a second concurrent read-only mapping of the same fd must also work. */
+/* The same content must be readable back-to-back through a fresh mapping, and a
+ * second concurrent read-only mapping of the same fd must also work.
+ */
 static void test_rdonly_shared_second_mapping(const char *path)
 {
     TEST("second MAP_SHARED PROT_READ mapping maps");
@@ -167,7 +174,8 @@ static void test_rdonly_shared_write_rejected(const char *path)
 
 /* A read-only mapping taken from a writable (O_RDWR) fd must also work; this
  * exercises the MAP_SHARED-PROT_READ-on-writable-fd branch (max_protection RWX
- * so the segment maps without dropping to MAP_PRIVATE). */
+ * so the segment maps without dropping to MAP_PRIVATE).
+ */
 static void test_rdwr_fd_readonly_mapping(const char *path)
 {
     TEST("MAP_SHARED PROT_READ on O_RDWR fd maps");
@@ -197,7 +205,8 @@ static void test_rdwr_fd_readonly_mapping(const char *path)
 
 /* A read-only mapping's max_protection must stay READ: mprotect must not be
  * able to upgrade it to PROT_WRITE after the fact. Linux remembers max_prot
- * from the O_RDONLY fd at mmap time and rejects the upgrade with EACCES. */
+ * from the O_RDONLY fd at mmap time and rejects the upgrade with EACCES.
+ */
 static void test_rdonly_mprotect_write_rejected(const char *path)
 {
     TEST("mprotect PROT_WRITE on read-only MAP_SHARED mapping is EACCES");

--- a/tests/test-mprotect-mt.c
+++ b/tests/test-mprotect-mt.c
@@ -1,4 +1,5 @@
-/* Multi-vCPU concurrent mprotect stress
+/*
+ * Multi-vCPU concurrent mprotect stress
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-mremap-infra.c
+++ b/tests/test-mremap-infra.c
@@ -1,4 +1,5 @@
-/* test-mremap-infra.c -- mremap/madvise must reject ranges hitting infra
+/*
+ * test-mremap-infra.c -- mremap/madvise must reject ranges hitting infra
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-mremap.c
+++ b/tests/test-mremap.c
@@ -1,4 +1,5 @@
-/* mremap syscall tests
+/*
+ * mremap syscall tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-msync.c
+++ b/tests/test-msync.c
@@ -1,4 +1,5 @@
-/* MAP_SHARED msync tests
+/*
+ * MAP_SHARED msync tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -547,8 +548,8 @@ out:
  * even when a previous shared mmap split an HVF stage-2 segment. The overlay
  * path tolerates multi-segment ranges and the gap finder keeps shared
  * file-backed allocations aligned to 2 MiB so subsequent mmaps do not re-split
- * mid-segment. Cover both: each chunk must mmap, accept guest writes, and
- * stay backed by its own memfd.
+ * mid-segment. Cover both: each chunk must mmap, accept guest writes, and stay
+ * backed by its own memfd.
  */
 static void test_shared_back_to_back_memfd_mappings(void)
 {

--- a/tests/test-mt-fork.c
+++ b/tests/test-mt-fork.c
@@ -1,4 +1,5 @@
-/* Multithreaded fork snapshot consistency test
+/*
+ * Multithreaded fork snapshot consistency test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-multi-vcpu.c
+++ b/tests/test-multi-vcpu.c
@@ -1,4 +1,5 @@
-/* Validate multi-vCPU support in Apple Hypervisor.framework
+/*
+ * Validate multi-vCPU support in Apple Hypervisor.framework
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -57,7 +58,7 @@
 #define PAGE_SIZE_4K 4096ULL
 #define BLOCK_2MIB (2ULL * 1024 * 1024)
 
-/* Memory layout (16MiB total, much smaller than elfuse's 32GiB) */
+/* Memory layout (16MiB total, much smaller than elfuse's 64GiB+) */
 
 #define GUEST_SIZE (16ULL * 1024 * 1024)
 
@@ -70,7 +71,7 @@
 #define STACK_A_BASE 0x00A00000ULL   /* EL0 stack A (RW) */
 #define STACK_B_BASE 0x00C00000ULL   /* EL0 stack B (RW) */
 
-/* vCPU-A and vCPU-B SP_EL1 (top of respective 512KiB regions within shim data)
+/* vCPU-A and vCPU-B SP_EL1 (top of respective 1 MiB regions within shim data)
  */
 #define SP_EL1_A (SHIM_DATA_BASE + BLOCK_2MIB)     /* 0x400000 */
 #define SP_EL1_B (SHIM_DATA_BASE + BLOCK_2MIB / 2) /* 0x300000 */
@@ -173,8 +174,9 @@ static uint64_t build_page_tables(vm_state_t *vm, int include_tlbi_region)
 
     uint64_t *l2 = (uint64_t *) ((uint8_t *) vm->host_base + l2_off);
 
-    /* Map 2MiB blocks. L2 index = addr / 2MiB. */
-    /* Shim code (RX) at 0x100000 -> L2[0] (shares 0x0-0x1FFFFF) */
+    /* Map 2MiB blocks. L2 index = addr / 2MiB. Shim code (RX) at 0x100000 ->
+     * L2[0] (shares 0x0-0x1FFFFF)
+     */
     l2[0] = make_block(0x000000, PERM_RX);
 
     /* Shim data/stacks (RW) at 0x200000 -> L2[1] */

--- a/tests/test-negative.c
+++ b/tests/test-negative.c
@@ -1,4 +1,5 @@
-/* Negative / error-path tests
+/*
+ * Negative / error-path tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-netlink.c
+++ b/tests/test-netlink.c
@@ -1,4 +1,5 @@
-/* Exercise the AF_NETLINK getsockname/sendto/recvfrom dispatch paths.
+/*
+ * Exercise the AF_NETLINK getsockname/sendto/recvfrom dispatch paths.
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -6,11 +7,10 @@
  *
  * Regression guard for the netlink socket emulation. Before getsockname,
  * sendto, and recvfrom were routed to the netlink handlers, these calls fell
- * through to the host socket syscalls on the underlying pipe fd and failed
- * with ENOTSOCK (errno 88), which in turn broke glibc getifaddrs(). The test
- * drives each of the three syscalls directly against a NETLINK_ROUTE socket
- * and then validates the end-to-end getifaddrs() path that originally
- * regressed.
+ * through to the host socket syscalls on the underlying pipe fd and failed with
+ * ENOTSOCK (errno 88), which in turn broke glibc getifaddrs(). The test drives
+ * each of the three syscalls directly against a NETLINK_ROUTE socket and then
+ * validates the end-to-end getifaddrs() path that originally regressed.
  *
  * The assertions hold for both the elfuse emulation and a real Linux kernel
  * (the test matrix runs the same binary under qemu-aarch64), so only

--- a/tests/test-netstat.c
+++ b/tests/test-netstat.c
@@ -1,4 +1,5 @@
-/* Validate /proc/net emulation with live sockets
+/*
+ * Validate /proc/net emulation with live sockets
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-opath.c
+++ b/tests/test-opath.c
@@ -1,4 +1,5 @@
-/* O_PATH semantics tests
+/*
+ * O_PATH semantics tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-pidfd.c
+++ b/tests/test-pidfd.c
@@ -1,4 +1,5 @@
-/* Test pidfd subsystem
+/*
+ * Test pidfd subsystem
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-poll.c
+++ b/tests/test-poll.c
@@ -1,4 +1,5 @@
-/* Test signals + I/O multiplexing syscalls (Batch 4)
+/*
+ * Test signals + I/O multiplexing syscalls (Batch 4)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-proc-fidelity.c
+++ b/tests/test-proc-fidelity.c
@@ -1,4 +1,5 @@
-/* /proc fidelity tests
+/*
+ * /proc fidelity tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-proc-limits.c
+++ b/tests/test-proc-limits.c
@@ -1,4 +1,5 @@
-/* Test /proc/self/limits synthetic file
+/*
+ * Test /proc/self/limits synthetic file
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-proc.c
+++ b/tests/test-proc.c
@@ -1,4 +1,5 @@
-/* Test /proc and /dev emulation
+/*
+ * Test /proc and /dev emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-procfs-exec.c
+++ b/tests/test-procfs-exec.c
@@ -1,4 +1,5 @@
-/* /proc/self/{auxv,environ} exec refresh regression test
+/*
+ * /proc/self/{auxv,environ} exec refresh regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-procfs.c
+++ b/tests/test-procfs.c
@@ -1,4 +1,5 @@
-/* /proc/self/* completeness tests
+/*
+ * /proc/self/* completeness tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-proctitle-host.c
+++ b/tests/test-proctitle-host.c
@@ -1,4 +1,5 @@
-/* Host-side regression for runtime_set_process_title.
+/*
+ * Host-side regression for runtime_set_process_title.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-pthread.c
+++ b/tests/test-pthread.c
@@ -1,4 +1,5 @@
-/* Test musl pthread_create/pthread_join in elfuse
+/*
+ * Test musl pthread_create/pthread_join in elfuse
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-pty.c
+++ b/tests/test-pty.c
@@ -1,4 +1,5 @@
-/* PTY ioctl regression test
+/*
+ * PTY ioctl regression test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-readv-writev.c
+++ b/tests/test-readv-writev.c
@@ -1,4 +1,5 @@
-/* Scatter-gather I/O tests
+/*
+ * Scatter-gather I/O tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-robust-futex.c
+++ b/tests/test-robust-futex.c
@@ -1,4 +1,5 @@
-/* Robust futex owner-died cleanup tests
+/*
+ * Robust futex owner-died cleanup tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -83,13 +84,12 @@ int main(void)
     memset(&rhead, 0, sizeof(rhead));
     memset(&entry1, 0, sizeof(entry1));
 
-    /* Clone a thread: CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND |
-     * CLONE_CHILD_CLEARTID. CLONE_THREAD (0x00010000) is the same bit as
-     * CLONE_VM so it's implicitly set.
+    /* Clone a thread: CLONE_THREAD | CLONE_VM | CLONE_FS | CLONE_SIGHAND |
+     * CLONE_CHILD_CLEARTID. CLONE_THREAD implies CLONE_VM and CLONE_SIGHAND.
      */
-    long flags = 0x00010000    /* CLONE_VM (= CLONE_THREAD) */
-                 | 0x00000100  /* CLONE_FS */
-                 | 0x00000200  /* CLONE_FILES */
+    long flags = 0x00010000    /* CLONE_THREAD */
+                 | 0x00000100  /* CLONE_VM */
+                 | 0x00000200  /* CLONE_FS */
                  | 0x00000800  /* CLONE_SIGHAND */
                  | 0x00200000; /* CLONE_CHILD_CLEARTID */
 

--- a/tests/test-roundtrip.c
+++ b/tests/test-roundtrip.c
@@ -1,4 +1,5 @@
-/* file write+read roundtrip test
+/*
+ * file write+read roundtrip test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-rseq.c
+++ b/tests/test-rseq.c
@@ -1,4 +1,5 @@
-/* Test rseq registration ABI
+/*
+ * Test rseq registration ABI
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-rwx.c
+++ b/tests/test-rwx.c
@@ -1,4 +1,5 @@
-/* Verify whether Apple HVF allows RWX page table entries
+/*
+ * Verify whether Apple HVF allows RWX page table entries
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-sched-policy.c
+++ b/tests/test-sched-policy.c
@@ -1,11 +1,12 @@
-/* Test scheduler policy stub syscalls
+/*
+ * Test scheduler policy stub syscalls
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * Exercises sched_setparam (118), sched_setscheduler (119), sched_getscheduler
- * (120), sched_getparam (121), sched_get_priority_min (125),
- * sched_get_priority_max (126), sched_rr_get_interval (127). The implementation
+ * (120), sched_getparam (121), sched_get_priority_max (125),
+ * sched_get_priority_min (126), sched_rr_get_interval (127). The implementation
  * is a stub: getters report SCHED_OTHER and a zero priority, RT priority
  * elevation is refused with -EPERM, SCHED_DEADLINE through the legacy entry
  * point is -EINVAL, and all entries validate guest pointers (-EFAULT).

--- a/tests/test-scm-creds.c
+++ b/tests/test-scm-creds.c
@@ -1,4 +1,5 @@
-/* Test SCM_CREDENTIALS / SO_PASSCRED over AF_UNIX sockets
+/*
+ * Test SCM_CREDENTIALS / SO_PASSCRED over AF_UNIX sockets
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-session.c
+++ b/tests/test-session.c
@@ -1,4 +1,5 @@
-/* Test session / process-group / TTY semantics
+/*
+ * Test session / process-group / TTY semantics
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-shebang-host.c
+++ b/tests/test-shebang-host.c
@@ -1,4 +1,5 @@
-/* Native-host unit test for shebang parsing.
+/*
+ * Native-host unit test for shebang parsing.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -122,7 +123,8 @@ int main(void)
     test_case(case7, sizeof(case7) - 1, 0, "", "");
 
     /* 8. Over-long/unterminated shebang line (exactly 511 bytes of 'a' without
-     * EOL) */
+     * EOL)
+     */
     char case8[512];
     case8[0] = '#';
     case8[1] = '!';

--- a/tests/test-shim-cred-race.c
+++ b/tests/test-shim-cred-race.c
@@ -1,4 +1,5 @@
-/* test-shim-cred-race.c -- shim identity cache stays consistent under
+/*
+ * test-shim-cred-race.c -- shim identity cache stays consistent under
  * concurrent setuid traffic.
  *
  * Copyright 2026 elfuse contributors

--- a/tests/test-shim-data-el1.c
+++ b/tests/test-shim-data-el1.c
@@ -1,4 +1,5 @@
-/* test-shim-data-el1.c -- guest EL0 cannot read or write shim_data.
+/*
+ * test-shim-data-el1.c -- guest EL0 cannot read or write shim_data.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-shim-identity-attention.c
+++ b/tests/test-shim-identity-attention.c
@@ -1,4 +1,5 @@
-/* test-shim-identity-attention.c -- SIGALRM survives fast paths.
+/*
+ * test-shim-identity-attention.c -- SIGALRM survives fast paths.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-shim-identity.c
+++ b/tests/test-shim-identity.c
@@ -1,4 +1,5 @@
-/* test-shim-identity.c -- verify identity syscalls do not trust vDSO memory
+/*
+ * test-shim-identity.c -- verify identity syscalls do not trust vDSO memory
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-shim-urandom-smp.c
+++ b/tests/test-shim-urandom-smp.c
@@ -1,4 +1,5 @@
-/* test-shim-urandom-smp.c -- multi-thread urandom-read stress.
+/*
+ * test-shim-urandom-smp.c -- multi-thread urandom-read stress.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-shim-urandom-toctou.c
+++ b/tests/test-shim-urandom-toctou.c
@@ -1,4 +1,5 @@
-/* test-shim-urandom-toctou.c -- urandom EL1 fault recovery survives concurrent
+/*
+ * test-shim-urandom-toctou.c -- urandom EL1 fault recovery survives concurrent
  * mprotect(PROT_NONE) of the read buffer.
  *
  * Copyright 2026 elfuse contributors

--- a/tests/test-shim-urandom-wrap.c
+++ b/tests/test-shim-urandom-wrap.c
@@ -1,4 +1,5 @@
-/* test-shim-urandom-wrap.c -- regression for wrapped shim urandom copies.
+/*
+ * test-shim-urandom-wrap.c -- regression for wrapped shim urandom copies.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-shim-verbose-trace.c
+++ b/tests/test-shim-verbose-trace.c
@@ -1,4 +1,5 @@
-/* test-shim-verbose-trace.c -- fixture for verbose tracing of shim fast paths
+/*
+ * test-shim-verbose-trace.c -- fixture for verbose tracing of shim fast paths
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-sigill.c
+++ b/tests/test-sigill.c
@@ -1,4 +1,5 @@
-/* Test SIGILL delivery for undefined instructions
+/*
+ * Test SIGILL delivery for undefined instructions
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -33,9 +34,9 @@ static void sigill_handler(int sig, siginfo_t *info, void *ucontext)
      * ucontext_t.uc_mcontext.__ss.__pc on aarch64 Linux is the faulting PC.
      */
     ucontext_t *uc = (ucontext_t *) ucontext;
-    /* Linux aarch64: mcontext_t has regs[31], sp, pc, pstate.
-     * pc is at offset regs[32] equivalent, but the layout varies.
-     * Use the struct field directly.
+    /* Linux aarch64: mcontext_t has regs[31], sp, pc, pstate. pc is at offset
+     * regs[32] equivalent, but the layout varies. Use the struct field
+     * directly.
      */
     uc->uc_mcontext.pc += 4;
 }

--- a/tests/test-signal-thread.c
+++ b/tests/test-signal-thread.c
@@ -1,4 +1,5 @@
-/* Signal + thread interaction tests
+/*
+ * Signal + thread interaction tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-signal.c
+++ b/tests/test-signal.c
@@ -1,4 +1,5 @@
-/* Test signal delivery and rt_sigreturn
+/*
+ * Test signal delivery and rt_sigreturn
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -9,7 +10,7 @@
  * 2. kill(getpid(), SIGUSR1) delivers the signal
  * 3. Handler fires with correct signum
  * 4. rt_sigreturn restores all callee-saved registers
- *    (aarch64: X19-X28, x86_64: rbx/r12-r15/rbp)
+ *    (aarch64: X19-X28, x86_64: rbx/r12-r15)
  * 5. sigprocmask blocks/unblocks signals correctly
  */
 

--- a/tests/test-signalfd-hardening.c
+++ b/tests/test-signalfd-hardening.c
@@ -1,4 +1,5 @@
-/* signalfd read semantics hardening
+/*
+ * signalfd read semantics hardening
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-signalfd.c
+++ b/tests/test-signalfd.c
@@ -1,4 +1,5 @@
-/* Test signalfd4 syscall emulation
+/*
+ * Test signalfd4 syscall emulation
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-simd-clone.c
+++ b/tests/test-simd-clone.c
@@ -1,4 +1,5 @@
-/* Verify SIMD/FP state preservation across clone(CLONE_THREAD)
+/*
+ * Verify SIMD/FP state preservation across clone(CLONE_THREAD)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-socket.c
+++ b/tests/test-socket.c
@@ -1,4 +1,5 @@
-/* Test socket syscalls (AF_UNIX socketpair)
+/*
+ * Test socket syscalls (AF_UNIX socketpair)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -11,10 +12,16 @@
  * 1. socketpair(AF_UNIX, SOCK_STREAM) creates two connected fds
  * 2. write/read through socketpair transfers data correctly
  * 3. getsockopt(SO_TYPE) returns SOCK_STREAM
- * 4. sendmsg/recvmsg transfers a single iovec payload
- * 5. sendmsg/recvmsg transfers a two-iovec payload
- * 6. sendmmsg/recvmmsg transfers a single message
- * 7. shutdown(SHUT_WR) causes read to return 0 (EOF)
+ * 4. getsockname/getpeername return the socketpair addresses
+ * 5. sendmsg/recvmsg transfers a single iovec payload
+ * 6. sendmsg/recvmsg transfers a two-iovec payload
+ * 7. sendmmsg/recvmmsg transfers a single message
+ * 8. sendto/recvfrom over an AF_UNIX datagram pair
+ * 9. recvmsg single iovec preserves MSG_TRUNC
+ * 10. getsockopt(SO_ERROR) read-and-clear
+ * 11. shutdown(SHUT_WR) causes read to return 0 (EOF)
+ * 12. socketpair(AF_UNIX, SOCK_SEQPACKET)
+ * 13. socket(AF_UNIX, SOCK_SEQPACKET)
  */
 
 #include <stdio.h>

--- a/tests/test-stress.c
+++ b/tests/test-stress.c
@@ -1,4 +1,5 @@
-/* Stress tests resource limits
+/*
+ * Stress tests resource limits
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-string.c
+++ b/tests/test-string.c
@@ -1,4 +1,5 @@
-/* string operations test
+/*
+ * string operations test
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-syscall-fidelity.c
+++ b/tests/test-syscall-fidelity.c
@@ -1,4 +1,5 @@
-/* Linux syscall fidelity tests
+/*
+ * Linux syscall fidelity tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-syscall-smoke.c
+++ b/tests/test-syscall-smoke.c
@@ -1,4 +1,5 @@
-/* Direct syscall smoke coverage for less frequently hit dispatch entries
+/*
+ * Direct syscall smoke coverage for less frequently hit dispatch entries
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -507,7 +508,8 @@ static void test_process_query_stubs(void)
     if (caps == 0) {
         if (getuid() == 0) {
             /* Under fakeroot, effective and permitted should be non-zero (full
-             * caps) */
+             * caps)
+             */
             caps_ok = (data[0].effective != 0);
         } else {
             caps_ok = (data[0].effective == 0);
@@ -924,7 +926,8 @@ static void test_sync_file_range(void)
     /* 1. Test basic success case with valid flags (SYNC_FILE_RANGE_WRITE, etc.)
      */
     /* Note: SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE |
-     * SYNC_FILE_RANGE_WAIT_AFTER is 7 */
+     * SYNC_FILE_RANGE_WAIT_AFTER is 7
+     */
     if (syscall(SYS_sync_file_range, fd, (off64_t) 0, (off64_t) 0, 7) != 0) {
         FAIL("sync_file_range basic");
         close(fd);
@@ -970,7 +973,8 @@ static void test_sync_file_range(void)
     }
 
     /* 6. SYNC_FILE_RANGE_WRITE only (async hint) returns 0 without blocking.
-     * Covers the deliberate-divergence branch. */
+     * Covers the deliberate-divergence branch.
+     */
     if (syscall(SYS_sync_file_range, fd, (off64_t) 0, (off64_t) 0, 2) != 0) {
         FAIL("sync_file_range write-only");
         close(fd);

--- a/tests/test-sysfs-cpu.c
+++ b/tests/test-sysfs-cpu.c
@@ -1,4 +1,5 @@
-/* Test /sys/devices/system/cpu emulation
+/*
+ * Test /sys/devices/system/cpu emulation
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-sysinfo.c
+++ b/tests/test-sysinfo.c
@@ -1,4 +1,5 @@
-/* Test process/system info syscalls (Batch 2)
+/*
+ * Test process/system info syscalls (Batch 2)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-sysroot-chdir.c
+++ b/tests/test-sysroot-chdir.c
@@ -1,4 +1,5 @@
-/* Sysroot chdir regression tests
+/*
+ * Sysroot chdir regression tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-sysroot-create-paths.c
+++ b/tests/test-sysroot-create-paths.c
@@ -1,4 +1,5 @@
-/* Sysroot create-path routing regression tests
+/*
+ * Sysroot create-path routing regression tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-sysroot-host-fallback.c
+++ b/tests/test-sysroot-host-fallback.c
@@ -1,15 +1,16 @@
-/* Host-literal fallback regression tests for case-insensitive sysroots
+/*
+ * Host-literal fallback regression tests for case-insensitive sysroots
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * proc_resolve_sysroot_path_flags resolves absolute guest paths inside the
  * sysroot when they exist there and otherwise falls back to the literal host
- * path so guests can reach host resources (mktemp dirs, /etc/resolv.conf).
- * On a case-insensitive sysroot the sidecar walk used to veto that fallback:
- * it anchored every absolute path at the sysroot root and returned ENOENT as
- * soon as a component was missing there, which broke every coreutils
- * invocation against a host mktemp directory (test-matrix "musl dyn" suite).
+ * path so guests can reach host resources (mktemp dirs, /etc/resolv.conf). On a
+ * case-insensitive sysroot the sidecar walk used to veto that fallback: it
+ * anchored every absolute path at the sysroot root and returned ENOENT as soon
+ * as a component was missing there, which broke every coreutils invocation
+ * against a host mktemp directory (test-matrix "musl dyn" suite).
  *
  * The harness (mk/tests.mk) runs this binary under --sysroot with a
  * case-insensitive sysroot so the sidecar is active, and passes:

--- a/tests/test-sysroot-nofollow.c
+++ b/tests/test-sysroot-nofollow.c
@@ -1,4 +1,5 @@
-/* Sysroot no-follow regression tests
+/*
+ * Sysroot no-follow regression tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-sysroot-rename.c
+++ b/tests/test-sysroot-rename.c
@@ -1,4 +1,5 @@
-/* Sysroot rename regression tests
+/*
+ * Sysroot rename regression tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-sysv-shm.c
+++ b/tests/test-sysv-shm.c
@@ -1,4 +1,5 @@
-/* SysV shared memory protection tests
+/*
+ * SysV shared memory protection tests
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-thread.c
+++ b/tests/test-thread.c
@@ -1,4 +1,5 @@
-/* Test clone(CLONE_THREAD) + futex in elfuse
+/*
+ * Test clone(CLONE_THREAD) + futex in elfuse
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
@@ -89,7 +90,8 @@ static void test_clone_thread(void)
 
     /* CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD |
      * CLONE_SYSVSEM | CLONE_SETTLS | CLONE_PARENT_SETTID |
-     * CLONE_CHILD_CLEARTID
+     * CLONE_CHILD_CLEARTID | CLONE_DETACHED (0x7d0f00; DETACHED is a legacy
+     * no-op on modern Linux)
      */
     unsigned long flags = 0x7d0f00;
     void *stack_top = child_stack_buf + sizeof(child_stack_buf);
@@ -111,8 +113,7 @@ static void test_clone_thread(void)
         return;
     }
 
-    /* Parent: ret = child TID */
-    /* Wait for child to signal completion */
+    /* Parent: ret = child TID Wait for child to signal completion */
     while (done_flag == 0) {
         raw_futex_wait((int *) &done_flag, 0);
     }
@@ -130,8 +131,9 @@ static void test_parent_settid(void)
 {
     TEST("CLONE_PARENT_SETTID");
 
-    /* child_tid was set by CLONE_PARENT_SETTID in test_clone_thread */
-    /* Wait for child to fully exit (CLONE_CHILD_CLEARTID clears it) */
+    /* child_tid was set by CLONE_PARENT_SETTID in test_clone_thread Wait for
+     * child to fully exit (CLONE_CHILD_CLEARTID clears it)
+     */
     while (child_tid != 0) {
         raw_futex_wait((int *) &child_tid, child_tid);
     }

--- a/tests/test-tier-a.c
+++ b/tests/test-tier-a.c
@@ -1,4 +1,5 @@
-/* Tier A compatibility tests
+/*
+ * Tier A compatibility tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-timerfd.c
+++ b/tests/test-timerfd.c
@@ -1,4 +1,5 @@
-/* Test timerfd emulation (kqueue backend)
+/*
+ * Test timerfd emulation (kqueue backend)
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-tlbi-encoder-host.c
+++ b/tests/test-tlbi-encoder-host.c
@@ -1,4 +1,5 @@
-/* Native-host unit test for the TLBI RVAE1IS operand encoder.
+/*
+ * Native-host unit test for the TLBI RVAE1IS operand encoder.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/test-util.h
+++ b/tests/test-util.h
@@ -1,4 +1,5 @@
-/* Shared test utilities
+/*
+ * Shared test utilities
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-vdso.c
+++ b/tests/test-vdso.c
@@ -1,4 +1,5 @@
-/* test-vdso.c -- vDSO ELF correctness and symbol-resolution probe
+/*
+ * test-vdso.c -- vDSO ELF correctness and symbol-resolution probe
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -6,7 +7,7 @@
  * Confirms the synthetic vDSO emitted by src/core/vdso.c:
  *   1. is published via AT_SYSINFO_EHDR
  *   2. parses as a valid ELF shared object
- *   3. exports the four __kernel_* symbols at addresses inside the page
+ *   3. exports the five __kernel_* symbols at addresses inside the page
  *   4. carries GNU symbol versioning naming LINUX_2.6.39 so glibc/musl
  *      dl_vdso_vsym() can resolve unversioned lookups
  *   5. trampolines actually execute (call __kernel_clock_gettime and

--- a/tests/test-x11.c
+++ b/tests/test-x11.c
@@ -1,4 +1,5 @@
-/* Test X11 connectivity via raw wire protocol
+/*
+ * Test X11 connectivity via raw wire protocol
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.

--- a/tests/test-xattr.c
+++ b/tests/test-xattr.c
@@ -1,4 +1,5 @@
-/* lgetxattr / getxattr / setxattr semantics tests
+/*
+ * lgetxattr / getxattr / setxattr semantics tests
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-glibc-dlopen.c
+++ b/tests/x86_64-glibc-dlopen.c
@@ -1,4 +1,5 @@
-/* x86_64-glibc-dlopen.c - Runtime dlopen probe for the Rosetta gate
+/*
+ * x86_64-glibc-dlopen.c - Runtime dlopen probe for the Rosetta gate
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-glibc-gdtls-lib.c
+++ b/tests/x86_64-glibc-gdtls-lib.c
@@ -1,4 +1,5 @@
-/* x86_64-glibc-gdtls-lib.c - Shared object with a general-dynamic thread-local
+/*
+ * x86_64-glibc-gdtls-lib.c - Shared object with a general-dynamic thread-local
  * variable, paired with x86_64-glibc-gdtls.c.
  *
  * Copyright 2026 elfuse contributors

--- a/tests/x86_64-glibc-gdtls.c
+++ b/tests/x86_64-glibc-gdtls.c
@@ -1,4 +1,5 @@
-/* x86_64-glibc-gdtls.c - General-dynamic TLS probe for the Rosetta gate
+/*
+ * x86_64-glibc-gdtls.c - General-dynamic TLS probe for the Rosetta gate
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-glibc-hello.c
+++ b/tests/x86_64-glibc-hello.c
@@ -1,4 +1,5 @@
-/* x86_64-glibc-hello.c - Minimal glibc dynamic hello for Rosetta smoke
+/*
+ * x86_64-glibc-hello.c - Minimal glibc dynamic hello for Rosetta smoke
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-glibc-pthread-tls.c
+++ b/tests/x86_64-glibc-pthread-tls.c
@@ -1,4 +1,5 @@
-/* x86_64-glibc-pthread-tls.c - pthread per-thread TLS probe
+/*
+ * x86_64-glibc-pthread-tls.c - pthread per-thread TLS probe
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-glibc-tls.c
+++ b/tests/x86_64-glibc-tls.c
@@ -1,4 +1,5 @@
-/* x86_64-glibc-tls.c - Initial-exec TLS probe for the Rosetta gate
+/*
+ * x86_64-glibc-tls.c - Initial-exec TLS probe for the Rosetta gate
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-rosetta-audit.c
+++ b/tests/x86_64-rosetta-audit.c
@@ -1,4 +1,5 @@
-/* x86_64-rosetta-audit.c - Rosetta thread/signal acceptance smoke
+/*
+ * x86_64-rosetta-audit.c - Rosetta thread/signal acceptance smoke
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-rosetta-madvise.c
+++ b/tests/x86_64-rosetta-madvise.c
@@ -1,14 +1,15 @@
-/* x86_64-rosetta-madvise.c - madvise(MADV_DONTNEED) on high-VA regions
+/*
+ * x86_64-rosetta-madvise.c - madvise(MADV_DONTNEED) on high-VA regions
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Regression for elfuse sys_madvise rejecting high-VA mmap regions with
- * ENOMEM. Under Rosetta, anonymous mmap(NULL) lands in the high-VA window
- * (the region's gpa_base diverges from its VA start), where sys_madvise was
- * primary-window-only: it computed off = addr - ipa_base and rejected any
- * range past guest_size with ENOMEM, even though sys_mprotect already handles
- * the same high-VA range. V8's page allocator decommits guard/code pages with
+ * Regression for elfuse sys_madvise rejecting high-VA mmap regions with ENOMEM.
+ * Under Rosetta, anonymous mmap(NULL) lands in the high-VA window (the region's
+ * gpa_base diverges from its VA start), where sys_madvise was
+ * primary-window-only: it computed off = addr - ipa_base and rejected any range
+ * past guest_size with ENOMEM, even though sys_mprotect already handles the
+ * same high-VA range. V8's page allocator decommits guard/code pages with
  * mprotect(PROT_NONE)+madvise(MADV_DONTNEED) and CHECK_EQ(0, ret)s the madvise
  * return, so the spurious ENOMEM aborted x86_64 Node.js the moment its JIT
  * initialized.
@@ -38,7 +39,8 @@ static int fails;
 
 /* The primary IPA window is a handful of GiB; Rosetta places guest mappings at
  * their native x86_64 VAs far above it. Anything past 4 GiB is the high-VA
- * window that exercises the regression. */
+ * window that exercises the regression.
+ */
 static int is_high_va(const void *p)
 {
     return (uint64_t) (uintptr_t) p > 0x100000000ULL;
@@ -82,7 +84,8 @@ static void test_dontneed_rw(void)
 
 /* The exact V8 decommit pattern: a guard page is set PROT_NONE and then
  * MADV_DONTNEED'd. Linux returns 0 for a mapped-but-PROT_NONE page; after
- * re-granting RW the page reads back as zero. */
+ * re-granting RW the page reads back as zero.
+ */
 static void test_dontneed_protnone(void)
 {
     size_t sz = 2u * PAGE;

--- a/tests/x86_64-rosetta-mremap.c
+++ b/tests/x86_64-rosetta-mremap.c
@@ -1,4 +1,5 @@
-/* x86_64-rosetta-mremap.c - mremap() on high-VA source regions
+/*
+ * x86_64-rosetta-mremap.c - mremap() on high-VA source regions
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -39,7 +40,8 @@ static int fails;
 
 /* The primary IPA window is a handful of GiB; Rosetta places guest mappings at
  * their native x86_64 VAs far above it. Anything past 4 GiB is the high-VA
- * window that exercises the regression. */
+ * window that exercises the regression.
+ */
 static int is_high_va(const void *p)
 {
     return (uint64_t) (uintptr_t) p > 0x100000000ULL;
@@ -105,7 +107,8 @@ static void test_mremap_maymove_grow(void)
 }
 
 /* Shrinking a high-VA region in place keeps its base address and preserves the
- * retained head; only the trimmed tail is released. */
+ * retained head; only the trimmed tail is released.
+ */
 static void test_mremap_shrink(void)
 {
     const char *tag = "mremap-shrink";

--- a/tests/x86_64-rosetta-msync.c
+++ b/tests/x86_64-rosetta-msync.c
@@ -1,4 +1,5 @@
-/* x86_64-rosetta-msync.c - msync(MS_SYNC/MS_ASYNC) on high-VA regions
+/*
+ * x86_64-rosetta-msync.c - msync(MS_SYNC/MS_ASYNC) on high-VA regions
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -11,7 +12,7 @@
  * lists with MAP_SHARED and periodically msyncs them, so under an x86_64 guest
  * the spurious ENOMEM surfaced as:
  *     E: Unable to synchronize mmap - msync (12: Cannot allocate memory)
- * and aborted `apt update` / `apt upgrade` at package-list parsing.
+ * and aborted "apt update" / "apt upgrade" at package-list parsing.
  *
  * The fix admits high-VA ranges the region tracker records as mapped and
  * resolves the write-back / refresh host pointers through host_ptr_for_gpa
@@ -41,19 +42,21 @@ static int fails;
 
 /* The primary IPA window is a handful of GiB; Rosetta places guest mappings at
  * their native x86_64 VAs far above it. Anything past 4 GiB is the high-VA
- * window that exercises the regression. */
+ * window that exercises the regression.
+ */
 static int is_high_va(const void *p)
 {
     return (uint64_t) (uintptr_t) p > 0x100000000ULL;
 }
 
-/* Create a zero-filled backing file of `sz` bytes, returning an open O_RDWR fd
+/* Create a zero-filled backing file of @sz bytes, returning an open O_RDWR fd
  * (unlinked so it cleans up on close). -1 on error.
  *
  * Backed by /dev/shm, not host-passthrough /tmp: elfuse refuses mmap on
  * FUSE-served fds (ENODEV), and /dev/shm is the mmap-able tmpfs the aarch64
- * test-msync uses too. `slot` disambiguates concurrent subtests. glibc static
- * shm_open is unreliable, so open the path directly. */
+ * test-msync uses too. @slot disambiguates concurrent subtests. glibc static
+ * shm_open is unreliable, so open the path directly.
+ */
 static int make_backing(size_t sz, int slot)
 {
     char path[64];
@@ -70,9 +73,10 @@ static int make_backing(size_t sz, int slot)
     return fd;
 }
 
-/* Read `sz` bytes at file offset 0 through a fresh fd (so the check reflects
+/* Read @sz bytes at file offset 0 through a fresh fd (so the check reflects
  * what actually reached the backing file, not the mapping) and confirm every
- * byte equals `want`. */
+ * byte equals @want.
+ */
 static int file_all_equal(int fd,
                           size_t sz,
                           unsigned char want,
@@ -99,7 +103,8 @@ static int file_all_equal(int fd,
 }
 
 /* MS_SYNC on a single writable high-VA MAP_SHARED page returns 0 and the write
- * reaches the backing file. */
+ * reaches the backing file.
+ */
 static void test_msync_writeback_single(void)
 {
     const char *tag = "msync-writeback-single";
@@ -189,7 +194,8 @@ static void test_msync_writeback_multi(void)
 }
 
 /* MS_ASYNC on a high-VA mapping returns 0 (the primary #108 symptom is the
- * -ENOMEM admission failure, which is flag-independent). */
+ * -ENOMEM admission failure, which is flag-independent).
+ */
 static void test_msync_async(void)
 {
     const char *tag = "msync-async";

--- a/tests/x86_64-rosetta-tls0.c
+++ b/tests/x86_64-rosetta-tls0.c
@@ -1,4 +1,5 @@
-/* x86_64-rosetta-tls0.c - CLONE_SETTLS tls=0 reproducer for Rosetta
+/*
+ * x86_64-rosetta-tls0.c - CLONE_SETTLS tls=0 reproducer for Rosetta
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0

--- a/tests/x86_64-stress.c
+++ b/tests/x86_64-stress.c
@@ -1,4 +1,5 @@
-/* x86_64-stress.c - High-VA mmap stress for x86_64-via-Rosetta
+/*
+ * x86_64-stress.c - High-VA mmap stress for x86_64-via-Rosetta
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Fix comments that contradicted the code. The vDSO anchor-age cap is $2^{22}$ cycles (~0.175 s), not $2^{31}$; shim_data is mapped EL1-only, so the direct-store spoofing gap is closed rather than open; the PI futex TID field is bits 0-29, not 0-30; non-root setuid sets only euid; FUSE directories are seekable; mknodat also creates regular files; the epoll registration table is per-instance; file-backed MAP_SHARED installs a live overlay. Several test descriptions were likewise stale: CLONE flag bits and labels, sched priority syscall numbers, the vDSO symbol count, and the socket test enumeration.

Prefix function-parameter references in doc comments with @ where the comment documents that function, and drop backticks from source comments to keep them ASCII-only per the project style.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale and contradictory comments across core, syscalls, debug, and tests, aligning docs with actual behavior and standardizing comment style. Clarifies behavior for vDSO timing, EL1-only shim_data, futex PI layout, identity changes, filesystem semantics, epoll, mmap, and GDB RSP.

- **Refactors**
  - Clarified behavior: vDSO anchor-age cap is 2^22 cycles (~0.175 s); `shim_data` is EL1-only (EL0 stores fault); PI futex owner TID uses bits 0–29 (bit 30 OWNER_DIED); non-root setuid updates only euid; FUSE directories are seekable; mknodat also creates regular files; epoll registration table is per instance; file-backed MAP_SHARED installs a live overlay.
  - Comment/doc fixes: use @-style param references; move gdb_rsp_recv docs to gdbstub-rsp.c and document gdb_reg_offset; restore cppcheck-suppress placement; keep comments ASCII-only; normalize file headers; clarify high-VA mmap/mremap/madvise notes; update test descriptions (CLONE bits/labels, sched priority syscall numbers, vDSO symbol count, socket test enumeration, and test-fork uses posix_spawn + IPC).

<sup>Written for commit eb3e52fa112e8f22560de4364f9e5fa74c34e721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



