### PR TITLE
Clear epoll registrations on close

### DIFF
--- a/src/syscall/fd.c
+++ b/src/syscall/fd.c
@@ -694,8 +694,8 @@ static void eventfd_close(int guest_fd)
  *   - Source identity. duplicate_guest_fd() snapshots src_fd under
  *     fd_lock, releases it, then calls us. Between those points src_fd
  *     could be closed and rebound to a different eventfd. We carry the
- *     caller's snapshot of fd_table[src_fd].host_fd as src_host_fd and verify
- *     under fd_lock + sfd_lock that the source fd still has that host fd and
+ *     caller's snapshot of fd_table[src_fd].host_fd and generation and verify
+ *     under fd_lock + sfd_lock that the source fd still has that identity and
  *     still maps to a live eventfd slot.
  *
  *   - Destination close. fd_alloc_*_relaxed publishes the new guest_fd
@@ -710,6 +710,7 @@ static void eventfd_close(int guest_fd)
  */
 int eventfd_dup_fd(int src_fd,
                    int src_host_fd,
+                   uint64_t src_generation,
                    int min_guest_fd,
                    int fixed_guest_fd,
                    bool fixed_slot,
@@ -724,6 +725,7 @@ int eventfd_dup_fd(int src_fd,
     int slot = eventfd_find(src_fd);
     if (slot < 0 || fd_table[src_fd].type != FD_EVENTFD ||
         fd_table[src_fd].host_fd != src_host_fd ||
+        fd_table[src_fd].generation != src_generation ||
         eventfd_state[slot].refcount <= 0) {
         pthread_mutex_unlock(&sfd_lock);
         pthread_mutex_unlock(&fd_lock);

--- a/src/syscall/fd.h
+++ b/src/syscall/fd.h
@@ -36,15 +36,16 @@ int64_t sys_eventfd2(unsigned int initval, int flags);
 
 /* Duplicate an eventfd into a new guest_fd slot, sharing the counter and pipe
  * state with src_fd. Mirrors the Linux contract that dup'd eventfds share the
- * same underlying kernel object. src_host_fd must be the host fd snapshotted
- * from fd_table[src_fd].host_fd by the caller; the implementation uses it to
- * verify under fd_lock + sfd_lock that the source fd still refers to the same
- * live eventfd between the caller's snapshot and the dup commit.
+ * same underlying kernel object. src_host_fd and src_generation must be
+ * snapshotted from fd_table[src_fd] by the caller; the implementation uses them
+ * to verify under fd_lock + sfd_lock that the source fd still refers to the
+ * same live eventfd between the caller's snapshot and the dup commit.
  *
  * Returns the new guest_fd or -1 with errno set.
  */
 int eventfd_dup_fd(int src_fd,
                    int src_host_fd,
+                   uint64_t src_generation,
                    int min_guest_fd,
                    int fixed_guest_fd,
                    bool fixed_slot,

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -25,6 +25,7 @@
 #include "runtime/procemu.h"
 #include "syscall/abi.h"
 #include "syscall/internal.h"
+#include "syscall/poll.h"
 
 /* Protects the FD table (fd_alloc, fd_alloc_at, fd_alloc_from, sys_close). File
  * descriptor operations from concurrent threads must be serialized.
@@ -207,6 +208,78 @@ int fd_alloc(int type, int host_fd, void (*cleanup)(int))
     return fd;
 }
 
+int fd_alloc_dir(int type,
+                 int host_fd,
+                 void (*cleanup)(int),
+                 void *dir,
+                 int linux_flags)
+{
+    pthread_mutex_lock(&fd_lock);
+    int fd = fd_alloc_locked(0, type, host_fd, cleanup);
+    if (fd >= 0) {
+        fd_table[fd].dir = dir;
+        fd_table[fd].linux_flags = linux_flags;
+    }
+    pthread_mutex_unlock(&fd_lock);
+    return fd;
+}
+
+/* Like fd_alloc_from() but publishes dir + linux_flags in the same fd_lock
+ * critical section as the slot identity, so the slot is never observable with
+ * the target type but a stale/NULL dir. Required for FD_EPOLL, where dir
+ * carries the shared eventpoll instance and the close hooks key their behavior
+ * off it.
+ */
+int fd_alloc_dir_from(int minfd,
+                      int type,
+                      int host_fd,
+                      void (*cleanup)(int),
+                      void *dir,
+                      int linux_flags)
+{
+    pthread_mutex_lock(&fd_lock);
+    int fd = fd_alloc_locked(minfd, type, host_fd, cleanup);
+    if (fd >= 0) {
+        fd_table[fd].dir = dir;
+        fd_table[fd].linux_flags = linux_flags;
+    }
+    pthread_mutex_unlock(&fd_lock);
+    return fd;
+}
+
+/* Fixed-slot counterpart of fd_alloc_dir_from(): overwrites fd with the new
+ * (type, host_fd, dir, flags) atomically, cleaning up any prior occupant
+ * outside fd_lock like fd_alloc_at().
+ */
+int fd_alloc_dir_at(int fd,
+                    int type,
+                    int host_fd,
+                    void (*cleanup)(int),
+                    void *dir,
+                    int linux_flags)
+{
+    if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
+        return -1;
+    if (fd >= rlimit_nofile_cur)
+        return -1;
+
+    fd_entry_t old = {.type = FD_CLOSED};
+    pthread_mutex_lock(&fd_lock);
+    if (fd_table[fd].type != FD_CLOSED) {
+        old = fd_table[fd];
+        epoll_note_fd_closed(fd);
+    }
+    fd_init_entry(fd, type, host_fd, cleanup);
+    fd_table[fd].dir = dir;
+    fd_table[fd].linux_flags = linux_flags;
+    pthread_mutex_unlock(&fd_lock);
+
+    if (old.type != FD_CLOSED)
+        fd_cleanup_entry(fd, &old);
+
+    return fd;
+}
+
 /* Allocate the lowest available FD >= minfd.
  *
  * Returns -1 if none available or RLIMIT_NOFILE would be exceeded.
@@ -248,8 +321,14 @@ int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int))
     fd_entry_t old = {.type = FD_CLOSED};
 
     pthread_mutex_lock(&fd_lock);
-    if (fd_table[fd].type != FD_CLOSED)
+    if (fd_table[fd].type != FD_CLOSED) {
         old = fd_table[fd];
+        /* dup2/dup3 over an open slot retires the old open file description at
+         * this fd number without routing through fd_mark_closed_unlocked, so
+         * clear its epoll registrations here too (see epoll_note_fd_closed).
+         */
+        epoll_note_fd_closed(fd);
+    }
     fd_init_entry(fd, type, host_fd, cleanup);
     pthread_mutex_unlock(&fd_lock);
 
@@ -295,6 +374,14 @@ void fd_mark_closed_unlocked(int fd)
     fd_table[fd].linux_flags = 0;
     fd_table[fd].seals = 0;
     fd_bitmap_set_free(fd);
+
+    /* Drop this fd from any epoll interest table. Matches Linux auto-removal on
+     * close and keeps sys_epoll_pwait's active-check honest rather than leaning
+     * on the epoll_ctl generation guard. Runs after the slot is FD_CLOSED so a
+     * just-closed epoll fd skips itself; caller holds fd_lock (or is
+     * single-threaded on the relaxed path).
+     */
+    epoll_note_fd_closed(fd);
 }
 
 void fd_mark_closed(int fd)
@@ -484,7 +571,7 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
         if (snap->type == FD_DIR)
             closedir((DIR *) snap->dir);
         else if (snap->type == FD_EPOLL)
-            free(snap->dir);
+            epoll_instance_free(snap->dir);
     }
 
     /* Type-specific teardown via vtable (replaces per-type switch) */

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -36,6 +36,7 @@
 #include "syscall/internal.h"
 #include "syscall/net.h" /* absock_unregister_fd */
 #include "syscall/path.h"
+#include "syscall/poll.h" /* epoll_dup_fd */
 #include "syscall/proc.h"
 #include "syscall/sidecar.h"
 
@@ -746,16 +747,29 @@ static int duplicate_guest_fd(int src_fd,
                            linux_flags);
     }
     /* eventfd dup must share the underlying counter and pipe state across the
-     * source and destination fds (Linux contract). Pass src_snap's host_fd
-     * through so eventfd_dup_fd can verify the source fd still refers to the
-     * same live eventfd between the snapshot here and the bind there.
+     * source and destination fds (Linux contract). Pass src_snap's identity
+     * through so eventfd_dup_fd can reject a close+reopen ABA between the
+     * snapshot here and the bind there.
      */
     if (src_snap.type == FD_EVENTFD) {
         proc_pty_unlock_for_dup();
         if (new_host_fd >= 0)
             close_keep_errno(new_host_fd);
-        return eventfd_dup_fd(src_fd, src_snap.host_fd, min_guest_fd,
-                              fixed_guest_fd, fixed_slot, linux_flags);
+        return eventfd_dup_fd(src_fd, src_snap.host_fd, src_snap.generation,
+                              min_guest_fd, fixed_guest_fd, fixed_slot,
+                              linux_flags);
+    }
+    /* epoll dup must share the source's eventpoll instance so the alias sees
+     * the same interest list. Pass src_snap's identity so epoll_dup_fd can
+     * reject a close+reopen ABA before pinning the shared instance.
+     */
+    if (src_snap.type == FD_EPOLL) {
+        proc_pty_unlock_for_dup();
+        if (new_host_fd >= 0)
+            close_keep_errno(new_host_fd);
+        return epoll_dup_fd(src_fd, src_snap.host_fd, src_snap.generation,
+                            min_guest_fd, fixed_guest_fd, fixed_slot,
+                            linux_flags);
     }
     if (new_host_fd < 0) {
         proc_pty_unlock_for_dup();

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -11,6 +11,9 @@
  *   mmap_lock    (syscall/mem.c):     mmap/brk allocators + page tables
  *   pt_lock      (core/guest.c):      page table pool allocator
  *   fd_lock      (syscall/fdtable.c): FD table (alloc/close/dup)
+ *   epoll inst   (syscall/poll.c):    per-epoll-instance regs[]; taken under
+ *                                     fd_lock by the close hook, taken alone
+ *                                     (no fd_lock held) by epoll_ctl/pwait
  *   sig_lock     (syscall/signal.c):  signal handlers/pending/blocked
  *   thread_lock  (runtime/thread.c):  thread table
  *   sfd_lock     (syscall/fd.c):      special fd (never held with thread_lock)
@@ -62,6 +65,37 @@ void fdtable_init(void);
  * NULL for plain fds).
  */
 int fd_alloc(int type, int host_fd, void (*cleanup)(int));
