### PR TITLE
Re-enter execve through the MMU-off shim boot path

### DIFF
--- a/src/core/shim.S
+++ b/src/core/shim.S
@@ -282,8 +282,18 @@ _start:
     /* Save SCTLR value from host (passed in X0) */
     mov x9, x0
 
-    /* TLB invalidation: ensure clean TLB state before enabling MMU */
+    /* TLB + I-cache invalidation: ensure clean translation state before
+     * enabling the MMU. Runs with SCTLR.M=0, so this fetch cannot be
+     * misdirected by stale TLB state -- which is exactly why the execve
+     * re-entry path lands here instead of resuming the interrupted
+     * svc_handler frame: after guest_reset recycles the PT pool in place,
+     * stale walk-cache entries can poison any translated fetch, and the
+     * only architecturally safe point to drop them is before MMU-on.
+     * IC IALLUIS covers stale I-cache lines from a pre-exec image that
+     * loaded code at the same addresses (no-op cost at cold boot).
+     */
     tlbi vmalle1is
+    ic ialluis
     dsb ish
     isb
 

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -60,7 +60,47 @@ static void exec_sync_vcpu_regs(hv_vcpu_t vcpu)
     (void) vcpu_get_sysreg(vcpu, HV_SYS_REG_ELR_EL1);
     (void) vcpu_get_sysreg(vcpu, HV_SYS_REG_SP_EL0);
     (void) vcpu_get_sysreg(vcpu, HV_SYS_REG_SPSR_EL1);
-    (void) vcpu_get_reg(vcpu, HV_REG_X8);
+    (void) vcpu_get_reg(vcpu, HV_REG_PC);
+}
+
+/* Re-enter the replacement image through the shim's _start cold-boot protocol
+ * instead of resuming the interrupted svc_handler frame.
+ *
+ * guest_reset recycles the PT pool in place, so after the rebuild the vCPU's
+ * hardware TLB can still hold walk-cache entries that point into recycled
+ * page-table pages. Resuming a translated fetch through that state is unsound:
+ * the walk can read a rewritten page and either fault (transient EL1
+ * instruction abort at the shim, observed as BAD_EXCEPTION vec=0x200) or
+ * silently translate to the wrong IPA. The TLBI VMALLE1IS in exec_drop_frame
+ * came too late -- fetching the instructions leading up to it already required
+ * translation.
+ *
+ * The only architecturally safe sequence is the one cold boot already uses:
+ * enter _start with SCTLR.M=0 (instruction fetches use flat IPA addressing and
+ * cannot be misdirected), let it TLBI + IC with the MMU off, then enable the
+ * MMU via HVC #4 and ERET to ELR_EL1. This mirrors the staging in
+ * guest_bootstrap_create_vcpu; the caller must have set TTBR0/TCR/TTBR1/
+ * ELR_EL1/SP_EL0/SPSR_EL1/TPIDR_EL0 for the new image beforehand.
+ */
+static void exec_stage_mmu_off_reentry(hv_vcpu_t vcpu, guest_t *g)
+{
+    uint64_t shim_ipa = guest_ipa(g, g->shim_base);
+    uint64_t el1_sp = guest_ipa(g, g->shim_data_base + BLOCK_2MIB);
+    uint64_t sctlr =
+        SCTLR_RES1 | SCTLR_C | SCTLR_I | SCTLR_DZE | SCTLR_UCT | SCTLR_UCI;
+
+    /* The old syscall frame on the EL1 stack is dead; _start never pops it,
+     * so reset SP_EL1 to the stack top as cold boot does. HV_CHECK on every
+     * write for parity with guest_bootstrap_create_vcpu: past the point of no
+     * return a silent HVF failure would resume the vCPU on half-staged
+     * register state, so abort instead.
+     */
+    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL1, el1_sp));
+    HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SCTLR_EL1, sctlr));
+    HV_CHECK(hv_vcpu_set_reg(vcpu, HV_REG_PC, shim_ipa));
+    HV_CHECK(hv_vcpu_set_reg(vcpu, HV_REG_CPSR, 0x3c5));
+    vcpu_zero_gprs(vcpu);
+    HV_CHECK(hv_vcpu_set_reg(vcpu, HV_REG_X0, sctlr | SCTLR_M));
 }
 
 static void exec_republish_shim_globals_or_die(hv_vcpu_t vcpu,
@@ -746,8 +786,7 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL0, sp_ipa);
         hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SPSR_EL1, 0x0);
         hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, 0);
