### PR TITLE
Deliver signal-driven I/O (O_ASYNC/SIG{IO,URG})

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ SRCS := \
     syscall/io.c \
     syscall/poll.c \
     syscall/fd.c \
+    syscall/asyncio.c \
     syscall/inotify.c \
     syscall/time.c \
     syscall/sys.c \

--- a/src/core/rosetta.c
+++ b/src/core/rosetta.c
@@ -497,7 +497,7 @@ int rosetta_finalize(guest_t *g,
      * RLIMIT_NOFILE, so the pre-PNR elf_load host open does not catch this
      * first; the preflight is the real guard and this branch is the backstop.
      */
-    int bin_guest_fd = fd_alloc_from(3, FD_REGULAR, bin_host_fd, NULL);
+    int bin_guest_fd = fd_alloc_from(3, FD_REGULAR, bin_host_fd, NULL, NULL);
     if (bin_guest_fd < 0) {
         log_error("rosetta_finalize: fd_alloc_from(3) failed");
         goto fail;

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -22,6 +22,7 @@
 
 #include "debug/log.h"
 #include "syscall/abi.h"
+#include "syscall/asyncio.h"
 #include "syscall/internal.h"
 #include "syscall/io.h"
 #include "syscall/mem.h"
@@ -296,6 +297,9 @@ int fork_ipc_send_fd_table(int ipc_sock)
         fd_entries[num_fds].type = fd_table[i].type;
         fd_entries[num_fds].linux_flags = fd_table[i].linux_flags;
         fd_entries[num_fds].seals = fd_table[i].seals;
+        fd_entries[num_fds].ofd_id = fd_table[i].ofd_id;
+        fd_entries[num_fds].fasync_owner_type = fd_table[i].fasync_owner_type;
+        fd_entries[num_fds].fasync_owner = fd_table[i].fasync_owner;
         memcpy(fd_entries[num_fds].proc_path, fd_table[i].proc_path,
                sizeof(fd_entries[num_fds].proc_path));
         host_fds_to_send[num_fds] = host_fd;
@@ -397,10 +401,21 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
         return -1;
     }
 
+    uint64_t parent_ofds[FD_TABLE_SIZE], child_ofds[FD_TABLE_SIZE];
+    uint32_t ofd_maps = 0;
+
     for (uint32_t i = 0; i < num_fds; i++) {
         int gfd = fd_entries[i].guest_fd;
         if (!RANGE_CHECK(gfd, 0, FD_TABLE_SIZE))
             continue;
+
+        uint64_t child_ofd = 0;
+        for (uint32_t j = 0; j < ofd_maps; j++) {
+            if (parent_ofds[j] == fd_entries[i].ofd_id) {
+                child_ofd = child_ofds[j];
+                break;
+            }
+        }
 
         if (fd_entries[i].type == FD_STDIO) {
             close(host_fds[i]);
@@ -426,7 +441,7 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
             continue;
         } else {
             void (*cleanup)(int) = fd_cleanup_for_type(fd_entries[i].type);
-            fd_alloc_at(gfd, fd_entries[i].type, host_fds[i], cleanup);
+            fd_alloc_at(gfd, fd_entries[i].type, host_fds[i], cleanup, NULL);
             fd_table[gfd].linux_flags = fd_entries[i].linux_flags;
             fd_refresh_urandom_bitmap(gfd);
             memcpy(fd_table[gfd].proc_path, fd_entries[i].proc_path,
@@ -435,43 +450,58 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
             if (fd_entries[i].type == FD_URANDOM)
                 urandom_fd_reset_cache(gfd);
 
-            if (fd_entries[i].type != FD_DIR)
-                continue;
-            /* Rebuild the directory stream. Every failure below must close
-             * the slot rather than leave it published as FD_DIR with
-             * dir=NULL: such a slot never faults, but sys_getdents64 would
-             * report ENOTDIR on it for the child's whole lifetime, masking
-             * the restore failure as a valid-but-broken fd. A closed slot
-             * yields EBADF, an honest signal that the fd did not survive
-             * the fork.
-             */
-            int dir_fd = dup(host_fds[i]);
-            if (dir_fd < 0) {
-                log_error("fork-child: dup failed for DIR gfd %d: %s", gfd,
-                          strerror(errno));
-                close(host_fds[i]);
-                fd_mark_closed(gfd);
-                continue;
+            if (fd_entries[i].type == FD_DIR) {
+                /* Rebuild the directory stream. Every failure below must close
+                 * the slot rather than leave it published as FD_DIR with
+                 * dir=NULL: such a slot never faults, but sys_getdents64 would
+                 * report ENOTDIR on it for the child's whole lifetime, masking
+                 * the restore failure as a valid-but-broken fd. A closed slot
+                 * yields EBADF, an honest signal that the fd did not survive
+                 * the fork.
+                 */
+                int dir_fd = dup(host_fds[i]);
+                if (dir_fd < 0) {
+                    log_error("fork-child: dup failed for DIR gfd %d: %s", gfd,
+                              strerror(errno));
+                    close(host_fds[i]);
+                    fd_mark_closed(gfd);
+                    continue;
+                }
+                DIR *dir = fdopendir(dir_fd);
+                if (!dir) {
+                    close(dir_fd);
+                    log_error("fork-child: fdopendir failed for gfd %d", gfd);
+                    close(host_fds[i]);
+                    fd_mark_closed(gfd);
+                    continue;
+                }
+                void *ds = dir_stream_create(dir);
+                if (!ds) {
+                    closedir(dir);
+                    log_error("fork-child: dir_stream_create failed for gfd %d",
+                              gfd);
+                    close(host_fds[i]);
+                    fd_mark_closed(gfd);
+                    continue;
+                }
+                fd_table[gfd].dir = ds;
             }
-            DIR *dir = fdopendir(dir_fd);
-            if (!dir) {
-                close(dir_fd);
-                log_error("fork-child: fdopendir failed for gfd %d", gfd);
-                close(host_fds[i]);
-                fd_mark_closed(gfd);
-                continue;
-            }
-            void *ds = dir_stream_create(dir);
-            if (!ds) {
-                closedir(dir);
-                log_error("fork-child: dir_stream_create failed for gfd %d",
-                          gfd);
-                close(host_fds[i]);
-                fd_mark_closed(gfd);
-                continue;
-            }
-            fd_table[gfd].dir = ds;
         }
+
+        if (!child_ofd && fd_entries[i].ofd_id) {
+            child_ofd = fd_table[gfd].ofd_id;
+            parent_ofds[ofd_maps] = fd_entries[i].ofd_id;
+            child_ofds[ofd_maps++] = child_ofd;
+        }
+        if (child_ofd)
+            fd_table[gfd].ofd_id = child_ofd;
+        fd_table[gfd].fasync_owner_type = fd_entries[i].fasync_owner_type;
+        fd_table[gfd].fasync_owner = fd_entries[i].fasync_owner;
+        if ((fd_table[gfd].linux_flags & LINUX_O_ASYNC) ||
+            (fd_table[gfd].type == FD_SOCKET &&
+             fd_table[gfd].fasync_owner_type != FASYNC_OWNER_NONE))
+            asyncio_arm(gfd, fd_table[gfd].generation, fd_table[gfd].host_fd,
+                        fd_table[gfd].type);
     }
 
     free(host_fds);

--- a/src/runtime/fork-state.h
+++ b/src/runtime/fork-state.h
@@ -97,6 +97,8 @@ typedef struct {
 
 typedef struct {
     int32_t guest_fd, type, linux_flags, seals;
+    uint64_t ofd_id;
+    int32_t fasync_owner_type, fasync_owner;
     char proc_path[FD_VIRTUAL_PATH_MAX];
 } ipc_fd_entry_t;
 

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -690,6 +690,11 @@ typedef struct {
 #define LINUX_F_ADD_SEALS 1033
 #define LINUX_F_GET_SEALS 1034
 
+/* f_owner_ex.type values for F_SETOWN_EX / F_GETOWN_EX (Linux uapi). */
+#define LINUX_F_OWNER_TID 0
+#define LINUX_F_OWNER_PID 1
+#define LINUX_F_OWNER_PGRP 2
+
 /* Socket option cache indices. Keep in sync with SOCK_OPT_COUNT. */
 enum {
     SOCK_OPT_KEEPALIVE,
@@ -731,8 +736,9 @@ typedef struct {
 } sock_opt_cache_t;
 
 typedef struct {
-    int type;            /* FD_CLOSED, FD_STDIO, FD_REGULAR, FD_DIR */
-    int host_fd;         /* Underlying macOS file descriptor */
+    int type;        /* FD_CLOSED, FD_STDIO, FD_REGULAR, FD_DIR */
+    int host_fd;     /* Underlying macOS file descriptor */
+    uint64_t ofd_id; /* Shared by dup aliases of one open file description */
     uint64_t generation; /* Bumped each time this guest fd slot is reused. Lets
                           * long-lived references (e.g. epoll registrations)
                           * detect a close+reopen ABA where the slot now holds a
@@ -747,6 +753,8 @@ typedef struct {
                      * once at allocation via fstat so the interruptible wait
                      * path can skip fds that never block.
                      */
+    int32_t fasync_owner_type; /* FASYNC_OWNER_* recipient kind (0 = none) */
+    int32_t fasync_owner;      /* pid/pgrp/tid for SIGIO/SIGURG delivery */
     sock_opt_cache_t sock; /* Socket option cache (zeroed for non-sockets) */
     void (*cleanup)(int guest_fd); /* Type-specific teardown (NULL if none) */
 } fd_entry_t;

--- a/src/syscall/asyncio.c
+++ b/src/syscall/asyncio.c
@@ -1,0 +1,289 @@
+/*
+ * Signal-driven I/O (O_ASYNC / SIGIO / SIGURG)
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See asyncio.h for the design. The watcher owns one kqueue; arm/disarm
+ * register EVFILT_READ (and EVFILT_EXCEPT/NOTE_OOB for sockets) as EV_CLEAR
+ * edge-triggered knotes so a persistently-ready fd fires once per readiness
+ * transition instead of storming signals. kevent() registration from a syscall
+ * thread while the watcher blocks in kevent() on the same kqueue is safe on
+ * macOS/BSD.
+ */
+
+#include "syscall/asyncio.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <sys/event.h>
+#include <unistd.h>
+
+#include "utils.h"
+
+#include "runtime/thread.h"
+#include "syscall/abi.h"
+#include "syscall/internal.h"
+#include "syscall/proc.h"
+#include "syscall/signal.h"
+
+static int async_kq = -1;
+static pthread_once_t async_once = PTHREAD_ONCE_INIT;
+
+/* fd types that can generate SIGIO. Regular files and directories are always
+ * "ready" and never carry ->fasync in Linux, so registering them would storm.
+ * FD_FUSE_FILE/FD_FUSE_DIR are omitted for the same reason and because they
+ * carry host_fd == -1 (no readiness fd to hand kqueue). Only /dev/fuse itself
+ * (FD_FUSE_DEV) has a real host fd worth watching.
+ */
+static bool async_is_pollable(int fd_type)
+{
+    switch (fd_type) {
+    case FD_SOCKET:
+    case FD_PIPE:
+    case FD_STDIO:
+    case FD_FUSE_DEV:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/* True when the fd owner names this guest process (its pid, its process group,
+ * or one of its live threads). elfuse runs one guest process per host process,
+ * so a foreign pid belongs to a forked child that this watcher cannot reach.
+ */
+static bool async_owner_is_local(int owner_type, int owner)
+{
+    switch (owner_type) {
+    case FASYNC_OWNER_PID:
+        return owner == (int) proc_get_pid();
+    case FASYNC_OWNER_PGRP:
+        return owner == (int) proc_get_pgid();
+    case FASYNC_OWNER_TID:
+        return thread_find(owner) != NULL;
+    default:
+        return false;
+    }
+}
+
+/* kqueue udata packs the guest fd (low 16 bits) plus the fd slot generation at
+ * arm time (upper 48 bits). The generation guards against ABA: if the slot was
+ * closed and reused between arm and a stale event firing, the generation no
+ * longer matches and the event is dropped, so a SIGIO cannot land on a later,
+ * unrelated occupant of the same guest fd number. FD_TABLE_SIZE is 1024 (fits
+ * 16 bits) and the generation counter is monotonic, so 48 bits will not wrap.
+ */
+static void *async_pack(int guest_fd, uint64_t generation)
+{
+    return (void *) (uintptr_t) (((generation & 0xFFFFFFFFFFFFULL) << 16) |
+                                 (uint32_t) (guest_fd & 0xFFFF));
+}
+
+static void async_unpack(void *udata, int *guest_fd, uint64_t *generation)
+{
+    uint64_t v = (uint64_t) (uintptr_t) udata;
+    *guest_fd = (int) (v & 0xFFFF);
+    *generation = (v >> 16) & 0xFFFFFFFFFFFFULL;
+}
+
+static void async_deliver(void *udata, int signum)
+{
+    int guest_fd;
+    uint64_t generation;
+    async_unpack(udata, &guest_fd, &generation);
+
+    fd_entry_t snap;
+    if (!fd_snapshot(guest_fd, &snap))
+        return; /* slot closed since the knote fired */
+    if ((snap.generation & 0xFFFFFFFFFFFFULL) != generation)
+        return; /* slot reused (ABA): this event belongs to the prior open */
+    if (signum != LINUX_SIGURG && !(snap.linux_flags & LINUX_O_ASYNC))
+        return; /* disarmed between fire and here (EV_CLEAR raced a disarm) */
+    if (!async_owner_is_local(snap.fasync_owner_type, snap.fasync_owner))
+        return; /* no owner, or a foreign guest pid */
+
+    /* ponytail: owner delivery is process-wide. F_OWNER_TID does not target a
+     * single thread and a foreign guest pid is not forwarded across the fork
+     * IPC boundary. Add per-thread signal queueing + cross-process forwarding
+     * when a real workload needs directed SIGIO.
+     */
+    signal_queue(signum);
+}
+
+static void *async_watcher(void *arg)
+{
+    (void) arg;
+    struct kevent evs[32];
+    for (;;) {
+        int n = kevent(async_kq, NULL, 0, evs, 32, NULL);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            return NULL; /* kqueue closed or fatal; disable delivery */
+        }
+        for (int i = 0; i < n; i++) {
+            int signum =
+                (evs[i].filter == EVFILT_EXCEPT) ? LINUX_SIGURG : LINUX_SIGIO;
+            async_deliver(evs[i].udata, signum);
+        }
+    }
+}
+
+static void async_init_once(void)
+{
+    async_kq = kqueue();
+    if (async_kq < 0)
+        return;
+    fcntl(async_kq, F_SETFD, FD_CLOEXEC);
+    pthread_t t;
+    if (pthread_create(&t, NULL, async_watcher, NULL) != 0) {
+        close(async_kq);
+        async_kq = -1;
+        return;
+    }
+    pthread_detach(t);
+}
+
+void asyncio_init(void)
+{
+    pthread_once(&async_once, async_init_once);
+}
+
+void asyncio_arm(int guest_fd, uint64_t generation, int host_fd, int fd_type)
+{
+    if (async_kq < 0 || host_fd < 0 || !async_is_pollable(fd_type))
+        return;
+    void *udata = async_pack(guest_fd, generation);
+    struct kevent ch[2];
+    int n = 0;
+    EV_SET(&ch[n++], host_fd, EVFILT_READ, EV_ADD | EV_CLEAR, 0, 0, udata);
+    if (fd_type == FD_SOCKET)
+        EV_SET(&ch[n++], host_fd, EVFILT_EXCEPT, EV_ADD | EV_CLEAR, NOTE_OOB, 0,
+               udata);
+    kevent(async_kq, ch, n, NULL, 0, NULL);
+}
+
+void asyncio_disarm(int host_fd)
+{
+    if (async_kq < 0)
+        return;
+    /* Issue each delete on its own kevent() call: with a NULL eventlist kevent
+     * stops at the first failing change, and ENOENT is expected here (the
+     * EVFILT_EXCEPT knote exists only for sockets, and a closed host fd has
+     * already auto-removed both).
+     */
+    struct kevent ch;
+    EV_SET(&ch, host_fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+    kevent(async_kq, &ch, 1, NULL, 0, NULL);
+    EV_SET(&ch, host_fd, EVFILT_EXCEPT, EV_DELETE, 0, 0, NULL);
+    kevent(async_kq, &ch, 1, NULL, 0, NULL);
+}
+
+/* Recompute one alias slot's readiness watch after its O_ASYNC bit or fasync
+ * owner changed. A slot is armed iff O_ASYNC is set (SIGIO on readiness) or it
+ * is a socket with an owner (SIGURG on OOB), matching the delivery-side checks
+ * in async_deliver. Caller holds fd_lock. This single rule replaces the two
+ * hand-rolled arm/disarm variants fasync_owner_set and asyncio_apply used to
+ * carry, which had diverged (the owner path relied on the O_ASYNC path having
+ * already armed non-socket slots rather than stating the invariant itself).
+ */
+static void async_reeval_slot_locked(int i)
+{
+    bool async = (fd_table[i].linux_flags & LINUX_O_ASYNC) != 0;
+    bool owned = fd_table[i].fasync_owner_type != FASYNC_OWNER_NONE;
+    if (async || (fd_table[i].type == FD_SOCKET && owned))
+        asyncio_arm(i, fd_table[i].generation, fd_table[i].host_fd,
+                    fd_table[i].type);
+    else
+        asyncio_disarm(fd_table[i].host_fd);
+}
+
+void fasync_owner_set(int guest_fd,
+                      uint64_t expect_gen,
+                      int owner_type,
+                      int owner)
+{
+    if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))
+        return;
+    /* Arm/disarm under fd_lock with the live host fd and generation. Doing the
+     * kevent registration inside the lock (rather than snapshotting aliases and
+     * acting after unlock) closes the close+reuse race: a sibling close cannot
+     * retire and reopen a host fd number while this scan holds fd_lock, so a
+     * disarm can never clobber the fresh registration of a reused fd. kevent()
+     * registration does not block, and the watcher thread never holds fd_lock
+     * while parked in kevent(), so there is no deadlock.
+     */
+    pthread_mutex_lock(&fd_lock);
+    uint64_t ofd_id = 0;
+    if (fd_table[guest_fd].type != FD_CLOSED &&
+        fd_table[guest_fd].generation == expect_gen)
+        ofd_id = fd_table[guest_fd].ofd_id;
+    if (ofd_id) {
+        /* ponytail: O(FD_TABLE_SIZE) scan to reach every alias sharing this
+         * open-file-description. Cold path (F_SETOWN only); an ofd_id->fd index
+         * is the upgrade if it ever shows up in a profile.
+         */
+        for (int i = 0; i < FD_TABLE_SIZE; i++) {
+            if (fd_table[i].type == FD_CLOSED || fd_table[i].ofd_id != ofd_id)
+                continue;
+            fd_table[i].fasync_owner_type = owner_type;
+            fd_table[i].fasync_owner = owner;
+            async_reeval_slot_locked(i);
+        }
+    }
+    pthread_mutex_unlock(&fd_lock);
+}
+
+void fasync_owner_get(int guest_fd,
+                      uint64_t expect_gen,
+                      int *owner_type_out,
+                      int *owner_out)
+{
+    *owner_type_out = FASYNC_OWNER_NONE;
+    *owner_out = 0;
+    if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))
+        return;
+    pthread_mutex_lock(&fd_lock);
+    if (fd_table[guest_fd].type != FD_CLOSED &&
+        fd_table[guest_fd].generation == expect_gen) {
+        *owner_type_out = fd_table[guest_fd].fasync_owner_type;
+        *owner_out = fd_table[guest_fd].fasync_owner;
+    }
+    pthread_mutex_unlock(&fd_lock);
+}
+
+void asyncio_apply(int guest_fd, uint64_t expect_gen, bool on)
+{
+    if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))
+        return;
+    /* Guard on generation, not just (type, host_fd): a close+reopen can reuse
+     * the same guest fd number, host fd number, and type, so only the monotonic
+     * generation distinguishes the caller's open from a new one. Arm/disarm run
+     * under fd_lock so a host fd cannot be retired and reused mid-scan; see
+     * fasync_owner_set for the deadlock argument.
+     */
+    pthread_mutex_lock(&fd_lock);
+    uint64_t ofd_id = 0;
+    if (fd_table[guest_fd].type != FD_CLOSED &&
+        fd_table[guest_fd].generation == expect_gen)
+        ofd_id = fd_table[guest_fd].ofd_id;
+    if (ofd_id) {
+        /* ponytail: O(FD_TABLE_SIZE) scan to reach every alias sharing this
+         * open-file-description. Cold path (O_ASYNC toggles only); an
+         * ofd_id->fd index is the upgrade if it ever shows up in a profile.
+         */
+        for (int i = 0; i < FD_TABLE_SIZE; i++) {
+            if (fd_table[i].type == FD_CLOSED || fd_table[i].ofd_id != ofd_id)
+                continue;
+            if (on)
+                fd_table[i].linux_flags |= LINUX_O_ASYNC;
+            else
+                fd_table[i].linux_flags &= ~LINUX_O_ASYNC;
+            async_reeval_slot_locked(i);
+        }
+    }
+    pthread_mutex_unlock(&fd_lock);
+}

--- a/src/syscall/asyncio.h
+++ b/src/syscall/asyncio.h
@@ -1,0 +1,79 @@
+/*
+ * Signal-driven I/O (O_ASYNC / SIGIO / SIGURG)
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Linux delivers SIGIO to the owner of an O_ASYNC descriptor whenever the fd
+ * becomes ready, and SIGURG to a socket owner when out-of-band data arrives
+ * even without O_ASYNC. macOS classic BSD SIGIO does not name the fd and
+ * coalesces, so instead a dedicated kqueue watcher thread registers the async
+ * host fds and, on a readiness edge, resolves the per-fd owner and injects the
+ * guest signal via signal_queue().
+ *
+ * O_ASYNC is per open-file-description: the armed bit lives in
+ * fd_entry_t.linux_flags and the owner in fd_entry_t.fasync_owner*. This module
+ * only owns the readiness watching; fs.c/io.c drive the arm/disarm from the
+ * fcntl(F_SETFL)/ioctl(FIOASYNC) paths through asyncio_apply().
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* fasync owner kinds stored in fd_entry_t.fasync_owner_type. Zero == NONE so a
+ * zero-initialized fd slot means "no owner", independent of the Linux
+ * f_owner_ex type numbering (which fs.c translates at the fcntl boundary).
+ */
+#define FASYNC_OWNER_NONE 0
+#define FASYNC_OWNER_TID 1
+#define FASYNC_OWNER_PID 2
+#define FASYNC_OWNER_PGRP 3
+
+/* Initialize the watcher (kqueue + detached thread). Idempotent; call once from
+ * syscall_init() before guest code runs. A failure to create the kqueue or
+ * thread leaves the subsystem disabled: arm/apply become no-ops and O_ASYNC is
+ * still tracked for F_GETFL round-trip, just without delivery.
+ */
+void asyncio_init(void);
+
+/* Flip the O_ASYNC armed bit for guest_fd and (dis)arm the readiness watcher.
+ * expect_gen is the caller's fd-slot snapshot generation; the linux_flags
+ * update is serialized under fd_lock and applied only when the slot still holds
+ * that generation, so a concurrent close+reopen cannot resurrect a stale bit.
+ * The scan reaches every alias sharing the open-file-description and reads each
+ * one's own host fd and class; pollability is decided per slot (regular files
+ * and directories never generate SIGIO on Linux, so they only carry the flag
+ * bit and are never registered).
+ */
+void asyncio_apply(int guest_fd, uint64_t expect_gen, bool on);
+
+/* Register readiness watching for an already-armed fd. Used by the dup path,
+ * which copies the armed bit under fd_lock and then arms the alias. generation
+ * is the fd-slot generation captured at arm time; it is packed into the kqueue
+ * event so a stale event on a reused slot is dropped. No-op for non-pollable fd
+ * types.
+ */
+void asyncio_arm(int guest_fd, uint64_t generation, int host_fd, int fd_type);
+
+/* Deregister readiness watching for host_fd. Keyed by host_fd because the guest
+ * slot may already be gone (close path). Safe to call for fds that were never
+ * armed.
+ */
+void asyncio_disarm(int host_fd);
+
+/* Store the SIGIO/SIGURG owner for guest_fd under fd_lock, guarded by the
+ * caller's snapshot generation so a close+reopen in the race window is a no-op.
+ * owner_type is a FASYNC_OWNER_* value.
+ */
+void fasync_owner_set(int guest_fd,
+                      uint64_t expect_gen,
+                      int owner_type,
+                      int owner);
+
+/* Read the owner back under fd_lock. A closed slot reports {NONE, 0}. */
+void fasync_owner_get(int guest_fd,
+                      uint64_t expect_gen,
+                      int *owner_type_out,
+                      int *owner_out);

--- a/src/syscall/fd.c
+++ b/src/syscall/fd.c
@@ -746,11 +746,11 @@ int eventfd_dup_fd(int src_fd,
      * eventfd_owner mapping is still -1, so a racing close here observes owner
      * == -1 and does nothing; we detect that below.
      */
-    int new_guest_fd = fixed_slot
-                           ? fd_alloc_at_relaxed(fixed_guest_fd, FD_EVENTFD,
-                                                 new_host_fd, eventfd_close)
-                           : fd_alloc_from_relaxed(min_guest_fd, FD_EVENTFD,
-                                                   new_host_fd, eventfd_close);
+    int new_guest_fd =
+        fixed_slot ? fd_alloc_at_relaxed(fixed_guest_fd, FD_EVENTFD,
+                                         new_host_fd, eventfd_close, NULL)
+                   : fd_alloc_from_relaxed(min_guest_fd, FD_EVENTFD,
+                                           new_host_fd, eventfd_close, NULL);
     if (new_guest_fd < 0) {
         close(new_host_fd);
         pthread_mutex_lock(&sfd_lock);

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -25,6 +25,7 @@
 #include "core/shim-globals.h"
 #include "runtime/procemu.h"
 #include "syscall/abi.h"
+#include "syscall/asyncio.h"
 #include "syscall/internal.h"
 #include "syscall/poll.h"
 
@@ -36,6 +37,7 @@ pthread_mutex_t fd_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 3 */
 /* FD table. */
 fd_entry_t fd_table[FD_TABLE_SIZE];
 static uint64_t fd_next_generation = 1;
+static uint64_t fd_next_ofd_id = 1;
 
 /* RLIMIT_NOFILE tracking. Guest-side soft limit for RLIMIT_NOFILE. fd_alloc
  * checks this. Default matches typical Linux default (1024). Updated by
@@ -114,6 +116,7 @@ static inline void fd_init_entry(int fd,
     fd_bitmap_set_used(fd);
     fd_table[fd].type = type;
     fd_table[fd].host_fd = host_fd;
+    fd_table[fd].ofd_id = fd_next_ofd_id++;
     fd_table[fd].generation = fd_next_generation++;
     fd_table[fd].linux_flags = 0;
     fd_table[fd].dir = NULL;
@@ -125,6 +128,8 @@ static inline void fd_init_entry(int fd,
      * here; pipes/sockets/synthetic fds resolve from the type alone.
      */
     fd_table[fd].can_block = type_may_block(type, host_fd);
+    fd_table[fd].fasync_owner_type = FASYNC_OWNER_NONE;
+    fd_table[fd].fasync_owner = 0;
     sock_opt_clear(&fd_table[fd]);
     fd_table[fd].cleanup = cleanup;
     /* Start conservative. Callers that set linux_flags after allocation
@@ -197,14 +202,18 @@ void fdtable_init(void)
 
     /* Pre-open stdin/stdout/stderr */
     fd_next_generation = 1;
+    fd_next_ofd_id = 1;
     fd_table[0] = (fd_entry_t) {.type = FD_STDIO,
                                 .host_fd = STDIN_FILENO,
+                                .ofd_id = fd_next_ofd_id++,
                                 .generation = fd_next_generation++};
     fd_table[1] = (fd_entry_t) {.type = FD_STDIO,
                                 .host_fd = STDOUT_FILENO,
+                                .ofd_id = fd_next_ofd_id++,
                                 .generation = fd_next_generation++};
     fd_table[2] = (fd_entry_t) {.type = FD_STDIO,
                                 .host_fd = STDERR_FILENO,
+                                .ofd_id = fd_next_ofd_id++,
                                 .generation = fd_next_generation++};
     /* The compound literals above zero can_block; recover the real value so a
      * terminal stdin still routes reads through the interruptible wait.
@@ -329,10 +338,21 @@ int fd_alloc_dir_at(int fd,
  *
  * Returns -1 if none available or RLIMIT_NOFILE would be exceeded.
  */
-int fd_alloc_from(int minfd, int type, int host_fd, void (*cleanup)(int))
+int fd_alloc_from(int minfd,
+                  int type,
+                  int host_fd,
+                  void (*cleanup)(int),
+                  uint64_t *out_gen)
 {
     pthread_mutex_lock(&fd_lock);
     int fd = fd_alloc_locked(minfd, type, host_fd, cleanup);
+    /* Capture the freshly-stamped generation inside the allocating critical
+     * section. Callers (dup) later revalidate it under fd_lock to prove the
+     * slot still holds this allocation and was not closed+reopened in the
+     * window, which a (type, host_fd) tuple alone cannot detect.
+     */
+    if (out_gen && fd >= 0)
+        *out_gen = fd_table[fd].generation;
     pthread_mutex_unlock(&fd_lock);
     return fd;
 }
@@ -340,11 +360,18 @@ int fd_alloc_from(int minfd, int type, int host_fd, void (*cleanup)(int))
 int fd_alloc_from_relaxed(int minfd,
                           int type,
                           int host_fd,
-                          void (*cleanup)(int))
+                          void (*cleanup)(int),
+                          uint64_t *out_gen)
 {
     if (!thread_is_single_active())
-        return fd_alloc_from(minfd, type, host_fd, cleanup);
-    return fd_alloc_locked(minfd, type, host_fd, cleanup);
+        return fd_alloc_from(minfd, type, host_fd, cleanup, out_gen);
+    /* Single active thread: no sibling can race the slot, so the unlocked
+     * generation read is safe.
+     */
+    int fd = fd_alloc_locked(minfd, type, host_fd, cleanup);
+    if (out_gen && fd >= 0)
+        *out_gen = fd_table[fd].generation;
+    return fd;
 }
 
 /* Report whether a guest fd slot >= minfd will be free for a fresh allocation
@@ -386,7 +413,11 @@ bool fd_reexec_slot_available(int minfd)
  *
  * Returns -1 if out of range.
  */
-int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int))
+int fd_alloc_at(int fd,
+                int type,
+                int host_fd,
+                void (*cleanup)(int),
+                uint64_t *out_gen)
 {
     if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
         return -1;
@@ -409,6 +440,8 @@ int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int))
         epoll_note_fd_closed(fd);
     }
     fd_init_entry(fd, type, host_fd, cleanup);
