### PR TITLE
Verify on-disk spelling in sidecar lookups

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -158,7 +158,10 @@ Practical notes:
 - The sysroot setting is preserved across guest `fork` and `execve`, so spawned
   children see the same view of the filesystem.
 - On case-insensitive macOS volumes, `elfuse` maintains per-directory
-  sidecar token files so case-colliding Linux names remain distinct.
+  sidecar token files so case-colliding Linux names remain distinct, and
+  lookups verify the on-disk spelling byte-for-byte: a name that differs
+  from an existing entry only by case (or Unicode normalization form)
+  reports `ENOENT`, matching Linux semantics instead of APFS's folding.
 - Use `--create-sysroot PATH` if the host filesystem is case-insensitive
   (default APFS) and the sysroot is being provisioned for the first
   time; `elfuse` creates a case-sensitive APFS sparsebundle, mounts it

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -11,7 +11,7 @@
         test-matrix test-matrix-elfuse-aarch64 test-matrix-qemu-aarch64 \
         test-full test-multi-vcpu test-rwx test-sysroot-rename \
         test-case-collision test-case-collision-fallback test-getdents64-overlong \
-        test-sysroot-host-fallback \
+        test-sysroot-host-fallback test-sysroot-case-exact \
         test-sysroot-create-paths test-fork-ipc-protocol-host test-identity-override-host \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-timeout-disable test-fuse-alpine \
@@ -63,6 +63,8 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 	@$(MAKE) --no-print-directory test-getdents64-overlong
 	@printf "\n$(BLUE)━━━ sysroot host-fallback validation ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-sysroot-host-fallback
+	@printf "\n$(BLUE)━━━ sysroot byte-exact lookup validation ━━━$(RESET)\n"
+	@$(MAKE) --no-print-directory test-sysroot-case-exact
 	@printf "\n$(BLUE)━━━ Alpine sysroot FUSE validation ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-fuse-alpine
 	@printf "\n$(BLUE)━━━ timeout=0 validation ━━━$(RESET)\n"
@@ -154,6 +156,31 @@ test-sysroot-host-fallback: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-host-fallbac
 	$(ELFUSE_BIN) --sysroot "$$sysroot" \
 	    $(BUILD_DIR)/test-sysroot-host-fallback \
 	    "$$hostdir" "$$mirror/final.txt" "$$mirror/both.txt"
+
+## Wrong-case (and wrong-normalization) lookups must fail with ENOENT:
+## Linux treats names as byte strings, while APFS resolves them case- and
+## normalization-insensitively. The sidecar walk verifies the on-disk
+## spelling of every unmapped component instead of trusting the folded
+## probe. Stages exact-case fixtures host-side; the guest asserts folded
+## spellings do not resolve. The normalization probes require the sidecar,
+## so the guest skips them when the staging volume is case-sensitive.
+test-sysroot-case-exact: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-case-exact
+	@set -e; \
+	tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot/data/sub"; \
+	printf 'exact\n' > "$$sysroot/data/Makefile"; \
+	printf 'sub\n' > "$$sysroot/data/sub/f.txt"; \
+	printf 'nfc\n' > "$$sysroot/data/caf$$(printf '\303\251')"; \
+	mode=cs; \
+	if [ -e "$$sysroot/data/MAKEFILE" ]; then mode=ci; fi; \
+	$(ELFUSE_BIN) --sysroot "$$sysroot" \
+	    $(BUILD_DIR)/test-sysroot-case-exact "$$mode"; \
+	if [ ! -e "$$sysroot/data/Makefile" ]; then \
+		printf "$(RED)FAIL$(RESET) wrong-case op removed the exact entry\n"; \
+		exit 1; \
+	fi
 
 # Build APFS-side dirents whose UTF-8 byte length exceeds Linux
 # NAME_MAX (255). 89 copies of U+3042 (3-byte UTF-8) plus a 1-byte