+
+/* Allocate the lowest available FD and publish type, host_fd, dir, and
+ * linux_flags in one fd_lock critical section, so the slot never becomes
+ * visible to a concurrent close/scan as type-set-but-dir-NULL. For fds (epoll)
+ * whose close hook and refcount rely on dir being present the instant the slot
+ * reads FD_EPOLL.
+ *
+ * Returns -1 (EMFILE) if the table is full.
+ */
+int fd_alloc_dir(int type,
+                 int host_fd,
+                 void (*cleanup)(int),
+                 void *dir,
+                 int linux_flags);
+
+/* fd_alloc_from()/fd_alloc_at() variants that publish dir + linux_flags in the
+ * same fd_lock section as the slot identity (see fd_alloc_dir). Used by
+ * epoll_dup_fd() so a duped epoll fd never appears as FD_EPOLL with a NULL dir.
+ */
+int fd_alloc_dir_from(int minfd,
+                      int type,
+                      int host_fd,
+                      void (*cleanup)(int),
+                      void *dir,
+                      int linux_flags);
+int fd_alloc_dir_at(int fd,
+                    int type,
+                    int host_fd,
+                    void (*cleanup)(int),
+                    void *dir,
+                    int linux_flags);
 
 /* Allocate the lowest available FD >= minfd.
  *

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -707,7 +707,8 @@ typedef struct {
                           * close+reopen ABA: if the guest fd's current
                           * generation no longer matches, the registered open
                           * file is gone and this stale entry must not drive
-                          * kevent against the reused host fd. */
+                          * kevent against the reused host fd.
+                          */
     bool active;         /* Registered in this instance */
     bool oneshot_armed;  /* EPOLLONESHOT and event already fired,
                           * waiting for EPOLL_CTL_MOD re-arm.
@@ -721,8 +722,199 @@ typedef struct {
  * not overwrite each other's user data.
  */
 typedef struct {
+    /* Reference count guarded by fd_lock. Starts at 1 (the fd-table's
+     * reference, held while the epfd is open) and gains one per in-flight
+     * epoll_ctl / epoll_pwait that pinned the instance via
+     * epoll_instance_acquire(). The allocation is freed only when the count
+     * reaches zero, so a concurrent close() of the epoll fd from a sibling
+     * thread cannot free it out from under a call still walking regs[]
+     * (including across a blocking kevent()).
+     */
+    int refcount;
+    /* Serializes all regs[] reads and writes: epoll_ctl / epoll_pwait take it
+     * for their short reg bookkeeping (never across the blocking kevent()
+     * wait), and epoll_note_fd_closed takes it while holding fd_lock. Mirrors
+     * the Linux eventpoll->mtx that serializes interest-list mutation against
+     * ready-list scans. Lock order: fd_lock -> lock (see internal.h).
+     */
+    pthread_mutex_t lock;
     epoll_reg_t regs[FD_TABLE_SIZE];
 } epoll_instance_t;