+    if (out_gen)
+        *out_gen = fd_table[fd].generation;
     pthread_mutex_unlock(&fd_lock);
 
     /* Clean up old resources outside fd_lock */
@@ -418,19 +451,28 @@ int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int))
     return fd;
 }
 
-int fd_alloc_at_relaxed(int fd, int type, int host_fd, void (*cleanup)(int))
+int fd_alloc_at_relaxed(int fd,
+                        int type,
+                        int host_fd,
+                        void (*cleanup)(int),
+                        uint64_t *out_gen)
 {
     if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
         return -1;
     if (fd >= rlimit_nofile_cur)
         return -1;
     if (!thread_is_single_active())
-        return fd_alloc_at(fd, type, host_fd, cleanup);
+        return fd_alloc_at(fd, type, host_fd, cleanup, out_gen);
 
     if (fd_table[fd].type != FD_CLOSED)
-        return fd_alloc_at(fd, type, host_fd, cleanup);
+        return fd_alloc_at(fd, type, host_fd, cleanup, out_gen);
 
+    /* Single active thread: no sibling can race the slot, so the unlocked init
+     * and generation read are safe.
+     */
     fd_init_entry(fd, type, host_fd, cleanup);
+    if (out_gen)
+        *out_gen = fd_table[fd].generation;
     return fd;
 }
 
