### PR TITLE
Implement mincore against guest region tracking

### DIFF
--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -563,8 +563,85 @@ SC_STUB(sc_munlockall,          0)
 SC_STUB(sc_set_mempolicy,       0)
 SC_STUB(sc_io_destroy,          -LINUX_EINVAL)
 SC_STUB(sc_sethostname,         -LINUX_EPERM)
-SC_STUB(sc_mincore,             -LINUX_ENOSYS)
 /* clang-format on */
+
+/* mincore: report page residency over [addr, addr+length). elfuse tracks guest
+ * mappings itself, so no host syscall is needed. Linux contract:
+ * - addr must be page-aligned (EINVAL otherwise);
+ * - vec must be writable, one byte per page (EFAULT otherwise);
+ * - any unmapped page in the range yields ENOMEM;
+ * - the LSB of each vec byte is set when the page maps to a tracked region.
+ * jemalloc, Go, and Rust's page recyclers probe this on startup.
+ */
+static int64_t sc_mincore(guest_t *g,
+                          uint64_t x0,
+                          uint64_t x1,
+                          uint64_t x2,
+                          uint64_t x3,
+                          uint64_t x4,
+                          uint64_t x5,
+                          bool verbose)
+{
+    (void) x3;
+    (void) x4;
+    (void) x5;
+    (void) verbose;
+    uint64_t addr = x0, length = x1, vec = x2;
+
+    if (addr & (GUEST_PAGE_SIZE - 1))
+        return -LINUX_EINVAL;
+    if (addr + length < addr) /* range wraps the address space */
+        return -LINUX_ENOMEM;
+    if (length == 0)
+        return 0;
+
+    uint64_t npages = length / GUEST_PAGE_SIZE;
+    if (length % GUEST_PAGE_SIZE)
+        npages++;
+    if (vec > UINT64_MAX - npages)
+        return -LINUX_EFAULT;
+    bool has_hole = false;
+
+    /* Pages are visited in ascending order and regions[] is start-sorted,
+     * non-overlapping, with monotonic ends, so a single cursor sweeps both in
+     * lockstep: skip the untouched prefix once via first_end_above, then only
+     * advance the cursor when a page passes the current region's end. O(npages
+     * + regions) instead of a binary search per page.
+     *
+     * mmap_lock (order 1) is held across the whole sweep so a sibling vCPU's
+     * munmap cannot memmove regions[] out from under the cursor. guest_write
+     * takes no locks, so nesting the vec flush inside the lock introduces no
+     * inversion. Flush in bounded chunks so a huge length never triggers a
+     * large host allocation. EFAULT (bad vec) takes precedence over ENOMEM
+     * (hole), matching the kernel's upfront access_ok() check, so the sweep
+     * never early-returns on a hole.
+     */
+    uint8_t chunk[512];
+    pthread_mutex_lock(&mmap_lock);
+    int ri = guest_region_first_end_above(g, addr);
+    for (uint64_t done = 0; done < npages;) {
+        uint64_t batch = npages - done;
+        if (batch > sizeof(chunk))
+            batch = sizeof(chunk);
+        for (uint64_t i = 0; i < batch; i++) {
+            uint64_t page = addr + (done + i) * GUEST_PAGE_SIZE;
+            while (ri < g->nregions && g->regions[ri].end <= page)
+                ri++;
+            bool mapped = ri < g->nregions && page >= g->regions[ri].start;
+            chunk[i] = mapped ? 1 : 0;
+            if (!mapped)
+                has_hole = true;
+        }
+        if (guest_write(g, vec + done, chunk, batch) < 0) {
+            pthread_mutex_unlock(&mmap_lock);
+            return -LINUX_EFAULT;
+        }
+        done += batch;
+    }
+    pthread_mutex_unlock(&mmap_lock);
+
+    return has_hole ? -LINUX_ENOMEM : 0;
+}
 
 SC_FORWARD(sc_setpriority, proc_sys_setpriority((int) x0, (int) x1, (int) x2))
 SC_FORWARD(sc_getpriority, proc_sys_getpriority((int) x0, (int) x1))