+
+/* Count of live epoll instances. When zero, epoll_note_fd_closed() skips its
+ * scan entirely -- the overwhelmingly common case (a process with no epoll fd
+ * pays nothing on every close). Guarded by fd_lock, matching the fd_table scan.
+ */
+static int epoll_live_count;
+
+/* Drop one reference; free when the last one goes. Caller holds fd_lock. Safe
+ * to destroy inst->lock here: the last reference is dropped only after every
+ * epoll_ctl / epoll_pwait that held one has released both its reg lock and its
+ * reference, so nothing is parked on the mutex.
+ */
+static void epoll_instance_unref_locked(epoll_instance_t *inst)
+{
+    if (--inst->refcount == 0) {
+        pthread_mutex_destroy(&inst->lock);
+        free(inst);
+    }
+}
+
+/* Pin the epoll instance behind epfd for the duration of a call, so a
+ * concurrent close(epfd) cannot free it mid-use.
+ *
+ * Returns the instance with an extra reference, or NULL if epfd is not a live
+ * epoll fd. Balance every non-NULL return with epoll_instance_release().
+ */
+static epoll_instance_t *epoll_instance_acquire(int epfd)
+{
+    if (!RANGE_CHECK(epfd, 0, FD_TABLE_SIZE))
+        return NULL;
+    pthread_mutex_lock(&fd_lock);
+    epoll_instance_t *inst = NULL;
+    if (fd_table[epfd].type == FD_EPOLL) {
+        inst = (epoll_instance_t *) fd_table[epfd].dir;
+        if (inst)
+            inst->refcount++;
+    }
+    pthread_mutex_unlock(&fd_lock);
+    return inst;
+}
+
+/* Release a reference taken by epoll_instance_acquire(). */
+static void epoll_instance_release(epoll_instance_t *inst)
+{
+    pthread_mutex_lock(&fd_lock);
+    epoll_instance_unref_locked(inst);
+    pthread_mutex_unlock(&fd_lock);
+}
+
+/* Duplicate an epoll fd. Linux dup(2)/dup3(2)/F_DUPFD of an epoll fd yield a
+ * second descriptor onto the SAME eventpoll instance -- shared interest list
+ * and all. The generic dup path in duplicate_guest_fd() cannot express that: it
+ * clones DIR streams but leaves fd_table[dst].dir NULL for every other type, so
+ * a duped epoll fd would have no interest table and every epoll_ctl/epoll_pwait
+ * on it would fail. Handle it here by pointing the new slot's dir at the shared
+ * instance and taking a reference, mirroring eventfd_dup_fd's counter sharing.
+ */
+int epoll_dup_fd(int src_fd,
+                 int src_host_fd,
+                 uint64_t src_generation,
+                 int min_guest_fd,
+                 int fixed_guest_fd,
+                 bool fixed_slot,
+                 int linux_flags)
+{
+    /* Pin the source instance and dup its host kqueue under fd_lock so a
+     * concurrent close(src_fd) can neither free the shared instance nor
+     * invalidate the host fd between validation and dup. The reference and the
+     * live-count bump both cover the new slot; on any failure below,
+     * epoll_instance_free() undoes exactly one of each.
+     */
+    pthread_mutex_lock(&fd_lock);
+    epoll_instance_t *inst = NULL;
+    if (fd_table[src_fd].type == FD_EPOLL &&
+        fd_table[src_fd].host_fd == src_host_fd &&
+        fd_table[src_fd].generation == src_generation)
+        inst = (epoll_instance_t *) fd_table[src_fd].dir;
+    if (!inst) {
+        pthread_mutex_unlock(&fd_lock);
+        errno = EBADF;
+        return -1;
+    }
+    inst->refcount++;
+    int new_host_fd = dup(src_host_fd);
+    if (new_host_fd < 0) {
+        epoll_instance_unref_locked(inst);
+        pthread_mutex_unlock(&fd_lock);
+        return -1;
+    }
+    epoll_live_count++;
+    pthread_mutex_unlock(&fd_lock);
+
+    /* Publish type, host_fd, the shared dir, and flags in one fd_lock critical
+     * section (fd_alloc_dir_*), so the slot is never observable as FD_EPOLL
+     * with a NULL dir -- matching sys_epoll_create1.
+     */
+    int lflags = linux_flags & LINUX_O_CLOEXEC;
+    int new_guest_fd = fixed_slot
+                           ? fd_alloc_dir_at(fixed_guest_fd, FD_EPOLL,
+                                             new_host_fd, NULL, inst, lflags)
+                           : fd_alloc_dir_from(min_guest_fd, FD_EPOLL,
+                                               new_host_fd, NULL, inst, lflags);
+    if (new_guest_fd < 0) {
+        /* fd_alloc_dir_at fails only when fixed_guest_fd is out of range or
+         * over RLIMIT_NOFILE; dup2/dup3 report that as EBADF, not the EMFILE
+         * that the lowest-free path returns. Capture the intended errno before
+         * cleanup so the close()/epoll_instance_free() below (either may touch
+         * errno) cannot clobber it; restore it last. Matches eventfd_dup_fd's
+         * override.
+         */
+        int saved_errno = fixed_slot ? EBADF : errno;
+        close(new_host_fd);
+        epoll_instance_free(inst); /* drops the ref and the live-count bump */
+        errno = saved_errno;
+        return -1;
+    }
+    return new_guest_fd;
+}
+
+/* Eagerly drop a closed guest fd from every epoll instance's interest table.
+ *
+ * Linux auto-removes a fd from all epoll interest lists when its last
+ * descriptor closes; elfuse keys epoll state on the guest fd number, so a close
+ * must clear that number from every instance or regs[fd].active keeps claiming
+ * the fd is still watched. Without this, correctness leans on the cross-call
+ * generation guard in sys_epoll_ctl() to lazily notice the stale entry, and
+ * sys_epoll_pwait() (which does not re-check generation) would surface a stale
+ * registration the moment a host fd or udata value gets reused.
+ *
+ * Called from fd_mark_closed_unlocked() -- the single chokepoint every close
+ * path funnels through -- so it covers sys_close, close_range, dup2 over an
+ * open slot, and the execve CLOEXEC sweep alike. The caller holds fd_lock (or
+ * runs single-threaded on the relaxed fast path), so the fd_table scan and the
+ * cleared slot's own instance (already FD_CLOSED, hence skipped) are stable.
+ * The kqueue knote itself needs no EV_DELETE: the host fd close that follows
+ * drops it automatically, and clearing the software state is what makes the
+ * pwait active-check honest.
+ */
+void epoll_note_fd_closed(int closed_fd)
+{
+    if (epoll_live_count == 0)
+        return;
+    for (int epfd = 0; epfd < FD_TABLE_SIZE; epfd++) {
+        if (fd_table[epfd].type != FD_EPOLL)
+            continue;
+        epoll_instance_t *inst = (epoll_instance_t *) fd_table[epfd].dir;
+        if (!inst)
+            continue;
+        /* fd_lock -> inst->lock ordering; the instance is in the table so its
+         * refcount is at least the table's reference and cannot be freed here.
+         */
+        pthread_mutex_lock(&inst->lock);
+        epoll_reg_t *reg = &inst->regs[closed_fd];
+        reg->active = false;
+        reg->oneshot_armed = false;
+        reg->generation = 0;
+        pthread_mutex_unlock(&inst->lock);
+    }
+}
+
+/* Drop the fd-table's reference to an epoll instance and remove it from the
+ * live count. Called by fd_cleanup_entry() when an FD_EPOLL slot closes. The
+ * memory is freed here only if no in-flight epoll_ctl / epoll_pwait still holds
+ * a reference; the last releaser frees it otherwise.
+ */
+void epoll_instance_free(void *inst)
+{
+    if (!inst)
+        return;
+    pthread_mutex_lock(&fd_lock);
+    if (epoll_live_count > 0)
+        epoll_live_count--;
+    epoll_instance_unref_locked(inst);
+    pthread_mutex_unlock(&fd_lock);
+}
 
 static inline void epoll_merge_event(linux_epoll_event_t *out,
                                      const struct kevent *kev,
@@ -758,19 +950,42 @@ int64_t sys_epoll_create1(int flags)
         close(kq);
         return -LINUX_ENOMEM;
     }