@@ -448,10 +490,13 @@ void fd_mark_closed_unlocked(int fd)
     shim_globals_mark_urandom_fd(fd, false);
     fd_table[fd].type = FD_CLOSED;
     fd_table[fd].host_fd = -1;
+    fd_table[fd].ofd_id = 0;
     fd_table[fd].dir = NULL;
     fd_table[fd].proc_path[0] = '\0';
     fd_table[fd].linux_flags = 0;
     fd_table[fd].seals = 0;
+    fd_table[fd].fasync_owner_type = FASYNC_OWNER_NONE;
+    fd_table[fd].fasync_owner = 0;
     fd_bitmap_set_free(fd);
 
     /* Drop this fd from any epoll interest table. Matches Linux auto-removal on
@@ -672,6 +717,15 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
      * still-live host master fd. No-op for non-pty fds.
      */
     proc_pty_close_keepalive(snap->host_fd);
+
+    /* Deregister any SIGIO/SIGURG readiness watch before the host fd closes.
+     * Closing the fd auto-removes the knote too, but doing it explicitly avoids
+     * a stale event landing on a host fd number reused by a racing open.
+     */
+    if ((snap->linux_flags & LINUX_O_ASYNC) ||
+        (snap->type == FD_SOCKET &&
+         snap->fasync_owner_type != FASYNC_OWNER_NONE))
+        asyncio_disarm(snap->host_fd);
 
     /* Keep stdin/stdout/stderr open on the host */
     if (snap->type != FD_STDIO)

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -29,6 +29,7 @@
 #include "runtime/procemu.h"
 
 #include "syscall/abi.h"
