### PR TITLE
Route vCPU preemption signals via sigwait thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,11 @@ $(BUILD_DIR)/test-pthread: tests/test-pthread.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
 
+# test-poll uses pthread_kill to verify blocked read signal delivery.
+$(BUILD_DIR)/test-poll: tests/test-poll.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
+
 # test-osync-requeue drives a raw FUTEX_REQUEUE against a plain-FUTEX_WAIT
 # waiter (musl unlock_requeue pattern) to guard the os_sync wake-at-source
 # degradation; needs -lpthread.

--- a/src/main.c
+++ b/src/main.c
@@ -362,6 +362,13 @@ int main(int argc, char **argv)
     }
     proc_set_fakeroot_enabled(fakeroot);
 
+    /* Block the vCPU-preemption signals and start the sigwait thread before any
+     * vCPU thread exists, so both the normal path and the fork-child path below
+     * inherit the block on every thread they spawn.
+     */
+    if (proc_preempt_init() < 0)
+        return 1;
+
     /* Fork-child mode: receive VM state over IPC and run */
     if (fork_child_fd >= 0)
         return fork_child_main(fork_child_fd, vfork_notify_fd, verbose,

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -740,7 +740,12 @@ typedef struct {
     int linux_flags;     /* Linux open flags (for CLOEXEC tracking) */
     void *dir;           /* DIR* for FD_DIR entries (NULL otherwise) */
     char proc_path[FD_VIRTUAL_PATH_MAX]; /* Virtual /proc dir root for *at */
-    int seals; /* F_SEAL_* bits (non-zero only for memfd_create fds) */
+    int seals;      /* F_SEAL_* bits (non-zero only for memfd_create fds) */
+    bool can_block; /* host read/write on this fd may block (pipe, socket, fifo,
+                     * char/tty); false for regular files and directories. Set
+                     * once at allocation via fstat so the interruptible wait
+                     * path can skip fds that never block.
+                     */
     sock_opt_cache_t sock; /* Socket option cache (zeroed for non-sockets) */
     void (*cleanup)(int guest_fd); /* Type-specific teardown (NULL if none) */
 } fd_entry_t;

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <dirent.h>
 #include <pthread.h>
+#include <sys/stat.h>
 
 #include "utils.h"
 
@@ -72,6 +73,38 @@ static inline void fd_bitmap_set_used(int fd)
     fd_free_bitmap[fd / 64] &= ~BIT64(fd % 64);
 }
 
+/* A host read/write blocks only on non-regular, non-directory fds (pipe,
+ * socket, fifo, char/tty). Callers cache this so the interruptible wait path
+ * can skip fds that never block.
+ */
+static bool host_fd_may_block(int host_fd)
+{
+    struct stat st;
+    return host_fd >= 0 && fstat(host_fd, &st) == 0 && !S_ISREG(st.st_mode) &&
+           !S_ISDIR(st.st_mode);
+}
+
+/* Whether a read/write on a newly allocated fd of this type can block. Pipes
+ * and sockets always can; regular-file slots may actually be a fifo or char
+ * device (opened_fd_type does not split those out) and stdio may be a tty, so
+ * both need an fstat; everything else (dir, path, urandom, fuse, synthetic)
+ * never reaches the blocking wait path. Avoiding the fstat for the common
+ * pipe/socket/synthetic allocations keeps it off the fd-creation lock hold.
+ */
+static bool type_may_block(int type, int host_fd)
+{
+    switch (type) {
+    case FD_PIPE:
+    case FD_SOCKET:
+        return true;
+    case FD_STDIO:
+    case FD_REGULAR:
+        return host_fd_may_block(host_fd);
+    default:
+        return false;
+    }
+}
+
 static inline void fd_init_entry(int fd,
                                  int type,
                                  int host_fd,
@@ -85,6 +118,12 @@ static inline void fd_init_entry(int fd,
     fd_table[fd].dir = NULL;
     fd_table[fd].proc_path[0] = '\0';
     fd_table[fd].seals = 0;
+    /* Cache whether a host read/write can block so the fast-path and slow-path
+     * readers can decide whether to divert into the interruptible wait without
+     * re-stating on every call. Only regular-file and stdio slots pay an fstat
+     * here; pipes/sockets/synthetic fds resolve from the type alone.
+     */
+    fd_table[fd].can_block = type_may_block(type, host_fd);
     sock_opt_clear(&fd_table[fd]);
     fd_table[fd].cleanup = cleanup;
     /* Start conservative. Callers that set linux_flags after allocation
@@ -166,6 +205,12 @@ void fdtable_init(void)
     fd_table[2] = (fd_entry_t) {.type = FD_STDIO,
                                 .host_fd = STDERR_FILENO,
                                 .generation = fd_next_generation++};
+    /* The compound literals above zero can_block; recover the real value so a
+     * terminal stdin still routes reads through the interruptible wait.
+     */
+    fd_table[0].can_block = host_fd_may_block(STDIN_FILENO);
+    fd_table[1].can_block = host_fd_may_block(STDOUT_FILENO);
+    fd_table[2].can_block = host_fd_may_block(STDERR_FILENO);
     fd_bitmap_set_used(0);
     fd_bitmap_set_used(1);
     fd_bitmap_set_used(2);
@@ -239,8 +284,9 @@ int fd_alloc_from_relaxed(int minfd,
  * does not catch this first.
  *
  * A slot qualifies if it is free now, or if it is open but CLOEXEC (the sweep
- * closes it before rosetta_finalize allocates). Returns true if at least one
- * such slot exists within RLIMIT_NOFILE.
+ * closes it before rosetta_finalize allocates).
+ *
+ * Returns true if at least one such slot exists within RLIMIT_NOFILE.
  */
 bool fd_reexec_slot_available(int minfd)
 {
@@ -447,6 +493,16 @@ int fd_get_type(int guest_fd)
     int type = fd_table[guest_fd].type;
     pthread_mutex_unlock(&fd_lock);
     return type;
+}
+
+bool fd_can_block(int guest_fd)
+{
+    if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))
+        return false;
+    pthread_mutex_lock(&fd_lock);
+    bool can_block = fd_table[guest_fd].can_block;
+    pthread_mutex_unlock(&fd_lock);
+    return can_block;
 }
 
 void fd_publish_linux_flags(int guest_fd, int linux_flags)

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -126,6 +126,12 @@ int fd_snapshot_and_dup(int guest_fd, fd_entry_t *out);
  */
 int fd_get_type(int guest_fd);
 
+/* True when a host read/write on this guest fd may block (pipe, socket, fifo,
+ * char/tty). Regular files and directories never block. Callers use this to
+ * decide whether to route a blocking I/O through the interruptible wait path.
+ */
+bool fd_can_block(int guest_fd);
+
 /* Publish linux_flags for a guest fd under fd_lock. Use after fd_alloc when the
  * creating syscall needs to set linux_flags atomically with respect to a
  * concurrent fcntl(F_SETFL/F_SETFD) on the same slot. The fd_alloc-then-
@@ -355,6 +361,15 @@ typedef struct {
     struct iovec *iov;
     struct iovec *heap; /* non-NULL only when iov was heap-allocated */
 } host_iov_buf_t;
+
+static inline bool host_iov_has_payload(const host_iov_buf_t *buf, int iovcnt)
+{
+    for (int i = 0; i < iovcnt; i++) {
+        if (buf->iov[i].iov_len > 0)
+            return true;
+    }
+    return false;
+}
 
 /* Translate a guest iovec array at iov_gva (iovcnt entries) into the host iovec
  * layout in buf->iov, resolving each guest_base to a contiguous host pointer

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -150,7 +150,7 @@ static int64_t io_return_zero(host_fd_ref_t *host_ref)
     return 0;
 }
 
-static int64_t wait_readable_or_interrupted(int host_fd)
+int64_t io_wait_fd_or_interrupted(int host_fd, short events)
 {
     int wake_fd = wakeup_pipe_read_fd();
 
@@ -158,7 +158,7 @@ static int64_t wait_readable_or_interrupted(int host_fd)
      * drops the second slot.
      */
     struct pollfd fds[2] = {
-        {.fd = host_fd, .events = POLLIN},
+        {.fd = host_fd, .events = events},
         {.fd = wake_fd, .events = POLLIN},
     };
 
@@ -184,6 +184,42 @@ static int64_t wait_readable_or_interrupted(int host_fd)
         if (fds[0].revents)
             return 0;
     }
+}
+
+/* Route a blocking read/write on a fd that can block (pipe, socket, fifo,
+ * char/tty) through the interruptible wait so the vCPU thread stays reachable
+ * by hv_vcpus_exit + the wakeup pipe. No-op for regular files, nonblocking fds,
+ * and direction mismatches (a POLLIN wait on an O_WRONLY fd would hang; the
+ * read then fails EBADF like Linux).
+ *
+ * Returns 0 to proceed or a negative Linux errno (EINTR) to abort.
+ */
+static int64_t io_block_wait(int fd, int host_fd, short events)
+{
+    if (!fd_can_block(fd))
+        return 0;
+    int fl = fcntl(host_fd, F_GETFL);
+    if (fl < 0 || (fl & O_NONBLOCK))
+        return 0;
+    int acc = fl & O_ACCMODE;
+    if ((events & POLLIN) && acc == O_WRONLY)
+        return 0;
+    if ((events & POLLOUT) && acc == O_RDONLY)
+        return 0;
+    return io_wait_fd_or_interrupted(host_fd, events);
+}
+
+static int64_t io_check_access(int host_fd, short events)
+{
+    int fl = fcntl(host_fd, F_GETFL);
+    if (fl < 0)
+        return linux_errno();
+    int acc = fl & O_ACCMODE;
+    if ((events & POLLIN) && acc == O_WRONLY)
+        return -LINUX_EBADF;
+    if ((events & POLLOUT) && acc == O_RDONLY)
+        return -LINUX_EBADF;
+    return 0;
 }
 
 void urandom_fd_reset_cache(int guest_fd)
@@ -922,6 +958,19 @@ int64_t sys_write(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         }
     }
 