-        vcpu_zero_gprs(vcpu);
-        hv_vcpu_set_reg(vcpu, HV_REG_X8, 2);
+        exec_stage_mmu_off_reentry(vcpu, g);
         tlbi_request_clear();
 
         exec_sync_vcpu_regs(vcpu);
@@ -1045,17 +1084,10 @@ int64_t sys_execve(hv_vcpu_t vcpu,
      */
     hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_TPIDR_EL0, 0);
 
-    /* Drop all register contents from the old image; X8 is set below as the
-     * shim control code.
+    /* Drop all register contents from the old image and re-enter through the
+     * shim's MMU-off _start protocol (TLBI before any translated fetch).
      */
-    vcpu_zero_gprs(vcpu);
-
-    /* Tell the shim that execve replaced the full guest register state. X8=2
-     * means: flush TLB, discard the old syscall frame, and return without
-     * restoring pre-exec registers. This bypasses the normal syscall epilogue,
-     * which would otherwise overwrite X8 from cpu_tlbi_req.
-     */
-    hv_vcpu_set_reg(vcpu, HV_REG_X8, 2);
+    exec_stage_mmu_off_reentry(vcpu, g);
     tlbi_request_clear();
 
     exec_sync_vcpu_regs(vcpu);

--- a/tests/test-rosetta-statics.sh
+++ b/tests/test-rosetta-statics.sh
@@ -232,6 +232,27 @@ else
     report_fail "env-execve: rc=$env_rc (expected 0)"
 fi
 
+# Re-run the same execve with the rosettad AOT cache now warm for this digest.
+# The warm path returns from rosettad almost immediately, which historically
+# left stale TLB walk-cache entries alive across the exec page-table rebuild
+# and crashed the re-entry with an EL1 instruction abort (BAD_EXCEPTION
+# vec=0x200, exit 128). Guards the MMU-off _start re-entry in sys_execve.
+total=$((total + 1))
+set +e
+env_warm_rc=$(
+    "$TIMEOUT" 10 "$ELFUSE" "${STATICBIN}/env" "${STATICBIN}/true" \
+        > /dev/null 2>&1
+    printf '%s' "$?"
+)
+set -e
+if [ "$env_warm_rc" = "0" ]; then
+    report_pass "env-execve-warm (stale-TLB regression)"
+elif [ "$env_warm_rc" = "124" ]; then
+    report_fail "env-execve-warm: timed out (likely hang in re-bootstrap)"
+else
+    report_fail "env-execve-warm: rc=$env_warm_rc (expected 0)"
+fi
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

