### PR TITLE
Add Infer static analysis job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,11 @@
 # Build elfuse and run the lint + analysis suites.
 #
-# Four jobs run in parallel:
+# Five jobs run in parallel:
 #   lint        : format/newline/security/cppcheck/dispatch on Linux
 #   build-macos : compile + entitlement check on macOS Apple Silicon
 #   tidy-macos  : clang-tidy via `make lint`
 #   scan-macos  : LLVM scan-build via `make analyze`
+#   infer-macos : Facebook Infer capture + analyze over the full build
 #
 # Runtime tests (test-hello, make check, test-multi-vcpu) require
 # Hypervisor.framework, which GitHub-hosted macOS runners do not expose
@@ -52,7 +53,7 @@ jobs:
       LINT_PKGS: clang-format-22 cppcheck shellcheck
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache apt packages
         uses: actions/cache@v5
@@ -125,7 +126,7 @@ jobs:
       BREW_PKGS: binutils
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache Homebrew downloads
         # No restore-keys: a partial match would mask upstream regressions.
@@ -185,7 +186,7 @@ jobs:
       CLANG_TIDY: /opt/homebrew/opt/llvm/bin/clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache Homebrew downloads
         uses: actions/cache@v5
@@ -224,7 +225,7 @@ jobs:
       LLVM_BIN: /opt/homebrew/opt/llvm/bin
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache Homebrew downloads
         uses: actions/cache@v5
@@ -259,3 +260,56 @@ jobs:
           path: build/scan-build
           retention-days: 7
           if-no-files-found: ignore
+
+  # Facebook Infer over the full elfuse build. Must run on macOS Apple
+  # Silicon because the build needs Hypervisor.framework and -arch arm64;
+  # Infer captures the real clang invocations, so it sees every TU.
+  #
+  # Advisory, matching tidy-macos/scan-macos: findings land in the uploaded
+  # report but do not gate the job. To make Infer gate, add --fail-on-issue
+  # to the `infer run` invocation below.
+  infer-macos:
+    name: Infer (macOS Apple Silicon)
+    runs-on: macos-15
+    timeout-minutes: 25
+    env:
+      GNU_OBJCOPY: /opt/homebrew/opt/binutils/bin/objcopy
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      BREW_PKGS: binutils
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Cache Homebrew downloads
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: brew-${{ runner.os }}-${{ runner.arch }}-${{ env.BREW_PKGS }}
+
+      - name: Install GNU objcopy
+        # shellcheck disable=SC2086 -- BREW_PKGS is a space-separated list.
+        run: |
+          set -euo pipefail
+          brew install --quiet $BREW_PKGS
+          "$GNU_OBJCOPY" --version | head -1
+
+      - name: Setup Infer
+        # Pinned so a new upstream release cannot silently change findings.
+        uses: srz-zumix/setup-infer@v1
+        with:
+          infer_version: v1.3.0
+
+      - name: Infer capture + analyze (make -B elfuse)
+        # -B forces a clean rebuild so Infer captures every translation unit.
+        # Non-C build steps (shim.S assembly, objcopy) pass through untouched.
+        run: infer run --keep-going -- make -B elfuse
+
+      - name: Upload Infer report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: infer-${{ runner.os }}-${{ runner.arch }}
+          path: infer-out/report.txt
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,8 @@ jobs:
           "$GNU_OBJCOPY" --version | head -1
 
       - name: Setup Infer
-        # Pinned so a new upstream release cannot silently change findings.
+        # Pinned to a full commit SHA so the third-party action cannot run
+        # different code over time; v1.3.0 pins the Infer binary itself.
         uses: srz-zumix/setup-infer@v1
         with:
           infer_version: v1.3.0
@@ -303,7 +304,17 @@ jobs:
       - name: Infer capture + analyze (make -B elfuse)
         # -B forces a clean rebuild so Infer captures every translation unit.
         # Non-C build steps (shim.S assembly, objcopy) pass through untouched.
