### PR TITLE
Fix kill() broadcast and process-group signal

### DIFF
--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -1528,6 +1528,14 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         }
     }
 
+    /* Refresh our own process group from the registry before capturing it: a
+     * parent-side setpgid(this, ...) updates the registry but not the local
+     * cached pgid, so both the child's inherited group (hdr.pgid below) and the
+     * publish that follows would otherwise carry -- and re-stamp the registry
+     * with -- the stale group, misrouting later kill(0)/kill(-pgid).
+     */
+    proc_registry_sync_self_pgid(g);
+
     /* Snapshot of the semantic region array, populated after the memory dump
      * but before sibling vCPUs resume. Declared up front so all goto paths to
      * fail_snapshot can free it unconditionally. Header
@@ -1572,6 +1580,7 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         .ctid_gva = ctid_gva,
         .shm_is_clone = (snapshot_shm_fd >= 0) ? 1 : 0,
     };
+    proc_registry_publish_self();
     if (fork_ipc_write_all(ipc_sock, &hdr, sizeof(hdr)) < 0) {
         log_error("clone: failed to send header");
         goto fail_snapshot;
@@ -1683,8 +1692,11 @@ int64_t sys_clone(hv_vcpu_t vcpu,
      * its own MAP_PRIVATE view of the same file.
      */
 
-    /* Register after successful IPC so wait4/waitid can observe the child. */
-    proc_register_child(child_host_pid, child_guest_pid);
+    /* Register after successful IPC so wait4/waitid can observe the child. Seed
+     * the child's group from the same value sent in the fork header so the
+     * parent's table matches the group the child actually inherited.
+     */
+    proc_register_child(child_host_pid, child_guest_pid, hdr.pgid);
 
     /* CLONE_VFORK suspends the parent until the child exits or execs. The
      * emulator cannot observe guest exec completion across the helper process,

--- a/src/syscall/proc-identity.c
+++ b/src/syscall/proc-identity.c
@@ -259,6 +259,14 @@ void proc_set_session(int64_t sid, int64_t pgid)
     guest_fg_pgrp = pgid;
 }
 
+void proc_set_pgid_from_registry(guest_t *g, int64_t pgid)
+{
+    pthread_mutex_lock(&session_lock);
+    guest_pgid = pgid;
+    proc_publish_pgsid_locked(g);
+    pthread_mutex_unlock(&session_lock);
+}
+
 void proc_set_fg_pgrp(int64_t pgrp)
 {
     guest_fg_pgrp = pgrp;

--- a/src/syscall/proc-pidfd.c
+++ b/src/syscall/proc-pidfd.c
@@ -245,7 +245,7 @@ int64_t sys_pidfd_send_signal(guest_t *g,
                 return -LINUX_ESRCH;
             return 0;
         }
-        if (proc_send_guest_signal(host_pid, sig) < 0)
+        if (proc_send_guest_signal(host_pid, pid, sig) < 0)
             return linux_errno();
         return 0;
     }

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -42,6 +42,7 @@
 #include "runtime/futex.h"
 
 #include "syscall/internal.h"
+#include "syscall/net.h"
 #include "syscall/proc-identity.h"
 #include "syscall/proc.h"
 #include "syscall/proc-pidfd.h"
@@ -90,6 +91,10 @@ static _Atomic int exit_group_requested = 0;
 static _Atomic int exit_group_code = 0;
 
 /* Public API. */
+
+static void proc_registry_publish(pid_t host_pid,
+                                  int64_t guest_pid_val,
+                                  int64_t pgid);
 
 void proc_init(void)
 {
@@ -145,11 +150,18 @@ static int proc_exit_group_code(void)
 
 static void proc_init_child_entry(proc_entry_t *entry,
                                   pid_t host_pid,
-                                  int64_t guest_pid_val)
+                                  int64_t guest_pid_val,
+                                  int64_t pgid)
 {
     entry->active = true;
     entry->host_pid = host_pid;
     entry->guest_pid = guest_pid_val;
+    /* Seed with the group the child inherited at fork. The caller passes the
+     * exact value sent in the fork IPC header so the parent's view and the
+     * child's own pgid cannot disagree even if a sibling thread changes the
+     * parent's group during the fork window.
+     */
+    entry->pgid = pgid;
     entry->exited = false;
     entry->exit_status = 0;
 }
@@ -281,13 +293,15 @@ static int proc_reap_finished(void)
     return reaped;
 }
 
-int proc_register_child(pid_t host_pid, int64_t guest_pid_val)
+int proc_register_child(pid_t host_pid, int64_t guest_pid_val, int64_t pgid)
 {
     pthread_mutex_lock(&pid_lock);
     proc_entry_t *entry = proc_find_free_entry();
     if (entry) {
-        proc_init_child_entry(entry, host_pid, guest_pid_val);
+        proc_init_child_entry(entry, host_pid, guest_pid_val, pgid);
         pthread_mutex_unlock(&pid_lock);
+        proc_registry_publish(host_pid, guest_pid_val, pgid);
+        proc_registry_publish_self();
         return 0;
     }
 
@@ -295,8 +309,10 @@ int proc_register_child(pid_t host_pid, int64_t guest_pid_val)
     if (proc_reap_finished() > 0)
         entry = proc_find_free_entry();
     if (entry) {
-        proc_init_child_entry(entry, host_pid, guest_pid_val);
+        proc_init_child_entry(entry, host_pid, guest_pid_val, pgid);
         pthread_mutex_unlock(&pid_lock);
+        proc_registry_publish(host_pid, guest_pid_val, pgid);
+        proc_registry_publish_self();
         return 0;
     }
     pthread_mutex_unlock(&pid_lock);
@@ -354,8 +370,278 @@ static bool signal_transport_path(char *out, size_t out_size, pid_t host_pid)
     return len > 0 && (size_t) len < out_size;
 }
 