`tests/test-rosetta-statics.sh` intermittently fails its `env-execve` case with
exit code 128 on Apple Silicon. The failure rate is machine- and
timing-dependent (from occasional to near-deterministic on an idle M4), which
is why the self-hosted runtime CI job (PR #91) flips between green and red on
identical code. The crash signature:

```
guest exception vec=0x200 ESR=0x86000005 FAR=0xeffdf6a00 ELR=0xeffdf6a00
```

vec=0x200 with ELR == FAR == shim_base+0xa00 (the current-EL sync vector) and
IFSC alternating between level-1/level-2 translation fault across runs: the EL1
shim itself takes an instruction abort right after execve re-entry, with the
crash dump still showing the re-entry register staging (all GPRs zero, X8=2).

## Root cause

`sys_execve` resumed the interrupted `svc_handler` frame after rebuilding the
address space and relied on `exec_drop_frame`'s `TLBI VMALLE1IS` to drop the
old image's TLB state. That TLBI runs too late:

- `guest_reset` recycles the PT pool **in place** (`pt_pool_next` back to
  `pt_pool_base`), so the rebuilt tables reuse the same IPAs with different
  content. `guest_tlb_flush()` only clears the host-side software `gva_tlb`
  cache; no guest hardware TLBI ever executes between the two address spaces.
- The instruction fetches leading up to `exec_drop_frame` are themselves
  translated. A stale TLB walk-cache entry can steer that walk into a recycled
  page-table page and either read an invalid descriptor (the transient
  translation fault observed) or a valid-looking descriptor pointing at the
  wrong IPA (silent misexecution — no fault to retry on).

A warm rosettad AOT cache makes the x86_64 → x86_64 re-exec return almost
immediately, so stale entries regularly survive the short host dwell — that is
why the second run of the same digest fails far more often than the first, and
why the failure looks "flaky" rather than deterministic. This is the same
root-cause family as the stale-TLB data aborts addressed by #117, but at EL1
on the instruction side, where no retry path exists (and none could be fully
sound, per the silent-wrong-translation case above).

## Fix

Re-enter the replacement image through the shim's `_start` cold-boot protocol
instead of resuming the interrupted frame — the exact sequence
`guest_bootstrap_create_vcpu` already relies on, for the same reason:

1. Host stages `SCTLR.M=0`, `PC=_start`, `CPSR=EL1h`, resets `SP_EL1`, and
   passes the final SCTLR value in X0 (`exec_stage_mmu_off_reentry`, shared by
   the rosetta and aarch64 exec branches).
2. With the MMU off, instruction fetches use flat IPA addressing and cannot be
   misdirected by any stale translation. `_start` executes
   `TLBI VMALLE1IS; IC IALLUIS; DSB ISH; ISB`, then enables the MMU via
   HVC 4 and ERETs to `ELR_EL1`.

The `IC IALLUIS` is new in `_start`: execve loads new code at addresses the old
image also used (previously covered by `exec_drop_frame`'s `ic iallu`); at cold
boot it is a no-op cost. The X8=2 `exec_drop_frame` wire code is no longer sent
by execve; `rt_sigreturn` still uses it, and that path does not rebuild page
tables.

## Verification (Apple M4, macOS 15.4.1)

- Minimal repro (fresh `$HOME`, `elfuse env true` twice so the second run hits
  the warm AOT digest): failed ~85% of pairs before, 10/10 pairs clean after.
- Full `test-rosetta-statics.sh`: 5/5 runs failed `env-execve` before at the
  same commit; 5/5 runs pass 21/21 after.
- 30 consecutive warm re-execs in one cache dir: 30/30.
- `make check`: 82 passed, 0 failed, 2 skipped — including the aarch64 exec
  coverage (`test-exec`, `test-fork-exec`, `test-procfs-exec`).

A new `env-execve-warm` case in `test-rosetta-statics.sh` pins the trigger
(second execve on a warm digest): it exits 128 against an unfixed binary and
passes with this fix, so the runtime CI job gets a precise guard instead of an
intermittent one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent execve crashes on Apple Silicon by re-entering through the shim cold-boot path with the MMU off, then flushing TLB and I-cache before enabling the MMU. Adds a warm re-exec test that previously exited 128 and now passes.

- **Bug Fixes**
  - Re-route execve re-entry through `_start` with `SCTLR.M=0`; run `TLBI VMALLE1IS` + `IC IALLUIS`, then enable the MMU via HVC #4 and `ERET` into `ELR_EL1`.
  - Introduce `exec_stage_mmu_off_reentry` and use it in `sys_execve`; stop sending the `X8=2` exec wire code (still used by `rt_sigreturn`).
  - Add `env-execve-warm` test to guard against the stale-TLB regression; stabilizes `env-execve` on Apple Silicon.

<sup>Written for commit a1e4174d6d291fa5ff2b733fcfecac0df7ef4b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