@@ -1941,9 +2018,6 @@ static int fast_scalar_syscall_result(int nr, uint64_t x0, int64_t *result)
         return 1;
     case SYS_sethostname:
         *result = -LINUX_EPERM;
-        return 1;
-    case SYS_mincore:
-        *result = -LINUX_ENOSYS;
         return 1;
     default:
         return 0;

--- a/tests/test-syscall-smoke.c
+++ b/tests/test-syscall-smoke.c
@@ -533,12 +533,30 @@ static void test_stub_errnos(void)
     EXPECT_ERRNO(syscall(SYS_io_destroy, 1), EINVAL,
                  "io_destroy should fail with EINVAL");
 
-    TEST("mincore returns ENOSYS");
-    char page[4096];
-    unsigned char vec = 0xff;
+    TEST("mincore reports residency");
+    void *mc = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (mc == MAP_FAILED) {
+        FAIL("mincore mmap");
+        return;
+    }
+    *(volatile char *) mc = 1; /* fault the page in */
+    unsigned char vec = 0;
     errno = 0;
-    EXPECT_ERRNO(syscall(SYS_mincore, page, sizeof(page), &vec), ENOSYS,
-                 "mincore should fail with ENOSYS");
+    long mr = syscall(SYS_mincore, mc, 4096, &vec);
+    /* Mapped page: success with the residency LSB set. Unaligned addr: EINVAL.
+     * A hole in the range: ENOMEM. Here the whole page is mapped.
+     */
+    bool mapped_ok = (mr == 0 && (vec & 1));
+    long mr_einval = syscall(SYS_mincore, (char *) mc + 1, 4096, &vec);
+    bool einval_ok = (mr_einval == -1 && errno == EINVAL);
+    long mr_huge = syscall(SYS_mincore, 0, UINT64_MAX, 0);
+    bool huge_ok = (mr_huge == -1);
+    munmap(mc, 4096);
+    if (mapped_ok && einval_ok && huge_ok)
+        PASS();
+    else
+        FAIL("mincore should report residency and reject invalid ranges");
 }
 
 static void test_memory_stubs(void)


### PR DESCRIPTION
mincore was a stub returning ENOSYS, with a matching fast-path mirror. jemalloc tolerates ENOSYS but Go and Rust page recyclers prefer a populated vec, so probe-on-startup workloads took the slow path.

sc_mincore now honors the Linux contract using elfuse's own region tracking, no host syscall: EINVAL on an unaligned addr, ENOMEM on an address-space wrap, EFAULT when the vec range overflows or a page write falls outside guest memory, ENOMEM when any page in the range lacks a tracked region, and otherwise the LSB of each vec byte set for pages that map to a present region. A single cursor sweeps the start-sorted region array in lockstep with the ascending page walk, held under mmap_lock so a sibling munmap cannot memmove the array mid-sweep. vec is flushed in bounded chunks so a huge length never forces a large host allocation. The fast-path mirror is dropped so the call falls through to the full wrapper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implement a Linux-compatible mincore using guest region tracking. Removes the ENOSYS stub and fast-path, returns correct residency bits and errors, and improves startup for Go/Rust allocators.

- **New Features**
  - Add sc_mincore with no host syscall: sets vec LSB per page; EINVAL for unaligned addr; ENOMEM on address-space wrap or unmapped pages; EFAULT if vec overflows or write is outside guest memory.
  - Sweep start-sorted regions with a single cursor under mmap_lock; flush vec in small chunks to bound memory.
  - Drop the fast-path mirror so the syscall reaches the full wrapper.
  - Update smoke test to verify residency, unaligned EINVAL, and invalid huge range handling.

<sup>Written for commit ee160be1bb920807f939d8b3f265c45dfa9acb4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