+    if (pthread_mutex_init(&inst->lock, NULL) != 0) {
+        free(inst);
+        close(kq);
+        return -LINUX_ENOMEM;
+    }
 
-    int gfd = fd_alloc(FD_EPOLL, kq, NULL);
+    int lflags = 0;
+    if (flags & LINUX_EPOLL_CLOEXEC)
+        lflags |= LINUX_O_CLOEXEC;
+
+    /* Publish type, host_fd, dir, and flags in one fd_lock critical section
+     * (fd_alloc_dir) so the slot is never visible to a concurrent close/scan as
+     * FD_EPOLL with a NULL dir. refcount is set on the still-private instance
+     * beforehand, so the close hook sees a fully formed instance the instant
+     * the slot reads FD_EPOLL.
+     */
+    inst->refcount = 1; /* the fd-table's reference */
+    int gfd = fd_alloc_dir(FD_EPOLL, kq, NULL, inst, lflags);
     if (gfd < 0) {
+        pthread_mutex_destroy(&inst->lock);
         free(inst);
         close(kq);
         return -LINUX_EMFILE;
     }
 
-    fd_table[gfd].dir = inst;
-    int lflags = 0;
-    if (flags & LINUX_EPOLL_CLOEXEC)
-        lflags |= LINUX_O_CLOEXEC;
-    fd_table[gfd].linux_flags = lflags;
+    /* Count this instance for epoll_note_fd_closed()'s fast-path skip. A
+     * pathological close_range() racing this create can close gfd between the
+     * publish above and here; the close hook then frees the instance and this
+     * increment leaves the counter one too high. Each such race can add one, so
+     * the counter may stay positive with no live instance -- that only forces
+     * the scan to run when it need not (perf only, and the guarded decrement
+     * still never underflows), never a correctness or memory-safety issue.
+     */
+    pthread_mutex_lock(&fd_lock);
+    epoll_live_count++;
+    pthread_mutex_unlock(&fd_lock);
 
     return gfd;
 }
@@ -784,16 +999,15 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     host_fd_ref_t epoll_ref;
     if (host_fd_ref_open(epfd, &epoll_ref) < 0)
         return -LINUX_EBADF;
-    if (fd_table[epfd].type != FD_EPOLL) {
-        host_fd_ref_close(&epoll_ref);
-        return -LINUX_EINVAL;
-    }
 
-    epoll_instance_t *inst = (epoll_instance_t *) fd_table[epfd].dir;
+    /* Pin the instance so a concurrent close(epfd) cannot free it under us. */
+    epoll_instance_t *inst = epoll_instance_acquire(epfd);
     if (!inst) {
         host_fd_ref_close(&epoll_ref);
         return -LINUX_EINVAL;
     }
+
+    int64_t ret;
 
     /* Validate the target fd and read its persistent host fd in a single
      * fd_lock snapshot, so the kqueue knote ident is taken from the same entry
@@ -810,11 +1024,17 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      */
     fd_entry_t target_snap;
     if (!fd_snapshot(fd, &target_snap)) {
-        host_fd_ref_close(&epoll_ref);
-        return -LINUX_EBADF;
+        ret = -LINUX_EBADF;
+        goto out;
     }
     int target_host_fd = target_snap.host_fd;
 
+    /* Serialize all regs[] access and the paired kqueue mutation against a
+     * concurrent close hook or a sibling epoll_ctl on the same instance. The
+     * kevent() calls below are change-only (non-blocking), so holding the lock
+     * across them is bounded. From here every exit goes through out_locked.
+     */
+    pthread_mutex_lock(&inst->lock);
     epoll_reg_t *reg = &inst->regs[fd];
 
     /* Cross-call ABA guard. If the guest closed this fd and reopened it (or the
@@ -834,8 +1054,8 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     if (op == LINUX_EPOLL_CTL_DEL) {
         /* Linux returns ENOENT when removing an unregistered fd */
         if (!reg->active) {
-            host_fd_ref_close(&epoll_ref);
-            return -LINUX_ENOENT;
+            ret = -LINUX_ENOENT;
+            goto out_locked;
         }
 
         /* Remove all filters for this fd. EPOLLRDHUP alone registers
@@ -860,8 +1080,8 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
             /* Clear stale state for potential re-add */
             reg->oneshot_armed = false;
         }
-        host_fd_ref_close(&epoll_ref);
-        return 0;
+        ret = 0;
+        goto out_locked;
     }
 
     /* Linux semantics: ADD fails with EEXIST if already registered; MOD fails
@@ -869,19 +1089,19 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      * fired, waiting for re-arm) are still valid for MOD.
      */
     if (op == LINUX_EPOLL_CTL_ADD && reg->active) {
-        host_fd_ref_close(&epoll_ref);
-        return -LINUX_EEXIST;
+        ret = -LINUX_EEXIST;
+        goto out_locked;
     }
     if (op == LINUX_EPOLL_CTL_MOD && !reg->active && !reg->oneshot_armed) {
-        host_fd_ref_close(&epoll_ref);
-        return -LINUX_ENOENT;
+        ret = -LINUX_ENOENT;
+        goto out_locked;
     }
 
     /* ADD or MOD: read the epoll_event from guest */
     linux_epoll_event_t ev;
     if (guest_read_small(g, event_gva, &ev, sizeof(ev)) < 0) {
-        host_fd_ref_close(&epoll_ref);
-        return -LINUX_EFAULT;
+        ret = -LINUX_EFAULT;
+        goto out_locked;
     }
 
     /* For MOD, remove old registrations first if they exist in kqueue.
@@ -943,8 +1163,8 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 
     if (nchanges > 0) {
         if (kevent(epoll_ref.fd, changes, nchanges, NULL, 0, NULL) < 0) {
-            host_fd_ref_close(&epoll_ref);
-            return linux_errno();
+            ret = linux_errno();
+            goto out_locked;
         }
     }
 
@@ -959,8 +1179,14 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     reg->active = true;
     reg->oneshot_armed = false;
 
+    ret = 0;
+
+out_locked:
+    pthread_mutex_unlock(&inst->lock);
+out:
     host_fd_ref_close(&epoll_ref);
-    return 0;
+    epoll_instance_release(inst);
+    return ret;
 }
 
 int64_t sys_epoll_pwait(guest_t *g,
@@ -973,20 +1199,22 @@ int64_t sys_epoll_pwait(guest_t *g,
     host_fd_ref_t epoll_ref;
     if (host_fd_ref_open(epfd, &epoll_ref) < 0)
         return -LINUX_EBADF;
-    if (fd_table[epfd].type != FD_EPOLL) {
-        host_fd_ref_close(&epoll_ref);
-        return -LINUX_EINVAL;
-    }
+
     if (maxevents <= 0) {
         host_fd_ref_close(&epoll_ref);
         return -LINUX_EINVAL;
     }
 
-    epoll_instance_t *inst = (epoll_instance_t *) fd_table[epfd].dir;
+    /* Pin the instance so a concurrent close(epfd) cannot free it under us --
+     * including across the blocking kevent() below.
+     */
+    epoll_instance_t *inst = epoll_instance_acquire(epfd);
     if (!inst) {
         host_fd_ref_close(&epoll_ref);
         return -LINUX_EINVAL;
     }
