### PR TITLE
Return 0 for zero-iovcnt vector I/O

### DIFF
--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -1250,8 +1250,62 @@ static int64_t single_guest_iov(guest_t *g,
     return 0;
 }
 
+/* Linux returns 0 for zero-iovcnt vector I/O once the fd validates:
+ * import_iovec() yields an empty iterator and do_iter_read/do_iter_write
+ * return before the file offset is touched, so even pwritev2(RWF_APPEND)
+ * leaves the position alone. macOS readv/writev instead reject iovcnt == 0
+ * with EINVAL, so short-circuit before any host call -- the append path's
+ * SEEK_END would otherwise move the shared offset. The iov pointer is not
+ * dereferenced (Linux ignores it for an empty vector), and negative counts
+ * keep flowing into host_iov_prepare's EINVAL.
+ *
+ * The checks Linux runs before its empty-vector return still apply, in this
+ * order: the positional variants fail non-seekable files with ESPIPE
+ * (FMODE_PREAD/FMODE_PWRITE in do_preadv/do_pwritev), and all variants fail
+ * wrong-direction fds with EBADF (FMODE_READ/FMODE_WRITE in
+ * do_iter_read/do_iter_write). Both are probed on the host fd, whose open
+ * mode mirrors the guest's for host-backed types; fd_table linux_flags
+ * cannot be used because pipe/socket entries only track CLOEXEC there.
+ * Virtual multiplexed fds (eventfd/timerfd/signalfd/...) sit on host pipes
+ * or kqueues whose mode says nothing about the guest-visible fd (the Linux
+ * anon-inode equivalents are O_RDWR), so they validate existence only. No
+ * F_SEAL_WRITE check: Linux never reaches the write path for an empty
+ * vector, so a write-sealed memfd returns 0 here too.
+ */
+static int64_t vec_zero_iovcnt(int fd, bool op_is_write, bool positional)
+{
+    fd_entry_t snap;
+    if (!fd_snapshot(fd, &snap) || snap.type == FD_PATH)
+        return -LINUX_EBADF;
+
+    bool host_mode_mirrors_guest =
+        snap.type == FD_REGULAR || snap.type == FD_DIR ||
+        snap.type == FD_PIPE || snap.type == FD_SOCKET ||
+        snap.type == FD_STDIO || snap.type == FD_URANDOM;
+    if (!host_mode_mirrors_guest)
+        return 0;
+
+    host_fd_ref_t host_ref;
+    if (host_fd_ref_open(fd, &host_ref) < 0)
+        return -LINUX_EBADF;
+
+    int64_t ret = 0;
+    if (positional && lseek(host_ref.fd, 0, SEEK_CUR) < 0 && errno == ESPIPE)
+        ret = -LINUX_ESPIPE;
+    if (ret == 0) {
+        int fl = fcntl(host_ref.fd, F_GETFL);
+        int accmode = fl >= 0 ? (fl & O_ACCMODE) : O_RDWR;
+        if (op_is_write ? accmode == O_RDONLY : accmode == O_WRONLY)
+            ret = -LINUX_EBADF;
+    }
+    host_fd_ref_close(&host_ref);
+    return ret;
+}
+
 int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
 {
+    if (iovcnt == 0)
+        return vec_zero_iovcnt(fd, false, false);
     if (iovcnt == 1) {
         linux_iovec_t giov;
         int64_t err = single_guest_iov(g, iov_gva, &giov);
@@ -1353,6 +1407,8 @@ int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
 
 int64_t sys_writev(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
 {
+    if (iovcnt == 0)
+        return vec_zero_iovcnt(fd, true, false);
     if (iovcnt == 1) {
         linux_iovec_t giov;
         int64_t err = single_guest_iov(g, iov_gva, &giov);
@@ -1424,6 +1480,15 @@ int64_t sys_preadv(guest_t *g,
                    int iovcnt,
                    int64_t offset)
 {
+    if (iovcnt == 0) {
+        /* do_preadv rejects a negative offset before looking up the fd, so
+         * EINVAL outranks EBADF here; nonzero counts keep getting EINVAL
+         * from the host preadv instead.
+         */
+        if (offset < 0)
+            return -LINUX_EINVAL;
+        return vec_zero_iovcnt(fd, false, true);
+    }
     if (iovcnt == 1) {
         linux_iovec_t giov;
         int64_t err = single_guest_iov(g, iov_gva, &giov);
@@ -1465,6 +1530,12 @@ int64_t sys_pwritev(guest_t *g,
                     int iovcnt,
                     int64_t offset)
 {
+    if (iovcnt == 0) {
+        /* Same ordering as sys_preadv: negative offset EINVAL first. */
+        if (offset < 0)
+            return -LINUX_EINVAL;
+        return vec_zero_iovcnt(fd, true, true);
+    }
     if (iovcnt == 1) {
         linux_iovec_t giov;
         int64_t err = single_guest_iov(g, iov_gva, &giov);
@@ -1556,6 +1627,17 @@ int64_t sys_preadv2(guest_t *g,
                     int64_t offset,
                     int flags)
 {
+    /* Linux validates RWF flags only once the write/read actually proceeds
+     * (kiocb_set_rw_flags sits behind the empty-vector return in
+     * do_iter_read/do_iter_write), so an empty vector short-circuits before
+     * the flag checks. Offset -1 selects do_readv (no seekability check);
+     * any other negative offset fails EINVAL before the fd lookup.
+     */
+    if (iovcnt == 0) {
+        if (offset < -1)
+            return -LINUX_EINVAL;
+        return vec_zero_iovcnt(fd, false, offset != -1);
+    }
     if (flags & ~RWF_SUPPORTED)
         return -LINUX_EOPNOTSUPP;
     if (flags & RWF_APPEND)
@@ -1575,6 +1657,14 @@ int64_t sys_pwritev2(guest_t *g,
                      int64_t offset,
                      int flags)
 {
+    /* Same ordering as sys_preadv2: empty vectors return before RWF flag
+     * validation, which also keeps RWF_APPEND from moving the offset.
+     */
+    if (iovcnt == 0) {
+        if (offset < -1)
+            return -LINUX_EINVAL;
+        return vec_zero_iovcnt(fd, true, offset != -1);
+    }
     if (flags & ~RWF_SUPPORTED)
         return -LINUX_EOPNOTSUPP;
     int64_t r;

--- a/tests/test-readv-writev.c
+++ b/tests/test-readv-writev.c
@@ -8,7 +8,8 @@
  * Tests readv/writev scatter-gather I/O operations including pipe round-trips,
  * file I/O, and edge cases.
  *
- * Syscalls exercised: writev(66), readv(65), pipe2(59), openat(56),
+ * Syscalls exercised: writev(66), readv(65), preadv(69), pwritev(70),
+ *                     preadv2(286), pwritev2(287), pipe2(59), openat(56),
  *                     lseek(62), close(57), unlink(35)
  */
 
@@ -24,6 +25,10 @@ int passes = 0, fails = 0;
 
 #ifndef RWF_APPEND
 #define RWF_APPEND 0x00000010
+#endif
+
+#ifndef O_PATH
+#define O_PATH 010000000
 #endif
 
 /* Test 1: writev + readv via pipe */
@@ -281,7 +286,11 @@ static void test_pwritev2_append(void)
     EXPECT_TRUE(nr == 6 && !memcmp(buf, "baseXY", 6), "append data mismatch");
 }
 
-/* Test 8: zero iovcnt must not move the append file offset */
+/* Test 8: zero iovcnt returns 0 without moving the append file offset.
+ * Linux reference (verified under qemu-system-aarch64): import_iovec()
+ * yields an empty iterator, do_iter_write returns 0 before the offset is
+ * touched, so pwritev2(RWF_APPEND) with iovcnt == 0 is a complete no-op.
+ */
 
 static void test_pwritev2_append_zero_iovcnt(void)
 {
@@ -308,7 +317,135 @@ static void test_pwritev2_append_zero_iovcnt(void)
     close(fd);
     unlink(path);
 
-    EXPECT_TRUE(ret == -EINVAL && pos == 1, "zero iovcnt changed offset");
+    EXPECT_TRUE(ret == 0 && pos == 1, "zero iovcnt not a no-op");
+}
+
+/* Test 8: zero-iovcnt validation ordering across all six vector entry
+ * points. Linux reference (fs/read_write.c): a negative offset fails EINVAL
+ * before the fd lookup (do_preadv/do_pwritev; -1 is a valid sentinel only
+ * for preadv2/pwritev2), the positional variants fail non-seekable files
+ * with ESPIPE (FMODE_PREAD/FMODE_PWRITE), wrong-direction and O_PATH fds
+ * fail EBADF (FMODE_READ/FMODE_WRITE in do_iter_read/do_iter_write), and
+ * RWF flags are never validated because do_iter_* return before
+ * kiocb_set_rw_flags for an empty vector.
+ */
+
+enum vec_op {
+    OP_READV,
+    OP_WRITEV,
+    OP_PREADV,
+    OP_PWRITEV,
+    OP_PREADV2,
+    OP_PWRITEV2
+};
+
+static long vec_zero_syscall(int op, int fd, long off, long flags)
+{
+    switch (op) {
+    case OP_READV:
+        return raw_syscall3(__NR_readv, fd, 0, 0);
+    case OP_WRITEV:
+        return raw_syscall3(__NR_writev, fd, 0, 0);
+    case OP_PREADV:
+        return raw_syscall5(__NR_preadv, fd, 0, 0, off, 0);
+    case OP_PWRITEV:
+        return raw_syscall5(__NR_pwritev, fd, 0, 0, off, 0);
+    case OP_PREADV2:
+        return raw_syscall6(__NR_preadv2, fd, 0, 0, off, 0, flags);
+    default:
+        return raw_syscall6(__NR_pwritev2, fd, 0, 0, off, 0, flags);
+    }
+}
+
+static void test_zero_iovcnt_validation(void)
+{
+    const char *path = "/tmp/elfuse-test-zero-iovcnt.txt";
+    int rw = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    int ro = open(path, O_RDONLY);
+    int wo = open(path, O_WRONLY);
+    int opath = open(path, O_PATH);
+    int stale = open(path, O_RDONLY);
+    int pfd[2] = {-1, -1};
+    if (rw < 0 || ro < 0 || wo < 0 || opath < 0 || stale < 0 ||
+        pipe(pfd) != 0) {
+        TEST("zero iovcnt setup");
+        FAIL("open/pipe");
+        goto out;
+    }
+    close(stale); /* keep the value: exercises the closed-fd path */
+
+    const struct {
+        const char *name;
+        int op;
+        int fd;
+        long off;
+        long flags;
+        long expect;
+    } cases[] = {
+        /* Valid fd, matching direction: 0 regardless of variant */
+        {"readv rdwr", OP_READV, rw, 0, 0, 0},
+        {"writev rdwr", OP_WRITEV, rw, 0, 0, 0},
+        {"preadv rdwr", OP_PREADV, rw, 0, 0, 0},
+        {"pwritev rdwr", OP_PWRITEV, rw, 0, 0, 0},
+        {"preadv2 rdwr", OP_PREADV2, rw, 0, 0, 0},
+        {"pwritev2 rdwr", OP_PWRITEV2, rw, 0, 0, 0},
+        {"readv rdonly", OP_READV, ro, 0, 0, 0},
+        {"writev wronly", OP_WRITEV, wo, 0, 0, 0},
+        /* Closed fd: EBADF */
+        {"readv closed", OP_READV, stale, 0, 0, -EBADF},
+        {"writev closed", OP_WRITEV, stale, 0, 0, -EBADF},
+        {"preadv closed", OP_PREADV, stale, 0, 0, -EBADF},
+        {"pwritev2 closed off=-1", OP_PWRITEV2, stale, -1, 0, -EBADF},
+        /* O_PATH: EBADF (no FMODE_READ/FMODE_WRITE) */
+        {"readv O_PATH", OP_READV, opath, 0, 0, -EBADF},
+        {"writev O_PATH", OP_WRITEV, opath, 0, 0, -EBADF},
+        /* Wrong access mode: EBADF */
+        {"writev rdonly", OP_WRITEV, ro, 0, 0, -EBADF},
+        {"pwritev rdonly", OP_PWRITEV, ro, 0, 0, -EBADF},
+        {"pwritev2 rdonly", OP_PWRITEV2, ro, 0, 0, -EBADF},
+        {"readv wronly", OP_READV, wo, 0, 0, -EBADF},
+        {"preadv wronly", OP_PREADV, wo, 0, 0, -EBADF},
+        {"preadv2 wronly", OP_PREADV2, wo, 0, 0, -EBADF},
+        /* Pipes: direction from the fd, ESPIPE for positional variants */
+        {"readv pipe rd-end", OP_READV, pfd[0], 0, 0, 0},
+        {"writev pipe wr-end", OP_WRITEV, pfd[1], 0, 0, 0},
+        {"writev pipe rd-end", OP_WRITEV, pfd[0], 0, 0, -EBADF},
+        {"readv pipe wr-end", OP_READV, pfd[1], 0, 0, -EBADF},
+        {"preadv pipe rd-end", OP_PREADV, pfd[0], 0, 0, -ESPIPE},
+        {"pwritev pipe wr-end", OP_PWRITEV, pfd[1], 0, 0, -ESPIPE},
+        {"preadv2 pipe off=-1", OP_PREADV2, pfd[0], -1, 0, 0},
+        /* Negative offsets: EINVAL, even before the fd lookup */
+        {"preadv rdwr off=-1", OP_PREADV, rw, -1, 0, -EINVAL},
+        {"pwritev rdwr off=-1", OP_PWRITEV, rw, -1, 0, -EINVAL},
+        {"preadv2 rdwr off=-2", OP_PREADV2, rw, -2, 0, -EINVAL},
+        {"pwritev2 rdwr off=-2", OP_PWRITEV2, rw, -2, 0, -EINVAL},
+        {"preadv closed off=-1", OP_PREADV, stale, -1, 0, -EINVAL},
+        /* RWF flags are not validated for an empty vector */
+        {"preadv2 rdwr RWF_APPEND", OP_PREADV2, rw, 0, RWF_APPEND, 0},
+        {"pwritev2 rdwr bogus flag", OP_PWRITEV2, rw, 0, 1L << 27, 0},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        TEST(cases[i].name);
+        long got = vec_zero_syscall(cases[i].op, cases[i].fd, cases[i].off,
+                                    cases[i].flags);
+        EXPECT_EQ(got, cases[i].expect, "wrong return");
+    }
+
+out:
+    if (rw >= 0)
+        close(rw);
+    if (ro >= 0)
+        close(ro);
+    if (wo >= 0)
+        close(wo);
+    if (opath >= 0)
+        close(opath);
+    if (pfd[0] >= 0)
+        close(pfd[0]);
+    if (pfd[1] >= 0)
+        close(pfd[1]);
+    unlink(path);
 }
 
 /* Main */
@@ -325,6 +462,7 @@ int main(void)
     test_many_iovecs();
     test_pwritev2_append();
     test_pwritev2_append_zero_iovcnt();
+    test_zero_iovcnt_validation();
 
     SUMMARY("test-readv-writev");
     return fails > 0 ? 1 : 0;


### PR DESCRIPTION
readv/writev/preadv/pwritev/pwritev2 with `iovcnt == 0` returned EINVAL because the request was funneled into the host syscall path and macOS rejects a zero count. Linux returns 0 and leaves the file offset untouched -- even for pwritev2(RWF_APPEND), which must not seek to EOF. Verified against a Linux reference under qemu-system-aarch64: `pwritev2(fd, iov, 0, -1, RWF_APPEND)` returns 0 with the offset unmoved.

Short-circuit `iovcnt == 0` in the five vector entry points before any host call: validate the fd (closed/O_PATH report EBADF, matching Linux), return 0, and leave the offset alone. test-readv-writev test 7 now encodes the Linux behavior, so the same binary passes under both elfuse and the qemu reference lane of tests/test-matrix.sh.

Testing: `make check` 105/105; test-readv-writev 7/7 under elfuse and under qemu.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 0 for zero-iovcnt vector I/O and match Linux’s validation order while keeping file offsets unchanged. Applies to readv, writev, preadv, pwritev, preadv2, and pwritev2, including pwritev2(RWF_APPEND).

- **Bug Fixes**
  - Short-circuit `iovcnt == 0` in all six syscalls to avoid macOS `EINVAL`.
  - Follow Linux’s ordering: negative offsets return `EINVAL` (`*v2` allows `-1` and treats it as non-positional), positional on non-seekable fds return `ESPIPE`, wrong-direction or `O_PATH`/closed fds return `EBADF`.
  - Skip `RWF_*` validation for empty vectors and keep the file offset unchanged (incl. `pwritev2(RWF_APPEND)`).
  - Tests: update append case and add a table covering closed/O_PATH/mode/pipe/offset/flag paths; passing on elfuse and the qemu Linux reference.

<sup>Written for commit 1e12fc530b4cca1a3ae590e720223d5b4d1855ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

