### PR TITLE
Allocate Rosetta fd dynamically instead of fd 3

### DIFF
--- a/src/core/bootstrap.c
+++ b/src/core/bootstrap.c
@@ -524,8 +524,8 @@ int guest_bootstrap_prepare(guest_t *g,
     if (want_rosetta) {
         /* /proc/self/maps for a rosetta guest reports the rosetta translator as
          * a single anonymous region covering [VA, VA+size). The original x86_64
-         * binary is not loaded into guest memory; rosetta exposes it via fd 3
-         * once rosetta_finalize pre-opens it.
+         * binary is not loaded into guest memory; rosetta exposes it via the
+         * guest fd rosetta_finalize pre-opens (published as AT_EXECFD).
          */
         register_elf_segment_regions(g, &rr.rosetta_info, 0,
                                      g->rosetta_guest_base - g->rosetta_va_base,
@@ -572,19 +572,22 @@ int guest_bootstrap_prepare(guest_t *g,
         proc_set_sysroot(sysroot);
     startup_trace_step("runtime_init", t0);
 
-    /* rosetta_finalize pre-opens the x86_64 binary at fd 3, constructs the
-     * binfmt_misc argv ([ROSETTA_PATH, binary, original_argv[1..]]), refreshes
+    /* rosetta_finalize pre-opens the x86_64 binary at the lowest free guest fd
+     * >= 3 (published as AT_EXECFD), constructs the binfmt_misc argv
+     * ([ROSETTA_PATH, binary, original_argv[1..]]), refreshes
      * /proc/self/cmdline, and installs the TTBR0 kbuf alias. The aarch64 path
      * uses the caller's argv directly. The remaining Rosetta runtime blocker is
      * high-VA mmap support for the translator's own slab and JIT allocations.
      */
     int rosetta_argc = 0;
     const char **rosetta_argv = NULL;
+    int rosetta_execfd = -1;
     if (want_rosetta) {
         t0 = startup_trace_now_ns();
         if (rosetta_finalize(g, 0, elf_host_path, elf_host_path_temp,
                              elf_guest_path, guest_argc, guest_argv, &rr,
-                             verbose, &rosetta_argc, &rosetta_argv, NULL) < 0) {
+                             verbose, &rosetta_argc, &rosetta_argv, NULL,
+                             &rosetta_execfd) < 0) {
             log_error("rosetta_finalize failed");
             return -1;
         }
@@ -607,8 +610,8 @@ int guest_bootstrap_prepare(guest_t *g,
     t0 = startup_trace_now_ns();
     boot->stack_pointer = build_linux_stack(
         g, g->stack_top, stack_argc, stack_argv, (const char **) environ,
-        stack_elf, stack_elf_load_base, stack_interp_base, native_vdso, -1,
-        &auxv);
+        stack_elf, stack_elf_load_base, stack_interp_base, native_vdso,
+        rosetta_execfd, &auxv);
     if (boot->stack_pointer == 0) {
         log_error("failed to build initial stack");
         free(rosetta_argv);
@@ -843,9 +846,11 @@ int guest_bootstrap_rosetta_post_reset(guest_t *g,
 
     int rosetta_argc = 0;
     const char **rosetta_argv = NULL;
+    int rosetta_execfd = -1;
     if (rosetta_finalize(g, 0, elf_host_path, elf_host_path_temp,
                          elf_guest_path, guest_argc, guest_argv, &rr, verbose,
-                         &rosetta_argc, &rosetta_argv, NULL) < 0) {
+                         &rosetta_argc, &rosetta_argv, NULL,
+                         &rosetta_execfd) < 0) {
         log_error("rosetta_finalize failed during exec re-bootstrap");
         return -1;
     }
@@ -855,9 +860,9 @@ int guest_bootstrap_rosetta_post_reset(guest_t *g,
 
     uint64_t native_vdso = vdso_build(g);
     linux_stack_auxv_t auxv;
-    uint64_t sp = build_linux_stack(
-        g, g->stack_top, rosetta_argc, rosetta_argv, (const char **) environ,
-        &rr.rosetta_info, 0, 0, native_vdso, -1 /* AT_EXECFD absent */, &auxv);
+    uint64_t sp = build_linux_stack(g, g->stack_top, rosetta_argc, rosetta_argv,
+                                    (const char **) environ, &rr.rosetta_info,
+                                    0, 0, native_vdso, rosetta_execfd, &auxv);
     free(rosetta_argv);
     if (sp == 0) {
         log_error("build_linux_stack failed during exec re-bootstrap");

--- a/src/core/bootstrap.h
+++ b/src/core/bootstrap.h
@@ -68,12 +68,12 @@ int guest_bootstrap_create_vcpu(guest_t *g,
  *
  * The helper runs rosetta_prepare, appends every region the page-table builder
  * needs, rebuilds page tables, registers guest_region_t entries for
- * /proc/self/maps, runs rosetta_finalize (pre-opens fd 3, installs the kbuf
- * user alias, publishes the binfmt-misc argv via proc_set_cmdline), and builds
- * the initial Linux stack using the rosetta image as the AT_PHDR/AT_BASE ELF
- * metadata. It does NOT touch the vCPU sysregs -- the caller writes TCR_EL1,
- * TTBR0_EL1, TTBR1_EL1, ELR_EL1, SP_EL0, and PC itself once the out_* fields
- * are returned.
+ * /proc/self/maps, runs rosetta_finalize (pre-opens the binary at the lowest
+ * free guest fd >= 3, published as AT_EXECFD; installs the kbuf user alias,
+ * publishes the binfmt-misc argv via proc_set_cmdline), and builds the initial
+ * Linux stack using the rosetta image as the AT_PHDR/AT_BASE ELF metadata. It
+ * does NOT touch the vCPU sysregs; the caller writes TCR_EL1, TTBR0_EL1,
+ * TTBR1_EL1, ELR_EL1, SP_EL0, and PC itself once the out_* fields are returned.
  *
  * Returns 0 on success with out_entry_point, out_stack_pointer, out_ttbr0 set.
  *

--- a/src/core/rosetta.c
+++ b/src/core/rosetta.c
@@ -9,7 +9,7 @@
  * low GPA and exposes it at its statically-linked high VA (0x800000000000) via
  * a non-identity mem_region_t.va_base. The TTBR1 kbuf is initialized at a 256
  * MiB window just below the rosetta image. rosetta_finalize wires the
- * bootstrap-visible pieces needed to enter the translator: fd 3 setup,
+ * bootstrap-visible pieces needed to enter the translator: binary fd setup,
  * binfmt-style argv construction, cmdline refresh, and the TTBR0 kbuf alias.
  * The runtime still depends on the high-VA mmap path in mem.c for Rosetta's own
  * slab and JIT allocations.
@@ -46,8 +46,8 @@
 #include "debug/log.h"
 #include "hvutil.h"
 #include "utils.h"
-#include "syscall/internal.h" /* fd_alloc_at, FD_REGULAR */
-#include "syscall/proc.h"     /* proc_set_cmdline */
+#include "syscall/internal.h" /* fd_alloc_from, fd_publish_linux_flags, FD_REGULAR */
+#include "syscall/proc.h" /* proc_set_cmdline */
 
 /* Round a guest virtual address (or size) up to the next 2 MiB boundary. */
 static inline uint64_t align2m_up(uint64_t v)
@@ -61,13 +61,13 @@ static inline uint64_t align2m_down(uint64_t v)
 }
 
 /* The VZ_CAPS payload only has room for a 42-byte inline path. Publish
- * /proc/self/fd/3 there when the real host path is longer so rosetta sees a
- * valid reopenable path without truncation, while the host-side translator
- * subprocess still retains the full original binary path. Both buffers are read
- * by the VZ_CAPS ioctl handler from any vCPU; writes happen during
- * rosetta_finalize on execve. A pthread_mutex covers both setter and snapshot
- * reader so a multi-vCPU guest doing concurrent execves cannot observe a torn
- * or stale string.
+ * /proc/self/fd/<bin_guest_fd> there when the real host path is longer so
+ * rosetta sees a valid reopenable path without truncation, while the host-side
+ * translator subprocess still retains the full original binary path. Both
+ * buffers are read by the VZ_CAPS ioctl handler from any vCPU; writes happen
+ * during rosetta_finalize on execve. A pthread_mutex covers both setter and
+ * snapshot reader so a multi-vCPU guest doing concurrent execves cannot observe
+ * a torn or stale string.
  */
 static pthread_mutex_t rosettad_path_lock = PTHREAD_MUTEX_INITIALIZER;
 static char rosettad_binary_path[PATH_MAX];
@@ -92,7 +92,9 @@ static bool rosettad_drain_owned_path_locked(char out[PATH_MAX])
     return true;
 }
 
-void rosettad_set_binary_path(const char *path, bool take_ownership)
+void rosettad_set_binary_path(const char *path,
+                              bool take_ownership,
+                              int bin_guest_fd)
 {
     if (!path)
         path = "";
@@ -114,8 +116,10 @@ void rosettad_set_binary_path(const char *path, bool take_ownership)
     rosettad_binary_path[full_n] = '\0';
 
     const char *caps_path = path;
+    char fd_path[sizeof("/proc/self/fd/") + 11];
     if (n >= sizeof(rosettad_caps_binary_path)) {
-        caps_path = "/proc/self/fd/3";
+        snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", bin_guest_fd);
+        caps_path = fd_path;
         log_debug("rosetta: using %s as caps binary path for long target %s",
                   caps_path, path);
     }
@@ -392,31 +396,36 @@ int rosetta_finalize(guest_t *g,
                      bool verbose,
                      int *out_argc,
                      const char ***out_argv,
-                     uint64_t *out_vdso_addr)
+                     uint64_t *out_vdso_addr,
+                     int *out_execfd)
 {
     (void) vcpu;          /* TCR_EL1 / TTBR1_EL1 set in bootstrap_create_vcpu */
     (void) out_vdso_addr; /* bootstrap drives vdso_build directly */
 
     if (!g || !binary_host_path || !binary_guest_path || !rr || !out_argc ||
-        !out_argv)
+        !out_argv || !out_execfd)
         return -1;
     *out_argc = 0;
     *out_argv = NULL;
+    *out_execfd = -1;
 
-    /* Defer every externally-visible state change (guest fd 3, cmdline,
+    /* Defer every externally-visible state change (guest binary fd, cmdline,
      * out_argc/out_argv) until after every fallible setup step succeeds. Any
      * failure before commit goes through the fail label and tears down only the
      * host-local resources allocated so far.
      */
-    int bin_host_fd;
     const char **rosetta_argv = NULL;
     int rosetta_argc = 0;
 
-    /* Pre-open the x86_64 binary so it can be installed at guest fd 3 once the
-     * full setup succeeds. Rosetta locates its target via /proc/self/fd/3
-     * (binfmt_misc convention).
+    /* Pre-open the x86_64 binary so it can be installed at a guest fd once the
+     * full setup succeeds. Rosetta locates its target via the VZ_CAPS binary
+     * path (the full guest path, or /proc/self/fd/<execfd> when that path does
+     * not fit the 42-byte inline field) plus AT_EXECFD (binfmt_misc
+     * convention). This is the first fallible step, so every goto fail below
+     * sees bin_host_fd already set (open returns -1 on failure, which the fail
+     * label treats as nothing to close).
      */
-    bin_host_fd = open(binary_host_path, O_RDONLY);
+    int bin_host_fd = open(binary_host_path, O_RDONLY);
     if (bin_host_fd < 0) {
         log_error("rosetta_finalize: failed to open binary '%s': %s",
                   binary_host_path, strerror(errno));
@@ -468,33 +477,52 @@ int rosetta_finalize(guest_t *g,
         goto fail;
     }
 
-    /* Install guest fd 3 last so any earlier failure unwinds without needing to
-     * roll back the ownership transfer. fd_alloc_at(3) is the final fallible
-     * step; once it succeeds, the host fd is owned by the guest fd table and no
-     * goto fail must be introduced below, or the fail handler would
-     * double-close it.
+    /* Install the guest binary fd last so any earlier failure unwinds without
+     * needing to roll back the ownership transfer. fd_alloc_from is the final
+     * fallible step; once it succeeds, the host fd is owned by the guest fd
+     * table and no goto fail must be introduced below, or the fail handler
+     * would double-close it.
+     *
+     * Use the lowest free non-stdio slot rather than a hardcoded fd 3: at
+     * initial launch only stdio (0-2) is open, so this still lands on 3, but on
+     * an execve re-bootstrap the guest may already hold fd 3 for its own use
+     * (apt hands gpgv a status pipe on fd 3). Evicting it would break the
+     * child; the dynamic slot steps over whatever the guest already opened.
+     *
+     * On an exec re-bootstrap this runs past execve's point of no return, where
+     * an fd_alloc_from failure would be fatal. sys_execve preflights slot
+     * availability via fd_reexec_slot_available(3) before guest_reset and
+     * returns -EMFILE there, so an exhausted table fails gracefully instead of
+     * aborting mid-exec. The guest fd ceiling sits below the host
+     * RLIMIT_NOFILE, so the pre-PNR elf_load host open does not catch this
+     * first; the preflight is the real guard and this branch is the backstop.
      */
-    int bin_guest_fd = fd_alloc_at(3, FD_REGULAR, bin_host_fd, NULL);
+    int bin_guest_fd = fd_alloc_from(3, FD_REGULAR, bin_host_fd, NULL);
     if (bin_guest_fd < 0) {
-        log_error("rosetta_finalize: fd_alloc_at(3) failed");
+        log_error("rosetta_finalize: fd_alloc_from(3) failed");
         goto fail;
     }
 
     /* Ownership of bin_host_fd is now held by the guest fd table. Mark the
      * rosetta target fd CLOEXEC so a rosetta-to-native execve does not leak it
-     * into the new image. fd_alloc_at clears linux_flags, so the OR is safe.
+     * into the new image. Publish through the fd_lock helper rather than a bare
+     * store so this writer stays on the same lock domain as every other
+     * linux_flags mutator; fd_alloc_from zero-initialized the slot, so setting
+     * the flag outright is correct.
      */
-    fd_table[bin_guest_fd].linux_flags |= LINUX_O_CLOEXEC;
+    fd_publish_linux_flags(bin_guest_fd, LINUX_O_CLOEXEC);
 
-    rosettad_set_binary_path(binary_host_path, binary_host_path_temp);
+    rosettad_set_binary_path(binary_host_path, binary_host_path_temp,
+                             bin_guest_fd);
     proc_set_cmdline(rosetta_argc, rosetta_argv);
 
     if (verbose)
-        log_debug("rosetta_finalize: argv=[%s, %s, ...], target_fd=3",
-                  rosetta_argv[0], rosetta_argv[1]);
+        log_debug("rosetta_finalize: argv=[%s, %s, ...], target_fd=%d",
+                  rosetta_argv[0], rosetta_argv[1], bin_guest_fd);
 
     *out_argc = rosetta_argc;
     *out_argv = rosetta_argv;
+    *out_execfd = bin_guest_fd;
 
     /* The VZ ioctl trio is in; the rosettad translate pipeline and the mem.c
      * body refactor for rosetta high-VA mmap allocations are still pending.

--- a/src/core/rosetta.h
+++ b/src/core/rosetta.h
@@ -15,13 +15,13 @@
  *   bits on M1), so a separate high-IPA mapping is not viable.
  * - rosetta_finalize() runs after guest_build_page_tables(), installing TTBR0
  *   kbuf user-VA alias, builds the vDSO, registers semantic regions for
- *   /proc/self/maps, pre-opens the x86_64 binary at fd 3, constructs
- *   binfmt_misc-style argv, and refreshes proc state.
+ *   /proc/self/maps, pre-opens the x86_64 binary at the lowest free guest fd
+ *   >= 3, constructs binfmt_misc-style argv, and refreshes proc state.
  *
- * Bootstrap-side wiring (placement, kbuf, page-tables, fd 3, binfmt argv, TTBR0
- * kbuf alias, VZ probe ioctls, rosettad socket bridge and AOT cache) is in. The
- * runtime still depends on the high-VA mmap body refactor for Rosetta's own
- * fixed-address slab and JIT allocations.
+ * Bootstrap-side wiring (placement, kbuf, page-tables, binary fd, binfmt argv,
+ * TTBR0 kbuf alias, VZ probe ioctls, rosettad socket bridge and AOT cache) is
+ * in. The runtime still depends on the high-VA mmap body refactor for Rosetta's
+ * own fixed-address slab and JIT allocations.
  */
 
 #pragma once
@@ -76,7 +76,9 @@
  * - The host-side translate subprocess needs the full original path. Subsequent
  * calls overwrite the previous value (execve into a different x86_64 binary).
  */
-void rosettad_set_binary_path(const char *path, bool take_ownership);
+void rosettad_set_binary_path(const char *path,
+                              bool take_ownership,
+                              int bin_guest_fd);
 void rosettad_clear_binary_path(void);
 
 /* Snapshot the published paths into caller-supplied buffers under the setter's
@@ -189,8 +191,9 @@ int rosetta_prepare(guest_t *g,
                     rosetta_result_t *result);
 
 /* Second-pass rosetta setup, runs after guest_build_page_tables(): install the
- * TTBR0 user-VA alias for the kbuf, pre-open the x86_64 binary at fd 3, build
- * the binfmt_misc argv ([ROSETTA_PATH, binary, original argv[1..]]) for
+ * TTBR0 user-VA alias for the kbuf, pre-open the x86_64 binary at the lowest
+ * free guest fd >= 3 (returned via out_execfd for AT_EXECFD), build the
+ * binfmt_misc argv ([ROSETTA_PATH, binary, original argv[1..]]) for
  * build_linux_stack to consume, and refresh proc state. The remaining runtime
  * blocker after this stage is high-VA mmap support for Rosetta's own internal
  * fixed-address allocations.
@@ -206,4 +209,5 @@ int rosetta_finalize(guest_t *g,
                      bool verbose,
                      int *out_argc,
                      const char ***out_argv,
-                     uint64_t *out_vdso_addr);
+                     uint64_t *out_vdso_addr,
+                     int *out_execfd);

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -569,6 +569,18 @@ int64_t sys_execve(hv_vcpu_t vcpu,
             err = -LINUX_ENOEXEC;
             goto fail;
         }
+        /* rosetta_finalize pre-opens the x86_64 binary at a guest fd >= 3 past
+         * the point of no return, where an EMFILE would be fatal. The guest fd
+         * ceiling is far below the host limit, so a guest can fill its table
+         * without the pre-PNR elf_load host open failing first. Reject here
+         * (recoverably) when no slot >= 3 will survive the CLOEXEC sweep below.
+         */
+        if (!fd_reexec_slot_available(3)) {
+            log_error("execve: no free guest fd for the Rosetta binary: %s",
+                      path);
+            err = -LINUX_EMFILE;
+            goto fail;
+        }
         target_is_rosetta = true;
     }
 

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -229,6 +229,39 @@ int fd_alloc_from_relaxed(int minfd,
     return fd_alloc_locked(minfd, type, host_fd, cleanup);
 }
 
+/* Report whether a guest fd slot >= minfd will be free for a fresh allocation
+ * once execve's CLOEXEC sweep has run. rosetta_finalize claims that slot for
+ * the pre-opened x86_64 binary past execve's point of no return, where an
+ * EMFILE is fatal; sys_execve calls this before guest_reset so an exhausted
+ * table fails gracefully with -EMFILE instead. The guest fd ceiling
+ * (FD_TABLE_SIZE) sits far below the host RLIMIT_NOFILE, so a guest can fill
+ * its table while the host still has fds, meaning the host open in elf_load
+ * does not catch this first.
+ *
+ * A slot qualifies if it is free now, or if it is open but CLOEXEC (the sweep
+ * closes it before rosetta_finalize allocates). Returns true if at least one
+ * such slot exists within RLIMIT_NOFILE.
+ */
+bool fd_reexec_slot_available(int minfd)
+{
+    if (minfd < 0)
+        minfd = 0;
+    pthread_mutex_lock(&fd_lock);
+    int limit = rlimit_nofile_cur;
+    if (limit > FD_TABLE_SIZE)
+        limit = FD_TABLE_SIZE;
+    bool available = false;
+    for (int i = minfd; i < limit; i++) {
+        if (fd_table[i].type == FD_CLOSED ||
+            (fd_table[i].linux_flags & LINUX_O_CLOEXEC)) {
+            available = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&fd_lock);
+    return available;
+}
+
 /* Allocate a specific FD slot. Enforces RLIMIT_NOFILE. Properly cleans up any
  * existing entry (including DIR* for directory FDs) before overwriting.
  *

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -89,6 +89,13 @@ int fd_alloc_at(int fd, int type, int host_fd, void (*cleanup)(int));
  */
 int fd_alloc_at_relaxed(int fd, int type, int host_fd, void (*cleanup)(int));
 
+/* Report whether a guest FD slot >= minfd will be free after execve's CLOEXEC
+ * sweep runs (free now, or open-but-CLOEXEC). sys_execve uses this before
+ * guest_reset so a Rosetta re-bootstrap that would fail fd_alloc_from past the
+ * point of no return is rejected gracefully with -EMFILE instead.
+ */
+bool fd_reexec_slot_available(int minfd);
+
 /* Look up a guest FD.
  *
  * Returns host FD or -1 if invalid. Unsafe for concurrent use; see

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -654,6 +654,10 @@ run_rosetta_x86_64_suites()
         run_summary_suite "rosetta-jit" \
             bash "${REPO_ROOT}/tests/test-rosetta-jit.sh" "$ELFUSE" || rc=1
 
+        printf "\nRosetta execve fd preservation\n"
+        run_summary_suite "rosetta-execfd" \
+            bash "${REPO_ROOT}/tests/test-rosetta-execfd.sh" "$ELFUSE" || rc=1
+
         printf "\nRosetta glibc dynamic\n"
         run_summary_suite "rosetta-glibc" \
             bash "${REPO_ROOT}/tests/test-rosetta-glibc.sh" "$ELFUSE" || rc=1
@@ -672,7 +676,8 @@ run_rosetta_x86_64_suites()
     else
         local suite
         for suite in rosetta-statics rosetta-alpine rosetta-audit rosetta-jit \
-            rosetta-glibc rosetta-madvise rosetta-msync rosetta-mremap; do
+            rosetta-execfd rosetta-glibc rosetta-madvise rosetta-msync \
+            rosetta-mremap; do
             skip_suite "$suite" "Rosetta translator not installed"
         done
     fi

--- a/tests/test-rosetta-execfd.sh
+++ b/tests/test-rosetta-execfd.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-rosetta-execfd.sh - guest fd is preserved across a rosetta execve
+#
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression for the hardcoded guest fd 3 in rosetta_finalize. The runner
+# used to install the x86_64 binary at guest fd 3, clobbering whatever the
+# guest had already opened there. apt hands gpgv a status pipe on fd 3
+# (gpgv --status-fd 3); the eviction broke signature verification with
+# "Good signature, but could not determine key fingerprint". rosetta_finalize
+# now takes the lowest free non-stdio slot and publishes it via AT_EXECFD, so a
+# guest fd opened before an x86_64 execve survives into the new image and
+# intentionally closed stdio fds stay closed.
+#
+# The probe: a shell opens fd 3 onto a marker file, then execs busybox to
+# cat /proc/self/fd/3. If the runner evicts fd 3, cat reads the busybox ELF
+# instead of the marker. Both processes are x86_64 statics, so the inner
+# exec goes through the rosetta exec re-bootstrap path.
+#
+# Skips cleanly when Rosetta Linux is absent or the x86_64 fixture tree is
+# missing (run tests/fetch-fixtures.sh INCLUDE_X86_64=1 first).
+#
+# Usage: tests/test-rosetta-execfd.sh [path/to/elfuse]
+
+set -euo pipefail
+
+ELFUSE_INPUT="${1:-build/elfuse}"
+case "$ELFUSE_INPUT" in
+    /*) ELFUSE="$ELFUSE_INPUT" ;;
+    *) ELFUSE="$(pwd)/$ELFUSE_INPUT" ;;
+esac
+
+FIXTURES="${FIXTURES_DIR:-externals/test-fixtures}"
+BUSYBOX="$(pwd)/${FIXTURES}/x86_64-musl/staticbin/bin/busybox"
+ROSETTA_PATH="${MATRIX_ROSETTA_TRANSLATOR:-/Library/Apple/usr/libexec/oah/RosettaLinux/rosetta}"
+
+# shellcheck source=tests/lib/rosetta-test.sh
+. "$(dirname "$0")/lib/rosetta-test.sh"
+
+pass=0
+fail=0
+skip=0
+total=0
+
+if [ ! -x "$ROSETTA_PATH" ]; then
+    printf 'rosetta translator not found at %s\n' "$ROSETTA_PATH" >&2
+    exit 77
+fi
+if [ ! -x "$ELFUSE" ]; then
+    printf 'elfuse binary not found: %s\n' "$ELFUSE" >&2
+    exit 1
+fi
+if [ ! -x "$BUSYBOX" ]; then
+    printf 'x86_64 busybox fixture missing; run fetch-fixtures.sh INCLUDE_X86_64=1\n' >&2
+    exit 77
+fi
+
+require_timeout
+
+MARKER="fd3-preserved-across-rosetta-execve"
+MARKER_FILE="$(mktemp -t elfuse-fd3.XXXXXX)"
+trap 'rm -f "$MARKER_FILE"' EXIT
+printf '%s\n' "$MARKER" > "$MARKER_FILE"
+
+total=$((total + 1))
+set +e
+out="$("$TIMEOUT" 30 "$ELFUSE" "$BUSYBOX" sh -c \
+    "exec 3<$MARKER_FILE; exec \"$BUSYBOX\" cat /proc/self/fd/3" 2> /dev/null)"
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && [ "$out" = "$MARKER" ]; then
+    report_pass "fd3-survives-rosetta-execve"
+else
+    report_fail "fd3-survives-rosetta-execve: rc=$rc"
+    printf 'expected %q, got %q\n' "$MARKER" "$out" >&2
+fi
+
+# Closing stdin frees fd 0, so the lowest free slot is below 3. Allocating the
+# pre-opened binary from 0 (a plain fd_alloc) would drop it onto fd 0; the
+# Rosetta cat then reads the ELF image instead of an empty/closed stdin.
+# fd_alloc_from(3) keeps the binary at >= 3, leaving fd 0 closed. The read must
+# be by the exec target itself: a child dd would exec-close the CLOEXEC binary
+# fd before reading it, hiding the leak. Assert empty stdout and no crash.
+total=$((total + 1))
+LEAK_OUT="$(mktemp -t elfuse-closed-stdin.XXXXXX)"
+trap 'rm -f "$MARKER_FILE" "$LEAK_OUT"' EXIT
+set +e
+"$TIMEOUT" 30 "$ELFUSE" "$BUSYBOX" sh -c "exec 0<&-; exec \"$BUSYBOX\" cat" \
+    > "$LEAK_OUT" 2> /dev/null
+rc=$?
+set -e
+leak_bytes="$(wc -c < "$LEAK_OUT" | tr -d ' ')"
+if [ "$leak_bytes" = 0 ] && [ "$rc" -ne 139 ] && [ "$rc" -ne 134 ]; then
+    report_pass "closed-stdin-not-backfilled-by-rosetta-binary"
+else
+    report_fail "closed-stdin-not-backfilled: rc=$rc leaked_bytes=$leak_bytes"
+fi
+
+# An x86_64 execve whose guest fd table is full must fail gracefully, not abort
+# elfuse after the point of no return. rosetta_finalize allocates the binary fd
+# post-reset; sys_execve preflights slot availability before guest_reset and
+# returns EMFILE. The guest fd ceiling (1024) is well below the host RLIMIT so a
+# guest can fill its table without the pre-PNR host open failing first, which is
+# why this is reachable. The helper fills every slot with dup(0) (no setrlimit,
+# so the host stays unconstrained) then execs the x86_64 binary; a graceful
+# reject lets it run its own "return 3", whereas a post-PNR abort kills elfuse
+# (exit 128/134/139). Needs an aarch64 cross-compiler; skips cleanly without.
+total=$((total + 1))
+CC_AARCH64="${CROSS_COMPILE:-/opt/toolchain/aarch64-linux-gnu/bin/aarch64-linux-gnu-}gcc"
+if command -v "$CC_AARCH64" > /dev/null 2>&1; then
+    EXH_SRC="$(mktemp -t elfuse-exh.XXXXXX)"
+    EXH_BIN="$(mktemp -t elfuse-exh.XXXXXX)"
+    trap 'rm -f "$MARKER_FILE" "$LEAK_OUT" "$EXH_SRC" "$EXH_BIN"' EXIT
+    printf '#include <unistd.h>\nint main(int c,char**v){(void)c;while(dup(0)>=0);execv(v[1],&v[1]);return 3;}\n' \
+        > "$EXH_SRC"
+    # -x c: macOS mktemp does not honor a .c suffix, so name the language.
+    if "$CC_AARCH64" -x c -O2 -static -o "$EXH_BIN" "$EXH_SRC" 2> /dev/null; then
+        set +e
+        "$TIMEOUT" 30 "$ELFUSE" "$EXH_BIN" "$BUSYBOX" true > /dev/null 2>&1
+        rc=$?
+        set -e
+        if [ "$rc" = 3 ]; then
+            report_pass "fd-exhausted-exec-fails-gracefully"
+        else
+            report_fail "fd-exhausted-exec-fails-gracefully: rc=$rc (128/134/139=abort)"
+        fi
+    else
+        report_skip "fd-exhausted-exec-fails-gracefully (helper compile failed)"
+    fi
+else
+    report_skip "fd-exhausted-exec-fails-gracefully (no aarch64 cross-compiler)"
+fi
+
+report_summary "$total"


### PR DESCRIPTION
rosetta_finalize pre-opens the x86_64 guest binary and hands it to the translator via guest fd. It hardcoded slot to fd 3 (fd_alloc_at(3)), evicting whatever the guest already held there. Since non-CLOEXEC fds survive execve, an x86_64 program that set up fd 3 for its own use before exec had it silently replaced by the binary fd. apt hits this: it launches gpgv --status-fd 3 and reads signature status off that pipe, so the eviction broke verification.

Allocate the lowest free slot >= 3 via fd_alloc_from(3) and return it through a new out_execfd out-parameter. At initial launch only stdio (0-2) is open, so the binary still lands on fd 3; on an execve re-bootstrap it steps over whatever the guest already opened, and starting at 3 avoids backfilling a stdio slot the guest deliberately closed. Both bootstrap callers thread the returned fd into build_linux_stack as AT_EXECFD (binfmt_misc convention), replacing the prior -1. rosettad_set_binary_path gained the fd so the long-path VZ_CAPS fallback publishes /proc/self/fd/<n> rather than a stale hardcoded /proc/self/fd/3. Mark the slot CLOEXEC through fd_publish_linux_flags so the write stays on the fd_lock domain.

tests/test-rosetta-execfd.sh guards two regressions: a guest fd opened before an x86_64 execve must survive (fd3-survives), and the binary must not backfill a freed stdio slot (closed-stdin-not-backfilled). The latter reads fd 0 from the exec target itself, since a child process would exec-close the CLOEXEC binary fd before observing the leak.

Close #106

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allocate the Rosetta target binary fd dynamically (lowest free >= 3) instead of hardcoding fd 3. This preserves guest fds across execve (fixes apt/gpgv --status-fd 3) and avoids EMFILE aborts during re-bootstrap.

- **Bug Fixes**
  - Use fd_alloc_from(3) for the binary; return via out_execfd and pass as AT_EXECFD to build_linux_stack in both bootstrap paths.
  - Preflight slot availability in sys_execve via fd_reexec_slot_available(3); fail with -EMFILE before the exec point-of-no-return.
  - rosettad_set_binary_path now publishes /proc/self/fd/<n> for long paths; set CLOEXEC via fd_publish_linux_flags.
  - Add tests/test-rosetta-execfd.sh (fd3 survives, closed stdin not backfilled, fd-table exhaustion handled); added to test-matrix.

<sup>Written for commit 0b4b18483925cce4f5008cee8f0bebddd7ff2c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