+
+    int64_t ret;
 
     /* Atomically install signal mask for the duration of the wait */
     uint64_t saved_mask = 0;
@@ -1078,8 +1306,10 @@ epoll_retry:;
 
     if (nready < 0) {
         errno = saved_errno;
+        ret = linux_errno();
         host_fd_ref_close(&epoll_ref);
-        return linux_errno();
+        epoll_instance_release(inst);
+        return ret;
     }
 
     /* Merge kevent results into epoll_event results. Multiple kevents for the
@@ -1094,6 +1324,14 @@ epoll_retry:;
     int nout = 0;
 
     memset(out_index, 0xff, sizeof(out_index));
+
+    /* Serialize the regs[] reads and the oneshot re-arm against a concurrent
+     * epoll_ctl or the close hook. Held only for this bookkeeping, never across
+     * the blocking kevent() above; out[] is a local snapshot, so the guest
+     * write happens after the unlock. Mirrors Linux dropping ep->mtx before
+     * copyout.
+     */
+    pthread_mutex_lock(&inst->lock);
 
     for (int i = 0; i < nready && nout < maxevents; i++) {
         int gfd = (int) (uintptr_t) kevents[i].udata;
@@ -1139,15 +1377,19 @@ epoll_retry:;
         }
     }
 
+    pthread_mutex_unlock(&inst->lock);
+
     /* Write results to guest */
     if (nout > 0) {
         if (guest_write_small(g, events_gva, out,
                               nout * sizeof(linux_epoll_event_t)) < 0) {
             host_fd_ref_close(&epoll_ref);
+            epoll_instance_release(inst);
             return -LINUX_EFAULT;
         }
     }
 
     host_fd_ref_close(&epoll_ref);
+    epoll_instance_release(inst);
     return nout;
 }

--- a/src/syscall/poll.h
+++ b/src/syscall/poll.h
@@ -37,6 +37,31 @@ int64_t sys_epoll_pwait(guest_t *g,
                         int timeout_ms,
                         uint64_t sigmask_gva);
 
+/* Eagerly clear a closed guest fd from every epoll instance's interest table.
+ * Called from the fd-table close chokepoint; caller holds fd_lock (or runs
+ * single-threaded on the relaxed close path).
+ */
+void epoll_note_fd_closed(int closed_fd);
+
+/* Free an epoll instance (fd_table[epfd].dir) and drop it from the live count.
+ * Called from fd_cleanup_entry() for FD_EPOLL slots.
+ */
+void epoll_instance_free(void *inst);
+
+/* Duplicate an epoll fd so the alias shares the source's eventpoll instance.
+ * src_host_fd and src_generation must be snapshotted from fd_table[src_fd] by
+ * the caller so a close+reopen ABA is rejected before pinning the instance.
+ *
+ * Returns the new guest fd or -1 with errno set.
+ */
+int epoll_dup_fd(int src_fd,
+                 int src_host_fd,
+                 uint64_t src_generation,
+                 int min_guest_fd,
+                 int fixed_guest_fd,
+                 bool fixed_slot,
+                 int linux_flags);
+
 /* Global wakeup pipe for interrupting blocking poll/select/epoll. When
  * exit_group or futex_interrupt is requested, write to wakeup_pipe_wr to
  * unblock any thread stuck in a host-side poll/select/kevent with infinite

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -66,6 +66,9 @@ test-epoll
 test-epoll-edge
 test-epoll-mt
 test-epoll-aba
+test-epoll-close
+test-epoll-dup
+test-epoll-refcount
 test-timerfd
 test-large-io-boundary
 test-ioctl-cloexec

--- a/tests/test-epoll-close.c
+++ b/tests/test-epoll-close.c
@@ -1,0 +1,192 @@
+/*
+ * epoll close/dup2 interest-list eager-removal regression test
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Companion to test-epoll-aba.c. That test drives the cross-call generation
+ * guard in sys_epoll_ctl() under a multi-threaded guest. This one pins the
+ * complementary invariant: closing (or dup2-replacing) a registered fd eagerly
+ * drops it from every epoll instance's interest table, matching Linux, which
+ * auto-removes an fd from all epoll interest lists when its last descriptor
+ * closes (src/syscall/poll.c epoll_note_fd_closed).
+ *
+ * The eager cleanup is what keeps sys_epoll_pwait's regs[gfd].active check
+ * honest instead of leaning on the epoll_ctl generation guard as the only
+ * defense. The generation guard alone already yields the correct observable
+ * DEL/MOD/ADD results after a reopen -- so these assertions pass with or
+ * without eager cleanup -- but this test exercises the cleanup code across the
+ * close chokepoints the guard never touches:
+ *
+ *   - single-threaded close (the relaxed fast paths fd_close_regular_relaxed /
+ *     fd_snapshot_and_close_relaxed, which the multi-threaded aba test
+ * bypasses);
+ *   - multiple epoll instances watching the same fd;
+ *   - dup2/dup3 over an already-registered fd number (fd_alloc_at overwrite),
+ *     which retires the old open file description without a close syscall.
+ *
+ * Deliberately single-threaded: no CLONE_THREAD sibling, so the close paths
+ * take their single-active-thread fast branches.
+ *
+ * Syscalls exercised: epoll_create1(20), epoll_ctl(21), epoll_pwait(22),
+ *                     eventfd2(19), dup3(24), write(64), read(63), close(57)
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* Reopen a fresh eventfd onto exactly the guest fd number just closed, so the
+ * A->B->A reuse is exercised regardless of allocator policy. The lowest-free
+ * allocator normally hands back oldfd; dup3() forces it otherwise.
+ *
+ * Returns oldfd on success, or -1.
+ */
+static int reopen_same_number(int oldfd)
+{
+    int nf = eventfd(0, EFD_NONBLOCK);
+    if (nf < 0)
+        return -1;
+    if (nf == oldfd)
+        return oldfd;
+    if (dup3(nf, oldfd, 0) < 0) {
+        close(nf);
+        return -1;
+    }
+    close(nf);
+    return oldfd;
+}
+
+static void drain_eventfd(int fd)
+{
+    uint64_t v;
+    (void) !read(fd, &v, sizeof(v));
+}
+
+/* Register fd for EPOLLIN, make it readable, and assert the edge is observed
+ * with the expected data.fd. Leaves the counter signalled; caller drains.
+ *
+ * Returns 1 on success.
+ */
+static int add_and_expect_edge(int epfd, int fd)
+{
+    struct epoll_event ev = {.events = EPOLLIN, .data.fd = fd};
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) < 0)
+        return 0;
+
+    uint64_t one = 1;
+    if (write(fd, &one, sizeof(one)) != (ssize_t) sizeof(one))
+        return 0;
+
+    struct epoll_event out[4];
+    int n = epoll_wait(epfd, out, 4, 2000);
+    return n == 1 && out[0].data.fd == fd;
+}
+
+int main(void)
+{
+    printf("test-epoll-close: epoll interest-list eager removal on close\n");
+
+    int epfd = epoll_create1(EPOLL_CLOEXEC);
+    TEST("epoll_create1");
+    EXPECT_TRUE(epfd >= 0, "epoll_create1 failed");
+
+    /* Case 1: single-instance close+reopen. The stale registration for the old
+     * open file must be gone; DEL/MOD report ENOENT and a fresh ADD delivers
+     * the new file's edge.
+     */
+    int efd = eventfd(0, EFD_NONBLOCK);
+    TEST("register + observe edge on file A");
+    EXPECT_TRUE(efd >= 0 && add_and_expect_edge(epfd, efd),
+                "file A failed to register/deliver");
+    drain_eventfd(efd);
+    close(efd);
+
+    int reused = reopen_same_number(efd);
+    TEST("reopen reuses the same fd number");
+    EXPECT_EQ(reused, efd, "could not reuse fd number");
+
+    TEST("DEL after close+reopen -> ENOENT");
+    EXPECT_ERRNO(epoll_ctl(epfd, EPOLL_CTL_DEL, efd, NULL), ENOENT,
+                 "stale DEL did not report ENOENT");
+
+    TEST("MOD after close+reopen -> ENOENT");
+    {
+        struct epoll_event ev = {.events = EPOLLIN | EPOLLOUT, .data.fd = efd};
+        EXPECT_ERRNO(epoll_ctl(epfd, EPOLL_CTL_MOD, efd, &ev), ENOENT,
+                     "stale MOD did not report ENOENT");
+    }
+
+    TEST("fresh ADD after reopen delivers edge for file B");
+    EXPECT_TRUE(add_and_expect_edge(epfd, efd),
+                "reused fd failed to register/deliver");
+    drain_eventfd(efd);
+    EXPECT_TRUE(epoll_ctl(epfd, EPOLL_CTL_DEL, efd, NULL) == 0,
+                "fresh DEL rejected");
+    close(efd);
+
+    /* Case 2: two epoll instances watching the same fd. A close must drop the
+     * fd from both interest tables independently -- eager cleanup walks every
+     * live instance, not just the one an epoll_ctl happens to touch next.
+     */
+    int epfd2 = epoll_create1(EPOLL_CLOEXEC);
+    TEST("second epoll_create1");
+    EXPECT_TRUE(epfd2 >= 0, "epoll_create1 #2 failed");
+
+    int shared = eventfd(0, EFD_NONBLOCK);
+    TEST("register shared fd in both instances");
+    {
+        struct epoll_event ev = {.events = EPOLLIN, .data.fd = shared};
+        int ok = shared >= 0 &&
+                 epoll_ctl(epfd, EPOLL_CTL_ADD, shared, &ev) == 0 &&
+                 epoll_ctl(epfd2, EPOLL_CTL_ADD, shared, &ev) == 0;
+        EXPECT_TRUE(ok, "shared registration failed");
+    }
+    close(shared);
+    int shared2 = reopen_same_number(shared);
+    TEST("reopen shared fd number");
+    EXPECT_EQ(shared2, shared, "could not reuse shared fd number");
+
+    TEST("instance A: stale DEL after reopen -> ENOENT");
+    EXPECT_ERRNO(epoll_ctl(epfd, EPOLL_CTL_DEL, shared, NULL), ENOENT,
+                 "instance A stale DEL did not report ENOENT");
+    TEST("instance B: stale DEL after reopen -> ENOENT");
+    EXPECT_ERRNO(epoll_ctl(epfd2, EPOLL_CTL_DEL, shared, NULL), ENOENT,
+                 "instance B stale DEL did not report ENOENT");
+    close(shared);
+    close(epfd2);
+
+    /* Case 3: dup2/dup3 over a registered fd number retires the old open file
+     * description without a close syscall (the fd_alloc_at overwrite path). The
+     * old registration must be gone -- MOD on it reports ENOENT.
+     */
+    int a = eventfd(0, EFD_NONBLOCK);
+    int b = eventfd(0, EFD_NONBLOCK);
+    TEST("register fd, then dup2 another file over it");
+    {
+        struct epoll_event ev = {.events = EPOLLIN, .data.fd = a};
+        int ok = a >= 0 && b >= 0 &&
+                 epoll_ctl(epfd, EPOLL_CTL_ADD, a, &ev) == 0 &&
+                 dup3(b, a, 0) == a;
+        EXPECT_TRUE(ok, "setup for dup2-over-registered failed");
+    }
+    TEST("MOD after dup2-over-registered -> ENOENT");
+    {
+        struct epoll_event ev = {.events = EPOLLIN | EPOLLOUT, .data.fd = a};
+        EXPECT_ERRNO(epoll_ctl(epfd, EPOLL_CTL_MOD, a, &ev), ENOENT,
+                     "MOD on dup2-retired registration did not report ENOENT");
+    }
+    close(a);
+    close(b);
+    close(epfd);
+
+    SUMMARY("test-epoll-close");
+    return fails > 0 ? 1 : 0;
+}