-int proc_send_guest_signal(pid_t host_pid, int signum)
+static bool process_registry_path(char *out, size_t out_size)
 {
+    char dir[PATH_MAX];
+    size_t n = confstr(_CS_DARWIN_USER_TEMP_DIR, dir, sizeof(dir));
+    if (n == 0 || n > sizeof(dir))
+        return false;
+    int len = snprintf(out, out_size, "%selfuse-procs-%llu", dir,
+                       (unsigned long long) absock_get_namespace_id());
+    return len > 0 && (size_t) len < out_size;
+}
+
+static void proc_registry_reset_if_owner(const char *path)
+{
+    static _Atomic bool reset_done;
+    if (absock_get_namespace_id() != (uint64_t) getpid())
+        return;
+    if (atomic_exchange(&reset_done, true))
+        return;
+    unlink(path);
+}
+
+/* One live member of a process group registry. */
+typedef struct {
+    pid_t host_pid;
+    int64_t guest_pid;
+    int64_t pgid;
+} registry_entry_t;
+
+#define REGISTRY_MAX_ENTRIES (PROC_TABLE_SIZE * 4)
+
+/* flock() retrying past EINTR. Returns 0 on success, -1 on failure. */
+static int flock_retry(int fd, int op)
+{
+    int r;
+    do {
+        r = flock(fd, op);
+    } while (r != 0 && errno == EINTR);
+    return r;
+}
+
+/* Read @fd from its current offset and invoke @cb once per newline-terminated
+ * record, passing a NUL-terminated copy. Records must fit in 63 bytes; both the
+ * registry ("hostpid guestpid pgid") and the signal transport ("ns tgpid sig")
+ * use short numeric lines. Overlong records and an unterminated trailing token
+ * are dropped -- every writer appends a whole record under an exclusive lock,
+ * so a partial line only appears after a crash mid-write.
+ */
+static void for_each_record(int fd, void (*cb)(char *rec, void *ctx), void *ctx)
+{
+    char chunk[8192];
+    char line[64];
+    size_t linelen = 0;
+    bool overlong = false;
+    ssize_t r;
+    while ((r = read(fd, chunk, sizeof(chunk))) > 0) {
+        for (ssize_t i = 0; i < r; i++) {
+            char c = chunk[i];
+            if (c != '\n') {
+                if (linelen < sizeof(line) - 1)
+                    line[linelen++] = c;
+                else
+                    overlong = true;
+                continue;
+            }
+            if (!overlong) {
+                line[linelen] = '\0';
+                cb(line, ctx);
+            }
+            linelen = 0;
+            overlong = false;
+        }
+    }
+}
+
+typedef struct {
+    registry_entry_t *entries;
+    int max;
+    int n;
+    bool truncated;
+} registry_parse_ctx_t;
+
+/* Upsert one "hostpid guestpid pgid" record, keeping the latest guest_pid/pgid
+ * per LIVE host pid. Dead, malformed, and out-of-range records are dropped.
+ */
+static void registry_parse_cb(char *rec, void *vctx)
+{
+    registry_parse_ctx_t *c = vctx;
+    long hp;
+    long long gp, pg;
+    if (sscanf(rec, "%ld %lld %lld", &hp, &gp, &pg) != 3)
+        return;
+    if (hp <= 0 || hp > INT_MAX || pg < 0 || pg > INT_MAX)
+        return;
+    if (kill((pid_t) hp, 0) != 0)
+        return;
+    int idx = -1;
+    for (int k = 0; k < c->n; k++)
+        if (c->entries[k].host_pid == (pid_t) hp) {
+            idx = k;
+            break;
+        }
+    if (idx < 0) {
+        if (c->n == c->max) {
+            c->truncated = true;
+            return;
+        }
+        idx = c->n++;
+        c->entries[idx].host_pid = (pid_t) hp;
+    }
+    c->entries[idx].guest_pid = (int64_t) gp;
+    c->entries[idx].pgid = (int64_t) pg;
+}
+
+/* Parse the whole registry from @fd (caller holds an flock) into @entries,
+ * keeping one record per live host pid.
+ *
+ * Returns the count. @truncated_out, if non-NULL, is set true when the entry
+ * array filled up.
+ */
+static int registry_read_locked(int fd,
+                                registry_entry_t *entries,
+                                int max,
+                                bool *truncated_out)
+{
+    if (truncated_out)
+        *truncated_out = false;
+    if (lseek(fd, 0, SEEK_SET) != 0)
+        return 0;
+    registry_parse_ctx_t ctx = {.entries = entries, .max = max};
+    for_each_record(fd, registry_parse_cb, &ctx);
+    if (truncated_out)
+        *truncated_out = ctx.truncated;
+    return ctx.n;
+}
+
+/* Publish (host_pid, guest_pid, pgid), compacting the registry in place: read
+ * the live set under LOCK_EX, upsert this entry, and rewrite so the file stays
+ * bounded by the number of live group members rather than growing per event.
+ */
+static void proc_registry_publish(pid_t host_pid,
+                                  int64_t guest_pid_val,
+                                  int64_t pgid)
+{
+    char path[PATH_MAX];
+    if (!process_registry_path(path, sizeof(path)))
+        return;
+    proc_registry_reset_if_owner(path);
+    int fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (fd < 0)
+        return;
+    if (flock_retry(fd, LOCK_EX) != 0) {
+        close(fd);
+        return;
+    }
+
+    registry_entry_t entries[REGISTRY_MAX_ENTRIES];
+    int n = registry_read_locked(fd, entries, REGISTRY_MAX_ENTRIES, NULL);
+    int idx = -1;
+    for (int i = 0; i < n; i++)
+        if (entries[i].host_pid == host_pid) {
+            idx = i;
+            break;
+        }
+    if (idx < 0) {
+        if (n == REGISTRY_MAX_ENTRIES)
+            /* No slot for a new live member: group signals (kill(-1),
+             * kill(-pgid), kill(0)) reaching this pid via the registry will
+             * miss it. Warn rather than drop silently.
+             */
+            log_warn(
+                "process registry full (%d live members); host pid %ld not "
+                "published, group signals may miss it",
+                REGISTRY_MAX_ENTRIES, (long) host_pid);
+        else {
+            idx = n++;
+            entries[idx].host_pid = host_pid;
+        }
+    }
+    if (idx >= 0) {
+        entries[idx].guest_pid = guest_pid_val;
+        entries[idx].pgid = pgid;
+    }
+
+    if (ftruncate(fd, 0) == 0 && lseek(fd, 0, SEEK_SET) == 0) {
+        for (int i = 0; i < n; i++) {
+            char lineb[64];
+            int len = snprintf(lineb, sizeof(lineb), "%ld %lld %lld\n",
+                               (long) entries[i].host_pid,
+                               (long long) entries[i].guest_pid,
+                               (long long) entries[i].pgid);
+            if (len > 0 && (size_t) len < sizeof(lineb) &&
+                proc_write_full(fd, lineb, (size_t) len) < 0)
+                break;
+        }
+    }
+    flock_retry(fd, LOCK_UN);
+    close(fd);
+}
+
+void proc_registry_publish_self(void)
+{
+    proc_registry_publish(getpid(), proc_get_pid(), proc_get_pgid());
+}
+
+void proc_registry_sync_self_pgid(guest_t *g)
+{
+    char path[PATH_MAX];
+    if (!process_registry_path(path, sizeof(path)))
+        return;
+    proc_registry_reset_if_owner(path);
+    int fd = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0)
+        return;
+    if (flock_retry(fd, LOCK_SH) != 0) {
+        close(fd);
+        return;
+    }
+    registry_entry_t entries[REGISTRY_MAX_ENTRIES];
+    int n = registry_read_locked(fd, entries, REGISTRY_MAX_ENTRIES, NULL);
+    flock_retry(fd, LOCK_UN);
+    close(fd);
+
+    pid_t self = getpid();
+    int64_t self_guest = proc_get_pid();
+    for (int i = 0; i < n; i++)
+        /* Match host pid AND guest pid: a stale same-host-pid record left by a
+         * recycled pid must not overwrite this process's group.
+         */
+        if (entries[i].host_pid == self && entries[i].guest_pid == self_guest) {
+            if (entries[i].pgid != proc_get_pgid())
+                proc_set_pgid_from_registry(g, entries[i].pgid);
+            return;
+        }
+}
+
+/* Path of this elfuse binary, cached. All elfuse processes run the same
+ * executable, so the value is process-independent and safe to keep across fork.
+ */
+static char elfuse_self_path_buf[PROC_PIDPATHINFO_MAXSIZE];
+static int elfuse_self_path_len;
+static pthread_once_t elfuse_self_path_once = PTHREAD_ONCE_INIT;
+
+static void elfuse_self_path_init(void)
+{
+    int l = proc_pidpath(getpid(), elfuse_self_path_buf,
+                         sizeof(elfuse_self_path_buf));
+    elfuse_self_path_len = (l > 0) ? l : 0;
+}
+
+static const char *elfuse_self_path(int *len_out)
+{
+    pthread_once(&elfuse_self_path_once, elfuse_self_path_init);
+    *len_out = elfuse_self_path_len;
+    return elfuse_self_path_buf;
+}
+
+int proc_send_guest_signal(pid_t host_pid, int64_t target_guest_pid, int signum)
+{
+    /* Refuse to signal a host pid that is not (or is no longer) an elfuse
+     * process: if it was recycled onto an unrelated program, a raw SIGUSR2
+     * would terminate it. This narrows -- but a sub-microsecond exit+reuse race
+     * before kill() remains -- see the signal-transport TODO.
+     */
+    int our_len;
+    const char *our_path = elfuse_self_path(&our_len);
+    char tpath[PROC_PIDPATHINFO_MAXSIZE];
+    int tlen = proc_pidpath(host_pid, tpath, sizeof(tpath));
+    if (our_len <= 0 || tlen != our_len || memcmp(tpath, our_path, our_len)) {
+        errno = ESRCH;
+        return -1;
+    }
+
     char path[PATH_MAX];
     if (!signal_transport_path(path, sizeof(path), host_pid)) {
         errno = ENAMETOOLONG;
@@ -367,8 +653,16 @@ int proc_send_guest_signal(pid_t host_pid, int signum)
     if (fd < 0)
         return -1;
 
-    char line[16];
-    int len = snprintf(line, sizeof(line), "%d\n", signum);
+    /* Tag the delivery with our fork-family namespace and the intended guest
+     * pid. A recycled host pid in another session sees a mismatched namespace;
+     * a host pid recycled onto a different guest inside this same session sees
+     * a mismatched guest pid. Either mismatch drops the signal instead of
+     * applying it to the wrong process.
+     */
+    char line[64];
+    int len = snprintf(line, sizeof(line), "%llu %lld %d\n",
+                       (unsigned long long) absock_get_namespace_id(),
+                       (long long) target_guest_pid, signum);
     if (len < 0 || (size_t) len >= sizeof(line)) {
         close(fd);
         errno = EINVAL;
@@ -381,12 +675,12 @@ int proc_send_guest_signal(pid_t host_pid, int signum)
      * after its truncate (and the SIGUSR2 below triggers the next drain).
      * Neither side can route this write to an orphaned inode or discard it.
      */
-    if (flock(fd, LOCK_EX) < 0) {
+    if (flock_retry(fd, LOCK_EX) != 0) {
         close(fd);
         return -1;
     }
     int wrc = proc_write_full(fd, line, (size_t) len);
-    flock(fd, LOCK_UN);
+    flock_retry(fd, LOCK_UN);
     if (wrc < 0) {
         close(fd);
         return -1;
@@ -399,9 +693,8 @@ int proc_send_guest_signal(pid_t host_pid, int signum)
     return kill(host_pid, SIGUSR2);
 }
 
-int proc_get_child_pids(pid_t *out, int max_pids)
+int proc_get_direct_child_pids(pid_t *out, int max_pids)
 {
-    /* Seed with direct children from the process table */
     int count = 0;
     pthread_mutex_lock(&pid_lock);
     for (int i = 0; i < PROC_TABLE_SIZE && count < max_pids; i++) {
@@ -409,6 +702,82 @@ int proc_get_child_pids(pid_t *out, int max_pids)
             out[count++] = proc_table[i].host_pid;
     }
     pthread_mutex_unlock(&pid_lock);
+    return count;
+}
+
+int proc_set_child_pgid(int64_t guest_pid_val, int64_t pgid)
+{
+    int ret = -1;
+    pid_t host_pid = -1;
+    pthread_mutex_lock(&pid_lock);
+    proc_entry_t *entry = proc_find_guest_entry(guest_pid_val);
+    if (entry) {
+        entry->pgid = pgid;
+        host_pid = entry->host_pid;
+        ret = 0;
+    }
+    pthread_mutex_unlock(&pid_lock);
+    if (host_pid > 0)
+        proc_registry_publish(host_pid, guest_pid_val, pgid);
+    return ret;
+}
+
+int proc_get_namespace_targets(proc_signal_target_t *out,
+                               int max,
+                               int64_t pgid_filter)
+{
+    /* No republish here: every group change already publishes (fork, setpgid,
+     * setsid), and this reader excludes its own entry anyway.
+     */
+    char path[PATH_MAX];
+    if (!process_registry_path(path, sizeof(path)))
+        return 0;
+    proc_registry_reset_if_owner(path);
+    int fd = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0)
+        return 0;
+    if (flock_retry(fd, LOCK_SH) != 0) {
+        close(fd);
+        return 0;
+    }
+    registry_entry_t entries[REGISTRY_MAX_ENTRIES];
+    bool truncated = false;
+    int nentries =
+        registry_read_locked(fd, entries, REGISTRY_MAX_ENTRIES, &truncated);
+    flock_retry(fd, LOCK_UN);
+    close(fd);
+    if (truncated)
+        log_warn(
+            "process-group registry exceeded %d live members; group "
+            "signal delivery may be partial",
+            REGISTRY_MAX_ENTRIES);
+
+    int count = 0;
+    pid_t self = getpid();
+    char our_path[PROC_PIDPATHINFO_MAXSIZE];
+    int our_len = proc_pidpath(self, our_path, sizeof(our_path));
+    if (our_len <= 0)
+        return 0;
+    for (int i = 0; i < nentries && count < max; i++) {
+        if (entries[i].host_pid == self)
+            continue;
+        if (pgid_filter != PROC_PGID_ANY && entries[i].pgid != pgid_filter)
+            continue;
+        char ppath[PROC_PIDPATHINFO_MAXSIZE];
+        int plen = proc_pidpath(entries[i].host_pid, ppath, sizeof(ppath));
+        if (plen != our_len || memcmp(ppath, our_path, (size_t) our_len))
+            continue;
+        out[count].host_pid = entries[i].host_pid;
+        out[count].guest_pid = entries[i].guest_pid;
+        count++;
+    }
+    return count;
+}
+
+int proc_get_child_pids(pid_t *out, int max_pids)
+{
+    /* Seed with direct children from the process table */
+    int count = proc_get_direct_child_pids(out, max_pids);
 
     /* Recursively collect descendants via proc_listchildpids. Orphaned
      * grandchildren (PPID=1) are not found this way, so also check all host
@@ -1035,6 +1404,38 @@ static void unlink_own_transport(void)
     char path[PATH_MAX];
     if (signal_transport_path(path, sizeof(path), getpid()))
         unlink(path);
+
+    /* The namespace owner cleans the registry, but only once no other live
+     * member still needs it: if the owner exits while fork children survive,
+     * deleting the file would blind their kill(-1)/kill(0)/kill(-pgid). A rare
+     * orphaned family that outlives its owner leaves the file for the next
+     * same-pid run's reset (proc_registry_reset_if_owner) or the OS temp-dir
+     * purge.
+     */
+    if (absock_get_namespace_id() != (uint64_t) getpid())
+        return;
+    if (!process_registry_path(path, sizeof(path)))
+        return;
+    int fd = open(path, O_RDWR | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0)
+        return;
+    if (flock_retry(fd, LOCK_EX) != 0) {
+        close(fd);
+        return;
+    }
+    registry_entry_t entries[REGISTRY_MAX_ENTRIES];
+    int n = registry_read_locked(fd, entries, REGISTRY_MAX_ENTRIES, NULL);
+    pid_t self = getpid();
+    bool others = false;
+    for (int i = 0; i < n; i++)
+        if (entries[i].host_pid != self) {
+            others = true;
+            break;
+        }
+    if (!others)
+        unlink(path);
+    flock_retry(fd, LOCK_UN);
+    close(fd);
 }
 
 /* Call once from the main thread before any vCPU thread is created; the
@@ -1089,6 +1490,41 @@ int proc_preempt_init(void)
     return 0;
 }
 
+typedef struct {
+    uint64_t my_ns;
+    int64_t my_guest_pid;
+} sig_drain_ctx_t;
+
+/* Parse one NUL-terminated "namespace target_guest_pid signum" transport record
+ * and queue the signal only when both the fork-family namespace and the
+ * intended guest pid match this process. A namespace mismatch means the host
+ * pid was recycled from an unrelated session; a guest-pid mismatch means it was
+ * recycled onto a different guest in this session. Either way the delivery is
+ * dropped.
+ */
+static void sig_drain_cb(char *rec, void *vctx)
+{
+    sig_drain_ctx_t *c = vctx;
+    char *p = rec, *end;
+    unsigned long long ns = strtoull(p, &end, 10);
+    if (end == p)
+        return;
+    p = end;
+    long long tgpid = strtoll(p, &end, 10);
+    if (end == p)
+        return;
+    p = end;
+    long signum = strtol(p, &end, 10);
+    /* Reject any trailing garbage so a forged record like "<ns> <pid> 9junk"
+     * from a same-user temp-dir writer cannot be accepted as a bare signal.
+     */
+    if (end == p || *end != '\0')
+        return;
+    if (ns == c->my_ns && tgpid == c->my_guest_pid &&
+        RANGE_CHECK(signum, 1, LINUX_NSIG))
+        signal_queue((int) signum);
+}
+
 static void drain_external_guest_signal(void)
 {
     if (!atomic_exchange_explicit(&g_external_guest_signal, 0,
@@ -1112,53 +1548,25 @@ static void drain_external_guest_signal(void)
      * reintroducing the unlink-vs-append race; the process unlinks its own
      * empty file at exit (unlink_own_transport) so the temp dir stays clean.
      */
-    if (flock(fd, LOCK_EX) < 0) {
+    if (flock_retry(fd, LOCK_EX) != 0) {
         close(fd);
         return;
     }
 
-    /* Read the whole file in chunks, queuing each complete "signum\n" line and
-     * carrying any partial trailing token across chunk boundaries. Valid tokens
-     * are a few bytes, so the carry never fills the buffer; a lone oversized
-     * garbage token is dropped harmlessly (read returns 0 once the buffer is
-     * full with no newline).
+    sig_drain_ctx_t ctx = {.my_ns = absock_get_namespace_id(),
+                           .my_guest_pid = proc_get_pid()};
+    for_each_record(fd, sig_drain_cb, &ctx);
+
+    /* Report a failed truncate: the same records would re-drain on the next
+     * doorbell and re-queue already-delivered signals. Do not early-return --
+     * the lock still has to be released and the fd closed.
      */
-    char buf[256];
-    size_t used = 0;
-    for (;;) {
-        ssize_t n = read(fd, buf + used, sizeof(buf) - 1 - used);
-        if (n <= 0)
-            break;
-        used += (size_t) n;
-        buf[used] = '\0';
-
-        char *start = buf, *nl;
-        while ((nl = memchr(start, '\n', (size_t) (buf + used - start))) !=
-               NULL) {
-            *nl = '\0';
-            long signum = strtol(start, NULL, 10);
-            if (RANGE_CHECK(signum, 1, LINUX_NSIG))
-                signal_queue((int) signum);
-            start = nl + 1;
-        }
-        size_t rem = (size_t) (buf + used - start);
-        memmove(buf, start, rem);
-        used = rem;
-    }
-
-    /* Senders write whole "signum\n" records under the same lock, so used is
-     * normally 0 here. Parse any unterminated trailing token defensively so a
-     * record left by a crashed sender is not silently dropped by the truncate.
-     */
-    if (used > 0) {
-        buf[used] = '\0';
-        long signum = strtol(buf, NULL, 10);
-        if (RANGE_CHECK(signum, 1, LINUX_NSIG))
-            signal_queue((int) signum);
-    }
-
-    ftruncate(fd, 0);
-    flock(fd, LOCK_UN);
+    if (ftruncate(fd, 0) != 0)
+        log_warn(
+            "signal transport truncate failed (%s); queued signals may "
+            "re-deliver",
+            strerror(errno));
+    flock_retry(fd, LOCK_UN);
     close(fd);
 }
 

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -151,6 +151,9 @@ void proc_publish_pgsid_snapshot(guest_t *g);
 /* Restore session/pgid from fork IPC. */
 void proc_set_session(int64_t sid, int64_t pgid);
 
+/* Refresh pgid from the fork-family registry after a parent-side setpgid. */
+void proc_set_pgid_from_registry(guest_t *g, int64_t pgid);
+
 /* setsid: create new session and publish pgid/sid cache under session_lock.
  * Returns SID or -LINUX_EPERM.
  */
@@ -295,6 +298,9 @@ typedef struct {
     bool active;       /* Slot is in use */
     pid_t host_pid;    /* macOS process ID of child elfuse instance */
     int64_t guest_pid; /* Guest-visible PID assigned to child */
+    int64_t pgid;      /* Child's process group, inherited at fork and updated
+                        * by a parent-side setpgid(child, ...)
+                        */
     bool exited;       /* Child has exited */
     int exit_status;   /* wait status (as returned by waitpid) */
 } proc_entry_t;
@@ -302,7 +308,7 @@ typedef struct {
 /* Register a child process in the process table.
  * Returns 0 on success, -1 if the table is full.
  */
-int proc_register_child(pid_t host_pid, int64_t guest_pid);
+int proc_register_child(pid_t host_pid, int64_t guest_pid, int64_t pgid);
 
 /* Mark a child as exited by host PID (for CLONE_VFORK wait). */
 void proc_mark_child_exited(pid_t host_pid, int status);
@@ -314,15 +320,63 @@ void proc_mark_child_exited(pid_t host_pid, int status);
  */
 int proc_get_child_pids(pid_t *out, int max_pids);
 
+/* Collect host PIDs of this process's direct, active (non-exited) fork children
+ * from the process table only. Unlike proc_get_child_pids it does NOT sweep the
+ * host for same-binary processes, so it cannot reach unrelated elfuse
+ * instances. Writes up to max_pids entries into out[]; returns the count
+ * written.
+ */
+int proc_get_direct_child_pids(pid_t *out, int max_pids);
+
+/* One signalable fork-family member: host pid for delivery plus guest pid so
+ * the transport record can be tagged and a recycled host pid cannot misapply
+ * the signal to an unrelated guest.
+ */
+typedef struct {
+    pid_t host_pid;
+    int64_t guest_pid;
+} proc_signal_target_t;
+
+/* Pass as the pgid_filter to proc_get_namespace_targets to collect every
+ * fork-family member regardless of process group (kill(-1) broadcast).
+ */
+#define PROC_PGID_ANY ((int64_t) -1)
+
+/* Collect every live process in this elfuse fork family from the namespace
+ * registry, excluding the caller. When pgid_filter is PROC_PGID_ANY all members
+ * are returned; otherwise only those whose tracked process group matches.
+ * Writes up to max entries into out[]; returns the count written.
+ */
+int proc_get_namespace_targets(proc_signal_target_t *out,
+                               int max,
+                               int64_t pgid_filter);
+
+/* Publish the caller's current guest pid/pgid to the fork-family registry. */
+void proc_registry_publish_self(void);
+
+/* Pull a parent-published pgid update into this process's local identity. */
+void proc_registry_sync_self_pgid(guest_t *g);
+
+/* Record the process group of a direct child (parent-side setpgid).
+ *
+ * Returns 0 if the child was found and updated, -1 otherwise.
+ */
+int proc_set_child_pgid(int64_t guest_pid, int64_t pgid);
+
 /* Look up a guest PID in the child process table.
  * Returns the host PID if found and still active, or -1.
  */
 pid_t proc_guest_to_host_pid(int64_t gpid);
 
-/* Queue a Linux guest signal in a fork-child elfuse process.
+/* Queue a Linux guest signal in a fork-child elfuse process. target_guest_pid
+ * tags the transport record so the receiver drops it if its host pid was
+ * recycled onto a different guest.
+ *
  * Returns 0 on success or -1 with errno set.
  */
-int proc_send_guest_signal(pid_t host_pid, int signum);
+int proc_send_guest_signal(pid_t host_pid,
+                           int64_t target_guest_pid,
+                           int signum);
 
 /* Block the vCPU-preemption signals (SIGUSR2 doorbell, SIGALRM timeout) on the
  * calling thread and start the dedicated sigwait thread that consumes them.

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -375,8 +375,41 @@ SC_FORWARD(sc_sched_rr_get_interval,  sys_sched_rr_get_interval(g, (int) x0, x1)
 SC_FORWARD(sc_exit,    SC_EXIT_SENTINEL | ((int) x0 & 0xFF))
 SC_FORWARD(sc_getpid,  proc_get_pid())
 SC_FORWARD(sc_getppid, proc_get_ppid())
-SC_FORWARD(sc_getpgid, ((int) x0 == 0 || (int) x0 == (int) proc_get_pid()) ? proc_get_pgid() : -LINUX_ESRCH)
-SC_FORWARD(sc_setsid,  proc_sys_setsid(g))
+/* getpgid(0) is served inline by the shim's pgid cache and never reaches here,
+ * so a registry sync in this path would be dead for the common form; the group
+ * signal path in sc_kill does the sync where it can actually run. getpgid may
+ * therefore lag a parent-side setpgid(child) until the child's next group op --
+ * the documented limitation.
+ */
+SC_FORWARD(sc_getpgid,
+           (((int) x0 == 0 || (int) x0 == (int) proc_get_pid())
+                ? (proc_registry_sync_self_pgid(g), proc_get_pgid())
+                : -LINUX_ESRCH))
+static int64_t sc_setsid(guest_t *g,
+                         uint64_t x0,
+                         uint64_t x1,
+                         uint64_t x2,
+                         uint64_t x3,
+                         uint64_t x4,
+                         uint64_t x5,
+                         bool verbose)
+{
+    (void) x0;
+    (void) x1;
+    (void) x2;
+    (void) x3;
+    (void) x4;
+    (void) x5;
+    (void) verbose;
+    proc_registry_sync_self_pgid(g);
+    /* setsid moves the caller into a new group; refresh the registry so the
+     * group signal path sees the new pgid without a per-query republish.
+     */
+    int64_t ret = proc_sys_setsid(g);
+    if (ret >= 0)
+        proc_registry_publish_self();
+    return ret;
+}
 SC_FORWARD(sc_getsid,  proc_sys_getsid((int64_t) x0))
 SC_FORWARD(sc_gettid,  current_thread ? current_thread->guest_tid : proc_get_pid())
 
@@ -554,7 +587,61 @@ SC_FORWARD(sc_setresgid, CRED_BRACKETED(g, proc_sys_setresgid((uint32_t) x0, (ui
  */
 SC_FORWARD(sc_setfsuid, (int64_t) proc_get_euid())
 SC_FORWARD(sc_setfsgid, (int64_t) proc_get_egid())
-SC_FORWARD(sc_setpgid, proc_sys_setpgid(g, (int64_t) x0, (int64_t) x1))
+static int64_t sc_setpgid(guest_t *g,
+                          uint64_t x0,
+                          uint64_t x1,
+                          uint64_t x2,
+                          uint64_t x3,
+                          uint64_t x4,
+                          uint64_t x5,
+                          bool verbose)
+{
+    (void) x2;
+    (void) x3;
+    (void) x4;
+    (void) x5;
+    (void) verbose;
+    /* setpgid takes pid_t (32-bit) args; cast as int like sc_kill so a negative
+     * pid/pgid is seen as negative, not a large positive.
+     */
+    int pid = (int) x0, pgid = (int) x1;
+    /* Linux rejects a negative group id with EINVAL and a negative pid (no such
+     * process) with ESRCH before any group change.
+     */
+    if (pgid < 0)
+        return -LINUX_EINVAL;
+    if (pid < 0)
+        return -LINUX_ESRCH;
+    int64_t self = proc_get_pid();
+    int64_t rpid = (pid == 0) ? self : pid;
+    int64_t rpgid = (pgid == 0) ? rpid : pgid;
+    /* setpgid on a direct child records the group so kill(0) and kill(-pgid)
+     * reach it. Kept in the syscall layer so proc-identity stays free of the
+     * process-table dependency. Only POSIX-plausible targets are recorded: the
+     * child leading its own group (rpgid == rpid), joining the caller's group
+     * (rpgid == caller pgid), or joining a group another tracked child already
+     * leads (a shell pipeline: setpgid(c1, c1) then setpgid(c2, c1)). Linux
+     * rejects any other group as not existing in the session, so recording it
+     * would fabricate a phantom group. Anything else is a no-op success,
+     * matching proc_sys_setpgid's permissive return for a non-self target.
+     */
+    if (rpid != self) {
+        proc_signal_target_t peer;
+        /* The registry is the single source of truth for group membership:
+         * every child publishes on fork, setpgid, and setsid. The old
+         * process-table enumerator was redundant and could report a phantom
+         * group from a pgid that went stale after a child changed its own.
+         */
+        bool group_exists = proc_get_namespace_targets(&peer, 1, rpgid) > 0;
+        if (rpgid == rpid || rpgid == proc_get_pgid() || group_exists)
+            proc_set_child_pgid(rpid, rpgid);
+        return 0;
+    }
+    int64_t ret = proc_sys_setpgid(g, pid, pgid);
+    if (ret == 0)
+        proc_registry_publish_self();
+    return ret;
+}
 SC_STUB(sc_fadvise64,           0)
 SC_STUB(sc_sched_yield,         (sched_yield(), 0))
 SC_STUB(sc_mlock,               0)
@@ -753,7 +840,6 @@ static int64_t sc_membarrier(guest_t *g,
                              uint64_t x5,
                              bool verbose)
 {
-    (void) g;
     (void) x2;
     (void) x3;
     (void) x4;
@@ -870,6 +956,26 @@ static int64_t sc_mremap(guest_t *g,
     return r;
 }
 
+/* Deliver @sig to each fork-family target over the cross-process transport.
+ * Returns the count successfully queued; *first_errno gets the errno of the
+ * first failed send, or 0 if none failed.
+ */
+static int kill_deliver_targets(const proc_signal_target_t *targets,
+                                int count,
+                                int sig,
+                                int *first_errno)
+{
+    int delivered = 0;
+    *first_errno = 0;
+    for (int i = 0; i < count; i++)
+        if (proc_send_guest_signal(targets[i].host_pid, targets[i].guest_pid,
+                                   sig) == 0)
+            delivered++;
+        else if (!*first_errno)
+            *first_errno = errno;
+    return delivered;
+}
+
 static int64_t sc_kill(guest_t *g,
                        uint64_t x0,
                        uint64_t x1,
@@ -889,11 +995,34 @@ static int64_t sc_kill(guest_t *g,
     int64_t our_pid = proc_get_pid();
     if (sig < 0 || sig > LINUX_NSIG)
         return -LINUX_EINVAL;
+    if (pid == 0 || pid < -1)
+        proc_registry_sync_self_pgid(g);
     if (sig == 0) {
-        int64_t r = (pid == (int) our_pid || pid == 0 || pid == -1 ||
-                     pid == -(int) our_pid)
-                        ? 0
-                        : -LINUX_ESRCH;
+        /* Existence/permission probe. The broadcast form reports success only
+         * when the caller has at least one other signalable process; in this
+         * model that is an emulated fork child, and no peers yields ESRCH.
+         */
+        if (pid == -1) {
+            proc_signal_target_t peer;
+            return proc_get_namespace_targets(&peer, 1, PROC_PGID_ANY) > 0
+                       ? 0
+                       : -LINUX_ESRCH;
+        }
+        /* Process-group probe: the caller always exists in its own group;
+         * pid<-1 needs the caller or a tracked child in group -pid.
+         */
+        if (pid == 0)
+            return 0;
+        if (pid < -1) {
+            int64_t target_pgid = -(int64_t) pid;
+            if (proc_get_pgid() == target_pgid)
+                return 0;
+            proc_signal_target_t peer;
+            return proc_get_namespace_targets(&peer, 1, target_pgid) > 0
+                       ? 0
+                       : -LINUX_ESRCH;
+        }
+        int64_t r = (pid == (int) our_pid) ? 0 : -LINUX_ESRCH;
         if (r == -LINUX_ESRCH) {
             pid_t hpid = proc_guest_to_host_pid((int64_t) pid);
             if (hpid > 0)
@@ -901,14 +1030,69 @@ static int64_t sc_kill(guest_t *g,
         }
         return r;
     }
-    if (pid == (int) our_pid || pid == 0 || pid == -1 ||
-        pid == -(int) our_pid) {
+    if (pid == -1) {
+        /* Broadcast: Linux delivers to every process the caller may signal
+         * except init, and per kill(2) explicitly NOT to the calling process
+         * itself. Reach every member of this fork family over the cross-process
+         * transport (the caller is excluded by proc_get_namespace_targets); the
+         * namespace-scoped, same-binary registry keeps the signal from leaking
+         * into unrelated elfuse instances.
+         */
+        proc_signal_target_t targets[256];
+        int count = proc_get_namespace_targets(targets, ARRAY_SIZE(targets),
+                                               PROC_PGID_ANY);
+        if (count == (int) ARRAY_SIZE(targets))
+            log_warn(
+                "kill(-1, %d): target set hit the %zu-pid cap; broadcast may "
+                "be partial",
+                sig, ARRAY_SIZE(targets));
+        int first_errno;
+        int delivered = kill_deliver_targets(targets, count, sig, &first_errno);
+        if (delivered > 0)
+            return 0;
+        if (count == 0)
+            return -LINUX_ESRCH;
+        /* Targets existed but every send failed: report the first transport
+         * error rather than a misleading ESRCH.
+         */
+        errno = first_errno ? first_errno : ESRCH;
+        return linux_errno();
+    }
+    if (pid == 0 || pid < -1) {
+        /* Process-group signal: pid==0 targets the caller's own group, pid<-1
+         * targets group -pid. Deliver to every tracked fork-family member in
+         * that group over the cross-process transport, plus the caller when it
+         * is a member.
+         */
+        int64_t target_pgid = (pid == 0) ? proc_get_pgid() : -(int64_t) pid;
+        proc_signal_target_t targets[256];
+        int count = proc_get_namespace_targets(targets, ARRAY_SIZE(targets),
+                                               target_pgid);
+        if (count == (int) ARRAY_SIZE(targets))
+            log_warn(
+                "kill(%d, %d): group set hit the %zu-pid cap; delivery may "
+                "be partial",
+                pid, sig, ARRAY_SIZE(targets));
+        int first_errno;
+        int delivered = kill_deliver_targets(targets, count, sig, &first_errno);
+        if (proc_get_pgid() == target_pgid) {
+            signal_queue(sig);
+            delivered++;
+        }
+        if (delivered > 0)
+            return 0;
+        errno = first_errno ? first_errno : ESRCH;
+        return count > 0 ? linux_errno() : -LINUX_ESRCH;
+    }
+    if (pid == (int) our_pid) {
         signal_queue(sig);
         return 0;
     }
     pid_t hpid = proc_guest_to_host_pid((int64_t) pid);
     if (hpid > 0)
-        return (proc_send_guest_signal(hpid, sig) == 0) ? 0 : linux_errno();
+        return (proc_send_guest_signal(hpid, (int64_t) pid, sig) == 0)
+                   ? 0
+                   : linux_errno();
     return -LINUX_ESRCH;
 }
 

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -37,6 +37,8 @@ test-pidfd                         # diff=skip
 
 [section] Signal tests
 test-signal
+test-kill-broadcast
+test-kill-pgroup
 
 [section] Socket tests
 test-socket

--- a/tests/test-kill-broadcast.c
+++ b/tests/test-kill-broadcast.c
@@ -1,0 +1,145 @@
+/*
+ * Test kill(-1, sig) broadcast semantics
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Per kill(2): kill(-1, sig) delivers to every process the caller may signal
+ * except init, and explicitly does NOT signal the calling process itself.
+ * Verifies:
+ * 1. kill(-1, sig) reaches a fork child.
+ * 2. kill(-1, sig) does NOT signal the caller (Linux excludes self).
+ * 3. A directed kill(getpid(), sig) still delivers to the caller, so the
+ *    exclusion check above cannot pass merely because delivery is broken.
+ *
+ * SIGWINCH is the broadcast signal: it is ignored by default, so reaching
+ * unrelated processes in a full system guest (init, getty) is harmless while
+ * our processes install a handler to observe delivery.
+ */
+
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got_winch = 0;
+static volatile sig_atomic_t got_usr1 = 0;
+
+static void winch_handler(int sig)
+{
+    (void) sig;
+    got_winch = 1;
+}
+
+static void usr1_handler(int sig)
+{
+    (void) sig;
+    got_usr1 = 1;
+}
+
+/* Spin up to ~2 s waiting for a flag so slow HVC-forwarded delivery has time
+ * to land without hanging the suite. */
+static bool wait_flag(volatile sig_atomic_t *flag)
+{
+    for (int i = 0; i < 2000 && !*flag; i++) {
+        struct timespec ts = {0, 1000000}; /* 1 ms */
+        nanosleep(&ts, NULL);
+    }
+    return *flag != 0;
+}
+
+int main(void)
+{
+    int failed = 0;
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = winch_handler;
+    sigaction(SIGWINCH, &sa, NULL);
+    sa.sa_handler = usr1_handler;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    /* Child re-installs the handler, then reports delivery via exit code. */
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        perror("pipe");
+        return 1;
+    }
+    pid_t child = fork();
+    if (child == 0) {
+        close(pipefd[0]);
+        struct sigaction csa;
+        memset(&csa, 0, sizeof(csa));
+        csa.sa_handler = winch_handler;
+        sigaction(SIGWINCH, &csa, NULL);
+        char c = 'R';
+        if (write(pipefd[1], &c, 1) != 1)
+            _exit(2);
+        _exit(wait_flag(&got_winch) ? 0 : 1);
+    }
+    if (child < 0) {
+        perror("fork");
+        return 1;
+    }
+    close(pipefd[1]);
+
+    /* Wait for the child to arm its handler before broadcasting. */
+    char c = 0;
+    if (read(pipefd[0], &c, 1) != 1 || c != 'R') {
+        fprintf(stderr, "child never signaled readiness\n");
+        return 1;
+    }
+    close(pipefd[0]);
+
+    /* 0: sig==0 broadcast probe succeeds while a signalable peer (the child)
+     * exists. Only the positive case is asserted: the no-peers ESRCH result
+     * would diverge from a full system guest where init is always signalable.
+     */
+    if (kill(-1, 0) != 0) {
+        perror("kill(-1, 0) probe");
+        failed++;
+    }
+
+    got_winch = 0;
+    if (kill(-1, SIGWINCH) != 0) {
+        perror("kill(-1)");
+        failed++;
+    }
+
+    /* 1: broadcast reaches the child. */
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        perror("waitpid");
+        failed++;
+    } else if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "FAIL: kill(-1) did not reach the fork child\n");
+        failed++;
+    }
+
+    /* 2: caller is excluded. Give any (incorrect) self-delivery time to land.
+     */
+    struct timespec settle = {0, 20000000}; /* 20 ms */
+    nanosleep(&settle, NULL);
+    if (got_winch) {
+        fprintf(stderr, "FAIL: kill(-1) wrongly signaled the caller itself\n");
+        failed++;
+    }
+
+    /* 3: directed self-signal still works. */
+    got_usr1 = 0;
+    if (kill(getpid(), SIGUSR1) != 0) {
+        perror("kill(self)");
+        failed++;
+    }
+    if (!wait_flag(&got_usr1)) {
+        fprintf(stderr, "FAIL: kill(getpid()) did not deliver to the caller\n");
+        failed++;
+    }
+
+    printf("%s: %d failed\n", failed == 0 ? "PASS" : "FAIL", failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test-kill-pgroup.c
+++ b/tests/test-kill-pgroup.c
@@ -1,0 +1,500 @@
+/*
+ * Test kill(0, sig) and kill(-pgid, sig) process-group delivery
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * POSIX kill(0, sig) signals the caller's whole process group; kill(-pgid, sig)
+ * (pid < -1) signals group pgid. Verifies:
+ * 1. kill(-childpgid) reaches a child placed in its own group.
+ * 2. kill(0) reaches the caller and a child still in the caller's group.
+ * 3. kill(0) does NOT reach a child that moved to a different group.
+ *
+ * SIGWINCH (default-ignore) is the delivery signal so it is harmless to any
+ * unrelated process in a full-system guest; our processes install a handler.
+ */
+
+#include <errno.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got_winch = 0;
+
+static void winch_handler(int sig)
+{
+    (void) sig;
+    got_winch = 1;
+}
+
+static void install(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = winch_handler;
+    sigaction(SIGWINCH, &sa, NULL);
+}
+
+static bool wait_flag(int max_ms)
+{
+    for (int i = 0; i < max_ms && !got_winch; i++) {
+        struct timespec ts = {0, 1000000}; /* 1 ms */
+        nanosleep(&ts, NULL);
+    }
+    return got_winch != 0;
+}
+
+/* Fork a child that arms SIGWINCH, optionally joins its own group, reports
+ * readiness on the pipe, then exits 0 if it received the signal within the
+ * window (want_signal) or 0 if it did not (when !want_signal).
+ */
+static pid_t spawn_child(int wfd, bool own_group, bool want_signal, int wait_ms)
+{
+    pid_t pid = fork();
+    if (pid != 0)
+        return pid;
+    got_winch = 0; /* clear any flag inherited across fork */
+    install();
+    if (own_group)
+        setpgid(0, 0); /* shell idiom: child also sets its group */
+    char c = 'R';
+    if (write(wfd, &c, 1) != 1)
+        _exit(2);
+    bool got = wait_flag(wait_ms);
+    _exit((got == want_signal) ? 0 : 1);
+}
+
+static bool wait_ready(int rfd)
+{
+    char c = 0;
+    return read(rfd, &c, 1) == 1 && c == 'R';
+}
+
+static bool child_ok(pid_t pid)
+{
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid)
+        return false;
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+static pid_t spawn_group_sender(int ready_wfd, int go_rfd)
+{
+    pid_t pid = fork();
+    if (pid != 0)
+        return pid;
+    got_winch = 0;
+    install();
+    char c = 'R';
+    if (write(ready_wfd, &c, 1) != 1)
+        _exit(2);
+    if (read(go_rfd, &c, 1) != 1)
+        _exit(2);
+    if (kill(0, SIGWINCH) != 0)
+        _exit(3);
+    _exit(wait_flag(2000) ? 0 : 1);
+}
+
+/* Fork a child that calls setsid() to leave the caller's group, then reports
+ * readiness and exits 0 only if it did NOT receive the signal in the window.
+ * Guards that setsid refreshes the process-group registry: without the refresh
+ * the child would linger in the parent's group and be wrongly hit.
+ */
+static pid_t spawn_setsid_child(int wfd, int wait_ms)
+{
+    pid_t pid = fork();
+    if (pid != 0)
+        return pid;
+    got_winch = 0;
+    install();
+    setsid();
+    char c = 'R';
+    if (write(wfd, &c, 1) != 1)
+        _exit(2);
+    _exit(wait_flag(wait_ms) ? 1 : 0);
+}
+
+static pid_t spawn_setsid_after_parent_setpgid(int ready_wfd, int go_rfd)
+{
+    pid_t pid = fork();
+    if (pid != 0)
+        return pid;
+    char c = 'R';
+    if (write(ready_wfd, &c, 1) != 1)
+        _exit(2);
+    if (read(go_rfd, &c, 1) != 1)
+        _exit(2);
+    errno = 0;
+    _exit(setsid() == -1 && errno == EPERM ? 0 : 1);
+}
+
+/* Fork a group leader that, once the parent has set its group, forks a
+ * throwaway grandchild (triggering its own fork-time registry republish) and
+ * then waits for the signal. Guards that the republish does not re-stamp the
+ * registry with the stale pre-setpgid group: without the sync-before-publish
+ * fix, kill(-leaderpgid) would miss this leader after it forks.
+ */
+static pid_t spawn_leader_then_fork(int ready_wfd, int go_rfd, int forked_wfd)
+{
+    pid_t pid = fork();
+    if (pid != 0)
+        return pid;
+    got_winch = 0;
+    install();
+    char c = 'R';
+    if (write(ready_wfd, &c, 1) != 1)
+        _exit(2);
+    if (read(go_rfd, &c, 1) != 1) /* wait until parent did setpgid(self,self) */
+        _exit(2);
+    pid_t gc = fork(); /* republish happens here */
+    if (gc == 0)
+        _exit(0);
+    if (gc < 0)
+        _exit(2);
+    waitpid(gc, NULL, 0); /* gc > 0: reap the throwaway grandchild */
+    char done = 'R'; /* c was clobbered by the go read; send a fresh byte */
+    if (write(forked_wfd, &done, 1) != 1)
+        _exit(2);
+    _exit(wait_flag(2000) ? 0 : 1);
+}
+
+int main(void)
+{
+    int failed = 0;
+    install();
+
+    /* 0: setpgid rejects a negative group (EINVAL) and negative pid (ESRCH). */
+    if (setpgid(0, -5) != -1 || errno != EINVAL) {
+        fprintf(stderr, "FAIL: setpgid(0,-5) should be EINVAL\n");
+        failed++;
+    }
+    if (setpgid(-9, 0) != -1 || errno != ESRCH) {
+        fprintf(stderr, "FAIL: setpgid(-9,0) should be ESRCH\n");
+        failed++;
+    }
+
+    /* 1: kill(-childpgid) reaches a child in its own group. */
+    int p1[2];
+    if (pipe(p1) != 0)
+        return 1;
+    pid_t c1 = spawn_child(p1[1], true, true, 2000);
+    if (c1 < 0)
+        return 1;
+    close(p1[1]);
+    setpgid(c1, c1); /* parent side of the group-set idiom */
+    if (!wait_ready(p1[0])) {
+        fprintf(stderr, "child 1 not ready\n");
+        return 1;
+    }
+    close(p1[0]);
+    if (kill(-c1, SIGWINCH) != 0) {
+        perror("kill(-childpgid)");
+        failed++;
+    }
+    if (!child_ok(c1)) {
+        fprintf(stderr, "FAIL: kill(-childpgid) did not reach the child\n");
+        failed++;
+    }
+
+    /* 2: kill(0) reaches the caller and a child in the caller's group. */
+    int p2[2];
+    if (pipe(p2) != 0)
+        return 1;
+    pid_t c2 = spawn_child(p2[1], false, true, 2000); /* inherits our group */
+    if (c2 < 0)
+        return 1;
+    close(p2[1]);
+    if (!wait_ready(p2[0])) {
+        fprintf(stderr, "child 2 not ready\n");
+        return 1;
+    }
+    close(p2[0]);
+    got_winch = 0;
+    if (kill(0, SIGWINCH) != 0) {
+        perror("kill(0)");
+        failed++;
+    }
+    if (!wait_flag(2000)) {
+        fprintf(stderr, "FAIL: kill(0) did not signal the caller\n");
+        failed++;
+    }
+    if (!child_ok(c2)) {
+        fprintf(stderr, "FAIL: kill(0) did not reach the in-group child\n");
+        failed++;
+    }
+
+    /* 3: kill(0) does NOT reach a child that left the caller's group. */
+    int p3[2];
+    if (pipe(p3) != 0)
+        return 1;
+    /* want_signal=false: child exits 0 only if it does NOT get the signal. */
+    pid_t c3 = spawn_child(p3[1], true, false, 300);
+    if (c3 < 0)
+        return 1;
+    close(p3[1]);
+    setpgid(c3, c3);
+    if (!wait_ready(p3[0])) {
+        fprintf(stderr, "child 3 not ready\n");
+        return 1;
+    }
+    close(p3[0]);
+    if (kill(0, SIGWINCH) != 0) {
+        perror("kill(0) #3");
+        failed++;
+    }
+    if (!child_ok(c3)) {
+        fprintf(stderr,
+                "FAIL: kill(0) wrongly reached a child in a different group\n");
+        failed++;
+    }
+
+    /* 4: pipeline. c4 leads group c4; c5 joins group c4. kill(-c4) reaches
+     * both, exercising the "join an existing tracked group" path.
+     */
+    int p4[2], p5[2];
+    if (pipe(p4) != 0 || pipe(p5) != 0)
+        return 1;
+    pid_t c4 = spawn_child(p4[1], true, true, 2000);
+    if (c4 < 0)
+        return 1;
+    close(p4[1]);
+    setpgid(c4, c4);
+    if (!wait_ready(p4[0])) {
+        fprintf(stderr, "child 4 not ready\n");
+        return 1;
+    }
+    close(p4[0]);
+    pid_t c5 = spawn_child(p5[1], false, true, 2000);
+    if (c5 < 0)
+        return 1;
+    close(p5[1]);
+    setpgid(c5, c4); /* c5 joins c4's existing group */
+    if (!wait_ready(p5[0])) {
+        fprintf(stderr, "child 5 not ready\n");
+        return 1;
+    }
+    close(p5[0]);
+    if (kill(-c4, SIGWINCH) != 0) {
+        perror("kill(-c4) pipeline");
+        failed++;
+    }
+    if (!child_ok(c4)) {
+        fprintf(stderr, "FAIL: kill(-pgid) did not reach the group leader\n");
+        failed++;
+    }
+    if (!child_ok(c5)) {
+        fprintf(stderr, "FAIL: kill(-pgid) did not reach the group joiner\n");
+        failed++;
+    }
+
+    /* 5: child-origin kill(0) reaches the inherited-group sibling and parent.
+     */
+    int p6[2], p7[2], go[2];
+    if (pipe(p6) != 0 || pipe(p7) != 0 || pipe(go) != 0)
+        return 1;
+    pid_t c6 = spawn_group_sender(p6[1], go[0]);
+    if (c6 < 0)
+        return 1;
+    close(p6[1]);
+    close(go[0]);
+    pid_t c7 = spawn_child(p7[1], false, true, 2000);
+    if (c7 < 0)
+        return 1;
+    close(p7[1]);
+    if (!wait_ready(p6[0]) || !wait_ready(p7[0])) {
+        fprintf(stderr, "child 6/7 not ready\n");
+        return 1;
+    }
+    close(p6[0]);
+    close(p7[0]);
+    got_winch = 0;
+    if (write(go[1], "G", 1) != 1)
+        return 1;
+    close(go[1]);
+    if (!wait_flag(2000)) {
+        fprintf(stderr, "FAIL: child kill(0) did not signal the parent\n");
+        failed++;
+    }
+    if (!child_ok(c6)) {
+        fprintf(stderr, "FAIL: child kill(0) did not signal the caller\n");
+        failed++;
+    }
+    if (!child_ok(c7)) {
+        fprintf(stderr, "FAIL: child kill(0) did not signal the sibling\n");
+        failed++;
+    }
+
+    /* 6: a child that calls setsid() leaves the caller's group, so kill(0) (the
+     * caller's group) must no longer reach it. Passes only if setsid refreshed
+     * the registry entry to the child's new group.
+     */
+    int p8[2];
+    if (pipe(p8) != 0)
+        return 1;
+    pid_t c8 = spawn_setsid_child(p8[1], 300);
+    if (c8 < 0)
+        return 1;
+    close(p8[1]);
+    if (!wait_ready(p8[0])) {
+        fprintf(stderr, "child 8 not ready\n");
+        return 1;
+    }
+    close(p8[0]);
+    if (kill(0, SIGWINCH) != 0) {
+        perror("kill(0) #6");
+        failed++;
+    }
+    if (!child_ok(c8)) {
+        fprintf(stderr,
+                "FAIL: kill(0) wrongly reached a child that called setsid\n");
+        failed++;
+    }
+
+    /* 7: parent-side setpgid(child, child) must update the child's local pgid
+     * too. Otherwise the child's kill(0) targets the inherited parent group.
+     */
+    int p9[2], go2[2];
+    if (pipe(p9) != 0 || pipe(go2) != 0)
+        return 1;
+    pid_t c9 = spawn_group_sender(p9[1], go2[0]);
+    if (c9 < 0)
+        return 1;
+    close(p9[1]);
+    close(go2[0]);
+    setpgid(c9, c9);
+    if (!wait_ready(p9[0])) {
+        fprintf(stderr, "child 9 not ready\n");
+        return 1;
+    }
+    close(p9[0]);
+    got_winch = 0;
+    if (write(go2[1], "G", 1) != 1)
+        return 1;
+    close(go2[1]);
+    if (wait_flag(300)) {
+        fprintf(stderr,
+                "FAIL: child kill(0) after parent setpgid signaled parent\n");
+        failed++;
+    }
+    if (!child_ok(c9)) {
+        fprintf(stderr,
+                "FAIL: child kill(0) after parent setpgid missed child\n");
+        failed++;
+    }
+
+    /* 8: parent-side setpgid(child, child) makes the child a group leader, so a
+     * later setsid() in that child must fail with EPERM.
+     */
+    int p10[2], go3[2];
+    if (pipe(p10) != 0 || pipe(go3) != 0)
+        return 1;
+    pid_t c10 = spawn_setsid_after_parent_setpgid(p10[1], go3[0]);
+    if (c10 < 0)
+        return 1;
+    close(p10[1]);
+    close(go3[0]);
+    if (!wait_ready(p10[0])) {
+        fprintf(stderr, "child 10 not ready\n");
+        return 1;
+    }
+    close(p10[0]);
+    setpgid(c10, c10);
+    if (write(go3[1], "G", 1) != 1)
+        return 1;
+    close(go3[1]);
+    if (!child_ok(c10)) {
+        fprintf(stderr,
+                "FAIL: setsid succeeded after parent setpgid(child, child)\n");
+        failed++;
+    }
+
+    /* 9: one child can create a group itself, then a parent can place a sibling
+     * into that registry-only group.
+     */
+    int p11[2], p12[2];
+    if (pipe(p11) != 0 || pipe(p12) != 0)
+        return 1;
+    pid_t c11 = spawn_child(p11[1], true, true, 2000);
+    if (c11 < 0)
+        return 1;
+    close(p11[1]);
+    if (!wait_ready(p11[0])) {
+        fprintf(stderr, "child 11 not ready\n");
+        return 1;
+    }
+    close(p11[0]);
+    pid_t c12 = spawn_child(p12[1], false, true, 2000);
+    if (c12 < 0)
+        return 1;
+    close(p12[1]);
+    setpgid(c12, c11);
+    if (!wait_ready(p12[0])) {
+        fprintf(stderr, "child 12 not ready\n");
+        return 1;
+    }
+    close(p12[0]);
+    if (kill(-c11, SIGWINCH) != 0) {
+        perror("kill(-child-created-pgid)");
+        failed++;
+    }
+    if (!child_ok(c11)) {
+        fprintf(stderr,
+                "FAIL: kill(-pgid) missed child-created group leader\n");
+        failed++;
+    }
+    if (!child_ok(c12)) {
+        fprintf(stderr,
+                "FAIL: kill(-pgid) missed sibling in child-created group\n");
+        failed++;
+    }
+
+    /* 10: a leader forks after the parent set its group. Its fork-time registry
+     * republish must not revert the entry to the stale inherited group, so
+     * kill(-leaderpgid) still reaches it.
+     */
+    int p13[2], go4[2], fk[2];
+    if (pipe(p13) != 0 || pipe(go4) != 0 || pipe(fk) != 0)
+        return 1;
+    pid_t c13 = spawn_leader_then_fork(p13[1], go4[0], fk[1]);
+    if (c13 < 0)
+        return 1;
+    close(p13[1]);
+    close(go4[0]);
+    close(fk[1]);
+    if (!wait_ready(p13[0])) {
+        fprintf(stderr, "child 13 not ready\n");
+        return 1;
+    }
+    close(p13[0]);
+    if (setpgid(c13, c13) != 0) { /* parent sets the leader's group */
+        perror("setpgid child 13");
+        return 1;
+    }
+    if (write(go4[1], "G", 1) != 1)
+        return 1;
+    close(go4[1]);
+    if (!wait_ready(
+            fk[0])) { /* wait until the leader has forked (republished) */
+        fprintf(stderr, "child 13 did not fork\n");
+        return 1;
+    }
+    close(fk[0]);
+    if (kill(-c13, SIGWINCH) != 0) {
+        perror("kill(-leaderpgid after fork)");
+        failed++;
+    }
+    if (!child_ok(c13)) {
+        fprintf(
+            stderr,
+            "FAIL: kill(-pgid) missed a leader that forked after setpgid\n");
+        failed++;
+    }
+
+    printf("%s: %d failed\n", failed == 0 ? "PASS" : "FAIL", failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -500,6 +500,10 @@ run_unit_tests()
     test_check "$runner" "test-signal" "PASS|0 failed" "$bindir/test-signal"
     test_check "$runner" "test-signal-thread" "PASS|0 failed" "$bindir/test-signal-thread"
     test_check "$runner" "test-sigill" "0 failed" "$bindir/test-sigill"
+    test_check "$runner" "test-kill-broadcast" "0 failed" \
+        "$bindir/test-kill-broadcast"
+    test_check "$runner" "test-kill-pgroup" "0 failed" \
+        "$bindir/test-kill-pgroup"
 
     printf "\nSocket tests\n"
     test_check "$runner" "test-socket" "PASS|0 failed" "$bindir/test-socket"


### PR DESCRIPTION
sc_kill mishandled the negative-pid forms. Correct them to match Linux and the qemu-aarch64 ground truth:
- kill(-1, sig): broadcast to the emulated fork children over the cross-process transport, excluding the caller. Per kill(2), Linux does not signal the calling process on kill(-1); the prior code did the opposite (self only, no children). Return 0 on any delivery, the first transport errno if children existed but every send failed, else ESRCH.
- kill(0, sig) and kill(-pgid, sig): deliver to every process in the target group -- children, siblings, and the parent -- not just self. Because each guest process is a separate host process, group membership is shared through a per-fork-family registry file keyed by the abstract-socket namespace id, so independent sessions stay isolated. Membership is published at fork, setpgid (self and parent-side), and setsid; publish compacts the file in place so it stays bounded by live members rather than growing per event. A process syncs its own pgid from registry before acting on its group, so setsid's already-leader check and the kill group path observe the current group even after a parent-side setpgid(child).

Hardening:
- setpgid rejects a negative group id (EINVAL) and negative pid (ESRCH), reading the args as 32-bit like sc_kill.
- The signal transport tags each line with the sender's namespace so a recycled host pid on an unrelated session drops the delivery instead of applying it, and proc_send_guest_signal revalidates that the target is still this binary before signaling.

Close #131

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes kill() negative-PID semantics to match Linux. kill(-1) now broadcasts to every member of the emulated fork family except self, and kill(0)/kill(-pgid) signal the full process group across host processes via a shared registry. Hardens signal transport to block cross-session and cross-guest PID reuse.

- **Bug Fixes**
  - kill(-1, sig) broadcasts to all fork-family peers and never to self.
  - kill(0, sig) and kill(-pgid, sig) reach the entire target group (children, siblings, parent) across processes.
  - Linux-compatible results: 0 on any delivery; ESRCH when no targets; for broadcast/group if all sends fail, return the first transport errno; sig==0 probes match Linux; setpgid rejects negative pgid (EINVAL) and negative pid (ESRCH).

- **New Features**
  - Fork-family process-group registry keyed by the abstract-socket namespace: published at fork, setpgid (self and parent-side), and setsid; processes sync pgid before group ops; setpgid’s group-existence check reads the registry; file compacted in place.
  - Hardened signal transport: tag deliveries with namespace and target guest pid; verify the target runs this binary; reader drops mismatched sessions/guests and rejects garbage; owner cleans the registry only when last member; warn when full; log failed truncates.
  - Tests added and wired into CI: `test-kill-broadcast`, `test-kill-pgroup`.

<sup>Written for commit 20d1be259b2881377dcad2a67919545a90dd4c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