-        run: infer run --keep-going -- make -B elfuse
+        # --keep-going tolerates a frontend failure on an odd TU, but that
+        # can also mask a total capture miss (wrapper never intercepts clang,
+        # 0 files analyzed, job passes vacuously). Assert the captured count
+        # is non-zero so a silent no-op fails the job instead.
+        run: |
+          set -euo pipefail
+          infer run --keep-going -- make -B elfuse 2>&1 | tee infer-run.log
+          n=$(grep -oE 'Found [0-9]+ source file' infer-run.log \
+              | grep -oE '[0-9]+' | tail -1 || true)
+          echo "Infer captured ${n:-0} source files"
+          test "${n:-0}" -gt 0
 
       - name: Upload Infer report
         if: ${{ !cancelled() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,9 +265,10 @@ jobs:
   # Silicon because the build needs Hypervisor.framework and -arch arm64;
   # Infer captures the real clang invocations, so it sees every TU.
   #
-  # Advisory, matching tidy-macos/scan-macos: findings land in the uploaded
-  # report but do not gate the job. To make Infer gate, add --fail-on-issue
-  # to the `infer run` invocation below.
+  # Gating (unlike tidy-macos/scan-macos): a separate step turns Infer's
+  # report.json into inline ::error:: annotations plus a job summary, then
+  # fails the job. Findings surface on the PR instead of a silent exit code,
+  # so bugs are pruned at PR time instead of merged.
   infer-macos:
     name: Infer (macOS Apple Silicon)
     runs-on: macos-15
@@ -295,8 +296,8 @@ jobs:
           "$GNU_OBJCOPY" --version | head -1
 
       - name: Setup Infer
-        # Pinned to a full commit SHA so the third-party action cannot run
-        # different code over time; v1.3.0 pins the Infer binary itself.
+        # infer_version pins the Infer binary; the action itself tracks the v1
+        # tag.
         uses: srz-zumix/setup-infer@v1
         with:
           infer_version: v1.3.0
@@ -304,10 +305,11 @@ jobs:
       - name: Infer capture + analyze (make -B elfuse)
         # -B forces a clean rebuild so Infer captures every translation unit.
         # Non-C build steps (shim.S assembly, objcopy) pass through untouched.
-        # --keep-going tolerates a frontend failure on an odd TU, but that
-        # can also mask a total capture miss (wrapper never intercepts clang,
-        # 0 files analyzed, job passes vacuously). Assert the captured count
-        # is non-zero so a silent no-op fails the job instead.
+        # No --fail-on-issue here: `infer run` must exit 0 so the reporting
+        # step below runs and surfaces findings before the job fails.
+        # --keep-going tolerates a frontend failure on an odd TU, but that can
+        # also mask a total capture miss (wrapper never intercepts clang, 0
+        # files analyzed). The count guard fails the job on that silent no-op.
         run: |
           set -euo pipefail
           infer run --keep-going -- make -B elfuse 2>&1 | tee infer-run.log
@@ -315,6 +317,13 @@ jobs:
               | grep -oE '[0-9]+' | tail -1 || true)
           echo "Infer captured ${n:-0} source files"
           test "${n:-0}" -gt 0
+
+      - name: Report Infer findings
+        # Emit GitHub annotations + a job summary from report.json, then exit
+        # non-zero if any finding exists. Runs even when a prior step failed so
+        # a partial report is still surfaced.
+        if: ${{ !cancelled() }}
+        run: python3 scripts/infer-annotate.py infer-out/report.json
 
       - name: Upload Infer report
         if: ${{ !cancelled() }}

--- a/scripts/infer-annotate.py
+++ b/scripts/infer-annotate.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Surface Infer findings to GitHub Actions.
+
+Reads an Infer report.json and emits one ::error:: workflow command per
+finding so each shows up as an inline annotation on the pull request, appends
+a Markdown table to $GITHUB_STEP_SUMMARY when that variable is set, and exits
+non-zero when any finding is present so the job fails after the findings have
+been surfaced (rather than dying silently on a raw exit code).
+
+An empty report ("[]") exits 0.
+
+Self-test: python3 scripts/infer-annotate.py --selftest
+"""
+
+import json
+import os
+import sys
+
+
+def escape(msg):
+    # GitHub annotation messages are single-line; encode the separators the
+    # workflow-command parser treats specially.
+    return msg.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def annotations(findings):
+    out = []
+    for f in findings:
+        detail = f.get("qualifier") or f.get("bug_type") or "issue"
+        out.append(
+            "::error file=%s,line=%s,title=Infer %s::%s"
+            % (
+                f.get("file", ""),
+                f.get("line", 0),
+                f.get("bug_type", ""),
+                escape(detail),
+            )
+        )
+    return out
+
+
+def summary(findings):
+    if not findings:
+        return "## Infer\n\nNo findings.\n"
+    rows = [
+        "## Infer findings (%d)\n" % len(findings),
+        "| Type | Location | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for f in findings:
+        detail = (f.get("qualifier", "") or "").replace("\n", " ").replace("|", "\\|")
+        rows.append(
+            "| %s | %s:%s | %s |"
+            % (f.get("bug_type", "?"), f.get("file", "?"), f.get("line", 0), detail)
+        )
+    return "\n".join(rows) + "\n"
+
+
+def selftest():
+    sample = [
+        {
+            "file": "a.c",
+            "line": 5,
+            "bug_type": "NULL_DEREFERENCE",
+            "qualifier": "x is\nnull",
+        }
+    ]
+    ann = annotations(sample)
+    assert ann[0].startswith("::error file=a.c,line=5,title=Infer "), ann
+    assert "%0A" in ann[0] and "NULL_DEREFERENCE" in ann[0], ann
+    assert "NULL_DEREFERENCE" in summary(sample)
+    assert summary([]).strip().endswith("No findings.")
+    assert annotations([]) == []
+    print("selftest ok")
+    return 0
+
+
+def main(argv):
+    if "--selftest" in argv:
+        return selftest()
+    path = argv[1] if len(argv) > 1 else "infer-out/report.json"
+    if not os.path.exists(path):
+        # The capture step failed before Infer wrote a report; that failure is
+        # already surfaced, so do not add a traceback on top of it.
+        print("::warning::%s missing; Infer produced no report" % path)
+        return 0
+    with open(path) as fh:
+        findings = json.load(fh)
+
+    for line in annotations(findings):
+        print(line)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as fh:
+            fh.write(summary(findings))
+
+    if findings:
+        print("Infer reported %d issue(s)" % len(findings), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/core/rosetta.c
+++ b/src/core/rosetta.c
@@ -408,7 +408,7 @@ int rosetta_finalize(guest_t *g,
      * failure before commit goes through the fail label and tears down only the
      * host-local resources allocated so far.
      */
-    int bin_host_fd = -1;
+    int bin_host_fd;
     const char **rosetta_argv = NULL;
     int rosetta_argc = 0;
 
@@ -718,65 +718,43 @@ static ssize_t rosettad_recv_fd(int sock, void *buf, size_t buflen, int *out_fd)
     if (n <= 0)
         return n;
 
-    /* Walk every cmsg first, closing kernel-allocated fds in malformed or extra
-     * payloads. Defer the MSG_CTRUNC bailout until after the walk so fds that
-     * fit in cmsg_buf are closed instead of leaked into the elfuse process.
-     * cmsg_len is validated against CMSG_LEN(0) before any payload arithmetic
-     * to keep a hostile peer from underflowing the size_t.
+    /* Take ownership of every fd the kernel delivered so none leak, then accept
+     * only the exact single-fd case. cmsg_buf is CMSG_SPACE(sizeof(int)): one
+     * fd on macOS, but CMSG alignment lets an LP64 kernel pack two into the
+     * same space, so read into distinct slots and close any surplus on reject.
      */
-    int n_rights = 0;
-    bool malformed = false;
-    for (struct cmsghdr *c = CMSG_FIRSTHDR(&msg); c; c = CMSG_NXTHDR(&msg, c)) {
-        if (c->cmsg_level != SOL_SOCKET || c->cmsg_type != SCM_RIGHTS) {
-            malformed = true;
-            continue;
-        }
-        /* cmsg_len must cover at least the cmsghdr header; the macro captures
-         * any alignment padding the platform inserts. Anything smaller is
-         * structurally invalid and the payload arithmetic below would underflow
-         * into a huge size_t.
+    int fds[sizeof(cmsg_buf) / sizeof(int)];
+    size_t nfd = 0;
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (cmsg && cmsg->cmsg_level == SOL_SOCKET &&
+        cmsg->cmsg_type == SCM_RIGHTS && cmsg->cmsg_len >= CMSG_LEN(0)) {
+        size_t payload = cmsg->cmsg_len - CMSG_LEN(0);
+        /* Cap by the fds that actually fit after the header so a corrupt
+         * cmsg_len cannot drive the memcpy source past the end of cmsg_buf.
          */
-        if (c->cmsg_len < CMSG_LEN(0)) {
-            malformed = true;
-            continue;
-        }
-        size_t payload = c->cmsg_len - CMSG_LEN(0);
-        if (payload % sizeof(int) != 0) {
-            malformed = true;
-            continue;
-        }
-        size_t nfd = payload / sizeof(int);
-        for (size_t i = 0; i < nfd; i++) {
-            int fd;
-            memcpy(&fd, (uint8_t *) CMSG_DATA(c) + i * sizeof(int), sizeof(fd));
-            /* Canonical case: exactly one fd in exactly one SCM_RIGHTS cmsg.
-             * Anything else (extra cmsgs, extra fds per cmsg) is malformed;
-             * close every fd that does not fit the canonical slot so none leak.
-             */
-            if (n_rights == 0 && nfd == 1) {
-                *out_fd = fd;
-            } else {
-                close(fd);
-                malformed = true;
-            }
-            n_rights++;
+        size_t cap = (sizeof(cmsg_buf) - CMSG_LEN(0)) / sizeof(int);
+        if (payload % sizeof(int) == 0) {
+            nfd = payload / sizeof(int);
+            if (nfd > cap)
+                nfd = cap;
+            memcpy(fds, CMSG_DATA(cmsg), nfd * sizeof(int));
         }
     }
 
-    /* MSG_CTRUNC means the kernel discarded part of the ancillary data because
-     * cmsg_buf was too small. fds in the discarded portion were dropped by the
-     * kernel without ever entering this process; fds in the surviving cmsgs
-     * were walked above. Treat as a hard protocol error because the message
-     * framing is no longer reliable.
+    /* Well-formed means exactly one fd, no truncation, no extra cmsg.
+     * MSG_CTRUNC means the peer sent more ancillary data than cmsg_buf could
+     * hold; a trailing cmsg means more than the one expected fd. nfd == 1
+     * short-circuits before CMSG_NXTHDR so a NULL cmsg is never dereferenced.
      */
-    if ((msg.msg_flags & MSG_CTRUNC) || malformed || n_rights != 1) {
-        if (*out_fd >= 0) {
-            close(*out_fd);
-            *out_fd = -1;
-        }
+    bool accept = nfd == 1 && !(msg.msg_flags & MSG_CTRUNC) &&
+                  CMSG_NXTHDR(&msg, cmsg) == NULL;
+    if (!accept) {
+        for (size_t i = 0; i < nfd; i++)
+            close(fds[i]);
         errno = EPROTO;
         return -1;
     }
+    *out_fd = fds[0];
     return n;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -47,7 +47,10 @@
 
 static int parse_int_arg(const char *s, int min, int max, int *out)
 {
-    char *end = NULL;
+    /* Seed end with s (strtol's no-conversion result) so the end == s guard
+     * below catches a failed parse without a separate NULL check.
+     */
+    char *end = (char *) s;
     errno = 0;
     long value = strtol(s, &end, 10);
     if (errno != 0 || end == s || *end != '\0' || value < min || value > max)

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -100,6 +100,14 @@ int fork_ipc_send_fds(int sock, const int *fds, int count)
         msg.msg_controllen = cmsg_size;
 
         struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+        /* cmsg_buf is sized via CMSG_SPACE for chunk >= 1, so this never
+         * returns NULL; the guard keeps the deref provably safe.
+         */
+        if (!cmsg) {
+            free(cmsg_buf);
+            errno = EINVAL;
+            return -1;
+        }
         cmsg->cmsg_level = SOL_SOCKET;
         cmsg->cmsg_type = SCM_RIGHTS;
         cmsg->cmsg_len = CMSG_LEN((size_t) chunk * sizeof(int));
@@ -216,7 +224,7 @@ int fork_ipc_recv_memory_regions(int ipc_fd, guest_t *g)
         log_debug("fork-child: receiving %u memory regions", num_regions);
 
     for (uint32_t i = 0; i < num_regions; i++) {
-        ipc_region_header_t rhdr;
+        ipc_region_header_t rhdr = {0};
         if (fork_ipc_read_all(ipc_fd, &rhdr, sizeof(rhdr)) < 0) {
             log_error("fork-child: failed to read region header");
             return -1;

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -106,7 +106,7 @@ int fork_child_main(int ipc_fd,
     /* The header magic identifies the fork IPC protocol before any
      * variable-length state is trusted.
      */
-    ipc_header_t hdr;
+    ipc_header_t hdr = {0};
     if (fork_ipc_read_all(ipc_fd, &hdr, sizeof(hdr)) < 0) {
         log_error("fork-child: failed to read header");
         return 1;

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -1767,7 +1767,7 @@ uint32_t proc_pty_master_adopt(int guest_fd)
      */
     char slave_path[PTY_SLAVE_PATH_MAX];
     uint32_t pts_num = UINT32_MAX;
-    int slave = -1;
+    int slave;
     if (ptsname_r(probe, slave_path, sizeof(slave_path)) != 0)
         goto out;
     pts_num = pty_extract_pts_num(slave_path);
@@ -1891,7 +1891,7 @@ static int pty_open_slave(uint32_t linux_pts_num, int linux_flags)
     int stale_hit = -1;
     int retained_slaves[PTY_KEEPALIVE_MAX];
     int nretained = 0;
-    int fd = -1;
+    int fd;
 
     pty_keepalive_lock_acquire();
     for (int i = 0; i < PTY_KEEPALIVE_MAX; i++) {

--- a/src/syscall/fd.c
+++ b/src/syscall/fd.c
@@ -1140,6 +1140,7 @@ retry:
 
     signal_rt_info_t pending_stack[LINUX_NSIG];
     signal_rt_info_t *pending = pending_stack;
+    signal_rt_info_t *heap = NULL;
     size_t total = 0;
     const signal_state_t *sig = signal_get_state();
     /* Match pending signals against the signalfd mask. Do NOT filter by
@@ -1149,9 +1150,10 @@ retry:
     uint64_t deliverable = sig->pending & mask;
 
     if (max_signals > LINUX_NSIG) {
-        pending = malloc(max_signals * sizeof(*pending));
-        if (!pending)
+        heap = malloc(max_signals * sizeof(*pending));
+        if (!heap)
             return -LINUX_ENOMEM;
+        pending = heap;
     }
 
     if (deliverable == 0) {
@@ -1175,8 +1177,7 @@ retry:
         int still_valid = (signalfd_state[slot].guest_fd == guest_fd);
         pthread_mutex_unlock(&sfd_lock);
         if (!still_valid) {
-            if (pending != pending_stack)
-                free(pending);
+            free(heap);
             return -LINUX_EBADF;
         }
 
@@ -1218,8 +1219,7 @@ retry:
                  * promise locked in by tests/test-fd-family's
                  * test_signalfd_efault_preserves_pending.
                  */
-                if (pending != pending_stack)
-                    free(pending);
+                free(heap);
                 return -LINUX_EFAULT;
             }
 
@@ -1236,8 +1236,7 @@ retry:
     if (total == 0) {
         if (written == 0)
             goto no_pending;
-        if (pending != pending_stack)
-            free(pending);
+        free(heap);
         goto retry;
     }
 
@@ -1252,13 +1251,11 @@ retry:
             break;
     }
 
-    if (pending != pending_stack)
-        free(pending);
+    free(heap);
     return (int64_t) total * (int64_t) sizeof(linux_signalfd_siginfo_t);
 
 no_pending:
-    if (pending != pending_stack)
-        free(pending);
+    free(heap);
     return -LINUX_EAGAIN;
 }
 

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -346,6 +346,7 @@ static inline int64_t host_fd_ref_open_io(guest_fd_t guest_fd,
 typedef struct {
     struct iovec stack[SYSCALL_IOV_STACK_MAX];
     struct iovec *iov;
+    struct iovec *heap; /* non-NULL only when iov was heap-allocated */
 } host_iov_buf_t;
 
 /* Translate a guest iovec array at iov_gva (iovcnt entries) into the host iovec

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -796,15 +796,17 @@ static int64_t proc_try_writev_intercept(int fd,
     size_t total = 0;
     char stack_buf[256];
     char *buf = stack_buf;
+    char *heap = NULL;
     ssize_t written = 0;
     int handled;
 
     for (int i = 0; i < iovcnt; i++)
         total += iov[i].iov_len;
     if (total > sizeof(stack_buf)) {
-        buf = malloc(total);
-        if (!buf)
+        heap = malloc(total);
+        if (!heap)
             return -LINUX_ENOMEM;
+        buf = heap;
     }
 
     size_t off = 0;
@@ -815,8 +817,7 @@ static int64_t proc_try_writev_intercept(int fd,
 
     handled = proc_intercept_write(fd, host_fd, buf, total, offset, use_pwrite,
                                    &written);
-    if (buf != stack_buf)
-        free(buf);
+    free(heap);
     if (handled < 0)
         return linux_errno();
     if (handled > 0)
@@ -1044,15 +1045,16 @@ static int64_t build_host_iov(guest_t *g,
 {
     linux_iovec_t stack_giov[SYSCALL_IOV_STACK_MAX];
     linux_iovec_t *guest_iov = stack_giov;
+    linux_iovec_t *heap = NULL;
     if (iovcnt > SYSCALL_IOV_STACK_MAX) {
-        guest_iov = malloc((size_t) iovcnt * sizeof(*guest_iov));
-        if (!guest_iov)
+        heap = malloc((size_t) iovcnt * sizeof(*guest_iov));
+        if (!heap)
             return -LINUX_ENOMEM;
+        guest_iov = heap;
     }
     if (guest_read(g, iov_gva, guest_iov,
                    (size_t) iovcnt * sizeof(*guest_iov)) < 0) {
-        if (guest_iov != stack_giov)
-            free(guest_iov);
+        free(heap);
         return -LINUX_EFAULT;
     }
     for (int i = 0; i < iovcnt; i++) {
@@ -1065,8 +1067,7 @@ static int64_t build_host_iov(guest_t *g,
         void *base = guest_ptr_bound(g, guest_iov[i].iov_base, &avail,
                                      required_perms, guest_iov[i].iov_len);
         if (!base) {
-            if (guest_iov != stack_giov)
-                free(guest_iov);
+            free(heap);
             return -LINUX_EFAULT;
         }
         /* Cap to contiguous permitted bytes. When the guest iov entry spans a
@@ -1088,8 +1089,7 @@ static int64_t build_host_iov(guest_t *g,
         }
         host_iov[i].iov_len = len;
     }
-    if (guest_iov != stack_giov)
-        free(guest_iov);
+    free(heap);
     return 0;
 }
 
@@ -1099,21 +1099,23 @@ int64_t host_iov_prepare(guest_t *g,
                          int required_perms,
                          host_iov_buf_t *buf)
 {
+    buf->iov = buf->stack;
+    buf->heap = NULL;
+
     if (iovcnt <= 0 || iovcnt > SYSCALL_IOV_MAX)
         return -LINUX_EINVAL;
 
-    buf->iov = buf->stack;
-
     if (iovcnt > SYSCALL_IOV_STACK_MAX) {
-        buf->iov = malloc((size_t) iovcnt * sizeof(*buf->iov));
-        if (!buf->iov)
+        buf->heap = malloc((size_t) iovcnt * sizeof(*buf->iov));
+        if (!buf->heap)
             return -LINUX_ENOMEM;
+        buf->iov = buf->heap;
     }
 
     int64_t err = build_host_iov(g, iov_gva, iovcnt, buf->iov, required_perms);
     if (err < 0) {
-        if (buf->iov != buf->stack)
-            free(buf->iov);
+        free(buf->heap);
+        buf->heap = NULL;
         buf->iov = NULL;
         return err;
     }
@@ -1129,6 +1131,7 @@ int64_t host_iov_prepare_msg(guest_t *g,
 {
     if (iovcnt == 0) {
         buf->iov = buf->stack;
+        buf->heap = NULL;
         return 0;
     }
     return host_iov_prepare(g, iov_gva, iovcnt, required_perms, buf);
@@ -1136,8 +1139,8 @@ int64_t host_iov_prepare_msg(guest_t *g,
 
 void host_iov_free(host_iov_buf_t *buf)
 {
-    if (buf->iov != buf->stack)
-        free(buf->iov);
+    free(buf->heap);
+    buf->heap = NULL;
     buf->iov = NULL;
 }
 

--- a/src/syscall/netlink.c
+++ b/src/syscall/netlink.c
@@ -131,14 +131,14 @@ typedef struct {
 
 typedef struct {
     bool in_use;
-    int guest_fd;   /* Guest fd number */
-    uint8_t *buf;   /* Response buffer */
-    size_t buf_len; /* Bytes written into buf */
-    size_t buf_pos; /* Current read position */
-    uint32_t seq;   /* Sequence number from last request */
-    uint32_t pid;   /* Bound PID (from bind or auto-assigned) */
-    int pipe_wr;    /* Host pipe write descriptor */
-    int pipe_rd;    /* Host pipe read descriptor */
+    int guest_fd;                  /* Guest fd number */
+    uint8_t buf[NETLINK_BUF_SIZE]; /* Response buffer */
+    size_t buf_len;                /* Bytes written into buf */
+    size_t buf_pos;                /* Current read position */
+    uint32_t seq;                  /* Sequence number from last request */
+    uint32_t pid;                  /* Bound PID (from bind or auto-assigned) */
+    int pipe_wr;                   /* Host pipe write descriptor */
+    int pipe_rd;                   /* Host pipe read descriptor */
 } netlink_state_t;
 
 static netlink_state_t nl_state[MAX_NETLINK_FDS];
@@ -167,11 +167,6 @@ static netlink_state_t *nl_alloc(int guest_fd)
         s->guest_fd = guest_fd;
         s->pipe_wr = -1;
         s->pipe_rd = -1;
-        s->buf = malloc(NETLINK_BUF_SIZE);
-        if (!s->buf) {
-            s->in_use = false;
-            return NULL;
-        }
         s->pid = (uint32_t) getpid();
         return s;
     }
@@ -973,8 +968,6 @@ static void netlink_close(int guest_fd)
         ns->pipe_wr = -1;
     }
     ns->pipe_rd = -1;
-    free(ns->buf);
-    ns->buf = NULL;
     ns->in_use = false;
     pthread_mutex_unlock(&nl_lock);
 }

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -309,7 +309,7 @@ int sys_path_has_symlink(guest_fd_t dirfd, const char *path)
     if (!path || path[0] == '\0')
         return 0;
 
-    host_fd_t base_fd = -1;
+    host_fd_t base_fd;
     bool owned_base_fd = false;
     const char *scan = path;
     char sysroot_buf[LINUX_PATH_MAX];
@@ -660,8 +660,19 @@ static int path_openat2_dirfd_host_path(guest_fd_t dirfd,
                                         size_t outsz)
 {
     if (dirfd == LINUX_AT_FDCWD) {
-        if (!getcwd(out, outsz))
+        /* getcwd into a provably non-NULL local buffer, then copy. Writing
+         * straight into the caller pointer trips a false-positive leak in
+         * static analyzers that model getcwd(NULL, ...) as allocating.
+         */
+        char cwd[LINUX_PATH_MAX];
+        if (!getcwd(cwd, sizeof(cwd)))
             return -1;
+        size_t n = strlen(cwd) + 1;
+        if (n > outsz) {
+            errno = ERANGE;
+            return -1;
+        }
+        memcpy(out, cwd, n);
         return 0;
     }
 

--- a/src/syscall/sidecar.c
+++ b/src/syscall/sidecar.c
@@ -1186,7 +1186,12 @@ static int sidecar_serialize_index(const sidecar_index_t *index,
             size_t new_cap = cap;
             while (new_cap < len + row_len)
                 new_cap *= 2;
-            char *nb = (char *) realloc(buf, new_cap);
+            /* Grow via malloc + copy rather than realloc: on realloc failure
+             * the original block stays valid and must be freed, but static
+             * analyzers model realloc as freeing its argument and flag that
+             * free as a use-after-free. An explicit copy keeps ownership clear.
+             */
+            char *nb = (char *) malloc(new_cap);
             if (!nb) {
                 int saved_errno = errno;
                 free(enc);
@@ -1194,6 +1199,8 @@ static int sidecar_serialize_index(const sidecar_index_t *index,
                 errno = saved_errno;
                 return -1;
             }
+            memcpy(nb, buf, len);
+            free(buf);
             buf = nb;
             cap = new_cap;
         }

--- a/src/syscall/sysvipc.c
+++ b/src/syscall/sysvipc.c
@@ -576,9 +576,14 @@ int64_t sys_msgsnd(guest_t *g,
 
     size_t total = sizeof(long) + (size_t) msgsz;
     char stack_buf[MSG_STACK_THRESHOLD + sizeof(long)];
-    char *buf = (total <= sizeof(stack_buf)) ? stack_buf : malloc(total);
-    if (!buf)
-        return -LINUX_ENOMEM;
+    char *heap = NULL;
+    char *buf = stack_buf;
+    if (total > sizeof(stack_buf)) {
+        heap = malloc(total);
+        if (!heap)
+            return -LINUX_ENOMEM;
+        buf = heap;
+    }
 
     int64_t result;
     if (guest_read(g, msgp_gva, buf, total) < 0) {
@@ -596,8 +601,7 @@ int64_t sys_msgsnd(guest_t *g,
     result =
         (msgsnd(msqid, buf, (size_t) msgsz, flags) < 0) ? linux_errno() : 0;
 out:
-    if (buf != stack_buf)
-        free(buf);
+    free(heap);
     return result;
 }
 
@@ -625,9 +629,14 @@ int64_t sys_msgrcv(guest_t *g,
 
     size_t total = sizeof(long) + (size_t) msgsz;
     char stack_buf[MSG_STACK_THRESHOLD + sizeof(long)];
-    char *buf = (total <= sizeof(stack_buf)) ? stack_buf : malloc(total);
-    if (!buf)
-        return -LINUX_ENOMEM;
+    char *heap = NULL;
+    char *buf = stack_buf;
+    if (total > sizeof(stack_buf)) {
+        heap = malloc(total);
+        if (!heap)
+            return -LINUX_ENOMEM;
+        buf = heap;
+    }
 
     int64_t result;
     ssize_t ret = msgrcv(msqid, buf, (size_t) msgsz, (long) msgtyp, flags);
@@ -644,8 +653,7 @@ int64_t sys_msgrcv(guest_t *g,
         result = ret;
 
 out:
-    if (buf != stack_buf)
-        free(buf);
+    free(heap);
     return result;
 }
 

--- a/src/syscall/time.c
+++ b/src/syscall/time.c
@@ -527,7 +527,7 @@ int64_t sys_getitimer(guest_t *g, int which, uint64_t val_gva)
     /* ITIMER_REAL/VIRTUAL/PROF are all emulated internally (see sys_setitimer
      * comment).
      */
-    struct timeval val, itv;
+    struct timeval val = {0}, itv = {0};
     if (which == 0)
         signal_get_itimer(&val, &itv);
     else if (which == 1 || which == 2)


### PR DESCRIPTION
This adds an infer-macos job that runs Infer over the full elfuse build. It must run on macOS Apple Silicon because the build needs Hypervisor.framework and -arch arm64; infer run captures the real clang invocations so every translation unit is analyzed. -B forces a clean rebuild so no cached objects are skipped; non-C steps (shim.S assembly, objcopy) pass through untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macOS Apple Silicon Infer job that captures the full `elfuse` build, surfaces findings inline and in the job summary, and fails when issues exist. Also fixes the first Infer findings across the tree and bumps `actions/checkout` to `v7`.

- **New Features**
  - Add `infer-macos` on `macos-15`; run `infer run --keep-going -- make -B elfuse` and guard against zero-file capture.
  - Add `scripts/infer-annotate.py` to emit `::error::` annotations and a job summary, then fail when findings exist (runs even on partial failures).
  - Upload `infer-out/report.txt`; use `srz-zumix/setup-infer@v1` with `infer_version: v1.3.0`; bump `actions/checkout` to `v7`.

- **Bug Fixes**
  - Rosetta: take ownership of all received fds, accept only the single-fd case, cap payload, close surplus, and remove double-close paths.
  - Fork/IPC/timers: guard `CMSG_FIRSTHDR` NULL; zero-init IPC and `timeval` structs to avoid uninitialized reads.
  - I/O and sysvipc: replace conditional-free patterns with explicit heap tracking; extend `host_iov_buf_t` with `heap` and free unconditionally.
  - Netlink: make the response buffer an inline array (no malloc/free).
  - Path: use local `getcwd` buffer then copy to avoid analyzer-flagged leaks.
  - Sidecar: grow buffers with malloc + copy instead of realloc to keep ownership clear.
  - Misc: drop dead `-1` initializers in PTY/open paths; seed `end` in `parse_int_arg` so `end == s` reliably detects parse failure.

<sup>Written for commit f7df173b43d03e1ae8df39391ea49ed82b143a5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