+    /* A blocking write on a full pipe/socket buffer would park this vCPU thread
+     * in an uninterruptible host write() where the preempt thread's
+     * hv_vcpus_exit cannot reach it. Wait for POLLOUT (or a guest signal)
+     * first. Unlike the socket send paths there is no per-call nonblocking flag
+     * for write(), so the tiny window where the buffer refills between the wait
+     * and write() can still block; that matches sys_read and the receive paths.
+     */
+    int64_t wwait = io_block_wait(fd, host_ref.fd, POLLOUT);
+    if (wwait < 0) {
+        host_fd_ref_close(&host_ref);
+        return wwait;
+    }
+
     ssize_t ret = write(host_ref.fd, buf, count);
     host_fd_ref_close(&host_ref);
     return io_write_result(ret);
@@ -984,18 +1033,13 @@ int64_t sys_read(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         }
     }
 
-    int flags = fcntl(host_ref.fd, F_GETFL);
-    /* Only wait when the fd can actually become readable. A write-only fd (e.g.
-     * the write end of a pipe) never signals POLLIN, so waiting would hang;
-     * fall straight through to read(), which returns EBADF like Linux.
+    /* Wait interruptibly when the fd can block on a read (pipe, socket, fifo,
+     * char/tty). Regular files never block and skip this.
      */
-    if ((type == FD_PIPE || type == FD_STDIO) && flags >= 0 &&
-        !(flags & O_NONBLOCK) && (flags & O_ACCMODE) != O_WRONLY) {
-        int64_t wait = wait_readable_or_interrupted(host_ref.fd);
-        if (wait < 0) {
-            host_fd_ref_close(&host_ref);
-            return wait;
-        }
+    int64_t rwait = io_block_wait(fd, host_ref.fd, POLLIN);
+    if (rwait < 0) {
+        host_fd_ref_close(&host_ref);
+        return rwait;
     }
 
     ssize_t ret = read(host_ref.fd, buf, count);
@@ -1275,6 +1319,12 @@ int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
         host_fd_ref_close(&host_ref);
         return err;
     }
+    if (!host_iov_has_payload(&host_iov, iovcnt)) {
+        err = io_check_access(host_ref.fd, POLLIN);
+        host_iov_free(&host_iov);
+        host_fd_ref_close(&host_ref);
+        return err < 0 ? err : 0;
+    }
 
     off_t offset = lseek(host_ref.fd, 0, SEEK_CUR);
     if (offset >= 0) {
@@ -1285,6 +1335,13 @@ int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
             host_fd_ref_close(&host_ref);
             return intercepted;
         }
+    }
+
+    int64_t rwait = io_block_wait(fd, host_ref.fd, POLLIN);
+    if (rwait < 0) {
+        host_iov_free(&host_iov);
+        host_fd_ref_close(&host_ref);
+        return rwait;
     }
 
     ssize_t ret = readv(host_ref.fd, host_iov.iov, iovcnt);
@@ -1329,6 +1386,12 @@ int64_t sys_writev(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
         host_fd_ref_close(&host_ref);
         return err;
     }
+    if (!host_iov_has_payload(&host_iov, iovcnt)) {
+        err = io_check_access(host_ref.fd, POLLOUT);
+        host_iov_free(&host_iov);
+        host_fd_ref_close(&host_ref);
+        return err < 0 ? err : 0;
+    }
 
     off_t offset = lseek(host_ref.fd, 0, SEEK_CUR);
     if (offset >= 0) {
@@ -1339,6 +1402,13 @@ int64_t sys_writev(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
             host_fd_ref_close(&host_ref);
             return intercepted;
         }
+    }
+
+    int64_t wwait = io_block_wait(fd, host_ref.fd, POLLOUT);
+    if (wwait < 0) {
+        host_iov_free(&host_iov);
+        host_fd_ref_close(&host_ref);
+        return wwait;
     }
 
     ssize_t ret = writev(host_ref.fd, host_iov.iov, iovcnt);

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <sys/uio.h>
 #include <sys/ioctl.h>
+#include <poll.h>
 #include <termios.h>
 
 #include "utils.h"
@@ -33,6 +34,7 @@
 #include "core/shim-globals.h"
 #include "hvutil.h"
 #include "runtime/procemu.h"
+#include "runtime/futex.h"
 #include "runtime/thread.h"
 
 #include "syscall/abi.h"
@@ -42,6 +44,7 @@
 #include "syscall/inotify.h"
 #include "syscall/io.h"
 #include "syscall/net.h"
+#include "syscall/poll.h"
 #include "syscall/proc.h"
 #include "syscall/signal.h"
 
@@ -145,6 +148,42 @@ static int64_t io_return_zero(host_fd_ref_t *host_ref)
 {
     host_fd_ref_close(host_ref);
     return 0;
+}
+
+static int64_t wait_readable_or_interrupted(int host_fd)
+{
+    int wake_fd = wakeup_pipe_read_fd();
+
+    /* poll() ignores entries with a negative fd, so a missing wakeup pipe just
+     * drops the second slot.
+     */
+    struct pollfd fds[2] = {
+        {.fd = host_fd, .events = POLLIN},
+        {.fd = wake_fd, .events = POLLIN},
+    };
+
+    for (;;) {
+        /* Ignored/default-ignore signals do not interrupt; restartable handlers
+         * still need to run promptly through the syscall epilogue.
+         */
+        if (proc_exit_group_requested() || futex_interrupt_consume() ||
+            signal_pending_interruption(NULL))
+            return -LINUX_EINTR;
+
+        /* Bounded wait even when the wakeup pipe exists: the pipe is a
+         * single-consumer channel, so a sibling thread blocked in read/poll can
+         * drain the byte meant to wake this one. The 200 ms recheck guarantees
+         * every waiter re-evaluates its own interrupt conditions.
+         */
+        int ret = poll(fds, 2, 200);
+        if (ret < 0)
+            return linux_errno();
+
+        if (wake_fd >= 0 && (fds[1].revents & POLLIN))
+            wakeup_pipe_drain();
+        if (fds[0].revents)
+            return 0;
+    }
 }
 
 void urandom_fd_reset_cache(int guest_fd)
@@ -942,6 +981,20 @@ int64_t sys_read(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         if (intercepted != INT64_MIN) {
             host_fd_ref_close(&host_ref);
             return intercepted;
+        }
+    }
+
+    int flags = fcntl(host_ref.fd, F_GETFL);
+    /* Only wait when the fd can actually become readable. A write-only fd (e.g.
+     * the write end of a pipe) never signals POLLIN, so waiting would hang;
+     * fall straight through to read(), which returns EBADF like Linux.
+     */
+    if ((type == FD_PIPE || type == FD_STDIO) && flags >= 0 &&
+        !(flags & O_NONBLOCK) && (flags & O_ACCMODE) != O_WRONLY) {
+        int64_t wait = wait_readable_or_interrupted(host_ref.fd);
+        if (wait < 0) {
+            host_fd_ref_close(&host_ref);
+            return wait;
         }
     }
 

--- a/src/syscall/io.h
+++ b/src/syscall/io.h
@@ -30,6 +30,17 @@ void urandom_fd_reset_cache(int guest_fd);
  * alongside the other subsystem init hooks.
  */
 void io_init(void);
+
+/* Wait until host_fd is ready for events (POLLIN and/or POLLOUT) or a
+ * guest-visible signal/exit is pending.
+ *
+ * Returns 0 when ready, -LINUX_EINTR when interrupted, or a negative Linux
+ * errno on poll failure. Shared by the read, write, recv, accept, connect, and
+ * send paths so a guest thread parked in a blocking host call stays reachable
+ * by hv_vcpus_exit + the wakeup pipe.
+ */
+int64_t io_wait_fd_or_interrupted(int host_fd, short events);
+
 int64_t sys_pread64(guest_t *g,
                     int fd,
                     uint64_t buf_gva,

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -20,6 +20,7 @@
 #include "utils.h"
 
 #include "syscall/internal.h"
+#include "syscall/io.h"
 #include "syscall/net.h"
 #include "syscall/net-sockopt.h"
 #include "syscall/net-abi.h"
@@ -182,7 +183,23 @@ int64_t sys_sendmsg(guest_t *g, int fd, uint64_t msg_gva, int linux_flags)
                 len = (size_t) avail;
         }
 
-        ssize_t ret = send(host_ref.fd, base, len, mac_flags);
+        bool blocking =
+            len > 0 && sock_op_should_block(host_ref.fd, linux_flags);
+        int host_flags = mac_flags | (blocking ? MSG_DONTWAIT : 0);
+        ssize_t ret;
+        for (;;) {
+            if (blocking) {
+                int64_t waited =
+                    io_wait_fd_or_interrupted(host_ref.fd, POLLOUT);
+                if (waited < 0) {
+                    host_fd_ref_close(&host_ref);
+                    return waited;
+                }
+            }
+            ret = send(host_ref.fd, base, len, host_flags);
+            if (!(blocking && ret < 0 && errno == EAGAIN))
+                break;
+        }
         host_fd_ref_close(&host_ref);
         if (ret < 0) {
             if (errno == EPIPE && !suppress_sigpipe)
@@ -350,7 +367,25 @@ int64_t sys_sendmsg(guest_t *g, int fd, uint64_t msg_gva, int linux_flags)
         .msg_flags = 0,
     };
 
-    ssize_t ret = sendmsg(host_ref.fd, &msg, mac_flags);
+    bool blocking = host_iov_has_payload(&host_iov, send_iovcnt) &&
+                    sock_op_should_block(host_ref.fd, linux_flags);
+    int host_flags = mac_flags | (blocking ? MSG_DONTWAIT : 0);
+    ssize_t ret;
+    for (;;) {
+        if (blocking) {
+            int64_t waited = io_wait_fd_or_interrupted(host_ref.fd, POLLOUT);
+            if (waited < 0) {
+                free(linux_ctrl_heap);
+                free(mac_ctrl_heap);
+                host_iov_free(&host_iov);
+                host_fd_ref_close(&host_ref);
+                return waited;
+            }
+        }
+        ret = sendmsg(host_ref.fd, &msg, host_flags);
+        if (!(blocking && ret < 0 && errno == EAGAIN))
+            break;
+    }
     free(linux_ctrl_heap);
     free(mac_ctrl_heap);
     host_iov_free(&host_iov);
