### PR TITLE
Mount a tmpfs on /tmp in the qemu guest

### DIFF
--- a/tests/qemu-runner.sh
+++ b/tests/qemu-runner.sh
@@ -158,6 +158,13 @@ qemu_start()
         fi
         sleep 1
     done
+
+    # The Alpine initramfs keeps /tmp on "rootfs", which busybox df cannot
+    # resolve to a /proc/mounts entry ("df: ...: can't find mount point").
+    # Mount a dedicated tmpfs, as any regular system has, so paths under
+    # /tmp map to a resolvable st_dev. Guarded so a repeated qemu_start
+    # against a running VM does not stack mounts.
+    _qemu_ssh_raw 'grep -q " /tmp tmpfs " /proc/mounts || mount -t tmpfs tmpfs /tmp'
 }
 
 # Each call opens a fresh ssh connection.  Avoids ControlMaster pitfalls

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -977,8 +977,8 @@ run_suite()
 # observed counts diverge. apple-unknown is the fallback row for SoC
 # strings the detector does not recognize yet.
 EXPECTED_BASELINES=(
-    "elfuse-aarch64|180|0"
-    "qemu-aarch64|180|1"
+    "elfuse-aarch64|169|0"
+    "qemu-aarch64|163|0"
     "elfuse-x86_64:apple-m1-m2|71|0"
     "elfuse-x86_64:apple-m3-plus|71|0"
     "elfuse-x86_64:apple-unknown|71|0"
@@ -1060,8 +1060,11 @@ detect_x86_64_host_class()
 # reporting), but this list is the canonical reference for "expected to
 # fail" in code review and CI triage.
 #
-# qemu-aarch64: test-poll diverges only inside the qemu reference VM.
-KNOWN_FAILURES_QEMU_AARCH64="test-poll"
+# qemu-aarch64: none. test-poll used to diverge inside the qemu reference
+# VM but now passes there (observed on the self-hosted runner and in local
+# captures); the qemu row in EXPECTED_BASELINES therefore pins exactly
+# zero failures.
+KNOWN_FAILURES_QEMU_AARCH64=""
 # elfuse-x86_64: rosetta limitations documented in the upstream hyper-linux
 # audit. test-signal-thread fails because rosetta shadows signal state
 # internally (SA_RESETHAND not reset); test-thread / test-stress hang on


### PR DESCRIPTION
busybox df (the static coreutils fixture, `staticbin/bin/df -> busybox`) exited 1 in the qemu reference lane ("df: /: can't find mount point"): the initramfs keeps /tmp on `rootfs`, which busybox's find_mount_point() cannot resolve against /proc/mounts. Rather than skipping the test, mount a tmpfs on /tmp in qemu_start once the VM is reachable -- as any regular system has -- so TEST_TMPDIR maps to a resolvable mount entry and df passes in all four runner/fixture combinations.

Also recalibrate EXPECTED_BASELINES to observed counts -- the recorded 180s predate suite growth and trims and no longer match the 173-test inventory:

- elfuse-aarch64: 169 pass, 0 fail, 4 skip (of 173)
- qemu-aarch64: 163 pass, 0 fail, 10 skip (of 173)

test-poll no longer diverges under the qemu reference VM, so the stale known-failure annotation is dropped and the lane pins exactly zero failures.