--- a/src/syscall/sidecar.c
+++ b/src/syscall/sidecar.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/attr.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -565,6 +566,72 @@ static int sidecar_open_base(guest_fd_t dirfd,
     return *base_fd < 0 ? -1 : 0;
 }
 
+static int sidecar_exact_name_exists(int dirfd, const char *name);
+
+/* Verdicts for the byte-exact on-disk spelling probe. */
+typedef enum {
+    SIDECAR_NAME_ERROR = -1, /* probe failed, errno set */
+    SIDECAR_NAME_EXACT = 0,
+    SIDECAR_NAME_ABSENT = 1,
+    SIDECAR_NAME_CASEFOLD = 2,
+} sidecar_name_verdict_t;
+
+/* Probe whether @name exists in @dirfd spelled exactly as given. APFS and
+ * HFS+ resolve names case- and normalization-insensitively, so a plain
+ * openat/fstatat existence probe cannot tell "entry exists as spelled" from
+ * "entry exists under a folded spelling"; Linux path resolution is byte-exact
+ * and must report ENOENT for the latter. getattrlistat(ATTR_CMN_NAME) goes
+ * through the same folding lookup but returns the on-disk spelling for a
+ * byte comparison. FSOPT_NOFOLLOW keeps the probe on the entry itself so a
+ * symlink component is verified by its own name, not its target's. The name
+ * buffer covers the APFS maximum (255 UTF-16 units, up to 765 UTF-8 bytes),
+ * so a returned name never truncates into a false mismatch.
+ *
+ * Returns a SIDECAR_NAME_* verdict; SIDECAR_NAME_ERROR carries errno.
+ * Filesystems that do not return ATTR_CMN_NAME fall back to the readdir
+ * scan, with a folded fstatat to separate ABSENT from CASEFOLD.
+ */
+static sidecar_name_verdict_t sidecar_probe_exact_name(int dirfd,
+                                                       const char *name)
+{
+    struct attrlist al = {
+        .bitmapcount = ATTR_BIT_MAP_COUNT,
+        .commonattr = ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_NAME,
+    };
+    struct {
+        u_int32_t length;
+        attribute_set_t returned;
+        attrreference_t name_ref;
+        char name[768];
+    } __attribute__((aligned(4), packed)) attr_buf;
+
+    int rc = getattrlistat(dirfd, name, &al, &attr_buf, sizeof(attr_buf),
+                           FSOPT_NOFOLLOW);
+    if (rc == 0 && (attr_buf.returned.commonattr & ATTR_CMN_NAME)) {
+        const char *disk_name = (const char *) &attr_buf.name_ref +
+                                attr_buf.name_ref.attr_dataoffset;
+        return strcmp(disk_name, name) == 0 ? SIDECAR_NAME_EXACT
+                                            : SIDECAR_NAME_CASEFOLD;
+    }
+    if (rc < 0) {
+        if (errno == ENOENT || errno == ENOTDIR)
+            return SIDECAR_NAME_ABSENT;
+        if (errno != ENOTSUP && errno != EINVAL)
+            return SIDECAR_NAME_ERROR;
+    }
+
+    int exists = sidecar_exact_name_exists(dirfd, name);
+    if (exists < 0)
+        return SIDECAR_NAME_ERROR;
+    if (exists == 1)
+        return SIDECAR_NAME_EXACT;
+    struct stat st;
+    if (fstatat(dirfd, name, &st, AT_SYMLINK_NOFOLLOW) == 0)
+        return SIDECAR_NAME_CASEFOLD;
+    return (errno == ENOENT || errno == ENOTDIR) ? SIDECAR_NAME_ABSENT
+                                                 : SIDECAR_NAME_ERROR;
+}
+
 int sidecar_translate_lookup_at(guest_fd_t dirfd,
                                 const char *path,
                                 char *out,
@@ -691,22 +758,56 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
         while (*peek == '/')
             peek++;
         if (*peek == '\0') {
-            /* Final component: an unmapped walk is the identity translation
-             * ${sysroot}${path}; claim it only if the entry actually exists
-             * there so the resolver's host-literal fallback stands otherwise.
+            /* Final component. Index-mapped components are byte-exact by
+             * construction. An unmapped one must exist under its exact
+             * spelling: a folded match is a Linux ENOENT and must veto the
+             * resolver's host-literal fallback outright, which would fold the
+             * same way against the host tree. A genuinely absent entry defers
+             * to that fallback when no mapping was consulted, and under a
+             * mapped prefix keeps the translated path so the actual syscall
+             * surfaces ENOENT.
              */
-            if (!used_mapping) {
-                struct stat st;
-                if (fstatat(cur_fd, host_comp, &st, AT_SYMLINK_NOFOLLOW) < 0) {
+            if (!mapped) {
+                sidecar_name_verdict_t probe =
+                    sidecar_probe_exact_name(cur_fd, host_comp);
+                if (probe == SIDECAR_NAME_ERROR) {
                     int saved_errno = errno;
                     close(cur_fd);
-                    if (saved_errno == ENOENT || saved_errno == ENOTDIR)
-                        return 0;
                     errno = saved_errno;
                     return -1;
                 }
+                if (probe == SIDECAR_NAME_CASEFOLD) {
+                    close(cur_fd);
+                    errno = ENOENT;
+                    return -1;
+                }
+                if (probe == SIDECAR_NAME_ABSENT && !used_mapping) {
+                    close(cur_fd);
+                    return 0;
+                }
             }
             break;
+        }
+
+        /* Intermediate components resolve through openat, which folds case on
+         * APFS: reject folded matches here for the same reason as above.
+         * Absent entries proceed to the openat below, whose ENOENT handling
+         * distinguishes the fallback and mapped-prefix flows.
+         */
+        if (!mapped) {
+            sidecar_name_verdict_t probe =
+                sidecar_probe_exact_name(cur_fd, host_comp);
+            if (probe == SIDECAR_NAME_ERROR) {
+                int saved_errno = errno;
+                close(cur_fd);
+                errno = saved_errno;
+                return -1;
+            }
+            if (probe == SIDECAR_NAME_CASEFOLD) {
+                close(cur_fd);
+                errno = ENOENT;
+                return -1;
+            }
         }
 
         int next_fd =

--- a/tests/test-sysroot-case-exact.c
+++ b/tests/test-sysroot-case-exact.c
@@ -1,0 +1,133 @@
+/*
+ * Byte-exact lookup regression tests for case-insensitive sysroots
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Linux path resolution treats names as byte strings: a lookup whose spelling
+ * differs from the on-disk entry only by case (or Unicode normalization form)
+ * must fail with ENOENT. APFS resolves such lookups case- and
+ * normalization-insensitively, so on a case-insensitive sysroot the sidecar
+ * walk has to verify the on-disk spelling of every unmapped component instead
+ * of trusting the folded openat/fstatat probe. Read-path syscalls (stat, open,
+ * access) used to leak the folded match through; mutation syscalls already
+ * went through a byte-exact readdir check.
+ *
+ * The harness (mk/tests.mk) stages inside the sysroot, host-side:
+ *   /data/Makefile   ("exact\n")
+ *   /data/sub/f.txt  ("sub\n")
+ *   /data/caf\xc3\xa9  NFC spelling ("nfc\n")
+ * and passes argv[1] = "ci" when the sysroot volume is case-insensitive
+ * (sidecar active) or "cs" when it is case-sensitive. The wrong-case probes
+ * hold either way; the normalization probes only hold with the sidecar's
+ * byte-exact verification, so they are skipped under "cs" (APFS folds
+ * normalization even on case-sensitive volumes -- a documented limitation of
+ * running without the sidecar).
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+#include "test-util.h"
+
+#define NFC_NAME "/data/caf\xc3\xa9"  /* e-acute, U+00E9 */
+#define NFD_NAME "/data/cafe\xcc\x81" /* e + combining acute, U+0301 */
+
+int passes = 0, fails = 0;
+
+int main(int argc, char **argv)
+{
+    bool case_insensitive = argc > 1 && !strcmp(argv[1], "ci");
+    char buf[64];
+    struct stat st;
+
+    printf("test-sysroot-case-exact: byte-exact lookups (%s sysroot)\n",
+           case_insensitive ? "case-insensitive" : "case-sensitive");
+
+    TEST("exact spelling resolves");
+    if (read_file_nul("/data/Makefile", buf, sizeof(buf)) <= 0 ||
+        strcmp(buf, "exact\n"))
+        FAIL("exact-case read failed");
+    else
+        PASS();
+
+    TEST("stat wrong-case final");
+    EXPECT_ERRNO(stat("/data/MAKEFILE", &st), ENOENT, "folded stat leaked");
+
+    TEST("open wrong-case final");
+    EXPECT_ERRNO(open("/data/makefile", O_RDONLY), ENOENT,
+                 "folded open leaked");
+
+    TEST("access wrong-case final");
+    EXPECT_ERRNO(access("/data/mAkEfIlE", F_OK), ENOENT,
+                 "folded access leaked");
+
+    TEST("stat wrong-case intermediate");
+    EXPECT_ERRNO(stat("/DATA/Makefile", &st), ENOENT,
+                 "folded intermediate leaked");
+
+    TEST("open wrong-case intermediate");
+    EXPECT_ERRNO(open("/data/SUB/f.txt", O_RDONLY), ENOENT,
+                 "folded intermediate leaked");
+
+    TEST("unlink wrong-case is ENOENT");
+    EXPECT_ERRNO(unlink("/data/mAKEFILE"), ENOENT, "folded unlink leaked");
+
+    TEST("wrong-case unlink kept file");
+    if (stat("/data/Makefile", &st) < 0)
+        FAIL("exact entry vanished");
+    else
+        PASS();
+
+    TEST("rename wrong-case source");
+    EXPECT_ERRNO(rename("/data/MAKEfile", "/data/moved"), ENOENT,
+                 "folded rename leaked");
+
+    /* O_CREAT with a wrong-case spelling must create a second, distinct
+     * entry (Linux semantics), not fold onto the existing one.
+     */
+    TEST("wrong-case O_CREAT|O_EXCL succeeds");
+    {
+        int fd = open("/data/MAKEFILE", O_CREAT | O_EXCL | O_WRONLY, 0644);
+        if (fd < 0) {
+            FAIL("create folded onto existing entry");
+        } else {
+            if (write_fd_all(fd, "upper\n", 6) < 0)
+                FAIL("write failed");
+            else
+                PASS();
+            close(fd);
+        }
+    }
+
+    TEST("collision pair stays distinct");
+    if (read_file_nul("/data/Makefile", buf, sizeof(buf)) <= 0 ||
+        strcmp(buf, "exact\n"))
+        FAIL("original clobbered");
+    else if (read_file_nul("/data/MAKEFILE", buf, sizeof(buf)) <= 0 ||
+             strcmp(buf, "upper\n"))
+        FAIL("new spelling unreadable");
+    else
+        PASS();
+
+    if (case_insensitive) {
+        TEST("stat NFD form of NFC entry");
+        EXPECT_ERRNO(stat(NFD_NAME, &st), ENOENT, "normalization folded");
+
+        TEST("NFC spelling still resolves");
+        if (read_file_nul(NFC_NAME, buf, sizeof(buf)) <= 0 ||
+            strcmp(buf, "nfc\n"))
+            FAIL("NFC read failed");
+        else
+            PASS();
+    }
+
+    SUMMARY("test-sysroot-case-exact");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Linux path resolution treats file names as byte strings: a lookup whose spelling differs from an existing entry only by case (or Unicode normalization form) must fail with `ENOENT`. On a case-insensitive sysroot the sidecar walk probed existence with plain `openat`/`fstatat`, which APFS resolves case- and normalization-insensitively, so read-path syscalls leaked the folded match. With only `Makefile` staged in the sysroot:

```
stat("/data/MAKEFILE")   -> succeeds   (Linux: ENOENT)
open("/data/makefile")   -> opens Makefile
access("/data/mAkEfIlE") -> succeeds
open("/data/SUB/f.txt")  -> folds the intermediate directory
```

Mutating syscalls were already byte-exact through the sidecar's readdir probe, leaving the semantics asymmetric: `unlink` reported `ENOENT` on the very spelling `stat` had just confirmed. Real-world impact: any unpacked rootfs (literal names on disk) gives false positives to case-probing workloads — `make` finding `makefile` when only `Makefile` exists, configure-style existence probes, tools distinguishing `README`/`readme`.

### Fix

Probe every unmapped component of the walk with `getattrlistat(ATTR_CMN_NAME, FSOPT_NOFOLLOW)`: it resolves through the same folding lookup but returns the on-disk spelling for a byte comparison. `FSOPT_NOFOLLOW` pins the probe to the entry itself, so a symlink component is verified by its own name, not its target's.

- exact match — proceed as before;
- genuinely absent — keep the existing deferral flows (resolver host-literal fallback without a mapping, translated-path `ENOENT` beneath a mapped prefix, #118 semantics unchanged);
- folded match — `ENOENT` outright. The veto must bypass the resolver too, whose own `access()` existence probe folds the same way.

Index-mapped components stay unprobed (tokens resolve byte-exactly by construction), filesystems that do not return `ATTR_CMN_NAME` fall back to the readdir scan. Cost: the probe replaces the final-component `fstatat` one-for-one and adds one `getattrlistat` per unmapped intermediate component, only on case-insensitive sysroots; the hot-syscall guardrail stays green.

The byte comparison also rejects normalization-folded matches (NFD lookup of an NFC entry), which APFS folds even on case-*sensitive* volumes, so with the sidecar active those now fail with `ENOENT` and `O_CREAT|O_EXCL` of the other form creates a distinct entry.

### Scope

Lookups that leave the sysroot for the host-literal fallback keep host semantics — the sidecar cannot speak for entries it does not index, so case folding on the host tree itself remains reachable through that hatch (it is a host-resource escape by design). Case-sensitive sysroots (`--create-sysroot`) are unaffected: the sidecar is inactive there and APFS enforces case exactness natively; its normalization folding remains a known limitation of that mode.

### Testing

`test-sysroot-case-exact` stages exact-case fixtures host-side and asserts folded spellings do not resolve: wrong-case `stat`/`open`/`access`/`unlink`/`rename` on final and intermediate components, collision-pair creation via wrong-case `O_CREAT|O_EXCL`, and NFC/NFD probes; wired into `make check`. Without the fix six of its thirteen cases fail. Full `make check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sidecar lookups byte-exact on case-insensitive sysroots by verifying the on-disk spelling and returning ENOENT for case- or normalization-folded matches. This aligns stat/open/access with Linux and removes asymmetric behavior vs mutating syscalls.

- **Bug Fixes**
  - Probe each unmapped component with getattrlistat(ATTR_CMN_NAME, FSOPT_NOFOLLOW) and compare the returned name byte-for-byte; exact proceeds, folded returns ENOENT (vetoes resolver fallback), genuine absence keeps existing fallback flows.
  - Do not probe index-mapped components; fall back to a readdir scan when ATTR_CMN_NAME is unavailable; symlink components are validated by their own name.
  - Reject normalization folding (e.g., NFD vs NFC); O_CREAT|O_EXCL with the other form creates a distinct entry.
  - Add test-sysroot-case-exact and wire it into make check; update docs to note byte-exact lookup semantics.

<sup>Written for commit 800395657fb0aba4b5d4b12b77bf73ec122071e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