@@ -407,6 +442,15 @@ int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
                 len = (size_t) avail;
         }
 
+        if (len > 0) {
+            int64_t waited =
+                net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
+            if (waited < 0) {
+                host_fd_ref_close(&host_ref);
+                return waited;
+            }
+        }
+
         struct iovec host_iov = {
             .iov_base = base,
             .iov_len = len,
@@ -449,6 +493,14 @@ int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
     if (iov_err < 0) {
         host_fd_ref_close(&host_ref);
         return iov_err;
+    }
+    if (host_iov_has_payload(&host_iov, recv_iovcnt)) {
+        int64_t waited = net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
+        if (waited < 0) {
+            host_iov_free(&host_iov);
+            host_fd_ref_close(&host_ref);
+            return waited;
+        }
     }
 
     struct sockaddr_storage mac_sa;
@@ -798,7 +850,22 @@ int64_t sys_sendmmsg(guest_t *g,
                     len = (size_t) avail;
             }
 
-            ssize_t ret = send(host_ref.fd, base, len, mac_flags);
+            bool blocking = len > 0 && sock_op_should_block(host_ref.fd, flags);
+            int host_flags = mac_flags | (blocking ? MSG_DONTWAIT : 0);
+            ssize_t ret;
+            for (;;) {
+                if (blocking) {
+                    int64_t waited =
+                        io_wait_fd_or_interrupted(host_ref.fd, POLLOUT);
+                    if (waited < 0) {
+                        host_fd_ref_close(&host_ref);
+                        return waited;
+                    }
+                }
+                ret = send(host_ref.fd, base, len, host_flags);
+                if (!(blocking && ret < 0 && errno == EAGAIN))
+                    break;
+            }
             host_fd_ref_close(&host_ref);
             if (ret < 0) {
                 if (errno == EPIPE && !suppress_sigpipe)
@@ -885,6 +952,14 @@ int64_t sys_recvmmsg(guest_t *g,
                 .msg_iov = &host_iov,
                 .msg_iovlen = 1,
             };
+            if (len > 0) {
+                int64_t waited =
+                    net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
+                if (waited < 0) {
+                    host_fd_ref_close(&host_ref);
+                    return waited;
+                }
+            }
             ssize_t ret = recvmsg(host_ref.fd, &host_msg, mac_flags);
             if (ret < 0) {
                 host_fd_ref_close(&host_ref);

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -40,7 +40,97 @@
 #include "syscall/net-absock.h"
 #include "syscall/net-sockopt.h"
 #include "syscall/proc.h"
+#include "syscall/io.h"
 #include "syscall/signal.h"
+
+/* Linux MSG_DONTWAIT: recv/send skip the interruptible wait when set. */
+#define LINUX_MSG_DONTWAIT 0x40
+
+/* Wait for a blocking socket op (recv/accept/connect/send) to become ready or
+ * be interrupted by a guest signal, so a vCPU thread parked in the host call
+ * stays reachable by hv_vcpus_exit + the wakeup pipe. No-op for nonblocking fds
+ * and for MSG_DONTWAIT callers. Pass msg_flags = 0 for ops with no flags
+ * argument (accept, connect).
+ *
+ * Returns 0 to proceed or a negative Linux errno (EINTR) to abort.
+ */
+int64_t net_wait_or_interrupted(int host_fd, short events, int msg_flags)
+{
+    if (msg_flags & LINUX_MSG_DONTWAIT)
+        return 0;
+    int fl = fcntl(host_fd, F_GETFL);
+    if (fl < 0 || (fl & O_NONBLOCK))
+        return 0;
+    return io_wait_fd_or_interrupted(host_fd, events);
+}
+
+/* True when a socket send/recv should wait interruptibly and retry rather than
+ * surface EAGAIN: the guest asked for blocking semantics (no MSG_DONTWAIT, fd
+ * not O_NONBLOCK). The send/recv paths probe with a per-call MSG_DONTWAIT and
+ * loop on EAGAIN when this holds, so a post-readiness buffer-full/steal race
+ * retries instead of parking the vCPU in an uninterruptible host call. Using
+ * MSG_DONTWAIT rather than toggling the fd's O_NONBLOCK keeps the flag off the
+ * shared open file description, so a sibling thread on the same fd is never hit
+ * with a spurious EAGAIN.
+ */
+bool sock_op_should_block(int host_fd, int msg_flags)
+{
+    if (msg_flags & LINUX_MSG_DONTWAIT)
+        return false;
+    int fl = fcntl(host_fd, F_GETFL);
+    return fl >= 0 && !(fl & O_NONBLOCK);
+}
+
+/* Drive an already-nonblocking connect to completion or interruption: start it,
+ * wait for POLLOUT (or a guest signal), then read SO_ERROR.
+ *
+ * Returns 0 on success or a negative Linux errno. Assumes the caller set
+ * O_NONBLOCK and will restore the original flags.
+ */
+static int64_t connect_nonblock_wait(int host_fd,
+                                     const struct sockaddr *sa,
+                                     socklen_t len)
+{
+    if (connect(host_fd, sa, len) == 0)
+        return 0;
+    if (errno != EINPROGRESS && errno != EINTR)
+        return linux_errno();
+
+    int64_t waited = io_wait_fd_or_interrupted(host_fd, POLLOUT);
+    if (waited < 0)
+        return waited; /* EINTR: connect continues in the background per Linux
+                        */
+
+    int soerr = 0;
+    socklen_t slen = sizeof(soerr);
+    if (getsockopt(host_fd, SOL_SOCKET, SO_ERROR, &soerr, &slen) < 0)
+        soerr = errno;
+    if (soerr) {
+        errno = soerr;
+        return linux_errno();
+    }
+    return 0;
+}
+
+/* Blocking connect that stays interruptible by a guest signal. Flips the socket
+ * nonblocking, drives the connect via connect_nonblock_wait, and restores the
+ * guest's file-status flags exactly once. A socket already in nonblocking mode,
+ * or one that cannot be flipped, falls back to a plain connect (best-effort
+ * interruptibility, never a lost connect); its EINPROGRESS surfaces unchanged.
+ */
+static int64_t connect_or_interrupted(int host_fd,
+                                      const struct sockaddr *sa,
+                                      socklen_t len)
+{
+    int fl = fcntl(host_fd, F_GETFL);
+    bool blocking = fl >= 0 && !(fl & O_NONBLOCK);
+    if (!blocking || fcntl(host_fd, F_SETFL, fl | O_NONBLOCK) < 0)
+        return connect(host_fd, sa, len) < 0 ? linux_errno() : 0;
+
+    int64_t result = connect_nonblock_wait(host_fd, sa, len);
+    fcntl(host_fd, F_SETFL, fl);
+    return result;
+}
 
 /* Syscall implementations. */
 
@@ -342,6 +432,12 @@ static int64_t do_accept(guest_t *g,
         return -LINUX_ENOTSOCK;
     }
 
+    int64_t waited = net_wait_or_interrupted(host_ref.fd, POLLIN, 0);
+    if (waited < 0) {
+        host_fd_ref_close(&host_ref);
+        return waited;
+    }
+
     struct sockaddr_storage mac_sa;
     socklen_t mac_len = sizeof(mac_sa);
 
@@ -543,13 +639,10 @@ int64_t sys_connect(guest_t *g, int fd, uint64_t addr_gva, uint32_t addrlen)
         return -LINUX_EPROTOTYPE;
     }
 
-    if (connect(host_ref.fd, (struct sockaddr *) &mac_sa, (socklen_t) mac_len) <
-        0) {
-        host_fd_ref_close(&host_ref);
-        return linux_errno();
-    }
+    int64_t crc = connect_or_interrupted(
+        host_ref.fd, (struct sockaddr *) &mac_sa, (socklen_t) mac_len);
     host_fd_ref_close(&host_ref);
-    return 0;
+    return crc;
 }
 
 /* Convert a resolved macOS sockaddr to Linux form and write it, plus its actual
@@ -709,6 +802,10 @@ int64_t sys_sendto(guest_t *g,
      */
     int suppress_sigpipe = (linux_flags & 0x4000);
 
+    /* sendto with a NULL destination is send(); merge both forms. */
+    struct sockaddr_storage mac_sa;
+    struct sockaddr *dest = NULL;
+    socklen_t dest_len = 0;
     if (dest_gva && addrlen > 0) {
         uint8_t linux_sa[128];
         if (addrlen > sizeof(linux_sa)) {
@@ -719,33 +816,37 @@ int64_t sys_sendto(guest_t *g,
             host_fd_ref_close(&host_ref);
             return -LINUX_EFAULT;
         }
-
-        struct sockaddr_storage mac_sa;
         int mac_len = linux_to_mac_sockaddr(linux_sa, addrlen, &mac_sa);
         if (mac_len < 0) {
             host_fd_ref_close(&host_ref);
             return -LINUX_EINVAL;
         }
-
-        ssize_t ret = sendto(host_ref.fd, buf, len, mac_flags,
-                             (struct sockaddr *) &mac_sa, (socklen_t) mac_len);
-        host_fd_ref_close(&host_ref);
-        if (ret < 0) {
-            if (errno == EPIPE && !suppress_sigpipe)
-                signal_queue(LINUX_SIGPIPE);
-            return linux_errno();
-        }
-        return ret;
-    } else {
-        ssize_t ret = send(host_ref.fd, buf, len, mac_flags);
-        host_fd_ref_close(&host_ref);
-        if (ret < 0) {
-            if (errno == EPIPE && !suppress_sigpipe)
-                signal_queue(LINUX_SIGPIPE);
-            return linux_errno();
-        }
-        return ret;
+        dest = (struct sockaddr *) &mac_sa;
+        dest_len = (socklen_t) mac_len;
     }
+
+    bool blocking = len > 0 && sock_op_should_block(host_ref.fd, linux_flags);
+    int host_flags = mac_flags | (blocking ? MSG_DONTWAIT : 0);
+    ssize_t ret;
+    for (;;) {
+        if (blocking) {
+            int64_t waited = io_wait_fd_or_interrupted(host_ref.fd, POLLOUT);
+            if (waited < 0) {
+                host_fd_ref_close(&host_ref);
+                return waited;
+            }
+        }
+        ret = sendto(host_ref.fd, buf, len, host_flags, dest, dest_len);
+        if (!(blocking && ret < 0 && errno == EAGAIN))
+            break;
+    }
+    host_fd_ref_close(&host_ref);
+    if (ret < 0) {
+        if (errno == EPIPE && !suppress_sigpipe)
+            signal_queue(LINUX_SIGPIPE);
+        return linux_errno();
+    }
+    return ret;
 }
 
 int64_t sys_recvfrom(guest_t *g,
@@ -774,6 +875,19 @@ int64_t sys_recvfrom(guest_t *g,
         len = avail;
 
     int mac_flags = translate_msg_flags(flags);
+
+    /* A zero-length recv returns 0 without blocking on Linux; only wait when
+     * there is a buffer to fill. A single interruptible wait (not a
+     * MSG_DONTWAIT probe loop) preserves MSG_WAITALL semantics; the tiny
+     * ready-then-stolen window can still block, matching sys_read.
+     */
+    if (len > 0) {
+        int64_t waited = net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
+        if (waited < 0) {
+            host_fd_ref_close(&host_ref);
+            return waited;
+        }
+    }
 
     struct sockaddr_storage mac_sa;
     socklen_t mac_len = sizeof(mac_sa);

--- a/src/syscall/net.h
+++ b/src/syscall/net.h
@@ -155,6 +155,23 @@ int64_t sys_getsockopt(guest_t *g,
                        uint64_t optval_gva,
                        uint64_t optlen_gva);
 int64_t sys_shutdown(int fd, int how);
+
+/* Wait for a blocking socket op (recv/accept/connect/send) to become ready for
+ * events (POLLIN/POLLOUT) or be interrupted by a guest signal. No-op for
+ * nonblocking fds and MSG_DONTWAIT callers (pass msg_flags = 0 for ops without
+ * a flags argument).
+ *
+ * Returns 0 to proceed or a negative Linux errno (EINTR).
+ */
+int64_t net_wait_or_interrupted(int host_fd, short events, int msg_flags);
+
+/* True when a socket send/recv should wait interruptibly and retry on EAGAIN
+ * rather than surface it (guest wants blocking semantics: no MSG_DONTWAIT, fd
+ * not O_NONBLOCK). Send/recv paths pair this with a per-call MSG_DONTWAIT probe
+ * so the interruptible wait cannot be defeated by a post-readiness buffer-full
+ * or steal race, without toggling the fd's shared O_NONBLOCK flag.
+ */
+bool sock_op_should_block(int host_fd, int msg_flags);
 int64_t sys_sendmsg(guest_t *g, int fd, uint64_t msg_gva, int flags);
 int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags);
 int64_t sys_sendmmsg(guest_t *g,

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -32,14 +32,21 @@
 #include "syscall/proc.h" /* proc_exit_group_requested */
 #include "syscall/signal.h"
 
-/* Global wakeup pipe: write end signals exit_group/futex_interrupt to threads
- * blocked in host poll/select/kevent. The read end is added to every blocking
- * wait with infinite timeout.
+/* Global wakeup pipe: write end signals exit_group/futex_interrupt/guest
+ * signals to threads blocked in host poll/select/kevent. The read end is added
+ * to every blocking wait with infinite timeout.
  */
 static int wakeup_pipe_rd = -1, wakeup_pipe_wr = -1;
 
 void wakeup_pipe_init(void)
 {
+    /* Idempotent: syscall_init is reached twice on some paths (bootstrap and
+     * the fork-child's fork_ipc_recv_fd_table), and re-running the pipe(2) here
+     * would overwrite the fds and leak the first pair.
+     */
+    if (wakeup_pipe_rd >= 0)
+        return;
+
     int pipefd[2];
     if (pipe(pipefd) == 0) {
         fcntl(pipefd[0], F_SETFL, O_NONBLOCK);
@@ -55,6 +62,21 @@ void wakeup_pipe_signal(void)
         uint8_t byte = 1;
         write(wakeup_pipe_wr, &byte, 1);
     }
+}
+
+int wakeup_pipe_read_fd(void)
+{
+    return wakeup_pipe_rd;
+}
+
+void wakeup_pipe_drain(void)
+{
+    if (wakeup_pipe_rd < 0)
+        return;
+
+    uint8_t drain;
+    while (read(wakeup_pipe_rd, &drain, 1) > 0)
+        ;
 }
 
 /* polling/select. */
@@ -183,10 +205,10 @@ int64_t sys_ppoll(guest_t *g,
         mask_installed = true;
     }
 
-    /* For indefinite polls, add the wakeup pipe so exit_group can interrupt
-     * threads blocked in host poll(). Without this, threads in poll(timeout=-1)
-     * cannot be interrupted by hv_vcpus_exit() because they're not in
-     * hv_vcpu_run().
+    /* For indefinite polls, add the wakeup pipe so exit_group/futex/signal
+     * requests can interrupt threads blocked in host poll(). Without this,
+     * host-blocked threads cannot be interrupted by hv_vcpus_exit() because
+     * they're not in hv_vcpu_run().
      */
     bool added_wakeup = false;
     if (timeout_ms < 0 && wakeup_pipe_rd >= 0 && nfds < 256) {
@@ -211,8 +233,9 @@ ppoll_retry:
         ret = poll(host_fds, nfds + added_wakeup,
                    poll_timeout_ms < 0 ? 200 : poll_timeout_ms);
 
-        /* Check for exit_group / futex_interrupt after waking */
-        if (proc_exit_group_requested() || futex_interrupt_consume()) {
+        /* Check for process/thread interrupts after waking. */
+        if (proc_exit_group_requested() || futex_interrupt_consume() ||
+            signal_pending_interruption(NULL)) {
             ret = -1;
             errno = EINTR;
             break;
@@ -241,9 +264,7 @@ ppoll_retry:
      * wakeup pipe is not visible to the guest.
      */
     if (added_wakeup && (host_fds[nfds].revents & POLLIN)) {
-        uint8_t drain;
-        while (read(wakeup_pipe_rd, &drain, 1) > 0)
-            ;
+        wakeup_pipe_drain();
         if (ret > 0)
             ret--;
         if (ret == 0 && poll_timeout_ms < 0)
@@ -453,8 +474,8 @@ int64_t sys_pselect6(guest_t *g,
         }
     }
 
-    /* For indefinite selects, add the wakeup pipe and use a short timeout so
-     * exit_group can interrupt.
+    /* For indefinite selects, add the wakeup pipe so exit_group/futex/signal
+     * requests can interrupt.
      */
     bool added_wakeup = false;
     if (!has_timeout && wakeup_pipe_rd >= 0) {
@@ -556,7 +577,8 @@ pselect_retry:
                           has_timeout ? &ts : &poll_ts, NULL);
         }
 
-        if (proc_exit_group_requested() || futex_interrupt_consume()) {
+        if (proc_exit_group_requested() || futex_interrupt_consume() ||
+            signal_pending_interruption(NULL)) {
             ret = -1;
             errno = EINTR;
             break;
@@ -573,9 +595,7 @@ pselect_retry:
         (use_poll_fallback ? poll_wakeup_fired
                            : FD_ISSET(wakeup_pipe_rd, &read_set));
     if (wakeup_fired) {
-        uint8_t drain;
-        while (read(wakeup_pipe_rd, &drain, 1) > 0)
-            ;
+        wakeup_pipe_drain();
         if (!use_poll_fallback)
             FD_CLR(wakeup_pipe_rd, &read_set);
         if (ret > 0)
@@ -1011,7 +1031,8 @@ int64_t sys_epoll_pwait(guest_t *g,
 
 epoll_retry:;
     /* For indefinite waits, register the wakeup pipe with the kqueue so
-     * exit_group can interrupt threads blocked in kevent().
+     * exit_group/futex/signal requests can interrupt threads blocked in
+     * kevent().
      */
     bool added_wakeup = false;
     if (!has_timeout && wakeup_pipe_rd >= 0) {
@@ -1042,7 +1063,8 @@ epoll_retry:;
         nready = kevent(epoll_ref.fd, NULL, 0, kevents, cap,
                         has_timeout ? &ts : &poll_ts);
 
-        if (proc_exit_group_requested() || futex_interrupt_consume()) {
+        if (proc_exit_group_requested() || futex_interrupt_consume() ||
+            signal_pending_interruption(NULL)) {
             nready = -1;
             errno = EINTR;
             break;
@@ -1056,10 +1078,7 @@ epoll_retry:;
         struct kevent del_ev;
         EV_SET(&del_ev, wakeup_pipe_rd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
         kevent(epoll_ref.fd, &del_ev, 1, NULL, 0, NULL);
-        /* Drain the wakeup pipe */
-        uint8_t drain;
-        while (read(wakeup_pipe_rd, &drain, 1) > 0)
-            ;
+        wakeup_pipe_drain();
         /* Filter out wakeup pipe events from results */
         for (int i = 0; i < nready; i++) {
             if ((uintptr_t) kevents[i].udata == (uintptr_t) -1) {

--- a/src/syscall/poll.h
+++ b/src/syscall/poll.h
@@ -38,9 +38,11 @@ int64_t sys_epoll_pwait(guest_t *g,
                         uint64_t sigmask_gva);
 
 /* Global wakeup pipe for interrupting blocking poll/select/epoll. When
- * exit_group or futex_interrupt is requested, write to wakeup_pipe_wr to
- * unblock any thread stuck in a host-side poll/select/kevent with infinite
- * timeout.
+ * exit_group, futex_interrupt, or a guest signal is requested, write to
+ * wakeup_pipe_wr to unblock any thread stuck in a host-side poll/select/kevent
+ * with infinite timeout.
  */
 void wakeup_pipe_init(void);
 void wakeup_pipe_signal(void);
+int wakeup_pipe_read_fd(void);
+void wakeup_pipe_drain(void);

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -24,6 +24,7 @@
 #include <limits.h>
 #include <pthread.h>
 #include <signal.h>
+#include <sys/file.h> /* flock() */
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/wait.h>
@@ -45,6 +46,7 @@
 #include "syscall/proc.h"
 #include "syscall/proc-pidfd.h"
 #include "syscall/proc-state.h"
+#include "syscall/poll.h"
 #include "syscall/signal.h"
 
 #include "debug/crashreport.h"
@@ -372,13 +374,28 @@ int proc_send_guest_signal(pid_t host_pid, int signum)
         errno = EINVAL;
         return -1;
     }
-    if (proc_write_full(fd, line, (size_t) len) < 0) {
+
+    /* Serialize the append against the receiver's read+truncate drain via an
+     * exclusive lock. The receiver holds the same lock and never unlinks the
+     * file, so this append either lands before its read (and is consumed) or
+     * after its truncate (and the SIGUSR2 below triggers the next drain).
+     * Neither side can route this write to an orphaned inode or discard it.
+     */
+    if (flock(fd, LOCK_EX) < 0) {
         close(fd);
         return -1;
     }
-    if (close(fd) < 0)
+    int wrc = proc_write_full(fd, line, (size_t) len);
+    flock(fd, LOCK_UN);
+    if (wrc < 0) {
+        close(fd);
         return -1;
-
+    }
+    /* The line is durably appended under the lock, so ring the doorbell even if
+     * close() reports an error; suppressing the kill would leave the queued
+     * line waiting for some later unrelated signal.
+     */
+    close(fd);
     return kill(host_pid, SIGUSR2);
 }
 
@@ -952,79 +969,197 @@ void proc_request_hvc6_yield(void)
     hvc6_yield_requested = true;
 }
 
-/* Global vCPU handle for the SIGALRM handler (unavoidable global state --
- * signal handlers cannot receive context parameters). Written once by
- * vcpu_run_loop before signal(SIGALRM), then only read by alarm_handler /
- * guest_signal_transport_handler. The write happens-before the signal() call
- * that installs the handlers, so no volatile needed.
+/* Preemption signals: SIGUSR2 is the cross-process guest-signal doorbell
+ * (proc_send_guest_signal), SIGALRM is the main thread's per-iteration safety
+ * timeout (armed by alarm() in vcpu_run_loop). Both are consumed by a dedicated
+ * sigwait thread rather than a per-thread signal handler.
+ *
+ * The reason is Apple HVF: when either signal is delivered to a vCPU thread
+ * while it is inside hv_vcpu_run, the run aborts with HV_EXIT_REASON_UNKNOWN
+ * instead of the clean HV_EXIT_REASON_CANCELED that hv_vcpus_exit() produces
+ * for a vCPU caught between runs. Routing every self-directed hv_vcpus_exit
+ * through a thread that never runs a vCPU makes CANCELED the only outcome, so
+ * the run loop can treat any UNKNOWN as a hard hypervisor fault.
+ *
+ * The two flags are a genuine cross-thread handoff (the preempt thread writes,
+ * a vCPU thread reads and clears), so they are _Atomic with release/acquire
+ * ordering rather than the old volatile sig_atomic_t, which only covered
+ * same-thread async signal handlers.
  */
-static hv_vcpu_t g_timeout_vcpu;
-static volatile sig_atomic_t g_timed_out, g_external_guest_signal;
+static _Atomic int g_timed_out, g_external_guest_signal;
 
-static void alarm_handler(int sig)
+static pthread_t g_preempt_thread;
+static bool g_preempt_started;
+
+static void drain_external_guest_signal(void);
+
+/* Dedicated sigwait consumer. SIGUSR2/SIGALRM are blocked on every other thread
+ * (see proc_preempt_init), so they land here. thread_interrupt_all() kicks
+ * every live vCPU off-thread; the signal/queue machinery in the vCPU loop sorts
+ * out which guest thread actually receives the delivery.
+ */
+static void *preempt_thread_main(void *arg)
 {
-    (void) sig;
-    g_timed_out = 1;
-    hv_vcpus_exit(&g_timeout_vcpu, 1);
+    (void) arg;
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+
+    sigset_t wait_set;
+    sigemptyset(&wait_set);
+    sigaddset(&wait_set, SIGUSR2);
+    sigaddset(&wait_set, SIGALRM);
+
+    for (;;) {
+        int sig = 0;
+        if (sigwait(&wait_set, &sig) != 0)
+            continue;
+        if (sig == SIGUSR2) {
+            atomic_store_explicit(&g_external_guest_signal, 1,
+                                  memory_order_release);
+            drain_external_guest_signal();
+            wakeup_pipe_signal();
+        } else if (sig == SIGALRM) {
+            atomic_store_explicit(&g_timed_out, 1, memory_order_release);
+        }
+        thread_interrupt_all();
+    }
+    return NULL;
 }
 
-static void guest_signal_transport_handler(int sig, siginfo_t *info, void *ctx)
+/* Unlink this process's own (now empty) transport file on normal exit so the
+ * truncate-not-unlink drain does not leave a zero-length file per pid. Runs via
+ * atexit, so it covers main returning and exit()/exit_group's clean shutdown; a
+ * crash leaves the empty file for the OS temp-dir purge, same as before.
+ */
+static void unlink_own_transport(void)
 {
-    (void) sig;
-    (void) info;
-    (void) ctx;
-    g_external_guest_signal = 1;
-    hv_vcpus_exit(&g_timeout_vcpu, 1);
+    char path[PATH_MAX];
+    if (signal_transport_path(path, sizeof(path), getpid()))
+        unlink(path);
 }
 
-static void install_guest_signal_transport(void)
+/* Call once from the main thread before any vCPU thread is created; the
+ * fork-child re-runs it in its own process. Not safe against concurrent callers
+ * (the g_preempt_started guard is a plain bool), which is fine because every
+ * call site is single-threaded process bring-up.
+ *
+ * Returns 0 on success, -1 if the sigwait thread cannot be started (fatal for
+ * this process).
+ */
+int proc_preempt_init(void)
 {
-    static int installed;
-    if (installed)
-        return;
+    if (g_preempt_started)
+        return 0;
 
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_sigaction = guest_signal_transport_handler;
-    sa.sa_flags = SA_SIGINFO;
-    sigemptyset(&sa.sa_mask);
-    sigaction(SIGUSR2, &sa, NULL);
-    installed = 1;
+    /* Block the preemption signals on the caller (the main thread) before any
+     * vCPU thread exists, so every thread created afterward -- CLONE_THREAD
+     * workers and posix_spawn fork-children -- inherits the block and only the
+     * sigwait thread ever consumes them. A missed site silently reintroduces
+     * HV_EXIT_REASON_UNKNOWN.
+     */
+    sigset_t block;
+    sigemptyset(&block);
+    sigaddset(&block, SIGUSR2);
+    sigaddset(&block, SIGALRM);
+    /* pthread_sigmask returns the error code directly. If the block fails, vCPU
+     * threads would inherit an unblocked mask and a signal landing mid-run
+     * could still produce HV_EXIT_REASON_UNKNOWN, so fail bring-up rather than
+     * proceed on a false invariant.
+     */
+    int merr = pthread_sigmask(SIG_BLOCK, &block, NULL);
+    if (merr != 0) {
+        log_error("elfuse: failed to block preemption signals: %s",
+                  strerror(merr));
+        return -1;
+    }
+
+    int err =
+        pthread_create(&g_preempt_thread, NULL, preempt_thread_main, NULL);
+    if (err != 0) {
+        /* pthread_create returns the error code directly; it does not set
+         * errno. Leave the signals blocked (pending, never default-terminate)
+         * and fail bring-up -- unblocking would restore the default SIGUSR2
+         * disposition and let a cross-process doorbell kill the process.
+         */
+        log_error("elfuse: failed to start preemption thread: %s",
+                  strerror(err));
+        return -1;
+    }
+    g_preempt_started = true;
+    atexit(unlink_own_transport);
+    return 0;
 }
 
 static void drain_external_guest_signal(void)
 {
-    if (!g_external_guest_signal)
+    if (!atomic_exchange_explicit(&g_external_guest_signal, 0,
+                                  memory_order_acquire))
         return;
-    g_external_guest_signal = 0;
 
     char path[PATH_MAX];
     if (!signal_transport_path(path, sizeof(path), getpid()))
         return;
-    int fd = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    /* O_RDWR (not O_RDONLY) so the drain can truncate under the lock. No
+     * O_CREAT: if no sender has written since the last drain, there is nothing
+     * to consume.
+     */
+    int fd = open(path, O_RDWR | O_NOFOLLOW | O_CLOEXEC);
     if (fd < 0)
         return;
 
-    char buf[256];
-    ssize_t n = read(fd, buf, sizeof(buf) - 1);
-    close(fd);
-    unlink(path);
-    if (n <= 0)
+    /* Hold the exclusive lock across the whole read+truncate so a sender's
+     * locked append is atomic with respect to the drain. The file is truncated
+     * to empty rather than unlinked (see proc_send_guest_signal), which avoids
+     * reintroducing the unlink-vs-append race; the process unlinks its own
+     * empty file at exit (unlink_own_transport) so the temp dir stays clean.
+     */
+    if (flock(fd, LOCK_EX) < 0) {
+        close(fd);
         return;
-    buf[n] = '\0';
+    }
 
-    char *p = buf;
-    while (*p) {
-        char *end;
-        long signum = strtol(p, &end, 10);
-        if (end == p)
+    /* Read the whole file in chunks, queuing each complete "signum\n" line and
+     * carrying any partial trailing token across chunk boundaries. Valid tokens
+     * are a few bytes, so the carry never fills the buffer; a lone oversized
+     * garbage token is dropped harmlessly (read returns 0 once the buffer is
+     * full with no newline).
+     */
+    char buf[256];
+    size_t used = 0;
+    for (;;) {
+        ssize_t n = read(fd, buf + used, sizeof(buf) - 1 - used);
+        if (n <= 0)
             break;
+        used += (size_t) n;
+        buf[used] = '\0';
+
+        char *start = buf, *nl;
+        while ((nl = memchr(start, '\n', (size_t) (buf + used - start))) !=
+               NULL) {
+            *nl = '\0';
+            long signum = strtol(start, NULL, 10);
+            if (RANGE_CHECK(signum, 1, LINUX_NSIG))
+                signal_queue((int) signum);
+            start = nl + 1;
+        }
+        size_t rem = (size_t) (buf + used - start);
+        memmove(buf, start, rem);
+        used = rem;
+    }
+
+    /* Senders write whole "signum\n" records under the same lock, so used is
+     * normally 0 here. Parse any unterminated trailing token defensively so a
+     * record left by a crashed sender is not silently dropped by the truncate.
+     */
+    if (used > 0) {
+        buf[used] = '\0';
+        long signum = strtol(buf, NULL, 10);
         if (RANGE_CHECK(signum, 1, LINUX_NSIG))
             signal_queue((int) signum);
-        p = end;
-        while (*p == '\n' || *p == ' ')
-            p++;
     }
+
+    ftruncate(fd, 0);
+    flock(fd, LOCK_UN);
+    close(fd);
 }
 
 /* HVC #4 (set sysreg) register index -> hv_sys_reg_t mapping. Index must match
@@ -1074,18 +1209,15 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
      */
     pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
 
-    install_guest_signal_transport();
-
-    /* Main thread: set up alarm-based per-iteration timeout. Guest ITIMER_REAL
-     * is emulated internally by signal_check_timer() rather than using host
-     * setitimer, because macOS shares alarm() and setitimer(ITIMER_REAL) as the
-     * same underlying timer.
+    /* Main thread: arm the alarm-based per-iteration timeout below. SIGALRM is
+     * blocked here and consumed by the preemption thread (proc_preempt_init),
+     * which sets g_timed_out and kicks the vCPU via hv_vcpus_exit. Guest
+     * ITIMER_REAL is emulated internally by signal_check_timer() rather than
+     * using host setitimer, because macOS shares alarm() and
+     * setitimer(ITIMER_REAL) as the same underlying timer.
      */
-    if (is_main) {
-        g_timeout_vcpu = vcpu;
-        g_timed_out = 0;
-        signal(SIGALRM, alarm_handler);
-    }
+    if (is_main)
+        atomic_store_explicit(&g_timed_out, 0, memory_order_relaxed);
 
     while (running) {
         /* Check if another thread called exit_group */
@@ -1121,7 +1253,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
         }
 
         /* Main: check for alarm timeout */
-        if (is_main && g_timed_out) {
+        if (is_main &&
+            atomic_load_explicit(&g_timed_out, memory_order_acquire)) {
             log_error("%s: vCPU execution timed out after %ds", prefix,
                       timeout_sec);
 
@@ -2057,33 +2190,21 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                 exit_code = 128;
                 running = false;
             }
-        } else if (vexit->reason == HV_EXIT_REASON_CANCELED ||
-                   (vexit->reason == HV_EXIT_REASON_UNKNOWN &&
-                    (signal_pending() || proc_exit_group_requested() ||
-                     (is_main && g_timed_out)))) {
+        } else if (vexit->reason == HV_EXIT_REASON_CANCELED) {
             /* Canceled by hv_vcpus_exit(). Can be: alarm timeout, exit_group
-             * from another thread, or signal preemption (signal_queue called
-             * hv_vcpus_exit to deliver a signal while the guest was in a tight
-             * loop).
+             * from another thread, or signal preemption (a queued guest signal,
+             * a fork barrier, or a ptrace interrupt kicked the vCPU out of a
+             * tight loop).
              *
-             * HV_EXIT_REASON_UNKNOWN is the same event seen from the other side
-             * of a race: when a host signal (e.g. the SIGUSR2 used by the
-             * cross-process guest-signal transport) is delivered to this thread
-             * while it is actively executing guest code inside hv_vcpu_run, the
-             * run aborts with UNKNOWN instead of the clean CANCELED that
-             * hv_vcpus_exit() produces for a vCPU caught between runs. The
-             * pending guest signal has already been drained and queued, so it
-             * is fully deliverable -- fall through to the same handling and
-             * resume rather than treating it as a fatal unexpected exit.
-             *
-             * Gate UNKNOWN on an actionable event actually being present (a
-             * queued signal, a pending exit_group, or a fired timeout) so it is
-             * only absorbed when there is real work to do. If HVF ever reports
-             * UNKNOWN for a genuine fault with nothing pending, fall through to
-             * the "unexpected exit reason" crash path at the end of the switch
-             * rather than silently retrying the run.
+             * Every self-directed hv_vcpus_exit is now issued from the
+             * preemption thread (proc_preempt_init), never from a vCPU thread,
+             * so hv_vcpu_run always returns CANCELED here.
+             * HV_EXIT_REASON_UNKNOWN therefore no longer has a legitimate
+             * producer -- it falls through to the "unexpected exit reason"
+             * crash path below.
              */
-            if (is_main && g_timed_out) {
+            if (is_main &&
+                atomic_load_explicit(&g_timed_out, memory_order_acquire)) {
                 /* Timeout already handled above the exception switch -- loop
                  * back so the timeout check fires.
                  */
@@ -2206,10 +2327,8 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
     }
 
     /* Clean up timeout if the run loop sets it up */
-    if (is_main) {
-        signal(SIGALRM, SIG_DFL);
+    if (is_main)
         alarm(0);
-    }
 
     return exit_code;
 }

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -324,6 +324,16 @@ pid_t proc_guest_to_host_pid(int64_t gpid);
  */
 int proc_send_guest_signal(pid_t host_pid, int signum);
 
+/* Block the vCPU-preemption signals (SIGUSR2 doorbell, SIGALRM timeout) on the
+ * calling thread and start the dedicated sigwait thread that consumes them.
+ * Call once from the main thread before any vCPU thread is created; the
+ * posix_spawn fork-child re-runs it in its own process.
+ *
+ * Returns 0 on success, -1 if the sigwait thread cannot be started (fatal for
+ * this process).
+ */
+int proc_preempt_init(void);
+
 /* Syscall handlers. */
 int64_t sys_pidfd_open(guest_t *g, int64_t pid, unsigned int flags);
 int64_t sys_pidfd_send_signal(guest_t *g,

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -36,6 +36,7 @@
 
 #include "syscall/abi.h"
 #include "syscall/fd.h"   /* signalfd_notify */
+#include "syscall/poll.h" /* wakeup_pipe_signal */
 #include "syscall/proc.h" /* proc_get_pid, proc_get_uid, SYSCALL_EXEC_HAPPENED */
 #include "syscall/signal.h"
 
@@ -303,6 +304,11 @@ void signal_set_shim_globals_guest(guest_t *g)
  * otherwise fall back to a bare vCPU interrupt. Both paths end up running
  * thread_interrupt_all (shim_globals_raise_attention issues it internally), so
  * callers only need this single helper.
+ *
+ * Also poke the wakeup pipe so a thread parked in a host poll/select/epoll/read
+ * wait -- which hv_vcpus_exit cannot reach because it is not inside
+ * hv_vcpu_run -- wakes and rechecks signal_pending(). Matches how exit_group
+ * and futex_interrupt already signal the pipe.
  */
 static inline void attention_raise(void)
 {
@@ -311,6 +317,7 @@ static inline void attention_raise(void)
         shim_globals_raise_attention(g);
     else
         thread_interrupt_all();
+    wakeup_pipe_signal();
 }
 
 /* Predicate matches the deliverability gate used by signal_queue and
@@ -504,54 +511,48 @@ bool signal_pending_interruption(bool *restart_out)
         return false;
     }
 
-    /* restart_out reports whether every deliverable signal is non-disruptive
-     * from the caller's point of view. A signal is non-disruptive if its
-     * effective delivery is either a no-op or an SA_RESTART handler:
-     *   - SIG_IGN: discarded by signal_deliver, no guest-visible effect.
-     *   - SIG_DFL with default-ignore disposition (SIGCHLD/SIGURG/SIGWINCH):
-     *     ditto.
-     *   - User handler with SA_RESTART: handler runs but the syscall is
-     *     expected to be retried transparently.
-     * Any other signal (default-TERM, default-CORE, non-restart handler) forces
-     * the wait to be treated as interrupted; otherwise a SIGTERM hiding behind
-     * an ignored SIGCHLD would never wake the caller.
+    /* Ignored/default-ignore signals are discarded by signal_deliver and must
+     * not interrupt waits. Any guest-visible delivery must escape the wait so
+     * the syscall epilogue can run the handler/default action; restart_out only
+     * tells FUSE whether all visible handlers are SA_RESTART.
      */
-    bool all_noninterrupt = true;
+    bool any_interrupt = false;
+    bool all_restart = true;
     uint64_t bits = deliverable;
     while (bits) {
         int idx = bit_ctz64(bits);
         bits &= bits - 1;
         if (!RANGE_CHECK(idx, 0, LINUX_NSIG)) {
-            all_noninterrupt = false;
+            any_interrupt = true;
+            all_restart = false;
             break;
         }
         linux_sigaction_t *act = &sig_state.actions[idx];
-        bool noninterrupt;
         if (act->sa_handler == LINUX_SIG_IGN) {
-            noninterrupt = true;
+            continue;
         } else if (act->sa_handler == LINUX_SIG_DFL) {
             /* Mirror signal_deliver's SIG_DFL switch: IGN, CONT, and STOP are
              * all discarded with no guest-visible effect on elfuse (STOP/CONT
              * are not meaningful here), so they cannot legitimately interrupt a
-             * FUSE wait. Treating CONT or STOP as disruptive would force a
-             * spurious EINTR that never corresponds to an actual delivery.
+             * wait.
              */
             sig_disposition_t disp = signal_default_disposition(idx + 1);
-            noninterrupt = disp == SIG_DISP_IGN || disp == SIG_DISP_CONT ||
-                           disp == SIG_DISP_STOP;
+            if (disp == SIG_DISP_IGN || disp == SIG_DISP_CONT ||
+                disp == SIG_DISP_STOP)
+                continue;
+            any_interrupt = true;
+            all_restart = false;
         } else {
-            noninterrupt = (act->sa_flags & LINUX_SA_RESTART) != 0;
-        }
-        if (!noninterrupt) {
-            all_noninterrupt = false;
-            break;
+            any_interrupt = true;
+            if ((act->sa_flags & LINUX_SA_RESTART) == 0)
+                all_restart = false;
         }
     }
 
     pthread_mutex_unlock(&sig_lock);
     if (restart_out)
-        *restart_out = all_noninterrupt;
-    return true;
+        *restart_out = any_interrupt && all_restart;
+    return any_interrupt;
 }
 
 const signal_state_t *signal_get_state(void)

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -2086,6 +2086,16 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
             if (tp != FD_REGULAR && tp != FD_STDIO && tp != FD_PIPE &&
                 tp != FD_SOCKET)
                 goto slow_path;
+            /* Same racy-but-benign read as tp above, and no worse than the
+             * shipped tp-based divert: a concurrent close+reopen (only possible
+             * with a live sibling thread; a single active thread has no
+             * mutator) that flips this slot to a blocking fd could skip the
+             * divert for one call. The guest is already reading an fd it is
+             * concurrently reopening, so the pinned fd it gets is undefined
+             * regardless; the slow path carries the identical window. Not worth
+             * a lock on the hot regular-file read.
+             */
+            bool can_block = fd_table[fd].can_block;
 
             /* Proc-backed fds may need synthetic read/write handling (for
              * example, oom_* rereads recompute content on each read and proc
@@ -2121,17 +2131,19 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
                 goto slow_path;
             }
 
-            /* A blocking read on a pipe/stdio fd would park this vCPU thread in
-             * an uninterruptible host read(), where the preempt thread's
-             * hv_vcpus_exit cannot reach it. Probe non-blocking: if nothing is
-             * ready the read would block, so divert to the slow path where
-             * sys_read waits interruptibly (poll + wakeup pipe). Regular files
-             * never block and stay on the fast path.
+            /* A blocking read/write on a pipe, socket, fifo, or char device
+             * would park this vCPU thread in an uninterruptible host call where
+             * the preempt thread's hv_vcpus_exit cannot reach it. Probe
+             * non-blocking: read waits for POLLIN, write for POLLOUT; if the fd
+             * would block, divert to the slow path where sys_read/sys_write
+             * wait interruptibly (poll + wakeup pipe). Regular files never
+             * block (can_block is false) and stay on the fast path.
              */
-            if (nr == SYS_read && (tp == FD_PIPE || tp == FD_STDIO)) {
-                struct pollfd pfd = {.fd = host_ref.fd, .events = POLLIN};
+            if (can_block) {
+                short ev = (nr == SYS_read) ? POLLIN : POLLOUT;
+                struct pollfd pfd = {.fd = host_ref.fd, .events = ev};
                 /* Divert on not-ready (0) or probe error (< 0, e.g. EINTR): a
-                 * blocking read here cannot be preempted, so let the
+                 * blocking call here cannot be preempted, so let the
                  * interruptible slow path handle both.
                  */
                 if (poll(&pfd, 1, 0) <= 0) {

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <poll.h>
 #include <sys/stat.h>
 #include <sys/file.h> /* flock() */
 #include <dirent.h>
@@ -2118,6 +2119,25 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
             if (!buf || avail < count) {
                 host_fd_ref_close(&host_ref);
                 goto slow_path;
+            }
+
+            /* A blocking read on a pipe/stdio fd would park this vCPU thread in
+             * an uninterruptible host read(), where the preempt thread's
+             * hv_vcpus_exit cannot reach it. Probe non-blocking: if nothing is
+             * ready the read would block, so divert to the slow path where
+             * sys_read waits interruptibly (poll + wakeup pipe). Regular files
+             * never block and stay on the fast path.
+             */
+            if (nr == SYS_read && (tp == FD_PIPE || tp == FD_STDIO)) {
+                struct pollfd pfd = {.fd = host_ref.fd, .events = POLLIN};
+                /* Divert on not-ready (0) or probe error (< 0, e.g. EINTR): a
+                 * blocking read here cannot be preempted, so let the
+                 * interruptible slow path handle both.
+                 */
+                if (poll(&pfd, 1, 0) <= 0) {
+                    host_fd_ref_close(&host_ref);
+                    goto slow_path;
+                }
             }
 
             ssize_t ret = (nr == SYS_read) ? read(host_ref.fd, buf, count)

--- a/tests/test-poll.c
+++ b/tests/test-poll.c
@@ -16,6 +16,7 @@
 #include <signal.h>
 #include <sys/epoll.h>
 #include <sys/select.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <time.h>
 
@@ -243,6 +244,59 @@ int main(void)
             }
             close(pipefd[0]);
             close(pipefd[1]);
+        }
+    }
+
+    /* A blocking recv on a socket must be reachable by a signal the same way a
+     * pipe read is: without the interruptible wait path, the vCPU thread parks
+     * in an uninterruptible host recv() and the handler never runs.
+     */
+    TEST("signal interrupts blocking recv");
+    {
+        int sv[2];
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+            FAIL("socketpair failed");
+        } else {
+            restart_pipe_write = sv[1];
+            got_usr1 = 0;
+            sigset_t unblock;
+            sigemptyset(&unblock);
+            sigaddset(&unblock, SIGUSR1);
+            sigprocmask(SIG_UNBLOCK, &unblock, NULL);
+            struct sigaction sa;
+            memset(&sa, 0, sizeof(sa));
+            sa.sa_handler = restart_read_handler;
+            sa.sa_flags = SA_RESTART;
+            sigemptyset(&sa.sa_mask);
+            if (sigaction(SIGUSR1, &sa, NULL) != 0) {
+                FAIL("sigaction failed");
+            } else {
+                pthread_t sender;
+                restart_read_target = pthread_self();
+                if (pthread_create(&sender, NULL, restart_read_sender,
+                                   &sv[1]) != 0) {
+                    FAIL("pthread_create failed");
+                } else {
+                    char c = 0;
+                    ssize_t n = recv(sv[0], &c, 1, 0);
+                    int saved = errno;
+                    pthread_join(sender, NULL);
+                    errno = saved;
+                    /* got_usr1 is the hard requirement: it proves the signal
+                     * reached a thread blocked in a host recv(). The recv
+                     * outcome is accepted either way (restarted read returns
+                     * the handler's 'h', or elfuse surfaces EINTR), matching
+                     * the pipe-read test above.
+                     */
+                    if (((n == 1 && c == 'h') || (n < 0 && errno == EINTR)) &&
+                        got_usr1)
+                        PASS();
+                    else
+                        FAIL("signal did not unblock recv");
+                }
+            }
+            close(sv[0]);
+            close(sv[1]);
         }
     }
 

--- a/tests/test-poll.c
+++ b/tests/test-poll.c
@@ -12,11 +12,50 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <pthread.h>
 #include <signal.h>
+#include <sys/epoll.h>
 #include <sys/select.h>
+#include <sys/wait.h>
 #include <time.h>
 
 #include "test-harness.h"
+
+static int restart_pipe_write = -1;
+static pthread_t restart_read_target;
+static volatile sig_atomic_t got_usr1;
+
+static void restart_read_handler(int signum)
+{
+    char c = 'h';
+    got_usr1 = 1;
+    (void) write(restart_pipe_write, &c, 1);
+}
+
+static void *restart_read_sender(void *arg)
+{
+    int *wfd = arg;
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
+    usleep(20000);
+    pthread_kill(restart_read_target, SIGUSR1);
+    usleep(200000);
+    char c = 'f';
+    (void) write(*wfd, &c, 1);
+    return NULL;
+}
+
+static int fork_exit_after_us(useconds_t usec)
+{
+    int pid = fork();
+    if (pid == 0) {
+        usleep(usec);
+        _exit(0);
+    }
+    return pid;
+}
 
 int main(void)
 {
@@ -90,6 +129,121 @@ int main(void)
             PASS();
         else
             FAIL("sigprocmask failed");
+    }
+
+    TEST("ppoll ignores default SIGCHLD");
+    {
+        int pid = fork_exit_after_us(20000);
+        if (pid < 0) {
+            FAIL("fork failed");
+        } else {
+            struct pollfd pfd = {.fd = -1, .events = POLLIN};
+            struct timespec ts = {.tv_sec = 0, .tv_nsec = 100000000};
+            errno = 0;
+            int ret = ppoll(&pfd, 1, &ts, NULL);
+            int saved = errno;
+            waitpid(pid, NULL, 0);
+            errno = saved;
+            if (ret == 0)
+                PASS();
+            else
+                FAIL("ppoll interrupted by ignored SIGCHLD");
+        }
+    }
+
+    TEST("pselect ignores default SIGCHLD");
+    {
+        int pid = fork_exit_after_us(20000);
+        if (pid < 0) {
+            FAIL("fork failed");
+        } else {
+            struct timespec ts = {.tv_sec = 0, .tv_nsec = 100000000};
+            errno = 0;
+            int ret = pselect(0, NULL, NULL, NULL, &ts, NULL);
+            int saved = errno;
+            waitpid(pid, NULL, 0);
+            errno = saved;
+            if (ret == 0)
+                PASS();
+            else
+                FAIL("pselect interrupted by ignored SIGCHLD");
+        }
+    }
+
+    TEST("epoll_wait ignores default SIGCHLD");
+    {
+        int epfd = epoll_create1(0);
+        int pid = fork_exit_after_us(20000);
+        if (epfd < 0 || pid < 0) {
+            if (epfd >= 0)
+                close(epfd);
+            FAIL("epoll_create1/fork failed");
+        } else {
+            struct epoll_event ev;
+            errno = 0;
+            int ret = epoll_wait(epfd, &ev, 1, 100);
+            int saved = errno;
+            waitpid(pid, NULL, 0);
+            close(epfd);
+            errno = saved;
+            if (ret == 0)
+                PASS();
+            else
+                FAIL("epoll_wait interrupted by ignored SIGCHLD");
+        }
+    }
+
+    TEST("SA_RESTART read handler runs");
+    {
+        int pipefd[2];
+        if (pipe(pipefd) != 0) {
+            FAIL("pipe failed");
+        } else {
+            restart_pipe_write = pipefd[1];
+            got_usr1 = 0;
+            sigset_t unblock;
+            sigemptyset(&unblock);
+            sigaddset(&unblock, SIGUSR1);
+            sigprocmask(SIG_UNBLOCK, &unblock, NULL);
+            struct sigaction sa;
+            memset(&sa, 0, sizeof(sa));
+            sa.sa_handler = restart_read_handler;
+            sa.sa_flags = SA_RESTART;
+            sigemptyset(&sa.sa_mask);
+            if (sigaction(SIGUSR1, &sa, NULL) != 0) {
+                FAIL("sigaction failed");
+            } else {
+                pthread_t sender;
+                restart_read_target = pthread_self();
+                if (pthread_create(&sender, NULL, restart_read_sender,
+                                   &pipefd[1]) != 0) {
+                    FAIL("pthread_create failed");
+                } else {
+                    char c = 0;
+                    ssize_t n = read(pipefd[0], &c, 1);
+                    int saved = errno;
+                    pthread_join(sender, NULL);
+                    errno = saved;
+                    /* The handler running is the hard requirement (got_usr1);
+                     * that alone proves the signal reached a thread blocked in
+                     * a host read(). The read outcome is accepted either way:
+                     * on Linux the SA_RESTART read transparently restarts and
+                     * returns the 'h' the handler wrote (n==1), but elfuse has
+                     * no transparent syscall restart -- like
+                     * nanosleep/poll/select it surfaces EINTR to the guest --
+                     * so n<0/EINTR is the expected result here, not a masked
+                     * failure.
+                     */
+                    if (((n == 1 && c == 'h') || (n < 0 && errno == EINTR)) &&
+                        got_usr1)
+                        PASS();
+                    else
+                        FAIL("SA_RESTART read handler did not unblock read");
+                }
+            }
+            close(pipefd[0]);
+            close(pipefd[1]);
+        }
     }
 
     /* Test sigaction (should succeed as stub) */

--- a/tests/test-readv-writev.c
+++ b/tests/test-readv-writev.c
@@ -169,7 +169,39 @@ static void test_zero_length_iovec(void)
                 "zero-length iovec handling wrong");
 }
 
-/* Test 5: Large writev (many iovecs) */
+/* Test 5: all-empty iovecs still validate descriptor access */
+
+static void test_empty_iovec_access_checks(void)
+{
+    TEST("empty readv/writev access checks");
+
+    struct iovec zv[2] = {{0}};
+    int rfd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+    int wfd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+    if (rfd < 0 || wfd < 0) {
+        if (rfd >= 0)
+            close(rfd);
+        if (wfd >= 0)
+            close(wfd);
+        FAIL("open");
+        return;
+    }
+
+    errno = 0;
+    ssize_t wr = writev(rfd, zv, 2);
+    int write_errno = errno;
+    errno = 0;
+    ssize_t rr = readv(wfd, zv, 2);
+    int read_errno = errno;
+    close(rfd);
+    close(wfd);
+
+    EXPECT_TRUE(
+        wr == -1 && write_errno == EBADF && rr == -1 && read_errno == EBADF,
+        "empty iovec access check skipped");
+}
+
+/* Test 6: Large writev (many iovecs) */
 
 static void test_many_iovecs(void)
 {
@@ -196,7 +228,7 @@ static void test_many_iovecs(void)
                 "10-iovec writev failed");
 }
 
-/* Test 6: pwritev2 RWF_APPEND semantics */
+/* Test 7: pwritev2 RWF_APPEND semantics */
 
 static void test_pwritev2_append(void)
 {
@@ -249,7 +281,7 @@ static void test_pwritev2_append(void)
     EXPECT_TRUE(nr == 6 && !memcmp(buf, "baseXY", 6), "append data mismatch");
 }
 
-/* Test 7: zero iovcnt must not move the append file offset */
+/* Test 8: zero iovcnt must not move the append file offset */
 
 static void test_pwritev2_append_zero_iovcnt(void)
 {
@@ -289,6 +321,7 @@ int main(void)
     test_file_roundtrip();
     test_single_iovec();
     test_zero_length_iovec();
+    test_empty_iovec_access_checks();
     test_many_iovecs();
     test_pwritev2_append();
     test_pwritev2_append_zero_iovcnt();

--- a/tests/test-socket.c
+++ b/tests/test-socket.c
@@ -22,6 +22,8 @@
  * 11. shutdown(SHUT_WR) causes read to return 0 (EOF)
  * 12. socketpair(AF_UNIX, SOCK_SEQPACKET)
  * 13. socket(AF_UNIX, SOCK_SEQPACKET)
+ * 14. zero-length recvmsg returns immediately
+ * 15. invalid recvmsg iov returns EFAULT immediately
  */
 
 #include <stdio.h>
@@ -384,6 +386,61 @@ int main(void)
     } else {
         printf("FAIL (read after shutdown returned %zd)\n", n);
         failures++;
+    }
+
+    /* Test 14: zero-length recvmsg returns immediately */
+    printf("test-socket: 14. zero-length recvmsg returns immediately... ");
+    {
+        int zsv[2];
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, zsv) < 0) {
+            printf("FAIL (socketpair: %m)\n");
+            failures++;
+        } else {
+            char dummy = 0;
+            struct iovec ziov[2] = {
+                {.iov_base = &dummy, .iov_len = 0},
+                {.iov_base = &dummy, .iov_len = 0},
+            };
+            struct msghdr zmsg = {.msg_iov = ziov, .msg_iovlen = 2};
+            n = recvmsg(zsv[1], &zmsg, 0);
+            if (n == 0)
+                printf("PASS\n");
+            else {
+                printf("FAIL (recvmsg returned %zd errno=%d)\n", n, errno);
+                failures++;
+            }
+            close(zsv[0]);
+            close(zsv[1]);
+        }
+    }
+
+    /* Test 15: invalid recvmsg iov returns EFAULT immediately */
+    printf("test-socket: 15. invalid recvmsg iov returns EFAULT... ");
+    {
+        int isv[2];
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, isv) < 0) {
+            printf("FAIL (socketpair: %m)\n");
+            failures++;
+        } else {
+            struct msghdr imsg = {
+                .msg_iov = (struct iovec *) 1,
+                .msg_iovlen = 1,
+            };
+            errno = 0;
+            alarm(2);
+            n = recvmsg(isv[1], &imsg, 0);
+            int saved_errno = errno;
+            alarm(0);
+            if (n == -1 && saved_errno == EFAULT)
+                printf("PASS\n");
+            else {
+                printf("FAIL (recvmsg returned %zd errno=%d)\n", n,
+                       saved_errno);
+                failures++;
+            }
+            close(isv[0]);
+            close(isv[1]);
+        }
     }
 
     close(sv[0]);


### PR DESCRIPTION
elfuse preempted a running vCPU by sending a host signal whose handler called hv_vcpus_exit(): SIGUSR2 for the cross-process guest-signal doorbell and SIGALRM for the per-iteration safety timeout. Because the signal landed on the vCPU thread inside hv_vcpu_run, Apple HVF aborted the run with HV_EXIT_REASON_UNKNOWN instead of the clean CANCELED that hv_vcpus_exit() produces for a vCPU caught between runs, leaving the run loop unable to tell a self-directed preemption from a genuine fault.

Block SIGUSR2 and SIGALRM on the main thread before any vCPU thread is created (proc_preempt_init), so every CLONE_THREAD worker and posix_spawn fork-child inherits the block. A dedicated thread sigwaits both and kicks every live vCPU via thread_interrupt_all() from a thread that never runs one, so hv_vcpu_run always returns CANCELED and the run loop treats any HV_EXIT_REASON_UNKNOWN as a hard hypervisor fault. The g_timed_out and g_external_guest_signal handoff flags become _Atomic with release/acquire ordering now that they cross the preempt-thread to vCPU-thread boundary.

Make a guest thread parked in a blocking host syscall reachable by a signal, which hv_vcpus_exit() alone cannot interrupt:
- attention_raise() pokes the wakeup pipe on every deliverable signal.
- ppoll/pselect/epoll_pwait break out on signal_pending_interruption.
- a blocking pipe/stdio read waits in wait_readable_or_interrupted, which returns EINTR only for a guest-visible delivery, skips O_WRONLY and O_NONBLOCK fds, and uses a bounded 200ms recheck; the non-verbose fast-path read diverts a would-block pipe/stdio read to this slow path.
- fork_child_main creates the wakeup pipe, which it skips via syscall_init.

Make the signal transport race-free: the sender holds flock around its append and the drain holds it across a full read plus ftruncate and no longer unlinks, so a concurrent append is never routed to an orphaned inode. Each process unlinks its own empty file at exit.

signal_pending_interruption() reports whether a guest-visible delivery is pending and excludes ignored and default-ignore signals, so read, poll, select, and epoll no longer wake spuriously on an ignored signal.

Close #77

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route vCPU preemption (SIGUSR2/SIGALRM) through a dedicated sigwait thread so hv_vcpu_run reliably returns CANCELED on HVF, and expand interruptible blocking I/O so reads, writes, and socket ops wake only for guest-visible signals. Also harden cross-process signal transport and clean up wakeup-pipe handling.

- **Bug Fixes**
  - Preemption: block SIGUSR2/SIGALRM before any vCPU threads; a sigwait thread sets _Atomic handoff flags and kicks vCPUs; HV_EXIT_REASON_UNKNOWN now indicates a hypervisor fault.
  - Blocking I/O: add per-fd can_block and a shared io_wait_fd_or_interrupted; used by read/write/readv/writev and socket recv/accept/connect/send; the fast-path read/write diverts on would-block or probe error; sends probe with MSG_DONTWAIT and retry on EAGAIN; connect flips nonblocking, waits for POLLOUT, checks SO_ERROR; zero-length iovecs still enforce EBADF; zero-length recvmsg returns immediately.
  - Signals and waits: attention_raise pokes the wakeup pipe; ppoll/pselect/epoll_pwait break only on guest-visible deliveries; ignored/default-ignore signals no longer interrupt; wakeup-pipe init is idempotent with read/drain helpers.
  - Signal transport: sender append and receiver drain are serialized with flock; drain reads fully and ftruncate’s; each process unlinks its empty file at exit.
  - Tests: `test-poll` covers ignored SIGCHLD and that SA_RESTART read handlers run and unblock recv; `test-socket` adds zero-length/invalid recvmsg cases; `test-readv-writev` adds an all-empty-iovec access-check.

<sup>Written for commit c3de5dcc4e33e13ef41c08cdfc2fe9781a7c293d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

