### PR TITLE
Increase sys_execve limits MAX_ARGS and STR_BUF_SIZE

### DIFF
--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -100,7 +100,9 @@ static void exec_republish_shim_globals_or_die(hv_vcpu_t vcpu,
  * before crossing the point of no return. Used by both the Rosetta and the
  * aarch64 success paths.
  */
-static void exec_cleanup_inputs(char *argv_buf,
+static void exec_cleanup_inputs(char **argv,
+                                char **envp,
+                                char *argv_buf,
                                 char *envp_buf,
                                 const char *path_host_buf,
                                 bool path_host_temp,
@@ -111,6 +113,8 @@ static void exec_cleanup_inputs(char *argv_buf,
         unlink(path_host_buf);
     if (interp_host_temp)
         unlink(interp_host_buf);
+    free(argv);
+    free(envp);
     free(argv_buf);
     free(envp_buf);
 }
@@ -174,53 +178,99 @@ static int exec_resolve_interp_host_path(const char *sysroot,
 
 /* Read a NULL-terminated pointer array from guest memory. Each pointer in the
  * array is a 64-bit GVA pointing to a string.
- * Returns the count of entries (excluding the NULL terminator), or -1 on error.
- * Strings are copied into the provided buffer.
+ * Returns the count of entries (excluding the NULL terminator), or a negative
+ * error code: -1: EFAULT (guest read error) -2: E2BIG (exceeded limits) -3:
+ * ENOMEM (host out of memory)
+ *
+ * *out_argv will be set to a heap-allocated array of pointers, which must be
+ * freed by caller. *out_buf will be set to a heap-allocated buffer containing
+ * all the strings, which must be freed by caller.
  */
 static int read_string_array(guest_t *g,
                              uint64_t array_gva,
-                             char **out,
-                             int max_count,
-                             char *str_buf,
-                             size_t str_buf_size)
+                             char ***out_argv,
+                             char **out_buf,
+                             size_t *out_buf_size,
+                             char *temp_str,
+                             size_t *running_bytes)
 {
-    size_t str_off = 0;
     int count = 0;
-
-    for (int i = 0; i < max_count; i++) {
+    while (true) {
         uint64_t ptr;
-        if (guest_read_small(g, array_gva + (uint64_t) i * 8, &ptr,
+        if (guest_read_small(g, array_gva + (uint64_t) count * 8, &ptr,
                              sizeof(ptr)) < 0)
             return -1;
         if (ptr == 0)
             break;
-
-        char *dst = str_buf + str_off;
-        size_t remaining = str_buf_size - str_off;
-        if (remaining < 2)
-            return -1;
-
-        if (guest_read_str(g, ptr, dst, remaining) < 0)
-            return -1;
-
-        out[count] = dst;
-        str_off += strlen(dst) + 1;
         count++;
+        if (count > 131072)
+            return -2;
     }
 
-    /* If all max_count slots are consumed, check whether the array continues
-     * (non-NULL next entry).
-     *
-     * Return -2 to signal E2BIG rather than silently truncating.
-     */
-    if (count == max_count) {
-        uint64_t next;
-        if (guest_read_small(g, array_gva + (uint64_t) count * 8, &next,
-                             sizeof(next)) == 0 &&
-            next != 0)
-            return -2; /* too many entries */
+    char **argv = malloc(sizeof(char *) * (count + 1));
+    if (!argv)
+        return -3;
+
+    size_t buf_size = 4096;
+    char *buf = malloc(buf_size);
+    if (!buf) {
+        free(argv);
+        return -3;
     }
 
+    size_t buf_off = 0;
+    for (int i = 0; i < count; i++) {
+        uint64_t ptr;
+        if (guest_read_small(g, array_gva + (uint64_t) i * 8, &ptr,
+                             sizeof(ptr)) < 0) {
+            free(argv);
+            free(buf);
+            return -1;
+        }
+
+        int rc = guest_read_str(g, ptr, temp_str, 131072);
+        if (rc < 0) {
+            size_t temp_len = strlen(temp_str);
+            free(argv);
+            free(buf);
+            return (temp_len >= 131072 - 1) ? -2 : -1;
+        }
+
+        size_t len = (size_t) rc;
+
+        if (*running_bytes + len + 1 > 2048 * 1024) {
+            free(argv);
+            free(buf);
+            return -2;
+        }
+
+        if (buf_off + len + 1 > buf_size) {
+            size_t new_size = (buf_off + len + 1 + 4095) & ~4095ULL;
+            char *new_buf = realloc(buf, new_size);
+            if (!new_buf) {
+                free(argv);
+                free(buf);
+                return -3;
+            }
+            if (new_buf != buf) {
+                ptrdiff_t diff = new_buf - buf;
+                for (int j = 0; j < i; j++)
+                    argv[j] += diff;
+                buf = new_buf;
+            }
+            buf_size = new_size;
+        }
+
+        memcpy(buf + buf_off, temp_str, len + 1);
+        argv[i] = buf + buf_off;
+        buf_off += len + 1;
+        *running_bytes += len + 1;
+    }
+
+    argv[count] = NULL;
+    *out_argv = argv;
+    *out_buf = buf;
+    *out_buf_size = buf_size;
     return count;
 }
 
@@ -255,38 +305,39 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     char interp_host_buf[LINUX_PATH_MAX];
     bool interp_host_temp = false;
 
-#define MAX_ARGS 256
-#define MAX_ENVS 4096
-#define STR_BUF_SIZE ((size_t) 256 * 1024)
-
     int64_t err = 0;
-    char *argv[MAX_ARGS + 1];
-    char *envp[MAX_ENVS + 1];
-    char *argv_buf = malloc(STR_BUF_SIZE);
-    char *envp_buf = malloc(STR_BUF_SIZE);
-    if (!argv_buf || !envp_buf) {
+    char **argv = NULL;
+    char **envp = NULL;
+    char *argv_buf = NULL;
+    char *envp_buf = NULL;
+    size_t argv_buf_size = 0;
+    size_t envp_buf_size = 0;
+    size_t running_bytes = 0;
+
+    char *temp_str = malloc(131072);
+    if (!temp_str) {
         err = -LINUX_ENOMEM;
         goto fail;
     }
 
-    int argc =
-        read_string_array(g, argv_gva, argv, MAX_ARGS, argv_buf, STR_BUF_SIZE);
+    int argc = read_string_array(g, argv_gva, &argv, &argv_buf, &argv_buf_size,
+                                 temp_str, &running_bytes);
     if (argc < 0) {
-        err = (argc == -2) ? -LINUX_E2BIG : -LINUX_EFAULT;
+        err = (argc == -2) ? -LINUX_E2BIG
+                           : ((argc == -3) ? -LINUX_ENOMEM : -LINUX_EFAULT);
         goto fail;
     }
-    argv[argc] = NULL;
 
     int envc = 0;
     if (envp_gva != 0) {
-        envc = read_string_array(g, envp_gva, envp, MAX_ENVS, envp_buf,
-                                 STR_BUF_SIZE);
+        envc = read_string_array(g, envp_gva, &envp, &envp_buf, &envp_buf_size,
+                                 temp_str, &running_bytes);
         if (envc < 0) {
-            err = (envc == -2) ? -LINUX_E2BIG : -LINUX_EFAULT;
+            err = (envc == -2) ? -LINUX_E2BIG
+                               : ((envc == -3) ? -LINUX_ENOMEM : -LINUX_EFAULT);
             goto fail;
         }
     }
-    envp[envc] = NULL;
 
     /* Resolve /proc/self/exe to the actual binary path. Busybox sh execs
      * applets via execve("/proc/self/exe", ["applet", ...]) and macOS has no
@@ -364,15 +415,17 @@ int64_t sys_execve(hv_vcpu_t vcpu,
          * original-argv[1:]]
          */
         int prefix = (has_arg ? 2 : 1) + 1;
-        if (argc > MAX_ARGS - prefix + 1) {
+        if (argc + prefix - 1 > 131072) {
             err = -LINUX_E2BIG;
             goto fail;
         }
-        /* Use a fixed-size stack array (MAX_ARGS+3 covers interpreter +
-         * optional arg + script + original argv[1:]).
-         */
-        char *new_argv[MAX_ARGS + 3];
         int ni = 0;
+        int new_cap = argc + prefix;
+        char **new_argv = malloc(sizeof(char *) * (new_cap + 1));
+        if (!new_argv) {
+            err = -LINUX_ENOMEM;
+            goto fail;
+        }
         new_argv[ni++] = interp_start;
         if (has_arg)
             new_argv[ni++] = interp_arg;
@@ -393,17 +446,34 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         int prefix_end = ni - (argc > 1 ? argc - 1 : 0);
         for (int i = 0; i < prefix_end; i++) {
             size_t len = strlen(new_argv[i]);
-            if (buf_off + len + 1 > STR_BUF_SIZE) {
+            if (running_bytes + len + 1 > 2048 * 1024) {
+                free(new_argv);
                 err = -LINUX_E2BIG;
                 goto fail;
             }
+            if (buf_off + len + 1 > argv_buf_size) {
+                size_t new_size = (buf_off + len + 1 + 4095) & ~4095ULL;
+                char *new_buf = realloc(argv_buf, new_size);
+                if (!new_buf) {
+                    free(new_argv);
+                    err = -LINUX_ENOMEM;
+                    goto fail;
+                }
+                if (new_buf != argv_buf) {
+                    ptrdiff_t diff = new_buf - argv_buf;
+                    for (int j = prefix_end; j < ni; j++)
+                        new_argv[j] += diff;
+                    argv_buf = new_buf;
+                }
+                argv_buf_size = new_size;
+            }
             memcpy(argv_buf + buf_off, new_argv[i], len + 1);
-            argv[i] = argv_buf + buf_off;
+            new_argv[i] = argv_buf + buf_off;
             buf_off += len + 1;
+            running_bytes += len + 1;
         }
-        for (int i = prefix_end; i < ni; i++)
-            argv[i] = new_argv[i];
-        argv[ni] = NULL;
+        free(argv);
+        argv = new_argv;
         argc = ni;
 
         /* Continue the same exec transaction using the interpreter image. */
@@ -536,8 +606,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
      */
     if (0) {
     fail:
-        exec_cleanup_inputs(argv_buf, envp_buf, path_host_buf, path_host_temp,
-                            interp_host_buf, interp_host_temp);
+        free(temp_str);
+        exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
+                            path_host_temp, interp_host_buf, interp_host_temp);
         return err;
     }
 
@@ -754,8 +825,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
 
         log_debug("execve: rosetta target %s, entry=0x%llx sp=0x%llx", path,
                   (unsigned long long) entry_ipa, (unsigned long long) sp_ipa);
-        exec_cleanup_inputs(argv_buf, envp_buf, path_host_buf, path_host_temp,
-                            interp_host_buf, interp_host_temp);
+        free(temp_str);
+        exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
+                            path_host_temp, interp_host_buf, interp_host_temp);
         return SYSCALL_EXEC_HAPPENED;
     }
 
@@ -1063,8 +1135,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     log_debug("execve: loaded %s, entry=0x%llx sp=0x%llx", path_host,
               (unsigned long long) entry_ipa, (unsigned long long) sp_ipa);
 
-    exec_cleanup_inputs(argv_buf, envp_buf, path_host_buf, path_host_temp,
-                        interp_host_buf, interp_host_temp);
+    free(temp_str);
+    exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
+                        path_host_temp, interp_host_buf, interp_host_temp);
 
     return SYSCALL_EXEC_HAPPENED;
 
@@ -1075,7 +1148,3 @@ too_many_regions:
         MAX_REGIONS);
     exit(128);
 }
-
-#undef MAX_ARGS
-#undef MAX_ENVS
-#undef STR_BUF_SIZE

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -30,6 +30,7 @@ test-comprehensive
 
 [section] Process tests
 test-exec $TESTDIR/echo-test exec-works
+test-exec-limits
 test-fork
 test-session
 test-pidfd                         # diff=skip

--- a/tests/test-exec-limits.c
+++ b/tests/test-exec-limits.c
@@ -1,0 +1,118 @@
+/*
+ * Test execve() limits (MAX_ARG_STRLEN and ARG_MAX)
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+int main(int argc, char **argv)
+{
+    if (argc > 1 && strcmp(argv[1], "success-case") == 0) {
+        printf("exec-limits-passed\n");
+        return 0;
+    }
+
+    extern char **environ;
+
+    // 1. Test single string too long (> 128 KB) -> expect E2BIG
+    {
+        size_t size = 130 * 1024;
+        char *huge_arg = malloc(size);
+        if (!huge_arg) {
+            perror("malloc");
+            return 1;
+        }
+        memset(huge_arg, 'a', size - 1);
+        huge_arg[size - 1] = '\0';
+
+        char *new_argv[] = {argv[0], huge_arg, NULL};
+        execve(argv[0], new_argv, environ);
+
+        if (errno != E2BIG) {
+            fprintf(stderr,
+                    "Expected E2BIG for >128KB single argument, got errno %d "
+                    "(%s)\n",
+                    errno, strerror(errno));
+            free(huge_arg);
+            return 1;
+        }
+        free(huge_arg);
+    }
+
+    // 2. Test total byte budget exceeded (> 2 MB) -> expect E2BIG
+    {
+        // 22 strings of 100 KB each is ~2.2 MB (exceeds 2 MB ARG_MAX limit)
+        int num_args = 22;
+        size_t arg_size = 100 * 1024;
+        char **new_argv = calloc(num_args + 2, sizeof(char *));
+        if (!new_argv) {
+            perror("calloc");
+            return 1;
+        }
+        new_argv[0] = argv[0];
+        for (int i = 0; i < num_args; i++) {
+            new_argv[i + 1] = malloc(arg_size);
+            if (!new_argv[i + 1]) {
+                perror("malloc");
+                return 1;
+            }
+            memset(new_argv[i + 1], 'b', arg_size - 1);
+            new_argv[i + 1][arg_size - 1] = '\0';
+        }
+        new_argv[num_args + 1] = NULL;
+
+        execve(argv[0], new_argv, environ);
+
+        if (errno != E2BIG) {
+            fprintf(stderr,
+                    "Expected E2BIG for >2MB total argument list, got errno %d "
+                    "(%s)\n",
+                    errno, strerror(errno));
+            return 1;
+        }
+
+        for (int i = 0; i < num_args; i++) {
+            free(new_argv[i + 1]);
+        }
+        free(new_argv);
+    }
+
+    // 3. Test success case (large arguments under 2 MB limit) -> expect success
+    {
+        // 12 strings of 100 KB each is ~1.2 MB
+        int num_args = 12;
+        size_t arg_size = 100 * 1024;
+        char **new_argv = calloc(num_args + 3, sizeof(char *));
+        if (!new_argv) {
+            perror("calloc");
+            return 1;
+        }
+        new_argv[0] = argv[0];
+        new_argv[1] = "success-case";
+        for (int i = 0; i < num_args; i++) {
+            new_argv[i + 2] = malloc(arg_size);
+            if (!new_argv[i + 2]) {
+                perror("malloc");
+                return 1;
+            }
+            memset(new_argv[i + 2], 'c', arg_size - 1);
+            new_argv[i + 2][arg_size - 1] = '\0';
+        }
+        new_argv[num_args + 2] = NULL;
+
+        execve(argv[0], new_argv, environ);
+
+        // If execve returns, it failed
+        perror("execve success-case failed");
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
MAX_ARGS: Increased from 256 to 4096 arguments.

STR_BUF_SIZE: Increased from 256 KB to 2 MB
(2048 * 1024 bytes).

fix #125

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use heap allocations for sys_execve argv/envp to avoid stack overflows and align limits with Linux, fixing #125. Enforces 128 KB per-arg (MAX_ARG_STRLEN) and 2 MB total (ARG_MAX) across argv/envp with correct E2BIG errors, and adds boundary tests.

<sup>Written for commit ffd68837c55f83dacc43284b78271e532c3677b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