--- a/tests/test-epoll-dup.c
+++ b/tests/test-epoll-dup.c
@@ -1,0 +1,140 @@
+/*
+ * epoll fd dup shares the eventpoll instance
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Linux dup(2)/dup3(2)/F_DUPFD of an epoll fd yield a second descriptor onto
+ * the SAME eventpoll instance: the interest list registered through one fd is
+ * visible through the other, and the instance survives until the last of them
+ * closes. elfuse keys epoll state on fd_table[epfd].dir; the generic dup path
+ * would leave the alias with dir == NULL, so this pins that epoll_dup_fd()
+ * shares the instance instead (src/syscall/poll.c epoll_dup_fd).
+ *
+ * Syscalls exercised: epoll_create1(20), epoll_ctl(21), epoll_pwait(22),
+ *                     eventfd2(19), dup(23), dup3(24), fcntl(25),
+ *                     write(64), read(63), close(57)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+static void drain_eventfd(int fd)
+{
+    uint64_t v;
+    (void) !read(fd, &v, sizeof(v));
+}
+
+/* Signal fd and assert epoll_wait on wait_fd reports exactly its edge. */
+static int expect_edge(int wait_fd, int fd)
+{
+    uint64_t one = 1;
+    if (write(fd, &one, sizeof(one)) != (ssize_t) sizeof(one))
+        return 0;
+    struct epoll_event out[4];
+    int n = epoll_wait(wait_fd, out, 4, 2000);
+    int ok = n == 1 && out[0].data.fd == fd;
+    drain_eventfd(fd);
+    return ok;
+}
+
+int main(void)
+{
+    printf("test-epoll-dup: epoll fd dup shares the eventpoll instance\n");
+
+    int epfd = epoll_create1(EPOLL_CLOEXEC);
+    TEST("epoll_create1");
+    EXPECT_TRUE(epfd >= 0, "epoll_create1 failed");
+
+    int efd = eventfd(0, EFD_NONBLOCK);
+    TEST("eventfd");
+    EXPECT_TRUE(efd >= 0, "eventfd failed");
+
+    /* Register through the original fd, wait through the dup: they must share
+     * the interest list.
+     */
+    int dupfd = dup(epfd);
+    TEST("dup(epfd)");
+    EXPECT_TRUE(dupfd >= 0 && dupfd != epfd, "dup failed");
+
+    {
+        struct epoll_event ev = {.events = EPOLLIN, .data.fd = efd};
+        EXPECT_TRUE(epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev) == 0,
+                    "ADD via original failed");
+    }
+    TEST("edge registered via original is visible through the dup");
+    EXPECT_TRUE(expect_edge(dupfd, efd), "dup did not see shared registration");
+
+    /* Mutate the interest list through the dup, observe through the original.
+     */
+    TEST("MOD via dup, then DEL via original -> instance is shared");
+    {
+        struct epoll_event ev = {.events = EPOLLIN | EPOLLOUT, .data.fd = efd};
+        int ok = epoll_ctl(dupfd, EPOLL_CTL_MOD, efd, &ev) == 0 &&
+                 epoll_ctl(epfd, EPOLL_CTL_DEL, efd, NULL) == 0;
+        EXPECT_TRUE(ok, "MOD/DEL across dup did not target one instance");
+    }
+
+    /* A duped-but-not-registered fd must report ENOENT on DEL, proving the dup
+     * really reaches a valid (shared, now-empty) instance rather than failing
+     * as a NULL-dir slot (which would give EBADF/EINVAL).
+     */
+    TEST("DEL of unregistered fd via dup -> ENOENT");
+    EXPECT_ERRNO(epoll_ctl(dupfd, EPOLL_CTL_DEL, efd, NULL), ENOENT,
+                 "dup slot is not a live epoll instance");
+
+    /* Closing the original must keep the instance alive for the dup. */
+    close(epfd);
+    {
+        struct epoll_event ev = {.events = EPOLLIN, .data.fd = efd};
+        TEST("dup still works after original closes");
+        EXPECT_TRUE(epoll_ctl(dupfd, EPOLL_CTL_ADD, efd, &ev) == 0,
+                    "dup broke after original close");
+    }
+    TEST("edge delivery through dup after original close");
+    EXPECT_TRUE(expect_edge(dupfd, efd), "dup lost delivery after close");
+    close(dupfd);
+
+    /* fcntl(F_DUPFD) and dup3 to a fixed high slot exercise the min-slot and
+     * fixed-slot allocator branches of epoll_dup_fd.
+     */
+    int ep2 = epoll_create1(0);
+    TEST("second epoll_create1");
+    EXPECT_TRUE(ep2 >= 0, "epoll_create1 #2 failed");
+
+    int dupf = fcntl(ep2, F_DUPFD, 100);
+    TEST("fcntl(F_DUPFD, 100)");
+    EXPECT_TRUE(dupf >= 100, "F_DUPFD failed");
+
+    int fixed = dup3(ep2, 150, O_CLOEXEC);
+    TEST("dup3 to fixed slot 150");
+    EXPECT_TRUE(fixed == 150, "dup3 to fixed slot failed");
+
+    {
+        struct epoll_event ev = {.events = EPOLLIN, .data.fd = efd};
+        TEST("register via ep2, observe through both alias fds");
+        int ok = epoll_ctl(ep2, EPOLL_CTL_ADD, efd, &ev) == 0;
+        EXPECT_TRUE(ok, "ADD via ep2 failed");
+    }
+    TEST("F_DUPFD alias sees ep2 registration");
+    EXPECT_TRUE(expect_edge(dupf, efd), "F_DUPFD alias missed edge");
+    TEST("dup3 fixed alias sees ep2 registration");
+    EXPECT_TRUE(expect_edge(fixed, efd), "dup3 alias missed edge");
+
+    close(dupf);
+    close(fixed);
+    close(ep2);
+    close(efd);
+
+    SUMMARY("test-epoll-dup");
+    return fails > 0 ? 1 : 0;
+}

