### PR TITLE
Raise host fd limit to back the guest fd table

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -15,7 +15,7 @@
         test-sysroot-create-paths test-fork-ipc-protocol-host test-identity-override-host \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-timeout-disable test-fuse-alpine \
-        test-sysroot-nofollow test-sysroot-chdir perf
+        test-sysroot-nofollow test-sysroot-chdir test-fd-limit-stock perf
 
 ## Build and run the assembly hello world test
 test-hello: $(ELFUSE_BIN) $(TEST_HELLO_DEP)
@@ -43,6 +43,8 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 		$(BUILD_DIR)/test-fork-ipc-protocol-host \
 		$(BUILD_DIR)/test-identity-override-host
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
+	@printf "\n$(BLUE)━━━ stock fd-limit (256) regression ━━━$(RESET)\n"
+	@$(MAKE) --no-print-directory test-fd-limit-stock
 	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-tlbi-encoder-host
 	@printf "\n$(BLUE)━━━ fork IPC protocol identity unit test ━━━$(RESET)\n"
@@ -73,6 +75,15 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 	@$(MAKE) --no-print-directory test-rosetta-cli
 	@printf "\n$(BLUE)━━━ hot-syscall guardrail ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-bench-guardrail
+
+## Rerun the fd-heavy stress test with the soft RLIMIT_NOFILE forced to the
+## stock macOS default (256): fdtable_init must raise the host limit itself.
+FD_LIMIT_STOCK_DEPS := $(ELFUSE_BIN)
+ifndef GUEST_TEST_BINARIES
+  FD_LIMIT_STOCK_DEPS += $(BUILD_DIR)/test-stress
+endif
+test-fd-limit-stock: $(FD_LIMIT_STOCK_DEPS)
+	@bash -c 'ulimit -S -n 256 && exec "$(ELFUSE_BIN)" "$(TEST_DIR)/test-stress"'
 
 ## Hot-syscall performance guardrail: ensure getpid, libc clock_gettime,
 ## and 1-byte /dev/urandom reads stay under their TODO ns/op ceilings.

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -10,10 +10,12 @@
  * access through fd_lock.
  */
 
+#include <limits.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <errno.h>
 #include <dirent.h>
@@ -145,11 +147,35 @@ static int fd_bitmap_find_free(int minfd)
 
 /* fdtable_init. */
 
+/* Raise the host RLIMIT_NOFILE soft limit to min(OPEN_MAX, rlim_max), the
+ * largest value macOS accepts. The stock soft limit is 256, far below the
+ * FD_TABLE_SIZE fds this table advertises to guests, and every guest fd needs
+ * at least one backing host fd.
+ *
+ * Returns without changing anything if getrlimit fails or the limit already
+ * meets the target (an inherited higher limit is never lowered); setrlimit
+ * failure is ignored.
+ */
+static void fd_raise_host_nofile(void)
+{
+    struct rlimit rl;
+
+    if (getrlimit(RLIMIT_NOFILE, &rl) != 0)
+        return;
+    rlim_t want = (rl.rlim_max < OPEN_MAX) ? rl.rlim_max : OPEN_MAX;
+    if (rl.rlim_cur >= want)
+        return;
+    rl.rlim_cur = want;
+    (void) setrlimit(RLIMIT_NOFILE, &rl);
+}
+
 /* Initialize the FD table and bitmap, pre-open stdin/stdout/stderr. Extracted
  * from syscall_init(); call before any guest code runs.
  */
 void fdtable_init(void)
 {
+    fd_raise_host_nofile();
+
     memset(fd_table, 0, sizeof(fd_table));
 
     /* Mark all FDs as free in bitmap */


### PR DESCRIPTION
 Fixes #68 

The test-stress FD-exhaustion subtest fails whenever make check runs from a shell with the stock macOS soft fd limit (256). The guest is told RLIMIT_NOFILE is 1024 (FD_TABLE_SIZE) and every guest fd is backed by a host fd, so once the host process runs out at ~250 the guest sees EMFILE far below its advertised limit.

Fix it in fdtable_init(): raise the host soft limit to min(OPEN_MAX, rlim_max) before any guest code runs, following the macOS setrlimit(2) man page. A limit that is already high enough is left alone, and a failed setrlimit is ignored. Host fds can now exceed FD_SETSIZE, which is fine — sys_pselect6 already falls back to poll() when a host fd doesn't fit in an fd_set.

Since dev machines usually run with raised shell limits, a regression here would go unnoticed, so this also adds a check step (test-fd-limit-stock) that reruns test-stress with the soft limit forced to 256 in a child shell.

Tested on an M3 Max: the repro above fails on unpatched main and passes with the patch; full make check stays green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the host soft file descriptor limit at startup so the guest can use its full fd table without hitting EMFILE on macOS’s stock 256 limit. Adds a regression check that reruns the stress test under the stock limit.

- **Bug Fixes**
  - In `fdtable_init()`, raise `RLIMIT_NOFILE` to `min(OPEN_MAX, rlim_max)`; leave higher limits as-is and ignore `setrlimit` failures.
  - Add `test-fd-limit-stock` to run `test-stress` with `ulimit -S -n 256` to catch regressions.

<sup>Written for commit 6d66e60313afb5c5e31173843ccb5ec665a702a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