+#include "syscall/asyncio.h"
 #include "syscall/chown-overlay.h"
 #include "syscall/fd.h" /* eventfd_dup_fd */
 #include "syscall/fuse.h"
@@ -217,11 +218,11 @@ static const char *proc_virtual_dir_path(const char *path,
 }
 
 /* Reference-counted wrapper around a directory stream. See the declaration in
- * syscall/internal.h for why this exists: a raw DIR* stored in
- * fd_table[fd].dir would let a sibling close()/dup2()/fork-restore free it via
- * closedir() while sys_getdents64() is still mid-loop reading it. The struct
- * itself is private to this file; every other module only ever sees the
- * opaque void* that fd_table[].dir already stores.
+ * syscall/internal.h for why this exists: a raw DIR* stored in fd_table[fd].dir
+ * would let a sibling close()/dup2()/fork-restore free it via closedir() while
+ * sys_getdents64() is still mid-loop reading it. The struct itself is private
+ * to this file; every other module only ever sees the opaque void* that
+ * fd_table[].dir already stores.
  */
 typedef struct {
     DIR *dir;
@@ -244,8 +245,10 @@ typedef struct {
 } dir_stream_t;
 
 /* Wrap an already-open DIR* for storage in fd_table[].dir. Takes ownership of
- * dir on success. Returns NULL on allocation failure, in which case the
- * caller still owns dir and must closedir() it.
+ * dir on success.
+ *
+ * Returns NULL on allocation failure, in which case the caller still owns dir
+ * and must closedir() it.
  */
 void *dir_stream_create(DIR *dir)
 {
@@ -272,9 +275,10 @@ static void dir_stream_discard(void *ds_ptr)
 }
 
 /* Pin fd's directory stream against a concurrent close()/dup2() so
- * sys_getdents64 can safely walk it. Returns the pinned wrapper, or NULL if
- * fd is not (or no longer) an open FD_DIR. Balance every non-NULL return with
- * dir_stream_release().
+ * sys_getdents64 can safely walk it.
+ *
+ * Returns the pinned wrapper, or NULL if fd is not (or no longer) an open
+ * FD_DIR. Balance every non-NULL return with dir_stream_release().
  */
 static dir_stream_t *dir_stream_acquire(int fd)
 {
@@ -293,9 +297,9 @@ static dir_stream_t *dir_stream_acquire(int fd)
 
 /* Drop a reference taken by dir_stream_acquire(), or the fd-table's own
  * reference from fd_cleanup_entry(). No-op when passed NULL. The decrement
- * happens under fd_lock; the actual closedir()/free() runs after releasing
- * it, matching fd_cleanup_entry's own "do not hold fd_lock across slow
- * syscalls" convention.
+ * happens under fd_lock; the actual closedir()/free() runs after releasing it,
+ * matching fd_cleanup_entry's own "do not hold fd_lock across slow syscalls"
+ * convention.
  */
 void dir_stream_release(void *ds_ptr)
 {
@@ -342,8 +346,8 @@ static int fd_alloc_opened_host(int host_fd,
 
     int guest_fd =
         min_guest_fd >= 0
-            ? fd_alloc_from_relaxed(min_guest_fd, type, host_fd, cleanup)
-            : fd_alloc_from_relaxed(0, type, host_fd, cleanup);
+            ? fd_alloc_from_relaxed(min_guest_fd, type, host_fd, cleanup, NULL)
+            : fd_alloc_from_relaxed(0, type, host_fd, cleanup, NULL);
     if (guest_fd < 0) {
         int saved_errno = errno;
         if (ds)
@@ -788,7 +792,8 @@ static bool install_fd_alias_metadata_atomic(int dst_fd,
                                              int expected_host_fd,
                                              const fd_entry_t *src_snap,
                                              int linux_flags,
-                                             dir_stream_t *ds)
+                                             dir_stream_t *ds,
+                                             uint64_t expected_gen)
 {
     /* LINUX_O_NONBLOCK is a file-status flag preserved by dup(2)/dup2(2).
      * Required for FD_TIMERFD (and any other type that stores NONBLOCK in
@@ -798,14 +803,23 @@ static bool install_fd_alias_metadata_atomic(int dst_fd,
     int preserved_flags =
         src_snap->linux_flags &
         (LINUX_O_ACCMODE | LINUX_O_PATH | LINUX_O_DIRECTORY | LINUX_O_NOFOLLOW |
-         LINUX_O_DIRECT | LINUX_O_LARGEFILE | LINUX_O_NONBLOCK);
+         LINUX_O_DIRECT | LINUX_O_LARGEFILE | LINUX_O_NONBLOCK | LINUX_O_ASYNC);
     int final_flags = preserved_flags | linux_flags;
 
     bool installed = false;
     pthread_mutex_lock(&fd_lock);
+    /* Generation is the unique discriminator: a close+reopen can reuse the same
+     * (type, host_fd) tuple, so only the monotonic generation stamped at alloc
+     * proves this is still the slot this dup created (matches asyncio_apply /
+     * fasync_owner_set). The tuple check stays as a cheap early-out.
+     */
     if (fd_table[dst_fd].type == expected_type &&
-        fd_table[dst_fd].host_fd == expected_host_fd) {
+        fd_table[dst_fd].host_fd == expected_host_fd &&
+        fd_table[dst_fd].generation == expected_gen) {
         fd_table[dst_fd].linux_flags = final_flags;
+        fd_table[dst_fd].ofd_id = src_snap->ofd_id;
+        fd_table[dst_fd].fasync_owner_type = src_snap->fasync_owner_type;
+        fd_table[dst_fd].fasync_owner = src_snap->fasync_owner;
         fd_table[dst_fd].seals = src_snap->seals;
         memcpy(fd_table[dst_fd].proc_path, src_snap->proc_path,
                sizeof(fd_table[dst_fd].proc_path));
@@ -899,10 +913,12 @@ static int duplicate_guest_fd(int src_fd,
 
     int new_type = (src_snap.type == FD_STDIO) ? FD_REGULAR : src_snap.type;
     void (*cleanup)(int) = fd_cleanup_for_type(new_type);
-    int guest_fd = fixed_slot ? fd_alloc_at_relaxed(fixed_guest_fd, new_type,
-                                                    new_host_fd, cleanup)
-                              : fd_alloc_from_relaxed(min_guest_fd, new_type,
-                                                      new_host_fd, cleanup);
+    uint64_t alloc_gen = 0;
+    int guest_fd =
+        fixed_slot ? fd_alloc_at_relaxed(fixed_guest_fd, new_type, new_host_fd,
+                                         cleanup, &alloc_gen)
+                   : fd_alloc_from_relaxed(min_guest_fd, new_type, new_host_fd,
+                                           cleanup, &alloc_gen);
     if (guest_fd < 0) {
         if (fixed_slot)
             errno = EBADF;
@@ -915,9 +931,9 @@ static int duplicate_guest_fd(int src_fd,
     }
 
     /* Clone the DIR stream outside fd_lock (dup + fdopendir would block other
-     * fd ops), then install everything atomically under fd_lock with a tuple
-     * verification so a sibling close + reopen on the same guest_fd cannot make
-     * this install land on an unrelated slot.
+     * fd ops), then install everything atomically under fd_lock with a
+     * generation verification so a sibling close + reopen on the same guest_fd
+     * cannot make this install land on an unrelated slot.
      */
     bool dir_clone_failed = false;
     dir_stream_t *ds =
@@ -930,7 +946,8 @@ static int duplicate_guest_fd(int src_fd,
     }
 
     if (!install_fd_alias_metadata_atomic(guest_fd, new_type, new_host_fd,
-                                          &src_snap, linux_flags, ds)) {
+                                          &src_snap, linux_flags, ds,
+                                          alloc_gen)) {
         /* Slot was reallocated by a sibling while metadata install was pending;
          * the sibling's close path already cleaned up new_host_fd via
          * fd_cleanup_entry, so the only resource this side still owns is the
@@ -938,6 +955,15 @@ static int duplicate_guest_fd(int src_fd,
          */
         if (ds)
             dir_stream_discard(ds);
+    } else if ((src_snap.linux_flags & LINUX_O_ASYNC) ||
+               (src_snap.type == FD_SOCKET &&
+                src_snap.fasync_owner_type != FASYNC_OWNER_NONE)) {
+        /* dup shares O_ASYNC (per open-file-description); register the alias
+         * with the readiness watcher. install only returns true when the slot
+         * still carries alloc_gen, so arming with it drops any stale event from
+         * a sibling close+reuse in this window.
+         */
+        asyncio_arm(guest_fd, alloc_gen, new_host_fd, new_type);
     }
 
     return guest_fd;
@@ -1078,6 +1104,10 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         linux_fl |= fd_snap.linux_flags &
                     (LINUX_O_PATH | LINUX_O_DIRECTORY | LINUX_O_NOFOLLOW |
                      LINUX_O_DIRECT | LINUX_O_LARGEFILE);
+        /* O_ASYNC is tracked in the shadow (never armed on the host fd), so
+         * surface it from there. See linux_to_mac_status_flags in translate.c.
+         */
+        linux_fl |= fd_snap.linux_flags & LINUX_O_ASYNC;
         return linux_fl;
     }
     case 4: /* F_SETFL */
@@ -1109,6 +1139,7 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
                                            LINUX_O_NOFOLLOW | LINUX_O_DIRECT |
                                            LINUX_O_LARGEFILE));
             pthread_mutex_unlock(&fd_lock);
+            asyncio_apply(fd, fd_snap.generation, ((int) arg & LINUX_O_ASYNC));
             return 0;
         }
         /* Timerfd: kqueue host fd rejects fcntl(F_SETFL), so mirror Linux's
@@ -1145,8 +1176,19 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
             return -LINUX_EBADF;
         int rc =
             fcntl(host_ref.fd, F_SETFL, linux_to_mac_status_flags((int) arg));
+        if (rc < 0) {
+            int64_t err = linux_errno();
+            host_fd_ref_close(&host_ref);
+            return err;
+        }
+        /* O_ASYNC is elfuse-managed: track the armed bit and (dis)arm the SIGIO
+         * watcher. asyncio_apply rescans the slot under fd_lock and uses each
+         * alias's real backing fd, not host_ref.fd (a per-syscall dup for
+         * multi-threaded callers).
+         */
+        asyncio_apply(fd, fd_snap.generation, ((int) arg & LINUX_O_ASYNC));
         host_fd_ref_close(&host_ref);
-        return rc < 0 ? linux_errno() : 0;
+        return 0;
     }
     case 5:   /* F_GETLK */
     case 6:   /* F_SETLK */
@@ -1243,38 +1285,97 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         host_fd_ref_close(&host_ref);
         return 0;
     }
-    case 8: /* F_SETOWN */
-        /* SIGIO/SIGURG delivery owner. nginx's ngx_spawn_process pairs
-         * ioctl(FIOASYNC) with fcntl(F_SETOWN) on the channel socket before
-         * fork() and aborts the worker (NGX_INVALID_PID) if either fails.
-         * elfuse does not deliver host SIGIO into the guest (see LINUX_FIOASYNC
-         * in sys_ioctl), so no owner is tracked: accept the request as a no-op.
-         * F_SETOWN's arg is the owner pid passed by value, so there is no user
-         * pointer to validate.
+    case 8: { /* F_SETOWN */
+        /* SIGIO/SIGURG delivery owner. The arg is a signed value passed by
+         * value: pid > 0 targets a process, pid < 0 targets a process group,
+         * pid == 0 clears the owner. Stored per open-file-description so the
+         * async watcher (asyncio.c) can resolve the recipient on readiness.
          */
+        int a = (int) arg;
+        int otype, owner;
+        if (a > 0) {
+            otype = FASYNC_OWNER_PID;
+            owner = a;
+        } else if (a < 0) {
+            /* Guard INT_MIN: -a would overflow (signed UB). A process group id
+             * with no representable magnitude cannot name a real pgrp.
+             */
+            if (a == INT32_MIN)
+                return -LINUX_EINVAL;
+            otype = FASYNC_OWNER_PGRP;
+            owner = -a;
+        } else {
+            otype = FASYNC_OWNER_NONE;
+            owner = 0;
+        }
+        fasync_owner_set(fd, fd_snap.generation, otype, owner);
         return 0;
+    }
     case 15: { /* F_SETOWN_EX */
-        /* Same no-op owner semantics as F_SETOWN, but the arg is a struct
-         * f_owner_ex { int type; int pid; } pointer that Linux reads before
-         * applying. Read it through so a bad guest pointer faults with EFAULT
-         * rather than silently succeeding; the value is then discarded.
+        /* Struct f_owner_ex { int type; int pid; } pointer. Read it through so
+         * a bad guest pointer faults with EFAULT, translate the Linux owner
+         * type, and store it. pid == 0 clears the owner.
          */
         int32_t owner_ex[2];
         if (guest_read_small(g, arg, owner_ex, sizeof(owner_ex)) < 0)
             return -LINUX_EFAULT;
+        int otype;
+        switch (owner_ex[0]) {
+        case LINUX_F_OWNER_TID:
+            otype = FASYNC_OWNER_TID;
+            break;
+        case LINUX_F_OWNER_PID:
+            otype = FASYNC_OWNER_PID;
+            break;
+        case LINUX_F_OWNER_PGRP:
+            otype = FASYNC_OWNER_PGRP;
+            break;
+        default:
+            return -LINUX_EINVAL;
+        }
+        /* F_SETOWN_EX carries the recipient in the type field, so the pid is a
+         * plain positive identifier: a negative pid is invalid (Linux owner
+         * semantics), and 0 clears the owner.
+         */
+        if (owner_ex[1] < 0)
+            return -LINUX_EINVAL;
+        if (owner_ex[1] == 0)
+            otype = FASYNC_OWNER_NONE;
+        fasync_owner_set(fd, fd_snap.generation, otype, owner_ex[1]);
         return 0;
     }