--- a/tests/test-epoll-refcount.c
+++ b/tests/test-epoll-refcount.c
@@ -1,0 +1,170 @@
+/*
+ * epoll instance lifetime stress: close(epfd) racing a sibling's epoll_pwait
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Guards the epoll-instance reference count in src/syscall/poll.c. An epoll
+ * instance (epoll_instance_t) is heap-allocated and reachable only through
+ * fd_table[epfd].dir. sys_epoll_ctl / sys_epoll_pwait read that pointer and
+ * walk inst->regs[] for the whole call -- including across the blocking
+ * kevent() in pwait. host_fd_ref_open() only pins the host kqueue fd, not the
+ * instance, so without a lifetime pin a sibling thread that close()es epfd
+ * frees the instance out from under an in-flight call (use-after-free).
+ *
+ * epoll_instance_acquire()/_release() bump a refcount under fd_lock so the
+ * allocation survives until the last in-flight caller releases it, even after
+ * close() drops the fd-table's reference.
+ *
+ * This test hammers that window: a long-lived sibling spins epoll_pwait() on a
+ * shared epfd while the main thread repeatedly creates an epoll instance,
+ * publishes it to the sibling, and close()es it -- so a close lands while the
+ * sibling is inside pwait on the same fd. Racing close() with epoll ops on the
+ * same fd is guest-undefined, so the sibling's return value is not asserted;
+ * the contract under test is that elfuse never faults or double-frees. Survival
+ * across all iterations with a clean exit is the pass condition.
+ *
+ * Raw syscalls in the sibling (a CLONE_THREAD child has no libc TLS).
+ *
+ * Syscalls exercised: clone(220), epoll_create1(20), epoll_ctl(21),
+ *                     epoll_pwait(22), eventfd2(19), close(57), nanosleep(101),
+ *                     futex(98), exit(93)
+ */
+
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+
+#include "test-harness.h"
+#include "raw-syscall.h"
+
+int passes = 0, fails = 0;
+
+/* Shared with the clone sibling; atomic because both threads touch them. */
+static _Atomic int shared_epfd = -1;
+static _Atomic int sibling_stop = 0;
+static char sibling_stack[32768] __attribute__((aligned(16)));
+
+/* Spin epoll_pwait() on whatever epfd the main thread has published. The fd may
+ * be closed (or reused) concurrently; a raw syscall just returns an error,
+ * which is exactly the window the refcount must make memory-safe.
+ */
+static int sibling_fn(void *arg)
+{
+    (void) arg;
+    while (!sibling_stop) {
+        int e = shared_epfd;
+        if (e >= 0) {
+            struct epoll_event evs[4];
+            /* epoll_pwait(epfd, events, maxevents, timeout_ms, sigmask,
+             * sigsetsize); 5ms timeout keeps the spin tight against close(). */
+            raw_syscall6(__NR_epoll_pwait, (long) e, (long) evs, 4, 5, 0, 0);
+        } else {
+            struct {
+                long tv_sec, tv_nsec;
+            } ts = {0, 200000}; /* 0.2ms */
+            raw_syscall2(__NR_nanosleep, (long) &ts, 0);
+        }
+    }
+    raw_syscall1(__NR_exit, 0);
+    return 0;
+}
+
+int main(void)
+{
+    printf("test-epoll-refcount: close(epfd) vs concurrent epoll_pwait\n");
+
+    long flags = 0x00000100 | 0x00000200 | 0x00000400 | 0x00000800 |
+                 0x00010000 | 0x00200000; /* CLONE_VM|FS|FILES|SIGHAND|THREAD|
+                                             CHILD_CLEARTID */
+    volatile uint32_t child_tid = 1;
+    long ret = raw_syscall5(__NR_clone, flags,
+                            (long) (sibling_stack + sizeof(sibling_stack)), 0,
+                            0, (long) &child_tid);
+    if (ret == 0) {
+        sibling_fn(NULL);
+        return 0; /* unreachable */
+    }
+
+    TEST("clone sibling waiter");
+    EXPECT_TRUE(ret > 0, "clone failed");
+
+    const int iterations = 300;
+    int completed = 0;
+    for (int i = 0; i < iterations; i++) {
+        int epfd = epoll_create1(EPOLL_CLOEXEC);
+        if (epfd < 0)
+            break;
+        int efd = eventfd(0, EFD_NONBLOCK);
+        if (efd >= 0) {
+            struct epoll_event ev = {.events = EPOLLIN, .data.fd = efd};
+            epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev);
+        }
+
+        /* Publish to the sibling and give it a moment to enter pwait(epfd). */
+        shared_epfd = epfd;
+        struct {
+            long tv_sec, tv_nsec;
+        } ts = {0, 500000}; /* 0.5ms */
+        raw_syscall2(__NR_nanosleep, (long) &ts, 0);
+
+        /* Mutate the same regs[] entry the sibling's pwait is reading, so the
+         * per-instance lock (not just the refcount) is exercised.
+         */
+        if (efd >= 0) {
+            struct epoll_event mev = {.events = EPOLLIN | EPOLLOUT,
+                                      .data.fd = efd};
+            epoll_ctl(epfd, EPOLL_CTL_MOD, efd, &mev);
+        }
+
+        /* Retract, then close under the sibling's in-flight pwait. Closing efd
+         * first fires the close hook (epoll_note_fd_closed) on the instance the
+         * sibling is still waiting on. */
+        shared_epfd = -1;
+        if (efd >= 0)
+            close(efd);
+        close(epfd);
+        completed++;
+    }
+
+    TEST("all iterations survived close/pwait race");
+    EXPECT_EQ(completed, iterations, "did not complete every iteration");
+
+    /* A fresh epoll instance still works after the churn (no leaked/corrupt
+     * state, refcount returned to a clean baseline).
+     */
+    TEST("epoll still functional after churn");
+    {
+        int epfd = epoll_create1(EPOLL_CLOEXEC);
+        int efd = eventfd(0, EFD_NONBLOCK);
+        struct epoll_event ev = {.events = EPOLLIN, .data.fd = efd};
+        uint64_t one = 1;
+        struct epoll_event out[4];
+        int ok = epfd >= 0 && efd >= 0 &&
+                 epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev) == 0 &&
+                 write(efd, &one, sizeof(one)) == (ssize_t) sizeof(one) &&
+                 epoll_wait(epfd, out, 4, 2000) == 1 && out[0].data.fd == efd;
+        EXPECT_TRUE(ok, "epoll broken after stress");
+        if (epfd >= 0)
+            close(epfd);
+        if (efd >= 0)
+            close(efd);
+    }
+
+    /* Release the sibling and join via the CLONE_CHILD_CLEARTID futex. */
+    sibling_stop = 1;
+    for (int i = 0; i < 200 && child_tid != 0; i++) {
+        struct {
+            long tv_sec, tv_nsec;
+        } ts = {0, 10000000}; /* 10ms */
+        raw_syscall6(__NR_futex, (long) &child_tid, 0 /* FUTEX_WAIT */,
+                     child_tid, (long) &ts, 0, 0);
+    }
+
+    SUMMARY("test-epoll-refcount");
+    return fails > 0 ? 1 : 0;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -517,6 +517,10 @@ run_unit_tests()
         "$bindir/test-signalfd-hardening"
     test_check "$runner" "test-epoll" "0 failed" "$bindir/test-epoll"
     test_check "$runner" "test-epoll-edge" "0 failed" "$bindir/test-epoll-edge"