-    case 9: /* F_GETOWN */
-        /* No owner tracked; report none. */
-        return 0;
-    case 16: { /* F_GETOWN_EX */
-        /* glibc implements fcntl(F_GETOWN) on top of F_GETOWN_EX, so this must
-         * answer coherently with the F_SETOWN no-op above rather than EINVAL
-         * (which would make F_GETOWN fail under glibc). Report "owned by no
-         * specific process": struct f_owner_ex { int type; int pid; } with
-         * type=F_OWNER_PID(1), pid=0.
+    case 9: { /* F_GETOWN */
+        /* Derive the signed owner from the stored f_owner_ex: pid for PID/TID,
+         * negated pgrp for PGRP, 0 when unowned.
          */
-        int32_t owner_ex[2] = {1 /* F_OWNER_PID */, 0 /* pid */};
+        int otype, owner;
+        fasync_owner_get(fd, fd_snap.generation, &otype, &owner);
+        if (otype == FASYNC_OWNER_PGRP)
+            return -owner;
+        if (otype == FASYNC_OWNER_NONE)
+            return 0;
+        return owner;
+    }
+    case 16: { /* F_GETOWN_EX */
+        /* struct f_owner_ex { int type; int pid; }. Report the stored owner;
+         * unowned reads back as {F_OWNER_PID, 0} to stay coherent with the
+         * F_GETOWN path glibc layers on top of this.
+         */
+        int otype, owner;
+        fasync_owner_get(fd, fd_snap.generation, &otype, &owner);
+        int32_t owner_ex[2];
+        switch (otype) {
+        case FASYNC_OWNER_TID:
+            owner_ex[0] = LINUX_F_OWNER_TID;
+            break;
+        case FASYNC_OWNER_PGRP:
+            owner_ex[0] = LINUX_F_OWNER_PGRP;
+            break;
+        default:
+            owner_ex[0] = LINUX_F_OWNER_PID;
+            break;
+        }
+        owner_ex[1] = (otype == FASYNC_OWNER_NONE) ? 0 : owner;
         if (guest_write_small(g, arg, owner_ex, sizeof(owner_ex)) < 0)
             return -LINUX_EFAULT;
         return 0;

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -23,6 +23,7 @@
 #include "runtime/procemu.h"
 
 #include "syscall/abi.h"
+#include "syscall/asyncio.h"
 #include "syscall/fuse.h"
 #include "syscall/internal.h"
 #include "syscall/path.h"
@@ -244,6 +245,7 @@ typedef struct {
     bool closed;
     bool daemon_dead;
     bool init_done;
+    int notify_wr;
     uint32_t max_write;
     uint16_t max_pages;
     uint64_t next_unique;
@@ -513,10 +515,29 @@ static void fuse_session_put_locked(fuse_session_t *session)
 {
     if (--session->refcount > 0)
         return;
+    if (session->notify_wr >= 0)
+        close(session->notify_wr);
     pthread_mutex_destroy(&session->lock);
     pthread_cond_destroy(&session->queue_cond);
     pthread_cond_destroy(&session->init_cond);
     memset(session, 0, sizeof(*session));
+}
+
+static void fuse_notify_readable_locked(fuse_session_t *session)
+{
+    if (session->notify_wr < 0)
+        return;
+    uint8_t byte = 1;
+    write(session->notify_wr, &byte, 1);
+}
+
+static void fuse_notify_drain_fd_locked(int fd)
+{
+    if (fd < 0)
+        return;
+    uint8_t byte;
+    while (read(fd, &byte, 1) > 0)
+        ;
 }
 
 static fuse_mount_t *fuse_mount_for_path_locked(const char *path,
@@ -730,11 +751,14 @@ static int fuse_queue_request_locked(fuse_session_t *session,
     if (payload_len)
         memcpy(req->frame + sizeof(*hdr), payload, payload_len);
 
+    bool was_empty = session->queue_head == NULL;
     if (session->queue_tail)
         session->queue_tail->next = req;
     else
         session->queue_head = req;
     session->queue_tail = req;
+    if (was_empty)
+        fuse_notify_readable_locked(session);
     pthread_cond_broadcast(&session->queue_cond);
     if (req_out)
         *req_out = req;
@@ -1298,6 +1322,7 @@ int fuse_proc_open(int linux_flags)
             pthread_mutex_init(&slot->lock, NULL);
             pthread_cond_init(&slot->queue_cond, NULL);
             pthread_cond_init(&slot->init_cond, NULL);
+            slot->notify_wr = -1;
             slot->max_write = 64 * 1024;
             slot->max_pages = 16;
             slot->next_unique = 1;
@@ -1310,8 +1335,22 @@ int fuse_proc_open(int linux_flags)
         return -1;
     }
 
-    int guest_fd = fd_alloc(FD_FUSE_DEV, -1, fuse_fd_cleanup);
+    int notify_pipe[2];
+    if (pipe(notify_pipe) < 0) {
+        pthread_mutex_lock(&fuse_lock);
+        fuse_session_put_locked(slot);
+        pthread_mutex_unlock(&fuse_lock);
+        return -1;
+    }
+    fcntl(notify_pipe[0], F_SETFL, O_NONBLOCK);
+    fcntl(notify_pipe[1], F_SETFL, O_NONBLOCK);
+    fcntl(notify_pipe[0], F_SETFD, FD_CLOEXEC);
+    fcntl(notify_pipe[1], F_SETFD, FD_CLOEXEC);
+    slot->notify_wr = notify_pipe[1];
+
+    int guest_fd = fd_alloc(FD_FUSE_DEV, notify_pipe[0], fuse_fd_cleanup);
     if (guest_fd < 0) {
+        close(notify_pipe[0]);
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(slot);
         pthread_mutex_unlock(&fuse_lock);
@@ -2199,10 +2238,15 @@ int64_t fuse_dev_read(int guest_fd,
                       uint64_t buf_gva,
                       uint64_t count)
 {
+    host_fd_ref_t notify_ref;
+    if (host_fd_ref_open_io(guest_fd, &notify_ref) < 0)
+        return -LINUX_EBADF;
+
     pthread_mutex_lock(&fuse_lock);
     fuse_session_t *session = fuse_session_by_fd_locked(guest_fd);
     if (!session) {
         pthread_mutex_unlock(&fuse_lock);
+        host_fd_ref_close(&notify_ref);
         return -LINUX_EBADF;
     }
     fuse_session_get_locked(session);
@@ -2215,6 +2259,7 @@ int64_t fuse_dev_read(int guest_fd,
             pthread_mutex_lock(&fuse_lock);
             fuse_session_put_locked(session);
             pthread_mutex_unlock(&fuse_lock);
+            host_fd_ref_close(&notify_ref);
             return -LINUX_EAGAIN;
         }
         pthread_cond_wait(&session->queue_cond, &session->lock);
@@ -2224,6 +2269,7 @@ int64_t fuse_dev_read(int guest_fd,
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
         pthread_mutex_unlock(&fuse_lock);
+        host_fd_ref_close(&notify_ref);
         return -LINUX_ENOTCONN;
     }
 
@@ -2238,6 +2284,7 @@ int64_t fuse_dev_read(int guest_fd,
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
         pthread_mutex_unlock(&fuse_lock);
+        host_fd_ref_close(&notify_ref);
         return -LINUX_EINVAL;
     }
     if (guest_write(g, buf_gva, req->frame, frame_len) < 0) {
@@ -2245,6 +2292,7 @@ int64_t fuse_dev_read(int guest_fd,
         pthread_mutex_lock(&fuse_lock);
         fuse_session_put_locked(session);
         pthread_mutex_unlock(&fuse_lock);
+        host_fd_ref_close(&notify_ref);
         return -LINUX_EFAULT;
     }
     /* Commit: dequeue only after the copy succeeded. */
@@ -2252,12 +2300,15 @@ int64_t fuse_dev_read(int guest_fd,
     if (!session->queue_head)
         session->queue_tail = NULL;
     req->next = NULL;
+    if (!session->queue_head)
+        fuse_notify_drain_fd_locked(notify_ref.fd);
     if (req->no_reply)
         fuse_free_request_locked(req);
     pthread_mutex_unlock(&session->lock);
     pthread_mutex_lock(&fuse_lock);
     fuse_session_put_locked(session);
     pthread_mutex_unlock(&fuse_lock);
+    host_fd_ref_close(&notify_ref);
     return (int64_t) frame_len;
 }
 
@@ -2571,11 +2622,18 @@ int fuse_dup_fd(int src_fd,
      * fd_table[guest_fd].cleanup assignment would skip fuse_fd_cleanup and leak
      * the session or file ref.
      */
-    int guest_fd = fixed_slot ? fd_alloc_at_relaxed(fixed_guest_fd, snap.type,
-                                                    -1, fuse_fd_cleanup)
-                              : fd_alloc_from_relaxed(min_guest_fd, snap.type,
-                                                      -1, fuse_fd_cleanup);
+    int new_host_fd = snap.type == FD_FUSE_DEV ? dup(snap.host_fd) : -1;
+    if (snap.type == FD_FUSE_DEV && new_host_fd < 0)
+        return -1;
+    uint64_t alloc_gen = 0;
+    int guest_fd =
+        fixed_slot ? fd_alloc_at_relaxed(fixed_guest_fd, snap.type, new_host_fd,
+                                         fuse_fd_cleanup, &alloc_gen)
+                   : fd_alloc_from_relaxed(min_guest_fd, snap.type, new_host_fd,
+                                           fuse_fd_cleanup, &alloc_gen);
     if (guest_fd < 0) {
+        if (new_host_fd >= 0)
+            close(new_host_fd);
         if (fixed_slot)
             errno = EBADF;
         return -1;
@@ -2618,21 +2676,36 @@ int fuse_dup_fd(int src_fd,
 
     pthread_mutex_unlock(&fuse_lock);
 
-    /* O_NONBLOCK is a file-status flag preserved by dup(2)/dup2(2); without it
-     * a duplicated non-blocking FUSE fd would silently become blocking because
-     * nothing else carries the flag forward.
+    /* Copy the source snapshot, not the live src fd: dup aliases one coherent
+     * open-file-description state even if another thread closes/reuses src_fd
+     * while the FUSE refs are being pinned.
      *
-     * Take fd_lock once for both the source read and the destination write so
-     * the dup snapshot is consistent with any concurrent F_SETFL on the source
-     * and so the destination publish cannot be overwritten by an early racing
-     * F_SETFL on the new slot.
+     * Revalidate the destination slot under fd_lock before publishing metadata,
+     * mirroring install_fd_alias_metadata_atomic in fs.c: a sibling close +
+     * reopen on a fixed-slot dup2 target could have replaced this slot in the
+     * window since fd_alloc. The generation stamped at alloc is the unique
+     * discriminator (a close+reopen can reuse the same type and host_fd,
+     * including host_fd == -1 for FUSE file/dir); a mismatch means the slot was
+     * reused, so skip the write and the asyncio arm rather than stomp the new
+     * occupant or fire SIGIO on an unrelated fd.
      */
     pthread_mutex_lock(&fd_lock);
-    int preserved_flags =
-        fd_table[src_fd].linux_flags &
-        (LINUX_O_PATH | LINUX_O_DIRECTORY | LINUX_O_NOFOLLOW | LINUX_O_DIRECT |
-         LINUX_O_LARGEFILE | LINUX_O_NONBLOCK);
-    fd_table[guest_fd].linux_flags = preserved_flags | linux_flags;
+    if (fd_table[guest_fd].type == snap.type &&
+        fd_table[guest_fd].host_fd == new_host_fd &&
+        fd_table[guest_fd].generation == alloc_gen) {
+        int preserved_flags =
+            snap.linux_flags &
+            (LINUX_O_ACCMODE | LINUX_O_PATH | LINUX_O_DIRECTORY |
+             LINUX_O_NOFOLLOW | LINUX_O_DIRECT | LINUX_O_LARGEFILE |
+             LINUX_O_NONBLOCK | LINUX_O_ASYNC);
+        fd_table[guest_fd].linux_flags = preserved_flags | linux_flags;
+        fd_table[guest_fd].ofd_id = snap.ofd_id;
+        fd_table[guest_fd].fasync_owner_type = snap.fasync_owner_type;
+        fd_table[guest_fd].fasync_owner = snap.fasync_owner;
+        if (fd_table[guest_fd].linux_flags & LINUX_O_ASYNC)
+            asyncio_arm(guest_fd, fd_table[guest_fd].generation,
+                        fd_table[guest_fd].host_fd, fd_table[guest_fd].type);
+    }
     pthread_mutex_unlock(&fd_lock);
     return guest_fd;
 }

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -101,9 +101,16 @@ int fd_alloc_dir_at(int fd,
 /* Allocate the lowest available FD >= minfd.
  *
  * Returns -1 if none available. cleanup is set atomically under fd_lock (pass
- * NULL for plain fds).
+ * NULL for plain fds). out_gen (nullable) receives the generation stamped on
+ * the new slot, captured inside the allocating fd_lock critical section so dup
+ * can later prove the slot still holds this allocation and was not
+ * closed+reopened in the window.
  */
-int fd_alloc_from(int minfd, int type, int host_fd, void (*cleanup)(int));
+int fd_alloc_from(int minfd,
+                  int type,
+                  int host_fd,
+                  void (*cleanup)(int),
+                  uint64_t *out_gen);
 
 /* Allocate the lowest available FD >= minfd with a single-thread fast path.
  * Falls back to fd_alloc_from() when multiple guest threads are active.
@@ -111,18 +118,27 @@ int fd_alloc_from(int minfd, int type, int host_fd, void (*cleanup)(int));
 int fd_alloc_from_relaxed(int minfd,
                           int type,
                           int host_fd,
-                          void (*cleanup)(int));
+                          void (*cleanup)(int),
+                          uint64_t *out_gen);
 
 /* Allocate a specific FD slot.
  * Returns -1 if out of range. cleanup is set atomically under fd_lock (pass
- * NULL for plain fds).
+ * NULL for plain fds). out_gen: see fd_alloc_from().
  */
-int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int));
+int fd_alloc_at(int fd,
+                int type,
+                int host_fd,
+                void (*cleanup)(int),
+                uint64_t *out_gen);
 
 /* Allocate a specific FD slot with a single-thread fast path. Falls back to
  * fd_alloc_at() when replacement/cleanup must stay serialized.
  */
-int fd_alloc_at_relaxed(int fd, int type, int host_fd, void (*cleanup)(int));
+int fd_alloc_at_relaxed(int fd,
+                        int type,
+                        int host_fd,
+                        void (*cleanup)(int),
+                        uint64_t *out_gen);
 
 /* Report whether a guest FD slot >= minfd will be free after execve's CLOEXEC
  * sweep runs (free now, or open-but-CLOEXEC). sys_execve uses this before
@@ -250,13 +266,13 @@ bool fd_close_regular_relaxed(int fd, int *host_fd_out);
  */
 void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap);
 
-/* Reference-counted wrapper around a directory stream, stored in
- * fd_table[].dir for FD_DIR entries (see syscall/fs.c). A raw DIR* would let a
- * sibling's close()/dup2()/fork-restore free it via closedir() while
- * sys_getdents64() is still mid-loop reading it; the wrapper defers the
- * closedir() until every acquirer -- the fd-table's own reference, plus any
- * in-flight sys_getdents64 -- has released it. Guarded by fd_lock, mirroring
- * poll.c's epoll_instance_t refcount.
+/* Reference-counted wrapper around a directory stream, stored in fd_table[].dir
+ * for FD_DIR entries (see syscall/fs.c). A raw DIR* would let a sibling's
+ * close()/dup2()/fork-restore free it via closedir() while sys_getdents64() is
+ * still mid-loop reading it; the wrapper defers the closedir() until every
+ * acquirer -- the fd-table's own reference, plus any in-flight sys_getdents64
+ * -- has released it. Guarded by fd_lock, mirroring poll.c's epoll_instance_t
+ * refcount.
  *
  * dir_stream_create() takes ownership of dir and returns the wrapper, or NULL
  * on allocation failure (caller still owns dir and must closedir() it itself).

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -38,6 +38,7 @@
 #include "runtime/thread.h"
 
 #include "syscall/abi.h"
+#include "syscall/asyncio.h"
 #include "syscall/fd.h"
 #include "syscall/fuse.h"
 #include "syscall/internal.h"
@@ -1251,26 +1252,26 @@ static int64_t single_guest_iov(guest_t *g,
 }
 
 /* Linux returns 0 for zero-iovcnt vector I/O once the fd validates:
- * import_iovec() yields an empty iterator and do_iter_read/do_iter_write
- * return before the file offset is touched, so even pwritev2(RWF_APPEND)
- * leaves the position alone. macOS readv/writev instead reject iovcnt == 0
- * with EINVAL, so short-circuit before any host call -- the append path's
- * SEEK_END would otherwise move the shared offset. The iov pointer is not
- * dereferenced (Linux ignores it for an empty vector), and negative counts
- * keep flowing into host_iov_prepare's EINVAL.
+ * import_iovec() yields an empty iterator and do_iter_read/do_iter_write return
+ * before the file offset is touched, so even pwritev2(RWF_APPEND) leaves the
+ * position alone. macOS readv/writev instead reject iovcnt == 0 with EINVAL, so
+ * short-circuit before any host call -- the append path's SEEK_END would
+ * otherwise move the shared offset. The iov pointer is not dereferenced (Linux
+ * ignores it for an empty vector), and negative counts keep flowing into
+ * host_iov_prepare's EINVAL.
  *
  * The checks Linux runs before its empty-vector return still apply, in this
  * order: the positional variants fail non-seekable files with ESPIPE
  * (FMODE_PREAD/FMODE_PWRITE in do_preadv/do_pwritev), and all variants fail
  * wrong-direction fds with EBADF (FMODE_READ/FMODE_WRITE in
- * do_iter_read/do_iter_write). Both are probed on the host fd, whose open
- * mode mirrors the guest's for host-backed types; fd_table linux_flags
- * cannot be used because pipe/socket entries only track CLOEXEC there.
- * Virtual multiplexed fds (eventfd/timerfd/signalfd/...) sit on host pipes
- * or kqueues whose mode says nothing about the guest-visible fd (the Linux
- * anon-inode equivalents are O_RDWR), so they validate existence only. No
- * F_SEAL_WRITE check: Linux never reaches the write path for an empty
- * vector, so a write-sealed memfd returns 0 here too.
+ * do_iter_read/do_iter_write). Both are probed on the host fd, whose open mode
+ * mirrors the guest's for host-backed types; fd_table linux_flags cannot be
+ * used because pipe/socket entries only track CLOEXEC there. Virtual
+ * multiplexed fds (eventfd/timerfd/signalfd/...) sit on host pipes or kqueues
+ * whose mode says nothing about the guest-visible fd (the Linux anon-inode
+ * equivalents are O_RDWR), so they validate existence only. No F_SEAL_WRITE
+ * check: Linux never reaches the write path for an empty vector, so a
+ * write-sealed memfd returns 0 here too.
  */
 static int64_t vec_zero_iovcnt(int fd, bool op_is_write, bool positional)
 {
@@ -1482,8 +1483,8 @@ int64_t sys_preadv(guest_t *g,
 {
     if (iovcnt == 0) {
         /* do_preadv rejects a negative offset before looking up the fd, so
-         * EINVAL outranks EBADF here; nonzero counts keep getting EINVAL
-         * from the host preadv instead.
+         * EINVAL outranks EBADF here; nonzero counts keep getting EINVAL from
+         * the host preadv instead.
          */
         if (offset < 0)
             return -LINUX_EINVAL;
@@ -1629,9 +1630,9 @@ int64_t sys_preadv2(guest_t *g,
 {
     /* Linux validates RWF flags only once the write/read actually proceeds
      * (kiocb_set_rw_flags sits behind the empty-vector return in
-     * do_iter_read/do_iter_write), so an empty vector short-circuits before
-     * the flag checks. Offset -1 selects do_readv (no seekability check);
-     * any other negative offset fails EINVAL before the fd lookup.
+     * do_iter_read/do_iter_write), so an empty vector short-circuits before the
+     * flag checks. Offset -1 selects do_readv (no seekability check); any other
+     * negative offset fails EINVAL before the fd lookup.
      */
     if (iovcnt == 0) {
         if (offset < -1)
@@ -1982,21 +1983,23 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
     }
 
     case LINUX_FIOASYNC: {
-        /* Set/clear O_ASYNC (SIGIO-driven I/O). nginx's ngx_spawn_process arms
-         * this on the master's channel socket right before fork() and treats a
-         * failure as fatal (ngx_close_channel + return NGX_INVALID_PID), so
-         * answering ENOTTY here aborts worker spawning entirely -- the master
-         * is left with no workers and accepted connections are never serviced.
-         * elfuse does not forward host SIGIO into the guest, and nginx workers
-         * receive both client I/O and channel commands via epoll rather than
-         * SIGIO, so accept the request as a no-op: read the int arg for EFAULT
-         * parity and report success without arming host async delivery.
+        /* Set/clear O_ASYNC (SIGIO-driven I/O). This is the ioctl form of
+         * fcntl(F_SETFL, O_ASYNC): unify both onto the same armed bit and
+         * kqueue watcher (asyncio.c) so the two entry points cannot drift.
+         * Snapshot only for the slot generation; asyncio_apply rescans under
+         * fd_lock for each alias's backing fd and class.
          */
         int32_t on = 0;
         if (guest_read_small(g, arg, &on, sizeof(on)) < 0) {
             host_fd_ref_close(&host_ref);
             return -LINUX_EFAULT;
         }
+        fd_entry_t snap;
+        if (!fd_snapshot(fd, &snap)) {
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EBADF;
+        }
+        asyncio_apply(fd, snap.generation, on != 0);
         host_fd_ref_close(&host_ref);
         return 0;
     }

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -613,7 +613,8 @@ int64_t sys_connect(guest_t *g, int fd, uint64_t addr_gva, uint32_t addrlen)
             return linux_errno();
         }
 
-        if (fd_alloc_at(fd, FD_SOCKET, pair[0], absock_unregister_fd) < 0) {
+        if (fd_alloc_at(fd, FD_SOCKET, pair[0], absock_unregister_fd, NULL) <
+            0) {
             close(pair[0]);
             close(pair[1]);
             host_fd_ref_close(&host_ref);

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -46,6 +46,7 @@
 #include "runtime/futex.h"
 
 #include "syscall/abi.h"
+#include "syscall/asyncio.h"
 #include "syscall/exec.h"
 #include "syscall/fd.h"
 #include "syscall/fuse.h"
@@ -111,6 +112,7 @@ void syscall_init(void)
     io_init();
     fd_register_cleanup(FD_URANDOM, urandom_fd_cleanup);
     wakeup_pipe_init();
+    asyncio_init();
 }
 
 /* Memory syscall implementations (sys_brk, sys_mmap, sys_mremap, etc.) are in

--- a/src/syscall/translate.c
+++ b/src/syscall/translate.c
@@ -250,7 +250,11 @@ int linux_to_mac_status_flags(int linux_flags)
         mac_flags |= O_NONBLOCK;
     if (linux_flags & LINUX_O_APPEND)
         mac_flags |= O_APPEND;
-    if (linux_flags & LINUX_O_ASYNC)
-        mac_flags |= O_ASYNC;
+    /* O_ASYNC is deliberately NOT mapped onto the host fd. elfuse delivers
+     * SIGIO/SIGURG itself via the kqueue watcher (see asyncio.c); arming host
+     * O_ASYNC would let the host raise its own SIGIO at the elfuse process,
+     * whose default disposition would terminate it. The armed state lives in
+     * fd_entry_t.linux_flags and F_GETFL surfaces it from there.
+     */
     return mac_flags;
 }

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -39,6 +39,7 @@ test-pidfd                         # diff=skip
 test-signal
 test-kill-broadcast
 test-kill-pgroup
+test-sigio                         # diff=skip
 
 [section] Socket tests
 test-socket

--- a/tests/test-fuse-basic.c
+++ b/tests/test-fuse-basic.c
@@ -153,11 +153,18 @@ typedef struct {
 } daemon_ctx_t;
 
 static volatile sig_atomic_t got_usr1;
+static volatile sig_atomic_t got_sigio;
 
 static void sigusr1_handler(int signum)
 {
     (void) signum;
     got_usr1 = 1;
+}
+
+static void sigio_handler(int signum)
+{
+    (void) signum;
+    got_sigio = 1;
 }
 
 static void *signal_sender_main(void *arg)
@@ -511,6 +518,17 @@ int main(void)
     fusefd = open("/dev/fuse", O_RDWR);
     if (fusefd < 0)
         die("open(/dev/fuse good)");
+    struct sigaction sigio_sa;
+    memset(&sigio_sa, 0, sizeof(sigio_sa));
+    sigio_sa.sa_handler = sigio_handler;
+    sigemptyset(&sigio_sa.sa_mask);
+    if (sigaction(SIGIO, &sigio_sa, NULL) < 0)
+        die("sigaction(SIGIO)");
+    if (fcntl(fusefd, F_SETOWN, getpid()) < 0)
+        die("fcntl(F_SETOWN fusefd)");
+    int fuse_fl = fcntl(fusefd, F_GETFL);
+    if (fuse_fl < 0 || fcntl(fusefd, F_SETFL, fuse_fl | O_ASYNC) < 0)
+        die("fcntl(F_SETFL O_ASYNC fusefd)");
 
     daemon_ctx_t ctx = {.fusefd = fusefd};
     pthread_t tid;
@@ -523,6 +541,12 @@ int main(void)
              fusefd, (unsigned) getuid(), (unsigned) getgid());
     if (syscall(SYS_mount, source_name, mount_dir, "fuse", 0, opts) < 0)
         die("mount(fuse)");
+    for (int i = 0; i < 2000 && !got_sigio; i++)
+        usleep(1000);
+    if (!got_sigio) {
+        fprintf(stderr, "no SIGIO on FUSE device readiness\n");
+        return 1;
+    }
 
     if (stat(mount_dir, &st) < 0)
         die("stat(mountpoint)");

--- a/tests/test-sigio.c
+++ b/tests/test-sigio.c
@@ -1,0 +1,303 @@
+/*
+ * Signal-driven I/O (O_ASYNC / SIGIO / F_SETOWN) tests
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tests:
+ *   1. F_SETOWN / F_GETOWN round-trip (pid and process-group forms)
+ *   2. F_SETOWN(0) clears the owner
+ *   3. F_SETOWN_EX / F_GETOWN_EX round-trip
+ *   4. SIGIO delivery on socket readiness after fcntl(F_SETFL, O_ASYNC)
+ *   5. SIGIO delivery after ioctl(FIOASYNC) (the unified second entry point)
+ *   6. dup inheritance and shared owner/armed state across aliases
+ *   7. SIGURG delivery on a TCP out-of-band byte with no O_ASYNC
+ *
+ * Syscalls: fcntl(25), ioctl(29), socketpair(199), socket(198), bind(200),
+ *           listen(201), accept(202), connect(203), sendto(206),
+ *           rt_sigaction(134), write(64)
+ */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+static volatile sig_atomic_t sigurg_count;
+
+static void sigurg_handler(int sig)
+{
+    (void) sig;
+    sigurg_count++;
+}
+
+/* Build a connected loopback TCP pair. Blocking connect(2) to a listening
+ * socket completes the handshake at the TCP layer before accept(2), so no
+ * second thread is needed.
+ *
+ * Returns 0 with sv[0]=server, sv[1]=client, else -1.
+ */
+static int tcp_loopback_pair(int sv[2])
+{
+    int lst = socket(AF_INET, SOCK_STREAM, 0);
+    if (lst < 0)
+        return -1;
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    socklen_t alen = sizeof(addr);
+    if (bind(lst, (struct sockaddr *) &addr, sizeof(addr)) < 0 ||
+        listen(lst, 1) < 0 ||
+        getsockname(lst, (struct sockaddr *) &addr, &alen) < 0) {
+        close(lst);
+        return -1;
+    }
+    int cli = socket(AF_INET, SOCK_STREAM, 0);
+    if (cli < 0) {
+        close(lst);
+        return -1;
+    }
+    if (connect(cli, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+        close(lst);
+        close(cli);
+        return -1;
+    }
+    int srv = accept(lst, NULL, NULL);
+    close(lst);
+    if (srv < 0) {
+        close(cli);
+        return -1;
+    }
+    sv[0] = srv;
+    sv[1] = cli;
+    return 0;
+}
+
+#ifndef F_SETOWN_EX
+#define F_SETOWN_EX 15
+#define F_GETOWN_EX 16
+struct f_owner_ex {
+    int type;
+    pid_t pid;
+};
+#endif
+#ifndef F_OWNER_PID
+#define F_OWNER_PID 1
+#define F_OWNER_PGRP 2
+#endif
+
+static volatile sig_atomic_t sigio_count;
+
+static void sigio_handler(int sig)
+{
+    (void) sig;
+    sigio_count++;
+}
+
+/* Arm a SIGIO handler, mark fd async + owned by this process, poke the peer,
+ * and wait (bounded) for the handler to fire. arm_via_ioctl selects the
+ * ioctl(FIOASYNC) entry point instead of fcntl(F_SETFL, O_ASYNC).
+ */
+static int expect_sigio(int arm_via_ioctl)
+{
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) < 0)
+        return -1;
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigio_handler;
+    sigaction(SIGIO, &sa, NULL);
+
+    if (fcntl(sv[0], F_SETOWN, getpid()) < 0) {
+        close(sv[0]);
+        close(sv[1]);
+        return -1;
+    }
+
+    sigio_count = 0;
+    if (arm_via_ioctl) {
+        int on = 1;
+        if (ioctl(sv[0], FIOASYNC, &on) < 0) {
+            close(sv[0]);
+            close(sv[1]);
+            return -1;
+        }
+    } else {
+        int fl = fcntl(sv[0], F_GETFL);
+        if (fcntl(sv[0], F_SETFL, fl | O_ASYNC) < 0) {
+            close(sv[0]);
+            close(sv[1]);
+            return -1;
+        }
+    }
+
+    /* Make sv[0] readable; the watcher should turn that into a SIGIO. */
+    if (write(sv[1], "x", 1) != 1) {
+        close(sv[0]);
+        close(sv[1]);
+        return -1;
+    }
+
+    /* Bounded wait: ~2s in 1ms steps. The syscalls keep the vCPU cycling so
+     * queued signals are delivered on syscall return.
+     */
+    for (int i = 0; i < 2000 && sigio_count == 0; i++)
+        usleep(1000);
+
+    int got = sigio_count;
+    close(sv[0]);
+    close(sv[1]);
+    return got > 0 ? 0 : 1;
+}
+
+int main(void)
+{
+    int fds[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) < 0) {
+        printf("socketpair failed\n");
+        return 1;
+    }
+
+    TEST("F_SETOWN/F_GETOWN pid round-trip");
+    fcntl(fds[0], F_SETOWN, getpid());
+    EXPECT_EQ(fcntl(fds[0], F_GETOWN), getpid(), "owner pid mismatch");
+
+    TEST("F_SETOWN/F_GETOWN pgrp round-trip");
+    fcntl(fds[0], F_SETOWN, -getpid());
+    EXPECT_EQ(fcntl(fds[0], F_GETOWN), -getpid(), "owner pgrp mismatch");
+
+    TEST("F_SETOWN(0) clears owner");
+    fcntl(fds[0], F_SETOWN, 0);
+    EXPECT_EQ(fcntl(fds[0], F_GETOWN), 0, "owner not cleared");
+
+    TEST("F_SETOWN_EX/F_GETOWN_EX round-trip");
+    {
+        struct f_owner_ex set = {.type = F_OWNER_PID, .pid = getpid()};
+        struct f_owner_ex get;
+        memset(&get, 0, sizeof(get));
+        fcntl(fds[0], F_SETOWN_EX, &set);
+        int rc = fcntl(fds[0], F_GETOWN_EX, &get);
+        EXPECT_TRUE(rc == 0 && get.type == F_OWNER_PID && get.pid == getpid(),
+                    "owner_ex mismatch");
+    }
+    TEST("F_SETOWN(INT_MIN) rejected without UB");
+    EXPECT_ERRNO(fcntl(fds[0], F_SETOWN, INT_MIN), EINVAL,
+                 "INT_MIN owner not rejected");
+
+    TEST("F_SETOWN_EX negative pid rejected");
+    {
+        struct f_owner_ex bad = {.type = F_OWNER_PID, .pid = -5};
+        EXPECT_ERRNO(fcntl(fds[0], F_SETOWN_EX, &bad), EINVAL,
+                     "negative pid not rejected");
+    }
+
+    close(fds[0]);
+    close(fds[1]);
+
+    TEST("SIGIO delivered via F_SETFL(O_ASYNC)");
+    EXPECT_EQ(expect_sigio(0), 0, "no SIGIO on readiness");
+
+    TEST("SIGIO delivered via ioctl(FIOASYNC)");
+    EXPECT_EQ(expect_sigio(1), 0, "no SIGIO on readiness (ioctl)");
+
+    TEST("dup inherits O_ASYNC + owner (SIGIO fires)");
+    {
+        int sv[2];
+        int ok = 0;
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0) {
+            struct sigaction sa;
+            memset(&sa, 0, sizeof(sa));
+            sa.sa_handler = sigio_handler;
+            sigaction(SIGIO, &sa, NULL);
+
+            fcntl(sv[0], F_SETOWN, getpid());
+            int fl = fcntl(sv[0], F_GETFL);
+            fcntl(sv[0], F_SETFL, fl | O_ASYNC);
+
+            sigio_count = 0;
+            int dfd = dup(sv[0]);
+            /* The original arming already covers readiness; closing sv[0]
+             * leaves only the dup armed, proving the alias inherited O_ASYNC.
+             */
+            close(sv[0]);
+            if (write(sv[1], "y", 1) == 1) {
+                for (int i = 0; i < 2000 && sigio_count == 0; i++)
+                    usleep(1000);
+                ok = sigio_count > 0;
+            }
+            close(dfd);
+            close(sv[1]);
+        }
+        EXPECT_TRUE(ok, "no SIGIO on dup'd async fd");
+    }
+
+    TEST("dup aliases share O_ASYNC + owner updates");
+    {
+        int sv[2];
+        int ok = 0;
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0) {
+            int dfd = dup(sv[0]);
+            if (dfd >= 0) {
+                fcntl(sv[0], F_SETOWN, getpid());
+                int fl = fcntl(dfd, F_GETFL);
+                fcntl(dfd, F_SETFL, fl | O_ASYNC);
+                ok = ((fcntl(sv[0], F_GETFL) & O_ASYNC) != 0) &&
+                     fcntl(dfd, F_GETOWN) == getpid();
+                close(dfd);
+            }
+            close(sv[0]);
+            close(sv[1]);
+        }
+        EXPECT_TRUE(ok, "dup aliases did not share async state");
+    }
+
+    TEST("SIGURG delivered on TCP out-of-band byte without O_ASYNC");
+    {
+        int sv[2];
+        int ok = 0;
+        if (tcp_loopback_pair(sv) == 0) {
+            struct sigaction sa;
+            memset(&sa, 0, sizeof(sa));
+            sa.sa_handler = sigurg_handler;
+            sigaction(SIGURG, &sa, NULL);
+
+            fcntl(sv[0], F_SETOWN, getpid());
+            int fl = fcntl(sv[0], F_GETFL);
+            fcntl(sv[0], F_SETFL, fl | O_ASYNC);
+            fcntl(sv[0], F_SETFL, fl & ~O_ASYNC);
+
+            sigurg_count = 0;
+            /* Urgent byte from the client; the server's OOB mark drives
+             * EVFILT_EXCEPT/NOTE_OOB, which the watcher maps to SIGURG.
+             */
+            if (send(sv[1], "!", 1, MSG_OOB) == 1) {
+                for (int i = 0; i < 2000 && sigurg_count == 0; i++)
+                    usleep(1000);
+                ok = sigurg_count > 0;
+            }
+            close(sv[0]);
+            close(sv[1]);
+        } else {
+            /* Loopback TCP unavailable in this environment; do not fail. */
+            ok = 1;
+        }
+        EXPECT_TRUE(ok, "no SIGURG on TCP OOB byte");
+    }
+
+    SUMMARY("test-sigio");
+    return fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Prior no-op stubs made FIOASYNC / F_SETOWN / F_GETOWN succeed so nginx could spawn workers, but O_ASYNC never delivered a signal and the owner was never tracked: a guest that depends on signal-driven I/O hung, and F_GETOWN / F_GETOWN_EX always reported 0.

New module src/syscall/asyncio.c owns one kqueue plus a detached watcher thread. It registers each async host fd as an EV_CLEAR edge-triggered EVFILT_READ knote (plus EVFILT_EXCEPT / NOTE_OOB for sockets); on a readiness edge the watcher resolves the fd owner and injects a guest SIGIO (SIGURG for out-of-band data) via signal_queue(). Host O_ASYNC is never armed on the host fd: a host SIGIO would land on the elfuse process and terminate it. F_GETFL surfaces the armed bit from the shadow.

Async state is per open-file description. fd_entry_t gains an ofd_id shared by every dup alias, plus the O_ASYNC armed bit and the owner. F_SETOWN, F_SETOWN_EX, F_SETFL(O_ASYNC), and ioctl(FIOASYNC) fan the update out to all aliases sharing the ofd_id under fd_lock and funnel through one asyncio_apply() source of truth; F_GETOWN / F_GETOWN_EX read it back. SIGIO requires O_ASYNC, but SIGURG on a socket out-of-band byte is delivered whenever an owner is set, matching Linux sk_send_sigurg.

The async state is serialized across the fork IPC path: the child rebuilds the parent-to-child ofd_id remap so aliases stay grouped, then re-arms the watcher for every inherited async fd once its own syscall_init has brought up the kqueue.

The kqueue udata packs the guest fd plus the fd-slot generation, and every mutator revalidates the generation under fd_lock so a close+reopen that reuses the slot cannot inject SIGIO into an unrelated occupant (SIGIO default action is terminate).

Close #115

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements signal-driven I/O for the guest: `O_ASYNC` now delivers `SIGIO`, and sockets deliver `SIGURG`. Replaces prior no-op `FIOASYNC`/`F_SETOWN` so apps relying on `SIGIO` work and ownership queries return real values.

- New Features
  - Added `asyncio` kqueue watcher thread that registers pollable fds (pipes, sockets, stdio, `/dev/fuse`) and maps readiness to guest `SIGIO` and OOB to `SIGURG`. Host `O_ASYNC` is never armed; `F_GETFL` surfaces the bit from the shadow.
  - Per open-file-description state via `ofd_id`: `F_SETOWN(_EX)` stores owners; `F_SETFL(O_ASYNC)` and `ioctl(FIOASYNC)` arm via `asyncio_apply`; `F_GETOWN(_EX)` returns the owner. Sockets raise `SIGURG` on OOB whenever an owner is set.
  - Fork/dup/close: async state is serialized across fork and re-armed in the child; dup inherits owner/`O_ASYNC` and is armed with a generation guard; close disarms. `/dev/fuse` now uses an internal nonblocking pipe so queue transitions trigger `SIGIO`. Tests add `test-sigio.c` and update `test-fuse-basic` to assert `SIGIO`.

- Bug Fixes
  - Arm/disarm runs under `fd_lock` and uses the fd-slot generation to drop stale kqueue events; disarm before host close. `F_GETFL` now reflects `O_ASYNC` from the shadow, not the host.
  - Ownership validation and reporting: `F_SETOWN(INT_MIN)` and `F_SETOWN_EX` with a negative pid return `EINVAL`; `F_GETOWN`/`F_GETOWN_EX` report real owners. Signals are delivered only to local owners.

<sup>Written for commit 3011c6ee2a33b037dece5ea731274e050f778674. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