+    test_check "$runner" "test-epoll-close" "0 failed" "$bindir/test-epoll-close"
+    test_check "$runner" "test-epoll-dup" "0 failed" "$bindir/test-epoll-dup"
+    test_check "$runner" "test-epoll-refcount" "0 failed" \
+        "$bindir/test-epoll-refcount"
     test_check "$runner" "test-timerfd" "0 failed" "$bindir/test-timerfd"
 
     printf "\n/proc and /dev\n"


### PR DESCRIPTION
Closing a guest fd did not remove it from any epoll instance's interest table. Each instance keeps its own regs[FD_TABLE_SIZE] indexed by guest fd number, and every close path (sys_close, close_range, dup2 over an open slot, the execve CLOEXEC sweep) tore down only the fd_table slot, leaving regs[fd].active set for a fd that was gone. Linux auto-removes a fd from every epoll interest list when its last descriptor closes; elfuse leaned entirely on the sys_epoll_ctl generation guard to notice the stale entry lazily, and sys_epoll_pwait never re-checks generation.

epoll_note_fd_closed() now clears regs[fd] across every live instance, hooked into fd_mark_closed_unlocked() -- the single close chokepoint -- and the fd_alloc_at overwrite path that dup2/dup3 takes around it. A fd-lock-guarded epoll_live_count keeps the scan a no-op when no epoll fd exists. The kqueue knote needs no EV_DELETE: the following host fd close drops it, and clearing the software state is what makes the pwait active-check honest instead of load-bearing on the generation guard, which stays as defense in depth.

The same audit closed two adjacent multi-threaded hazards on the heap-allocated epoll instance, reachable only through fd_table[epfd].dir:
- Use-after-free: sys_epoll_ctl / sys_epoll_pwait walked inst->regs for the whole call (including across the blocking kevent() in pwait) while host_fd_ref_open pinned only the host kqueue fd. A sibling closing epfd freed inst mid-call. Fixed with a refcount guarded by fd_lock (epoll_instance_acquire / _release); the allocation is freed only once the table reference and every in-flight reference are gone. ASAN pinned the fault at sys_epoll_pwait before the fix and is clean after.
- Data race on regs[]: the new close hook writes regs[] under fd_lock while ctl/pwait accessed it locklessly. Added a per-instance mutex (mirroring the Linux eventpoll->mtx) held only for the short reg bookkeeping, never across the blocking kevent(); the close hook takes it under fd_lock (order documented in internal.h). ThreadSanitizer flagged the epoll_note_fd_closed vs sys_epoll_pwait race without the lock and is clean with it.
- Slot publication window: sys_epoll_create1 made the FD_EPOLL slot visible before attaching dir, so a close_range racing the create could tear down a half-built slot. New fdtable helper fd_alloc_dir() installs type, host_fd, dir, and flags in one fd_lock critical section, so the slot is never observable as FD_EPOLL with a NULL dir.

Close #78

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale epoll watches by clearing registrations on close/dup2 and makes dup of an epoll fd share the same instance, matching Linux. Also hardens epoll lifetime to eliminate a use-after-free and data races.

- **Bug Fixes**
  - Clear epoll interest for a closed or dup2/dup3-overwritten guest fd across all instances; wired into the close chokepoint and the fd overwrite path; fast no-op when no epoll fds via epoll_live_count.
  - Remove UAF/races by refcounting epoll instances and guarding regs[] with a per-instance mutex (lock order: fd_lock → inst->lock; never held across kevent()).
  - Dup/dup3/F_DUPFD of an epoll fd now shares the eventpoll instance; slots are published atomically via `fd_alloc_dir*`, lifetime pinned via refcount, and freed with `epoll_instance_free` (source validated by host_fd + generation to reject ABA).
  - Tests added and in matrix: `test-epoll-close`, `test-epoll-dup`, `test-epoll-refcount`.

<sup>Written for commit c711243b5464bae64ca39b1d51648ebff37e25da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

