### PR TITLE
Route thread-directed signals to the target thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,11 @@ $(BUILD_DIR)/test-poll: tests/test-poll.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
 
+# test-tgkill-directed verifies thread-directed (pthread_kill/tgkill) routing.
+$(BUILD_DIR)/test-tgkill-directed: tests/test-tgkill-directed.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
+
 # test-osync-requeue drives a raw FUTEX_REQUEUE against a plain-FUTEX_WAIT
 # waiter (musl unlock_requeue pattern) to guard the os_sync wake-at-source
 # degradation; needs -lpthread.

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -289,15 +289,13 @@ int fork_child_main(int ipc_fd,
     }
 
     /* POSIX: "Signals pending to the parent shall not be pending to the child."
-     * Clear pending bitmask and RT queue before applying state.
-     * signal_set_state() is deferred until after thread_register_main() so that
-     * current_thread is non-NULL and per-thread state (blocked mask, altstack)
-     * is properly restored.
+     * Clear the entire shared pending set before applying state. The child's
+     * single thread starts with an empty private set (thread_register_main
+     * zeroes the slot). signal_set_state() is deferred until after
+     * thread_register_main() so that current_thread is non-NULL and per-thread
+     * state (blocked mask, altstack) is properly restored.
      */
-    sig.pending = 0;
-    memset(sig.rt_queue, 0, sizeof(sig.rt_queue));
-    memset(sig.rt_head, 0, sizeof(sig.rt_head));
-    memset(sig.rt_info, 0, sizeof(sig.rt_info));
+    memset(&sig.shared, 0, sizeof(sig.shared));
 
     /* execve in the child needs the shim bytes after guest_reset clears memory.
      * Close IPC socket

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -60,10 +60,14 @@ static _Atomic int active_thread_count = 0;
 #define THREAD_FOR_EACH(t) \
     for (thread_entry_t *t = thread_table; t < thread_table + MAX_THREADS; t++)
 
-/* Iterate active slots. Caller must hold thread_lock for stable reads. */
+/* Iterate active slots. Caller must hold thread_lock; the lock already orders
+ * these reads against the release-stores of active, so a relaxed atomic load
+ * suffices. It is used (rather than a plain read) only to keep every access to
+ * active uniformly atomic -- no mixed atomic-write / plain-read on one object.
+ */
 #define THREAD_FOR_EACH_ACTIVE(t) \
     THREAD_FOR_EACH (t)           \
-        if (t->active)
+        if (__atomic_load_n(&t->active, __ATOMIC_RELAXED))
 
 /* Iterate active slots without holding thread_lock. Uses an acquire load on the
  * active flag so the lock-free observers in thread_tid_alive() and
@@ -112,10 +116,14 @@ void thread_register_main(hv_vcpu_t vcpu,
     t->clear_child_tid = 0;
     t->sp_el1 = sp_el1;
     t->sp_el1_slot = 0; /* Main thread always owns slot 0 */
-    t->active = 1;
     t->altstack_flags = LINUX_SS_DISABLE;
     t->on_altstack = false;
     thread_ptrace_init(t);
+    /* Release-store so a lock-free scanner that acquire-loads active == 1 sees
+     * this slot's initialized fields (see thread_pending_union,
+     * thread_tid_alive).
+     */
+    __atomic_store_n(&t->active, 1, __ATOMIC_RELEASE);
 
     /* Slot 0 is consumed by main thread */
     sp_el1_allocated = BIT64(0);
@@ -135,7 +143,7 @@ thread_entry_t *thread_alloc(int64_t tid,
 
     pthread_mutex_lock(&thread_lock);
     THREAD_FOR_EACH (t) {
-        if (t->active)
+        if (__atomic_load_n(&t->active, __ATOMIC_RELAXED))
             continue;
         /* Skip slots where a tracer is still inside pthread_cond_wait on
          * ptrace_cond. Memset+reinit while a waiter holds a reference is UB.
@@ -153,9 +161,12 @@ thread_entry_t *thread_alloc(int64_t tid,
             t->stack_map_start = stack_start;
             t->stack_map_end = stack_end;
         }
-        t->active = 1;
         t->altstack_flags = LINUX_SS_DISABLE;
         thread_ptrace_init(t);
+        /* Release-store last so a lock-free scanner that observes active == 1
+         * also sees the zeroed tpending / guest_tid set above.
+         */
+        __atomic_store_n(&t->active, 1, __ATOMIC_RELEASE);
         atomic_fetch_add(&active_thread_count, 1);
         result = t;
         break;
@@ -179,7 +190,8 @@ static void thread_free_sp_el1_locked(thread_entry_t *t)
 
 static void thread_ptrace_cleanup_locked(thread_entry_t *t)
 {
-    if (!t->ptrace_conds_inited || t->active || t->ptrace_waiters != 0)
+    if (!t->ptrace_conds_inited ||
+        __atomic_load_n(&t->active, __ATOMIC_RELAXED) || t->ptrace_waiters != 0)
         return;
 
     pthread_cond_destroy(&t->ptrace_cond);
@@ -200,7 +212,7 @@ void thread_deactivate(thread_entry_t *t)
      * condvars, since broadcasting a destroyed condvar is undefined behavior.
      * Guard against double-deactivation: if already inactive, skip.
      */
-    if (!t->active) {
+    if (!__atomic_load_n(&t->active, __ATOMIC_RELAXED)) {
         pthread_mutex_unlock(&thread_lock);
         return;
     }
@@ -213,7 +225,7 @@ void thread_deactivate(thread_entry_t *t)
     /* Free SP_EL1 slot so it can be reused by future threads */
     thread_free_sp_el1_locked(t);
 
-    t->active = 0;
+    __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
     atomic_fetch_sub(&active_thread_count, 1);
 
     /* Destroy condvars once no waiters still reference them. A tracer woken by
@@ -223,6 +235,14 @@ void thread_deactivate(thread_entry_t *t)
     thread_ptrace_cleanup_locked(t);
 
     pthread_mutex_unlock(&thread_lock);
+
+    /* The slot is now inactive, so thread_pending_union() excludes it.
+     * Recompute the global pending hint so any thread-directed signal left
+     * unconsumed in this thread's private set stops pinning the
+     * identity-syscall fast path off for the surviving threads. Done outside
+     * thread_lock to honor sig_lock (4) before thread_lock (5).
+     */
+    signal_refresh_pending_hint();
 }
 
 thread_entry_t *thread_find(int64_t tid)
@@ -239,6 +259,28 @@ thread_entry_t *thread_find(int64_t tid)
     pthread_mutex_unlock(&thread_lock);
 
     return result;
+}
+
+thread_entry_t *thread_find_locked(int64_t tid)
+{
+    THREAD_FOR_EACH_ACTIVE (t) {
+        if (t->guest_tid == tid)
+            return t;
+    }
+    return NULL;
+}
+
+uint64_t thread_pending_union(void)
+{
+    /* Lock-free active scan; sig_lock (held by the caller) already serializes
+     * every tpending write, so reads here are stable. A slot mid-(de)activation
+     * only ever contributes extra bits, which the caller treats as a harmless
+     * false positive in the pending hint.
+     */
+    uint64_t u = 0;
+    THREAD_FOR_EACH_ACTIVE_RELAXED (t)
+        u |= t->tpending.pending;
+    return u;
 }
 
 int thread_tid_alive(int64_t tid)
@@ -366,7 +408,7 @@ void thread_destroy_all_vcpus(void)
         hv_vcpu_destroy(t->vcpu);
         t->vcpu = 0;
         thread_free_sp_el1_locked(t);
-        t->active = 0;
+        __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
         /* Do NOT destroy condvars. Same race as thread_deactivate: a waiter
          * woken by an earlier broadcast may still reference the condvar.
          * Process is exiting, so the leak is harmless.
@@ -588,7 +630,8 @@ void thread_finish_deferred_stack_ranges(
     for (int i = 0; i < nranges; i++) {
         thread_entry_t *t = txns[i].thread;
 
-        if (!t || !t->active || t->guest_tid != txns[i].guest_tid ||
+        if (!t || !__atomic_load_n(&t->active, __ATOMIC_RELAXED) ||
+            t->guest_tid != txns[i].guest_tid ||
             t->deferred_stack_unmap_busy <= 0)
             continue;
         t->deferred_stack_unmap_busy--;
@@ -612,7 +655,8 @@ void thread_rollback_deferred_stack_ranges(
     for (int i = 0; i < nranges; i++) {
         thread_entry_t *t = txns[i].thread;
 
-        if (!t || !t->active || t->guest_tid != txns[i].guest_tid)
+        if (!t || !__atomic_load_n(&t->active, __ATOMIC_RELAXED) ||
+            t->guest_tid != txns[i].guest_tid)
             continue;
         t->deferred_stack_unmap_count = txns[i].deferred_count;
         for (int j = 0; j < txns[i].deferred_count; j++) {
@@ -854,7 +898,7 @@ static bool thread_matches_tracer_child(const thread_entry_t *t,
                                         int64_t tracer_tid,
                                         int pid)
 {
-    if (!t->active)
+    if (!__atomic_load_n(&t->active, __ATOMIC_RELAXED))
         return false;
     bool is_child = (t->ptraced && t->tracer_tid == tracer_tid) ||
                     (t->is_vm_clone && t->parent_tid == tracer_tid);
@@ -901,11 +945,17 @@ int64_t thread_ptrace_wait(int64_t tracer_tid,
                  * pthread_cond_wait().
                  */
                 thread_free_sp_el1_locked(t);
-                t->active = 0;
+                __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
                 atomic_fetch_sub(&active_thread_count, 1);
                 t->ptrace_cleanup_pending = true;
                 thread_ptrace_cleanup_locked(t);
                 pthread_mutex_unlock(&thread_lock);
+                /* Slot is now inactive; drop any unconsumed thread-directed
+                 * pending bits from the global hint (same rationale as
+                 * thread_deactivate). Outside thread_lock to honor sig_lock (4)
+                 * before thread_lock (5).
+                 */
+                signal_refresh_pending_hint();
                 return tid;
             }
         }

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -22,15 +22,19 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "core/guest.h"  /* guest_t (for thread_alloc_sp_el1) */
-#include "syscall/abi.h" /* linux_user_pt_regs_t */
+#include "core/guest.h"     /* guest_t (for thread_alloc_sp_el1) */
+#include "syscall/abi.h"    /* linux_user_pt_regs_t */
+#include "syscall/signal.h" /* signal_pending_t (per-thread directed signals) */
 
 /* Maximum number of concurrent guest threads in one VM. */
 #define MAX_THREADS 64
 #define MAX_DEFERRED_STACK_UNMAPS 8
 
-/* Per-thread state. One entry per guest thread (main + workers). */
-typedef struct {
+/* Per-thread state. One entry per guest thread (main + workers). Tagged (struct
+ * thread_entry) so signal.h can forward-declare it for the thread-directed
+ * signal API without an include cycle.
+ */
+typedef struct thread_entry {
     int64_t guest_tid;        /* Linux TID (unique per thread) */
     hv_vcpu_t vcpu;           /* HVF vCPU handle for this thread */
     hv_vcpu_exit_t *vexit;    /* vCPU exit info pointer */
@@ -41,7 +45,8 @@ typedef struct {
                                * Stored at alloc time so the free path does
                                * not need to recompute (top - sp) / 4096; the
                                * shim data block is now at high IPA and only
-                               * known via guest_t. */
+                               * known via guest_t.
+                               */
     int active;               /* Non-zero while thread is running.
                                * Stays int (not bool) because lock-free paths in thread.c
                                * use __atomic_load_n on this field; the 32-bit width keeps
@@ -53,6 +58,12 @@ typedef struct {
     uint64_t blocked;       /* Signal mask for this thread */
     uint64_t saved_blocked; /* Original mask saved by sigsuspend */
     bool saved_blocked_valid;
+
+    /* Thread-directed pending signals (Linux task->pending). tgkill/tkill and
+     * pthread_kill queue here so only this thread consumes them. Written and
+     * read under the signal module's sig_lock; do not touch without it.
+     */
+    signal_pending_t tpending;
 
     /* Per-thread alternate signal stack (Linux sigaltstack is per-thread).
      * Fields mirror linux_stack_t layout for easy copy.
@@ -172,6 +183,14 @@ void thread_deactivate(thread_entry_t *t);
 /* Find a thread by guest TID. Returns NULL if not found. */
 thread_entry_t *thread_find(int64_t tid);
 
+/* Find a thread by guest TID with thread_lock already held by the caller.
+ * Returns a pointer that stays valid only while the caller keeps thread_lock.
+ * Used by the signal module to resolve a tgkill target and enqueue into its
+ * private pending set atomically against slot reuse. Acquire sig_lock (4)
+ * before thread_lock (5) per the documented lock order.
+ */
+thread_entry_t *thread_find_locked(int64_t tid);
+
 /* Lock-free check: is there an active thread with this TID?
  * Returns 1 if found, 0 if not. Safe to call without holding any lock (used
  * from futex_lock_pi to avoid lock order inversion with bucket locks). May
@@ -182,6 +201,14 @@ int thread_tid_alive(int64_t tid);
 
 /* Count currently active threads. */
 int thread_active_count(void);
+
+/* OR of every active thread's private pending bitmask (thread-directed
+ * signals). The signal module folds this into its global "maybe pending" hint.
+ * Caller must hold sig_lock so the tpending fields are stable; the active-slot
+ * scan itself takes no lock and tolerates a racing (de)activation as a harmless
+ * superset.
+ */
+uint64_t thread_pending_union(void);
 
 /* Fast path: return non-zero when exactly one guest thread is active. */
 int thread_is_single_active(void);

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -100,6 +100,7 @@
 #define SYS_sched_get_priority_min 126
 #define SYS_sched_rr_get_interval 127
 #define SYS_kill 129
+#define SYS_tkill 130
 #define SYS_tgkill 131
 #define SYS_sigaltstack 132
 #define SYS_rt_sigsuspend 133
@@ -736,7 +737,8 @@ typedef struct {
     uint64_t generation; /* Bumped each time this guest fd slot is reused. Lets
                           * long-lived references (e.g. epoll registrations)
                           * detect a close+reopen ABA where the slot now holds a
-                          * different open file. */
+                          * different open file.
+                          */
     int linux_flags;     /* Linux open flags (for CLOEXEC tracking) */
     void *dir;           /* DIR* for FD_DIR entries (NULL otherwise) */
     char proc_path[FD_VIRTUAL_PATH_MAX]; /* Virtual /proc dir root for *at */

--- a/src/syscall/dispatch.tbl
+++ b/src/syscall/dispatch.tbl
@@ -107,6 +107,7 @@ SYS_membarrier sc_membarrier 0
 
 # Signals
 SYS_kill sc_kill 0
+SYS_tkill sc_tkill 0
 SYS_tgkill sc_tgkill 0
 SYS_sigaltstack sc_sigaltstack 1
 SYS_rt_sigsuspend sc_rt_sigsuspend 1

--- a/src/syscall/fd.c
+++ b/src/syscall/fd.c
@@ -1141,19 +1141,30 @@ retry:
     signal_rt_info_t pending_stack[LINUX_NSIG];
     signal_rt_info_t *pending = pending_stack;
     signal_rt_info_t *heap = NULL;
-    size_t total = 0;
-    const signal_state_t *sig = signal_get_state();
-    /* Match pending signals against the signalfd mask. Do NOT filter by
-     * sig->blocked because signalfd is specifically designed to read signals
-     * that were blocked from normal delivery via sigprocmask().
+    /* Parallel source-set tag per peeked entry (0 = private, 1 = shared) so the
+     * take consumes each signal from the exact set it was peeked from.
      */
-    uint64_t deliverable = sig->pending & mask;
+    uint8_t src_stack[LINUX_NSIG];
+    uint8_t *src = src_stack;
+    uint8_t *src_heap = NULL;
+    size_t total = 0;
+    /* Match pending signals against the signalfd mask. Do NOT filter by the
+     * blocked mask because signalfd is specifically designed to read signals
+     * that were blocked from normal delivery via sigprocmask(). The visible set
+     * is this thread's private (thread-directed) pending plus the shared set.
+     */
+    uint64_t deliverable = signal_signalfd_pending_mask() & mask;
 
     if (max_signals > LINUX_NSIG) {
         heap = malloc(max_signals * sizeof(*pending));
-        if (!heap)
+        src_heap = malloc(max_signals * sizeof(*src));
+        if (!heap || !src_heap) {
+            free(heap);
+            free(src_heap);
             return -LINUX_ENOMEM;
+        }
         pending = heap;
+        src = src_heap;
     }
 
     if (deliverable == 0) {
@@ -1178,18 +1189,33 @@ retry:
         pthread_mutex_unlock(&sfd_lock);
         if (!still_valid) {
             free(heap);
+            free(src_heap);
             return -LINUX_EBADF;
         }
 
-        /* Re-check: a signal matching the current mask should now be pending */
-        sig = signal_get_state();
-        deliverable = sig->pending & mask;
-        if (deliverable == 0)
-            goto no_pending;
+        /* Re-check: a racing consumer may have drained the signal that woke the
+         * pipe. A blocking read must keep waiting rather than surface a
+         * spurious -EAGAIN, so loop back to re-wait.
+         */
+        deliverable = signal_signalfd_pending_mask() & mask;
+        if (deliverable == 0) {
+            free(heap);
+            free(src_heap);
+            goto retry;
+        }
     }
-    size_t peeked = signal_peek_signalfd(mask, pending, max_signals);
-    if (peeked == 0)
+    size_t peeked = signal_peek_signalfd(mask, pending, src, max_signals);
+    if (peeked == 0) {
+        /* Raced empty after a positive recheck: block-mode re-waits, nonblock
+         * reports EAGAIN.
+         */
+        if (!nonblock) {
+            free(heap);
+            free(src_heap);
+            goto retry;
+        }
         goto no_pending;
+    }
 
     /* Write-then-take. Writing first means that on a guest_write_small EFAULT
      * the rt-queue is still intact and signals are not lost: no re-queue dance,
@@ -1220,6 +1246,7 @@ retry:
                  * test_signalfd_efault_preserves_pending.
                  */
                 free(heap);
+                free(src_heap);
                 return -LINUX_EFAULT;
             }
 
@@ -1232,11 +1259,12 @@ retry:
         written++;
     }
 
-    total = signal_take_signalfd_exact(pending, written);
+    total = signal_take_signalfd_exact(pending, src, written);
     if (total == 0) {
         if (written == 0)
             goto no_pending;
         free(heap);
+        free(src_heap);
         goto retry;
     }
 
@@ -1252,15 +1280,18 @@ retry:
     }
 
     free(heap);
+    free(src_heap);
     return (int64_t) total * (int64_t) sizeof(linux_signalfd_siginfo_t);
 
 no_pending:
     free(heap);
+    free(src_heap);
     return -LINUX_EAGAIN;
 }
 
-/* Notify signalfd pipes when a signal is queued. Called from signal_queue();
- * writes a byte to make poll/epoll see readability.
+/* Notify signalfd pipes when a process-directed signal is queued. Thread-
+ * directed signals stay private to their target thread and must not wake every
+ * signalfd watching that signum.
  */
 void signalfd_notify(int signum)
 {

--- a/src/syscall/fd.h
+++ b/src/syscall/fd.h
@@ -79,8 +79,11 @@ int64_t timerfd_read(int guest_fd,
                      uint64_t buf_gva,
                      uint64_t count);
 
-/* Notify signalfd pipes when a signal is queued. Called from signal_queue();
- * writes a byte to make poll/epoll see readability.
+/* Notify signalfd pipes when a signal is queued (process- or thread-directed),
+ * making poll/epoll/blocking-read see readability. Mirrors Linux waking the one
+ * shared sighand wait queue: every signalfd is woken and each reader
+ * re-evaluates against its own pending, so a non-target reader simply gets
+ * EAGAIN.
  */
 void signalfd_notify(int signum);
 

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1325,7 +1325,7 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                             "%s: post-sigreturn state: "
                             "pending=0x%llx global_blocked=0x%llx "
                             "thread_blocked=0x%llx signal_pending=%d",
-                            prefix, (unsigned long long) ss->pending,
+                            prefix, (unsigned long long) ss->shared.pending,
                             (unsigned long long) ss->blocked,
                             (unsigned long long) tblocked, signal_pending());
                     }
@@ -1691,7 +1691,7 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                                 "pending=0x%llx",
                                 prefix, (unsigned long long) thread_blocked,
                                 (unsigned long long) signal_get_state()
-                                    ->pending);
+                                    ->shared.pending);
                         }
                         int sig_ret = signal_deliver_fault(
                             vcpu, g, LINUX_SIGTRAP, &exit_code);

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -174,61 +174,99 @@ static signal_rt_info_t signal_default_info(int signum)
     };
 }
 
-static void signal_standard_enqueue_locked(int signum,
+static void signal_standard_enqueue_locked(signal_pending_t *p,
+                                           int signum,
                                            const signal_rt_info_t *info)
 {
     int idx = signum - 1;
     uint64_t bit = sig_bit(signum);
 
-    if (!(sig_state.pending & bit)) {
-        sig_state.std_info[idx] = info ? *info : signal_default_info(signum);
-        sig_state.std_info_valid[idx] = info != NULL;
+    if (!(p->pending & bit)) {
+        p->std_info[idx] = info ? *info : signal_default_info(signum);
+        p->std_info_valid[idx] = info != NULL;
     }
-    sig_state.pending |= bit;
+    p->pending |= bit;
 }
 
-static signal_rt_info_t signal_standard_peek_locked(int signum)
+static signal_rt_info_t signal_standard_peek_locked(signal_pending_t *p,
+                                                    int signum)
 {
     int idx = signum - 1;
-    if (sig_state.std_info_valid[idx])
-        return sig_state.std_info[idx];
+    if (p->std_info_valid[idx])
+        return p->std_info[idx];
     return signal_default_info(signum);
 }
 
-static void signal_rt_enqueue_locked(int signum, const signal_rt_info_t *info)
+static void signal_rt_enqueue_locked(signal_pending_t *p,
+                                     int signum,
+                                     const signal_rt_info_t *info)
 {
     int idx = signum - LINUX_SIGRTMIN;
     signal_rt_info_t fallback = signal_default_info(signum);
     const signal_rt_info_t *entry = info ? info : &fallback;
 
-    sig_state.pending |= sig_bit(signum);
-    if (sig_state.rt_queue[idx] >= RT_SIGQUEUE_MAX)
+    p->pending |= sig_bit(signum);
+    if (p->rt_queue[idx] >= RT_SIGQUEUE_MAX)
         return;
 
-    int tail =
-        (sig_state.rt_head[idx] + sig_state.rt_queue[idx]) % RT_SIGQUEUE_MAX;
-    sig_state.rt_info[idx][tail] = *entry;
-    sig_state.rt_queue[idx]++;
+    int tail = (p->rt_head[idx] + p->rt_queue[idx]) % RT_SIGQUEUE_MAX;
+    p->rt_info[idx][tail] = *entry;
+    p->rt_queue[idx]++;
 }
 
-static int signal_rt_dequeue_locked(int signum, signal_rt_info_t *out)
+static int signal_rt_dequeue_locked(signal_pending_t *p,
+                                    int signum,
+                                    signal_rt_info_t *out)
 {
     int idx = signum - LINUX_SIGRTMIN;
-    if (sig_state.rt_queue[idx] <= 0) {
-        sig_state.pending &= ~sig_bit(signum);
+    if (p->rt_queue[idx] <= 0) {
+        p->pending &= ~sig_bit(signum);
         return 0;
     }
 
     if (out)
-        *out = sig_state.rt_info[idx][sig_state.rt_head[idx]];
-    sig_state.rt_head[idx] =
-        (uint8_t) ((sig_state.rt_head[idx] + 1) % RT_SIGQUEUE_MAX);
-    sig_state.rt_queue[idx]--;
-    if (sig_state.rt_queue[idx] == 0) {
-        sig_state.pending &= ~sig_bit(signum);
-        sig_state.rt_head[idx] = 0;
+        *out = p->rt_info[idx][p->rt_head[idx]];
+    p->rt_head[idx] = (uint8_t) ((p->rt_head[idx] + 1) % RT_SIGQUEUE_MAX);
+    p->rt_queue[idx]--;
+    if (p->rt_queue[idx] == 0) {
+        p->pending &= ~sig_bit(signum);
+        p->rt_head[idx] = 0;
     }
     return 1;
+}
+
+/* Route a signal into a specific pending set (shared or a thread's private). */
+static void signal_enqueue_locked(signal_pending_t *p,
+                                  int signum,
+                                  const signal_rt_info_t *info)
+{
+    if (signum >= LINUX_SIGRTMIN)
+        signal_rt_enqueue_locked(p, signum, info);
+    else
+        signal_standard_enqueue_locked(p, signum, info);
+}
+
+/* Recompute the global "maybe pending" hint from the shared set plus every
+ * thread's private set. Caller holds sig_lock. The hint never produces a false
+ * negative (a real pending bit is always represented), so signal_pending()'s
+ * lock-free fast path can trust a zero result; false positives only cost one
+ * extra locked recheck.
+ */
+static void refresh_pending_hint_locked(void)
+{
+    uint64_t hint = sig_state.shared.pending | thread_pending_union();
+    atomic_store_explicit(&sig_pending_hint, hint, memory_order_release);
+}
+
+/* Signals pending for the current thread: its private (thread-directed) set
+ * unioned with the shared (process-directed) set. Caller holds sig_lock.
+ */
+static inline uint64_t self_pending_locked(void)
+{
+    uint64_t pending = sig_state.shared.pending;
+    if (current_thread)
+        pending |= current_thread->tpending.pending;
+    return pending;
 }
 
 /* Per-thread signal mask accessors. POSIX requires each thread to have its own
@@ -306,9 +344,9 @@ void signal_set_shim_globals_guest(guest_t *g)
  * callers only need this single helper.
  *
  * Also poke the wakeup pipe so a thread parked in a host poll/select/epoll/read
- * wait -- which hv_vcpus_exit cannot reach because it is not inside
- * hv_vcpu_run -- wakes and rechecks signal_pending(). Matches how exit_group
- * and futex_interrupt already signal the pipe.
+ * wait -- which hv_vcpus_exit cannot reach because it is not inside hv_vcpu_run
+ * -- wakes and rechecks signal_pending(). Matches how exit_group and
+ * futex_interrupt already signal the pipe.
  */
 static inline void attention_raise(void)
 {
@@ -373,13 +411,9 @@ void signal_queue(int signum)
     if (signum < 1 || signum > LINUX_NSIG)
         return;
     pthread_mutex_lock(&sig_lock);
-    if (signum >= LINUX_SIGRTMIN)
-        signal_rt_enqueue_locked(signum, NULL);
-    else
-        signal_standard_enqueue_locked(signum, NULL);
+    signal_enqueue_locked(&sig_state.shared, signum, NULL);
     /* Publish hint before releasing lock so vCPU hot path sees it. */
-    atomic_store_explicit(&sig_pending_hint, sig_state.pending,
-                          memory_order_release);
+    refresh_pending_hint_locked();
     pthread_mutex_unlock(&sig_lock);
 
     /* Notify any signalfd instances whose mask includes this signal. This makes
@@ -432,12 +466,8 @@ void signal_queue_info(int signum,
         .si_int = si_int,
         .si_ptr = si_ptr,
     };
-    if (signum >= LINUX_SIGRTMIN)
-        signal_rt_enqueue_locked(signum, &info);
-    else
-        signal_standard_enqueue_locked(signum, &info);
-    atomic_store_explicit(&sig_pending_hint, sig_state.pending,
-                          memory_order_release);
+    signal_enqueue_locked(&sig_state.shared, signum, &info);
+    refresh_pending_hint_locked();
     pthread_mutex_unlock(&sig_lock);
     signalfd_notify(signum);
     /* Same shim-globals attention raise as signal_queue: force the fast path
@@ -445,6 +475,83 @@ void signal_queue_info(int signum,
      */
     if (signal_should_interrupt(signum))
         attention_raise();
+}
+
+/* Thread-directed queueing (tgkill/tkill/pthread_kill). The signal lands in the
+ * target thread's private pending set, so only that thread consumes it and
+ * standard signals do not coalesce across threads. The target is resolved and
+ * the enqueue performed while holding thread_lock so a concurrent thread exit
+ * or slot reuse cannot misroute the signal.
+ *
+ * Returns true if the target was found. Lock order: sig_lock (4) then
+ * thread_lock (5).
+ */
+static bool signal_queue_thread_common(int64_t tid,
+                                       int signum,
+                                       const signal_rt_info_t *info)
+{
+    if (signum < 1 || signum > LINUX_NSIG)
+        return false;
+
+    bool found = false;
+    uint64_t blocked = 0;
+    pthread_mutex_lock(&sig_lock);
+    pthread_mutex_lock(thread_get_lock());
+    thread_entry_t *t = thread_find_locked(tid);
+    if (t) {
+        signal_enqueue_locked(&t->tpending, signum, info);
+        refresh_pending_hint_locked();
+        blocked = __atomic_load_n(&t->blocked, __ATOMIC_ACQUIRE);
+        found = true;
+    }
+    pthread_mutex_unlock(thread_get_lock());
+    pthread_mutex_unlock(&sig_lock);
+
+    if (!found)
+        return false;
+
+    /* Wake signalfd waiters. Linux backs every signalfd with the one shared
+     * sighand wait queue, so a queued signal (directed or not) wakes it and
+     * each reader re-evaluates against its own pending: the target thread finds
+     * the signal (its private set), a sibling finds nothing and reads EAGAIN.
+     * Skipping this for directed signals would leave the target thread's own
+     * signalfd wait unwoken -- the standard "block the signal, drain it via
+     * signalfd" pattern -- which matters far more than sparing a sibling a
+     * spurious wake.
+     */
+    signalfd_notify(signum);
+
+    /* Interrupt only if the signal can actually reach the target: uncatchable
+     * signals always, otherwise the target must not block it. A concurrent
+     * rt_sigprocmask unblock re-checks pending afterwards.
+     */
+    if (sig_uncatchable(signum) || !(blocked & sig_bit(signum)))
+        attention_raise();
+    return true;
+}
+
+bool signal_queue_thread(int64_t tid, int signum)
+{
+    return signal_queue_thread_common(tid, signum, NULL);
+}
+
+bool signal_queue_thread_info(int64_t tid,
+                              int signum,
+                              int32_t si_code,
+                              int32_t si_pid,
+                              uint32_t si_uid,
+                              int32_t si_int,
+                              uint64_t si_ptr)
+{
+    signal_rt_info_t info = {
+        .signum = signum,
+        .si_code = si_code,
+        .si_pid = si_pid,
+        .si_uid = si_uid,
+        .si_int = si_int,
+        .si_ptr = si_ptr,
+    };
+    return signal_queue_thread_common(tid, signum, &info);
 }
 
 void signal_set_fault_info(int si_code, uint64_t addr, uint64_t esr)
@@ -468,10 +575,12 @@ int signal_pending(void)
     if ((hint & ~blocked) == 0)
         return 0;
 
-    /* Slow path: confirm under lock */
+    /* Slow path: confirm under lock. Deliverable = this thread's private set
+     * (thread-directed) plus the shared set (process-directed), minus blocked.
+     */
     pthread_mutex_lock(&sig_lock);
     blocked = __atomic_load_n(thread_blocked_ptr(), __ATOMIC_ACQUIRE);
-    int result = (sig_state.pending & ~blocked) != 0;
+    int result = (self_pending_locked() & ~blocked) != 0;
     pthread_mutex_unlock(&sig_lock);
     return result;
 }
@@ -503,7 +612,7 @@ bool signal_pending_interruption(bool *restart_out)
 {
     pthread_mutex_lock(&sig_lock);
     uint64_t blocked = __atomic_load_n(thread_blocked_ptr(), __ATOMIC_ACQUIRE);
-    uint64_t deliverable = sig_state.pending & ~blocked;
+    uint64_t deliverable = self_pending_locked() & ~blocked;
     if (deliverable == 0) {
         pthread_mutex_unlock(&sig_lock);
         if (restart_out)
@@ -594,78 +703,95 @@ void signal_set_state(const signal_state_t *state)
     pthread_mutex_unlock(&sig_lock);
 }
 
-static size_t signal_collect_signalfd(uint64_t mask,
-                                      signal_rt_info_t *out,
-                                      size_t max,
-                                      int consume)
+size_t signal_peek_signalfd(uint64_t mask,
+                            signal_rt_info_t *out,
+                            uint8_t *src,
+                            size_t max)
 {
     size_t total = 0;
-    int rt_offset[RT_SIGNAL_COUNT] = {0};
+    /* Per-set RT read cursor so a peek does not re-report the same queued
+     * instance.
+     */
+    int rt_offset[RT_SIGNAL_COUNT];
+
+    /* signalfd observes the reading thread's private (thread-directed) set and
+     * the shared (process-directed) set, in Linux dequeue order: task->pending
+     * is drained before shared_pending. Iterate sets outer, signums inner so
+     * every private signal precedes every shared one. Consumption is a separate
+     * step (signal_take_signalfd_exact), so this only reads.
+     */
+    signal_pending_t *sets[2];
+    size_t nsets = 0;
+    if (current_thread)
+        sets[nsets++] = &current_thread->tpending;
+    sets[nsets++] = &sig_state.shared;
 
     pthread_mutex_lock(&sig_lock);
-    uint64_t deliverable = sig_state.pending & mask;
-    /* signum runs 1..LINUX_NSIG inclusive (64 is the highest valid RT signal on
-     * aarch64 Linux). Bare-musl applications can target SIGRTMAX directly, so
-     * the inclusive bound matters even though glibc reserves the top of the RT
-     * range for itself.
-     */
-    for (int signum = 1; signum <= LINUX_NSIG && total < max; signum++) {
-        uint64_t bit = BIT64(signum - 1);
-        if (!(deliverable & bit))
-            continue;
+    for (size_t s = 0; s < nsets && total < max; s++) {
+        signal_pending_t *sp = sets[s];
+        memset(rt_offset, 0, sizeof(rt_offset));
+        /* signum runs 1..LINUX_NSIG inclusive (64 is the highest valid RT
+         * signal on aarch64 Linux). Bare-musl applications can target SIGRTMAX
+         * directly, so the inclusive bound matters even though glibc reserves
+         * the top of the RT range for itself.
+         */
+        for (int signum = 1; signum <= LINUX_NSIG && total < max; signum++) {
+            uint64_t bit = BIT64(signum - 1);
+            if (!(mask & bit) || !(sp->pending & bit))
+                continue;
 
-        if (signum >= LINUX_SIGRTMIN) {
-            int idx = signum - LINUX_SIGRTMIN;
-            while (sig_state.rt_queue[idx] > 0 && total < max) {
-                signal_rt_info_t info;
-                if (consume) {
-                    info = (signal_rt_info_t) {
-                        .signum = signum,
-                        .si_code = LINUX_SI_USER,
-                        .si_pid = (int32_t) proc_get_pid(),
-                        .si_uid = proc_get_uid(),
-                    };
-                    signal_rt_dequeue_locked(signum, &info);
-                } else {
-                    if (rt_offset[idx] >= sig_state.rt_queue[idx])
-                        break;
-                    int head = sig_state.rt_head[idx];
+            if (signum >= LINUX_SIGRTMIN) {
+                int idx = signum - LINUX_SIGRTMIN;
+                while (rt_offset[idx] < sp->rt_queue[idx] && total < max) {
+                    int head = sp->rt_head[idx];
                     int slot = (head + rt_offset[idx]) % RT_SIGQUEUE_MAX;
-                    info = sig_state.rt_info[idx][slot];
+                    if (out)
+                        out[total] = sp->rt_info[idx][slot];
+                    if (src)
+                        src[total] = (uint8_t) s;
                     rt_offset[idx]++;
+                    total++;
                 }
+            } else {
                 if (out)
-                    out[total] = info;
+                    out[total] = signal_standard_peek_locked(sp, signum);
+                if (src)
+                    src[total] = (uint8_t) s;
                 total++;
             }
-        } else {
-            signal_rt_info_t info = signal_standard_peek_locked(signum);
-            if (consume)
-                sig_state.std_info_valid[signum - 1] = false;
-            if (consume)
-                sig_state.pending &= ~bit;
-            if (out)
-                out[total] = info;
-            total++;
         }
-    }
-    if (consume) {
-        atomic_store_explicit(&sig_pending_hint, sig_state.pending,
-                              memory_order_release);
     }
     pthread_mutex_unlock(&sig_lock);
 
     return total;
 }
 
-size_t signal_peek_signalfd(uint64_t mask, signal_rt_info_t *out, size_t max)
+uint64_t signal_signalfd_pending_mask(void)
 {
-    return signal_collect_signalfd(mask, out, max, 0);
+    pthread_mutex_lock(&sig_lock);
+    uint64_t m = self_pending_locked();
+    pthread_mutex_unlock(&sig_lock);
+    return m;
 }
 
-size_t signal_take_signalfd_exact(const signal_rt_info_t *expected, size_t max)
+void signal_refresh_pending_hint(void)
+{
+    pthread_mutex_lock(&sig_lock);
+    refresh_pending_hint_locked();
+    pthread_mutex_unlock(&sig_lock);
+}
+
+size_t signal_take_signalfd_exact(const signal_rt_info_t *expected,
+                                  const uint8_t *src,
+                                  size_t max)
 {
     size_t total = 0;
+
+    signal_pending_t *sets[2];
+    size_t nsets = 0;
+    if (current_thread)
+        sets[nsets++] = &current_thread->tpending;
+    sets[nsets++] = &sig_state.shared;
 
     pthread_mutex_lock(&sig_lock);
     for (; total < max; total++) {
@@ -673,17 +799,24 @@ size_t signal_take_signalfd_exact(const signal_rt_info_t *expected, size_t max)
         if (signum <= 0 || signum > LINUX_NSIG)
             break;
 
+        /* Consume from the exact set this entry was peeked from. A same-valued
+         * instance in the other set must not be substituted -- that would drop
+         * a signal the reader never returned.
+         */
+        size_t s = src[total];
+        if (s >= nsets)
+            break;
+        signal_pending_t *sp = sets[s];
         uint64_t bit = sig_bit(signum);
-        if (!(sig_state.pending & bit))
+        if (!(sp->pending & bit))
             break;
 
+        const signal_rt_info_t *want = &expected[total];
         if (signum >= LINUX_SIGRTMIN) {
             int idx = signum - LINUX_SIGRTMIN;
-            if (sig_state.rt_queue[idx] <= 0)
+            if (sp->rt_queue[idx] <= 0)
                 break;
-            const signal_rt_info_t *head =
-                &sig_state.rt_info[idx][sig_state.rt_head[idx]];
-            const signal_rt_info_t *want = &expected[total];
+            const signal_rt_info_t *head = &sp->rt_info[idx][sp->rt_head[idx]];
             /* Compare field by field; signal_rt_info_t has padding between
              * si_int and si_ptr that memcmp would treat as significant.
              */
@@ -692,23 +825,21 @@ size_t signal_take_signalfd_exact(const signal_rt_info_t *expected, size_t max)
                 head->si_pid != want->si_pid || head->si_uid != want->si_uid ||
                 head->si_int != want->si_int || head->si_ptr != want->si_ptr)
                 break;
-            signal_rt_dequeue_locked(signum, NULL);
-            continue;
+            signal_rt_dequeue_locked(sp, signum, NULL);
+        } else {
+            signal_rt_info_t current = signal_standard_peek_locked(sp, signum);
+            if (current.signum != want->signum ||
+                current.si_code != want->si_code ||
+                current.si_pid != want->si_pid ||
+                current.si_uid != want->si_uid ||
+                current.si_int != want->si_int ||
+                current.si_ptr != want->si_ptr)
+                break;
+            sp->std_info_valid[signum - 1] = false;
+            sp->pending &= ~bit;
         }
-
-        signal_rt_info_t current = signal_standard_peek_locked(signum);
-        const signal_rt_info_t *want = &expected[total];
-        if (current.signum != want->signum ||
-            current.si_code != want->si_code ||
-            current.si_pid != want->si_pid || current.si_uid != want->si_uid ||
-            current.si_int != want->si_int || current.si_ptr != want->si_ptr)
-            break;
-
-        sig_state.std_info_valid[signum - 1] = false;
-        sig_state.pending &= ~bit;
     }
-    atomic_store_explicit(&sig_pending_hint, sig_state.pending,
-                          memory_order_release);
+    refresh_pending_hint_locked();
     pthread_mutex_unlock(&sig_lock);
 
     return total;
@@ -1119,10 +1250,8 @@ int64_t signal_rt_sigprocmask(guest_t *g,
          * unblocked it.
          */
         uint64_t newly_unblocked = old_blocked & ~*blocked;
-        if (newly_unblocked & sig_state.pending) {
-            atomic_store_explicit(&sig_pending_hint, sig_state.pending,
-                                  memory_order_release);
-        }
+        if (newly_unblocked & self_pending_locked())
+            refresh_pending_hint_locked();
     }
 
     pthread_mutex_unlock(&sig_lock);
@@ -1159,7 +1288,7 @@ int64_t signal_rt_sigsuspend(guest_t *g, uint64_t mask_gva, uint64_t sigsetsize)
          * If yes, the vCPU loop will deliver it. If no, restore the mask; the
          * caller will loop (musl retries on -EINTR).
          */
-        if (!(sig_state.pending & ~*blocked)) {
+        if (!(self_pending_locked() & ~*blocked)) {
             *blocked = saved_blocked;
         }
         /* If a signal IS pending, the mask stays temporarily modified.
@@ -1190,11 +1319,12 @@ int64_t signal_rt_sigpending(guest_t *g, uint64_t set_gva, uint64_t sigsetsize)
         return -LINUX_EFAULT;
 
     pthread_mutex_lock(&sig_lock);
-    /* Return all pending signals (matching Linux kernel do_sigpending). In
-     * practice unblocked signals are delivered before sigpending can observe
-     * them, but returning the full set is strictly correct.
+    /* Return all pending signals (matching Linux kernel do_sigpending): the
+     * calling thread's private set unioned with the shared set. In practice
+     * unblocked signals are delivered before sigpending can observe them, but
+     * returning the full set is strictly correct.
      */
-    uint64_t result = sig_state.pending;
+    uint64_t result = self_pending_locked();
     pthread_mutex_unlock(&sig_lock);
 
     if (guest_write_small(g, set_gva, &result, sizeof(result)) < 0)
@@ -1317,9 +1447,10 @@ static void build_sigcontext_reserved(uint8_t *reserved,
  * signal_deliver() (signal selected from the process-wide pending set) and
  * signal_deliver_fault() (synchronous fault forced onto the faulting thread).
  * rt_info supplies si_code/si_pid/sigval when no thread-local pending_fault is
- * set; the pending_fault is consumed (one-shot) when valid. Returns 1 if a
- * handler frame was installed, 0 if the signal was ignored, and -1 (with
- * *exit_code set) when the default disposition terminates the guest.
+ * set; the pending_fault is consumed (one-shot) when valid.
+ *
+ * Returns 1 if a handler frame was installed, 0 if the signal was ignored, and
+ * -1 (with *exit_code set) when the default disposition terminates the guest.
  */
 static int deliver_signal_locked(hv_vcpu_t vcpu,
                                  guest_t *g,
@@ -1619,27 +1750,49 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
 {
     pthread_mutex_lock(&sig_lock);
     uint64_t *blocked = thread_blocked_ptr();
-    uint64_t deliverable = sig_state.pending & ~*blocked;
-    if (deliverable == 0) {
+    /* Consider this thread's private (thread-directed) set plus the shared
+     * (process-directed) set. Linux dequeue_signal() drains task->pending
+     * before signal->shared_pending, so for a given signum the private instance
+     * wins.
+     */
+    signal_pending_t *tp = current_thread ? &current_thread->tpending : NULL;
+    uint64_t thread_d = tp ? (tp->pending & ~*blocked) : 0;
+    uint64_t shared_d = sig_state.shared.pending & ~*blocked;
+    if ((thread_d | shared_d) == 0) {
         pthread_mutex_unlock(&sig_lock);
         return 0;
     }
 
-    /* Find lowest pending unblocked signal */
-    int signum = bit_ctz64(deliverable) + 1;
+    /* Linux dequeue_signal() drains task->pending before shared_pending, so the
+     * private set wins even when the shared set holds a lower signal number.
+     * Within the chosen set, pick the lowest pending unblocked signal.
+     */
+    int signum;
+    signal_pending_t *src;
+    if (thread_d) {
+        signum = bit_ctz64(thread_d) + 1;
+        src = tp;
+    } else {
+        signum = bit_ctz64(shared_d) + 1;
+        src = &sig_state.shared;
+    }
     signal_rt_info_t rt_info = signal_default_info(signum);
 
-    /* Dequeue: for RT signals, decrement count and only clear the
-     * pending bit when the queue is empty. Standard signals are
-     * always cleared (single instance, bitmask semantics).
+    /* Dequeue: for RT signals, decrement count and only clear the pending bit
+     * when the queue is empty. Standard signals are always cleared (single
+     * instance, bitmask semantics).
      */
     if (signum >= LINUX_SIGRTMIN) {
-        signal_rt_dequeue_locked(signum, &rt_info);
+        signal_rt_dequeue_locked(src, signum, &rt_info);
     } else {
-        rt_info = signal_standard_peek_locked(signum);
-        sig_state.std_info_valid[signum - 1] = false;
-        sig_state.pending &= ~sig_bit(signum);
+        rt_info = signal_standard_peek_locked(src, signum);
+        src->std_info_valid[signum - 1] = false;
+        src->pending &= ~sig_bit(signum);
     }
+    /* A directed dequeue cleared a bit that only this thread's set held, so the
+     * global hint must be recomputed from the surviving pending state.
+     */
+    refresh_pending_hint_locked();
 
     return deliver_signal_locked(vcpu, g, signum, rt_info, exit_code);
 }
@@ -1661,9 +1814,9 @@ int signal_deliver_fault(hv_vcpu_t vcpu, guest_t *g, int signum, int *exit_code)
     /* Linux force_sig_info_to_task(): a forced synchronous fault cannot be
      * postponed or ignored. If the disposition is SIG_IGN or the signum is
      * blocked, reset to SIG_DFL and unblock before delivery, so the default
-     * disposition terminates the process instead of resuming at the faulting
-     * PC (SIG_IGN would re-fault forever) or running a handler the guest
-     * asked to block.
+     * disposition terminates the process instead of resuming at the faulting PC
+     * (SIG_IGN would re-fault forever) or running a handler the guest asked to
+     * block.
      */
     int idx = signum - 1;
     if (RANGE_CHECK(idx, 0, LINUX_NSIG)) {

--- a/src/syscall/signal.h
+++ b/src/syscall/signal.h
@@ -176,15 +176,15 @@ typedef struct {
     uint64_t si_ptr;
 } signal_rt_info_t;
 
-/* Signal state. */
+/* One pending-signal set. Linux keeps two of these per task: the thread's
+ * private set (task->pending, targeted by tgkill/tkill) and the thread-group
+ * shared set (signal->shared_pending, targeted by kill). elfuse mirrors that:
+ * signal_state_t holds one shared instance and each thread_entry_t holds its
+ * own private instance. Delivery drains the current thread's private set first,
+ * then the shared set.
+ */
 typedef struct {
-    linux_sigaction_t actions[LINUX_NSIG]; /* Per-signal handler state */
-    uint64_t pending;                      /* Bitmask of pending signals */
-    uint64_t blocked;                      /* Bitmask of blocked signals */
-    uint64_t saved_blocked;                /* Original mask before sigsuspend */
-    bool saved_blocked_valid;              /* True if saved_blocked is set */
-    linux_stack_t altstack; /* Alternate signal stack (sigaltstack) */
-    bool on_altstack;       /* True if currently delivering on altstack */
+    uint64_t pending; /* Bitmask of pending signals in this set */
     /* Standard signal metadata: Linux coalesces signals 1-31, but preserves one
      * siginfo payload for the pending instance.
      */
@@ -197,6 +197,17 @@ typedef struct {
     int rt_queue[RT_SIGNAL_COUNT];
     uint8_t rt_head[RT_SIGNAL_COUNT];
     signal_rt_info_t rt_info[RT_SIGNAL_COUNT][RT_SIGQUEUE_MAX];
+} signal_pending_t;
+
+/* Signal state. */
+typedef struct {
+    linux_sigaction_t actions[LINUX_NSIG]; /* Per-signal handler state */
+    signal_pending_t shared;               /* Process-directed pending set */
+    uint64_t blocked;                      /* Bitmask of blocked signals */
+    uint64_t saved_blocked;                /* Original mask before sigsuspend */
+    bool saved_blocked_valid;              /* True if saved_blocked is set */
+    linux_stack_t altstack; /* Alternate signal stack (sigaltstack) */
+    bool on_altstack;       /* True if currently delivering on altstack */
 } signal_state_t;
 
 /* API */
@@ -210,8 +221,28 @@ void signal_init(void);
  */
 void signal_reset_for_exec(void);
 
-/* Queue a signal for delivery. */
+/* Queue a process-directed signal (kill(2) semantics): lands in the shared
+ * pending set, delivered to whichever eligible thread reaches a delivery point
+ * first.
+ */
 void signal_queue(int signum);
+
+/* Queue a thread-directed signal (tgkill/tkill semantics): lands in the target
+ * thread's private pending set so only that thread consumes it, and standard
+ * signals do not coalesce across threads. The target is resolved by guest tid
+ * and enqueued atomically against thread-slot reuse.
+ *
+ * Returns true if the target thread was found (and the signal queued), false
+ * otherwise (caller maps false to -ESRCH).
+ */
+bool signal_queue_thread(int64_t tid, int signum);
+bool signal_queue_thread_info(int64_t tid,
+                              int signum,
+                              int32_t si_code,
+                              int32_t si_pid,
+                              uint32_t si_uid,
+                              int32_t si_int,
+                              uint64_t si_ptr);
 
 /* Queue an RT signal with sender metadata and payload from sigqueue. */
 void signal_queue_rt(int signum,
@@ -239,6 +270,15 @@ void signal_queue_info(int signum,
  * appended to __reserved after FPSIMD.
  */
 void signal_set_fault_info(int si_code, uint64_t addr, uint64_t esr);
+
+/* Recompute the global pending hint (shared set OR every active thread's
+ * private set) under sig_lock. Call after a thread exits so its unconsumed
+ * thread-directed pending bits stop keeping the identity-syscall fast path
+ * disabled. Must NOT be called while holding thread_lock (sig_lock <
+ * thread_lock in the lock order); the exiting thread's slot must already be
+ * inactive so the union excludes it.
+ */
+void signal_refresh_pending_hint(void);
 
 /* Check if any unblocked signal is pending. */
 int signal_pending(void);
@@ -284,8 +324,8 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code);
  *
  * Follows Linux force_sig_info_to_task() semantics: a SIG_IGN or blocked
  * disposition is reset to SIG_DFL and unblocked before delivery, so an
- * unhandleable fault terminates the process rather than re-faulting forever
- * or invoking a handler the guest asked to block.
+ * unhandleable fault terminates the process rather than re-faulting forever or
+ * invoking a handler the guest asked to block.
  */
 int signal_deliver_fault(hv_vcpu_t vcpu,
                          guest_t *g,
@@ -333,10 +373,26 @@ void signal_set_state(const signal_state_t *state);
 /* Snapshot or consume pending signals for signalfd. signal_peek_signalfd()
  * snapshots up to max matching entries without consuming them.
  * signal_take_signalfd_exact() then consumes those exact entries, preserving
- * any matching signals that arrived later.
+ * any matching signals that arrived later. Peek fills out[] with matching
+ * pending siginfo and, when src is non-NULL, tags each entry with the pending
+ * set it came from (0 = the reading thread's private set, 1 = the shared set).
+ * signal_take_signalfd_exact() must be handed that same src array so it
+ * consumes each entry from the exact set it was peeked from, never a
+ * same-valued entry in the other set.
  */
-size_t signal_peek_signalfd(uint64_t mask, signal_rt_info_t *out, size_t max);
-size_t signal_take_signalfd_exact(const signal_rt_info_t *expected, size_t max);
+size_t signal_peek_signalfd(uint64_t mask,
+                            signal_rt_info_t *out,
+                            uint8_t *src,
+                            size_t max);
+size_t signal_take_signalfd_exact(const signal_rt_info_t *expected,
+                                  const uint8_t *src,
+                                  size_t max);
+
+/* Bitmask of signals a signalfd read on the current thread could observe: the
+ * shared set unioned with this thread's private (thread-directed) set. Used to
+ * gate the signalfd fast path before peeking.
+ */
+uint64_t signal_signalfd_pending_mask(void);
 
 /* Save and restore blocked mask for pselect6/ppoll signal mask atomicity.
  * signal_save_blocked returns the current blocked mask. signal_set_blocked

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -912,6 +912,35 @@ static int64_t sc_kill(guest_t *g,
     return -LINUX_ESRCH;
 }
 
+/* tkill(tid, sig): the legacy 2-arg thread-directed kill. Same routing as
+ * tgkill but without a thread-group id to validate. Modern libcs use tgkill;
+ * tkill remains for older or bare callers.
+ */
+static int64_t sc_tkill(guest_t *g,
+                        uint64_t x0,
+                        uint64_t x1,
+                        uint64_t x2,
+                        uint64_t x3,
+                        uint64_t x4,
+                        uint64_t x5,
+                        bool verbose)
+{
+    (void) g;
+    (void) x2;
+    (void) x3;
+    (void) x4;
+    (void) x5;
+    (void) verbose;
+    int tid = (int) x0, sig = (int) x1;
+    if (sig < 0 || sig > LINUX_NSIG)
+        return -LINUX_EINVAL;
+    if (tid <= 0)
+        return -LINUX_EINVAL;
+    if (sig == 0)
+        return thread_tid_alive((int64_t) tid) ? 0 : -LINUX_ESRCH;
+    return signal_queue_thread((int64_t) tid, sig) ? 0 : -LINUX_ESRCH;
+}
+
 static int64_t sc_tgkill(guest_t *g,
                          uint64_t x0,
                          uint64_t x1,
@@ -926,20 +955,105 @@ static int64_t sc_tgkill(guest_t *g,
     (void) x4;
     (void) x5;
     (void) verbose;
-    int sig = (int) x2, tid = (int) x1;
+    int tgid = (int) x0, tid = (int) x1, sig = (int) x2;
     if (sig < 0 || sig > LINUX_NSIG)
         return -LINUX_EINVAL;
-    thread_entry_t *target = thread_find((int64_t) tid);
-    if (!target) {
-        if (tid == (int) proc_get_pid())
-            target = current_thread;
-    }
-    if (target) {
-        if (sig > 0)
-            signal_queue(sig);
+    if (tgid <= 0 || tid <= 0)
+        return -LINUX_EINVAL;
+    /* All guest threads share the single guest tgid; a mismatch names a thread
+     * that is not in this group (or a foreign process elfuse cannot reach),
+     * which Linux reports as -ESRCH.
+     */
+    if (tgid != (int) proc_get_pid())
+        return -LINUX_ESRCH;
+    /* sig == 0 is the existence/permission probe: report whether the thread is
+     * live without queueing anything.
+     */
+    if (sig == 0)
+        return thread_tid_alive((int64_t) tid) ? 0 : -LINUX_ESRCH;
+    /* Thread-directed: only the target thread consumes it (Linux
+     * task->pending). The enqueue resolves and validates the tid atomically.
+     */
+    return signal_queue_thread((int64_t) tid, sig) ? 0 : -LINUX_ESRCH;
+}
+
+/* Shared body for rt_tgsigqueueinfo (directed=true, thread-targeted) and
+ * rt_sigqueueinfo (directed=false, process-targeted). Existence is resolved by
+ * guest tid (thread_tid_alive accepts any live thread, including the main
+ * thread whose tid equals the pid). tgsigqueueinfo queues into the target
+ * thread's private set; sigqueueinfo queues into the shared set.
+ */
+static int64_t rt_sigqueueinfo_impl(guest_t *g,
+                                    int tid,
+                                    int sig,
+                                    uint64_t uinfo_gva,
+                                    bool directed)
+{
+    if (sig < 0 || sig > LINUX_NSIG)
+        return -LINUX_EINVAL;
+    if (!thread_tid_alive((int64_t) tid))
+        return -LINUX_ESRCH;
+    /* sig == 0 is the existence/permission probe: the target is live, queue
+     * nothing.
+     */
+    if (sig == 0)
         return 0;
+    linux_siginfo_t info;
+    memset(&info, 0, sizeof(info));
+    if (uinfo_gva && guest_read_small(g, uinfo_gva, &info, sizeof(info)) < 0) {
+        log_debug("rt_sigqueueinfo(tid=%d, sig=%d, uinfo=0x%llx [unreadable])",
+                  tid, sig, (unsigned long long) uinfo_gva);
+        return -LINUX_EFAULT;
     }
-    return -LINUX_ESRCH;
+    if (uinfo_gva) {
+        bool is_fault =
+            (sig == LINUX_SIGTRAP || sig == LINUX_SIGSEGV ||
+             sig == LINUX_SIGBUS || sig == LINUX_SIGFPE || sig == LINUX_SIGILL);
+        if (is_fault && info.si_code > 0) {
+            uint64_t fault_addr;
+            memcpy(&fault_addr, &info.si_pid, sizeof(fault_addr));
+            signal_set_fault_info(info.si_code, fault_addr, 0);
+            log_debug(
+                "rt_sigqueueinfo(tid=%d, sig=%d, si_code=%d, "
+                "fault_addr=0x%llx)",
+                tid, sig, info.si_code, (unsigned long long) fault_addr);
+        } else
+            log_debug("rt_sigqueueinfo(tid=%d, sig=%d, si_code=%d)", tid, sig,
+                      info.si_code);
+    }
+    /* Queued signals carry sigval in si_value for both standard and RT signals;
+     * standard signals still coalesce to one pending instance.
+     */
+    int32_t si_int = 0;
+    uint64_t si_ptr = 0;
+    if (uinfo_gva) {
+        memcpy(&si_int, &info.si_value, sizeof(si_int));
+        memcpy(&si_ptr, &info.si_value, sizeof(si_ptr));
+    }
+    if (directed) {
+        bool queued = uinfo_gva
+                          ? signal_queue_thread_info(
+                                (int64_t) tid, sig, info.si_code, info.si_pid,
+                                (uint32_t) info.si_uid, si_int, si_ptr)
+                          : signal_queue_thread((int64_t) tid, sig);
+        /* The target may have exited between the liveness check and the
+         * enqueue; report -ESRCH as Linux would for a vanished thread.
+         */
+        return queued ? 0 : -LINUX_ESRCH;
+    }
+    /* Process-directed: queue into the shared set. Existence was checked
+     * lock-free above; if the named tid was a worker that exits in the gap, the
+     * signal still lands in the surviving thread group and this returns 0 where
+     * Linux would -ESRCH. The window is nanoseconds and the common sigqueue
+     * target is the group leader (tid == pid), which never exits before the
+     * process, so the shared enqueue is left lock-free.
+     */
+    if (uinfo_gva)
+        signal_queue_info(sig, info.si_code, info.si_pid,
+                          (uint32_t) info.si_uid, si_int, si_ptr);
+    else
+        signal_queue(sig);
+    return 0;
 }
 
 static int64_t sc_rt_tgsigqueueinfo(guest_t *g,
@@ -953,57 +1067,15 @@ static int64_t sc_rt_tgsigqueueinfo(guest_t *g,
 {
     (void) x4;
     (void) x5;
-    int tgid = (int) x0, tid = (int) x1, sig = (int) x2;
-    uint64_t uinfo_gva = x3;
-    (void) tgid;
-    if (sig < 1 || sig > LINUX_NSIG)
+    (void) verbose;
+    /* x0=tgid, x1=tid, x2=sig, x3=uinfo. */
+    int tgid = (int) x0, tid = (int) x1;
+    if (tgid <= 0 || tid <= 0)
         return -LINUX_EINVAL;
-    thread_entry_t *target = thread_find((int64_t) tid);
-    if (!target) {
-        if (tid == (int) proc_get_pid())
-            target = current_thread;
-    }
-    if (!target)
+    /* All guest threads share the single guest tgid; a mismatch is -ESRCH. */
+    if (tgid != (int) proc_get_pid())
         return -LINUX_ESRCH;
-    linux_siginfo_t info;
-    memset(&info, 0, sizeof(info));
-    if (uinfo_gva && guest_read_small(g, uinfo_gva, &info, sizeof(info)) < 0) {
-        log_debug(
-            "rt_tgsigqueueinfo(tgid=%d, tid=%d, sig=%d, "
-            "uinfo=0x%llx [unreadable])",
-            tgid, tid, sig, (unsigned long long) uinfo_gva);
-        return -LINUX_EFAULT;
-    }
-    if (uinfo_gva) {
-        bool is_fault =
-            (sig == LINUX_SIGTRAP || sig == LINUX_SIGSEGV ||
-             sig == LINUX_SIGBUS || sig == LINUX_SIGFPE || sig == LINUX_SIGILL);
-        if (is_fault && info.si_code > 0) {
-            uint64_t fault_addr;
-            memcpy(&fault_addr, &info.si_pid, sizeof(fault_addr));
-            signal_set_fault_info(info.si_code, fault_addr, 0);
-            log_debug(
-                "rt_tgsigqueueinfo(tgid=%d, tid=%d, sig=%d, "
-                "si_code=%d, fault_addr=0x%llx)",
-                tgid, tid, sig, info.si_code, (unsigned long long) fault_addr);
-        } else
-            log_debug("rt_tgsigqueueinfo(tgid=%d, tid=%d, sig=%d, si_code=%d)",
-                      tgid, tid, sig, info.si_code);
-    }
-    /* Queued signals carry sigval in si_value for both standard and RT signals;
-     * standard signals still coalesce to one pending instance.
-     */
-    if (uinfo_gva) {
-        int32_t si_int = 0;
-        memcpy(&si_int, &info.si_value, sizeof(si_int));
-        uint64_t si_ptr = 0;
-        memcpy(&si_ptr, &info.si_value, sizeof(si_ptr));
-        signal_queue_info(sig, info.si_code, info.si_pid,
-                          (uint32_t) info.si_uid, si_int, si_ptr);
-    } else {
-        signal_queue(sig);
-    }
-    return 0;
+    return rt_sigqueueinfo_impl(g, tid, (int) x2, x3, true);
 }
 
 /* rt_sigqueueinfo(pid, sig, info) -- POSIX sigqueue() in glibc/musl uses this.
@@ -1011,15 +1083,13 @@ static int64_t sc_rt_tgsigqueueinfo(guest_t *g,
  * The first argument is documented as a process identifier, but real Linux is
  * permissive: kill_pid_info() looks pid up in the task table and routes the
  * signal through PIDTYPE_TGID, so a thread id that resolves to a task succeeds
- * and the signal lands in that task's thread-group pending set. Foreign pids
- * that match no task return -ESRCH.
+ * and the signal lands in that task's thread-group (shared) pending set.
+ * Foreign pids that match no task return -ESRCH.
  *
- * elfuse mirrors this by forwarding to sc_rt_tgsigqueueinfo with
- * tgid==tid==pid: the downstream thread_find() lookup accepts any guest
- * thread's tid (collapsing to the single guest tgid), the proc_get_pid()
- * fallback accepts the main thread's tid, and unknown pids fall through to
- * -ESRCH. signal_queue_info() then queues process-wide so the routing semantics
- * match Linux even though the lookup goes through the per-thread table.
+ * elfuse mirrors this with directed=false so the signal queues into the shared
+ * set: the thread_find() lookup accepts any guest thread's tid (collapsing to
+ * the single guest tgid), the proc_get_pid() fallback accepts the main thread's
+ * tid, and unknown pids fall through to -ESRCH.
  *
  * Earlier review feedback flagged "incorrectly accepting thread ids" and
  * recommended a strict pid==tgid gate; that gate was tried and rejected because
@@ -1037,7 +1107,9 @@ static int64_t sc_rt_sigqueueinfo(guest_t *g,
     (void) x3;
     (void) x4;
     (void) x5;
-    return sc_rt_tgsigqueueinfo(g, x0, x0, x1, x2, 0, 0, verbose);
+    (void) verbose;
+    /* x0=pid, x1=sig, x2=uinfo. */
+    return rt_sigqueueinfo_impl(g, (int) x0, (int) x1, x2, false);
 }
 
 static int64_t sc_rt_sigreturn(guest_t *g,

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#
 # Run aarch64 test suites under both elfuse and self-contained QEMU.
 #
 # Copyright 2026 elfuse contributors
@@ -24,8 +23,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FIXTURES="${REPO_ROOT}/externals/test-fixtures"
-# Allow tests to point the translator probe at a missing path to exercise
-# the non-Rosetta-host skip path without uninstalling the translator.
+# Allow tests to point the translator probe at a missing path to exercise the
+# non-Rosetta-host skip path without uninstalling the translator.
 : "${MATRIX_ROSETTA_TRANSLATOR:=/Library/Apple/usr/libexec/oah/RosettaLinux/rosetta}"
 
 MODE="${1:?Usage: $0 <elfuse-aarch64|qemu-aarch64|elfuse-x86_64|all>}"
@@ -33,9 +32,8 @@ MODE="${1:?Usage: $0 <elfuse-aarch64|qemu-aarch64|elfuse-x86_64|all>}"
 # Tool paths.
 ELFUSE="${ELFUSE:-${REPO_ROOT}/build/elfuse}"
 
-# Default fixture paths.
-# Each variable points at the actual directory (or file for busybox);
-# no implicit /bin suffix is appended.
+# Default fixture paths. Each variable points at the actual directory (or file
+# for busybox); no implicit /bin suffix is appended.
 : "${GUEST_TEST_BINARIES:=${REPO_ROOT}/build}"
 : "${GUEST_COREUTILS:=${FIXTURES}/aarch64-musl/staticbin/bin}"
 : "${GUEST_BUSYBOX:=${FIXTURES}/aarch64-musl/staticbin/bin/busybox}"
@@ -45,9 +43,9 @@ ELFUSE="${ELFUSE:-${REPO_ROOT}/build/elfuse}"
 : "${GUEST_GLIBC_SYSROOT:=}"
 : "${GUEST_GLIBC_DYNAMIC_COREUTILS:=}"
 
-# x86_64-via-Rosetta fixture roots. Populated by scripts/fetch-fixtures.sh
-# once the x86_64 corpus lands. Empty defaults make the suite skip cleanly
-# on hosts where the fixtures are not yet present.
+# x86_64-via-Rosetta fixture roots. Populated by scripts/fetch-fixtures.sh once
+# the x86_64 corpus lands. Empty defaults make the suite skip cleanly on hosts
+# where the fixtures are not yet present.
 : "${GUEST_X86_64_TEST_BINARIES:=${FIXTURES}/x86_64-musl/test-bin}"
 : "${GUEST_X86_64_COREUTILS:=${FIXTURES}/x86_64-musl/staticbin/bin}"
 : "${GUEST_X86_64_BUSYBOX:=${FIXTURES}/x86_64-musl/staticbin/bin/busybox}"
@@ -57,8 +55,8 @@ ELFUSE="${ELFUSE:-${REPO_ROOT}/build/elfuse}"
 : "${GUEST_X86_64_GLIBC_SYSROOT:=}"
 : "${GUEST_X86_64_GLIBC_DYNAMIC_COREUTILS:=}"
 
-# Reuse the shared per-test reporter so the output matches 'make check'
-# (which drives tests through tests/driver.sh). TEST_LABEL_WIDTH controls the
+# Reuse the shared per-test reporter so the output matches 'make check' (which
+# drives tests through tests/driver.sh). TEST_LABEL_WIDTH controls the
 # left-aligned name column and must be set before the source so the helper
 # library picks it up.
 # shellcheck disable=SC2034  # Consumed by tests/lib/test-runner.sh.
@@ -66,8 +64,8 @@ TEST_LABEL_WIDTH=45
 # shellcheck source=tests/lib/test-runner.sh
 source "${REPO_ROOT}/tests/lib/test-runner.sh"
 
-# Globals (test-runner.sh seeds pass/fail/skip; test-matrix.sh resets them
-# per mode and tracks no extra counters).
+# Globals (test-runner.sh seeds pass/fail/skip; test-matrix.sh resets them per
+# mode and tracks no extra counters).
 pass=0
 fail=0
 skip=0
@@ -141,10 +139,9 @@ cleanup_qemu()
 
 trap 'cleanup_fixtures; cleanup_qemu' EXIT
 
-# Launch helpers.
-# When the binary being launched lives under GUEST_SYSROOT (i.e., it's a
-# dynamically-linked Alpine binary), pass --sysroot so the loader can find
-# its libc.  Static binaries from build/ run unchanged.
+# Launch helpers. When the binary being launched lives under GUEST_SYSROOT
+# (i.e., it's a dynamically-linked Alpine binary), pass --sysroot so the loader
+# can find its libc. Static binaries from build/ run unchanged.
 run_elfuse()
 {
     local first="${1:-}" args=()
@@ -158,11 +155,10 @@ run_elfuse()
 }
 
 # 'timeout' cannot wrap a shell function, so this runner inlines the path
-# rewriting + ssh invocation that qemu_exec would otherwise do.
-# Repo paths under REPO_ROOT are rewritten to /mnt/host/...; the remote
-# command is launched with cwd=/mnt/host so unqualified paths in test
-# arguments (e.g. "tests/hello.S") resolve against the
-# 9p-shared repo just like in elfuse mode.
+# rewriting + ssh invocation that qemu_exec would otherwise do. Repo paths under
+# REPO_ROOT are rewritten to /mnt/host/...; the remote command is launched with
+# cwd=/mnt/host so unqualified paths in test arguments (e.g. "tests/hello.S")
+# resolve against the 9p-shared repo just like in elfuse mode.
 run_qemu()
 {
     local args=() a
@@ -247,14 +243,13 @@ unstage_sysroot_fixtures()
 
 # Generic test helpers.
 
-# Tests that either hang under qemu-system-aarch64 on Apple Silicon
-# (raw clone / PI futex / massive thread+mmap stress) or currently diverge
-# from the Alpine linux-virt reference kernel on the deprecated oom_adj
-# procfs compatibility path exercised by test-io-opt. test-sysfs-cpu asserts
-# the elfuse stub contract (cache/topology subtree empty, possible == online,
-# cpuN count == online count) which a real kernel does not honor. All listed
-# tests still run in elfuse-aarch64 mode and in 'make check'; the qemu
-# reference run skips them.
+# Tests that either hang under qemu-system-aarch64 on Apple Silicon (raw clone /
+# PI futex / massive thread+mmap stress) or currently diverge from the Alpine
+# linux-virt reference kernel on the deprecated oom_adj procfs compatibility
+# path exercised by test-io-opt. test-sysfs-cpu asserts the elfuse stub contract
+# (cache/topology subtree empty, possible == online, cpuN count == online count)
+# which a real kernel does not honor. All listed tests still run in
+# elfuse-aarch64 mode and in 'make check'; the qemu reference run skips them.
 QEMU_SKIP="test-thread test-stress test-futex-pi test-osync-requeue test-io-opt test-sysfs-cpu"
 
 is_qemu_skipped()
@@ -266,8 +261,10 @@ is_qemu_skipped()
     esac
 }
 
-# Honor QEMU_SKIP across all test_* wrappers.  Returns 0 (and prints SKIP)
-# if the caller should not run the test; non-zero means proceed.
+# Honor QEMU_SKIP across all test_* wrappers.
+#
+# Returns 0 (and prints SKIP) if the caller should not run the test; non-zero
+# means proceed.
 maybe_qemu_skip()
 {
     local runner="$1" label="$2"
@@ -287,12 +284,12 @@ report_timeout()
     fail=$((fail + 1))
 }
 
-# Account for an optional binary or fixture being absent. The previous
-# pattern ('if [ -e "$bin/X" ]; then test_check ... fi') silently erased
-# the assertion when X was missing, so the suite summary could report
-# "all passed" while major coverage blocks never ran. require_binary
-# always increments skip and emits a skip line, so absences are visible
-# in the summary line at the bottom of each mode.
+# Account for an optional binary or fixture being absent. The previous pattern
+# ('if [ -e "$bin/X" ]; then test_check ... fi') silently erased the assertion
+# when X was missing, so the suite summary could report "all passed" while major
+# coverage blocks never ran. require_binary always increments skip and emits a
+# skip line, so absences are visible in the summary line at the bottom of each
+# mode.
 require_binary()
 {
     local label="$1" path="$2"
@@ -331,9 +328,9 @@ run_summary_suite()
     if [ -n "$fields" ]; then
         local suite_pass=0 suite_fail=0 suite_skip=0 suite_total=0
         read -r suite_pass suite_fail suite_skip suite_total <<< "$fields"
-        # Force decimal: a sub-suite that ever emits a zero-padded count
-        # ('08', '09') would otherwise trip bash's "invalid octal" error
-        # inside $((...)) and abort the matrix under 'set -e'.
+        # Force decimal: a sub-suite that ever emits a zero-padded count ('08',
+        # '09') would otherwise trip bash's "invalid octal" error inside
+        # $((...)) and abort the matrix under 'set -e'.
         pass=$((pass + 10#${suite_pass:-0}))
         fail=$((fail + 10#${suite_fail:-0}))
         skip=$((skip + 10#${suite_skip:-0}))
@@ -352,9 +349,9 @@ run_summary_suite()
     return "$rc"
 }
 
-# Suite-level analog of require_binary for whole fixture directories.
-# The label names the suite that is being skipped. Use this in place of
-# bare 'printf "SKIP\n"' lines so the skip counter reflects reality.
+# Suite-level analog of require_binary for whole fixture directories. The label
+# names the suite that is being skipped. Use this in place of bare 'printf
+# "SKIP\n"' lines so the skip counter reflects reality.
 skip_suite()
 {
     local label="$1" reason="$2"
@@ -380,11 +377,11 @@ test_check()
         report_timeout "$label"
         return
     fi
-    # Require a clean exit before trusting the regex. A crashing tool can
-    # still emit the expected substring on stdout before dying, and the
-    # earlier "regex match alone passes" behavior would have reported
-    # that as OK -- the same silent-skip shape that motivated the
-    # tightening of tests/driver.sh evaluate_result.
+    # Require a clean exit before trusting the regex. A crashing tool can still
+    # emit the expected substring on stdout before dying, and the earlier "regex
+    # match alone passes" behavior would have reported that as OK -- the same
+    # silent-skip shape that motivated the tightening of tests/driver.sh
+    # evaluate_result.
     if [ "$rc" -ne 0 ]; then
         test_report fail "$label" " (exit $rc)"
         test_excerpt "$output"
@@ -449,10 +446,9 @@ test_pipe()
         report_timeout "$label"
         return
     fi
-    # See test_check for the rc=0 precondition rationale: a non-zero
-    # exit must surface as FAIL even when the regex matches, otherwise
-    # a crashing pipeline that happens to print the expected substring
-    # would be reported OK.
+    # See test_check for the rc=0 precondition rationale: a non-zero exit must
+    # surface as FAIL even when the regex matches, otherwise a crashing pipeline
+    # that happens to print the expected substring would be reported OK.
     if [ "$rc" -ne 0 ]; then
         test_report fail "$label" " (exit $rc)"
         test_excerpt "$output"
@@ -499,6 +495,7 @@ run_unit_tests()
     printf "\nSignal tests\n"
     test_check "$runner" "test-signal" "PASS|0 failed" "$bindir/test-signal"
     test_check "$runner" "test-signal-thread" "PASS|0 failed" "$bindir/test-signal-thread"
+    test_check "$runner" "test-tgkill-directed" "0 failed" "$bindir/test-tgkill-directed"
     test_check "$runner" "test-sigill" "0 failed" "$bindir/test-sigill"
 
     printf "\nSocket tests\n"
@@ -607,10 +604,10 @@ run_coreutils_tests()
     test_rc "$runner" "timeout" 0 "$bindir/timeout" 5 "$guest_bindir/true"
 
     printf "\nCoreutils encoding%s\n" "$_COREUTILS_SUFFIX"
-    # The if/then form contains require_binary's exit status so missing
-    # binaries do not propagate as a function-exit-1 under 'set -e'. The
-    # earlier '&& test_check' chain failed the matrix script outright
-    # whenever the LAST optional binary in a function was absent.
+    # The if/then form contains require_binary's exit status so missing binaries
+    # do not propagate as a function-exit-1 under 'set -e'. The earlier '&&
+    # test_check' chain failed the matrix script outright whenever the LAST
+    # optional binary in a function was absent.
     if require_binary "base32" "$bindir/base32"; then
         test_check "$runner" "base32" "NBSWY" "$bindir/base32" "$TEST_TMPDIR/hello.txt"
     fi
@@ -741,8 +738,8 @@ run_static_tests()
         test_check "$runner" "bash echo" "hello" "$bindir/bash" -c "echo hello"
         test_pipe "$runner" "bash subshell" "sub=25" "" "$bindir/bash" -c 'echo "sub=$(echo $((5*5)))"'
     fi
-    # lua has two acceptable names; prefer 5.4, then fall back to plain lua,
-    # and skip with accounting if neither is present.
+    # lua has two acceptable names; prefer 5.4, then fall back to plain lua, and
+    # skip with accounting if neither is present.
     if [ -e "$bindir/lua5.4" ]; then
         test_check "$runner" "lua hello" "Hello" "$bindir/lua5.4" -e 'print("Hello from " .. _VERSION)'
         test_check "$runner" "lua fib(30)" "832040" "$bindir/lua5.4" -e 'local function f(n) if n<2 then return n end; return f(n-1)+f(n-2) end; print(f(30))'
@@ -849,7 +846,8 @@ run_suite()
         # run_elfuse auto-adds --sysroot for binaries under GUEST_SYSROOT or the
         # dyn-bin dir (see its case), so tree/find/diff here run chrooted and
         # must read the fixtures from inside the sysroot, same as the dynamic
-        # coreutils run. Stage them only for elfuse runs when that trigger applies.
+        # coreutils run. Stage them only for elfuse runs when that trigger
+        # applies.
         local static_staged=0
         if [ "$mode" = "elfuse-aarch64" ] && [ -n "${GUEST_SYSROOT:-}" ]; then
             case "$GUEST_STATIC_BINS" in
@@ -867,10 +865,9 @@ run_suite()
         skip_suite "static-bins" "no $GUEST_STATIC_BINS"
     fi
 
-    # Dynamic-musl coreutils: elfuse needs --sysroot, qemu runs natively.
-    # The skip line always increments the counter so a partial fixture
-    # set surfaces in the per-mode summary instead of looking like a
-    # full pass.
+    # Dynamic-musl coreutils: elfuse needs --sysroot, qemu runs natively. The
+    # skip line always increments the counter so a partial fixture set surfaces
+    # in the per-mode summary instead of looking like a full pass.
     if [ -d "$GUEST_DYNAMIC_COREUTILS" ]; then
         if {
             [ "$mode" = "elfuse-aarch64" ] || [ "$mode" = "elfuse-x86_64" ]
@@ -934,23 +931,24 @@ run_suite()
     cleanup_fixtures
     cleanup_qemu
 
-    # Compare against the per-mode expected outcome. Return its verdict
-    # rather than the raw fail count so modes with recorded known-failure
-    # baselines still exit 0 when their observed results match the table.
+    # Compare against the per-mode expected outcome.
+    #
+    # Return its verdict rather than the raw fail count so modes with recorded
+    # known-failure baselines still exit 0 when their observed results match the
+    # table.
     verify_expected_counts "$mode"
     return $?
 }
 
-# Per-mode expected outcome envelope. Each mode lists the minimum pass
-# count and the exact failure count the matrix is allowed to report.
-# Skip counts are advisory because some skips depend on the host
-# environment (qemu running on Apple Silicon vs Linux, x86_64 fixtures
-# present or not). When the runtime advances, bump these counts in the
-# same commit that changes behaviour so reviewers see the new headline
-# numbers explicitly.
+# Per-mode expected outcome envelope. Each mode lists the minimum pass count and
+# the exact failure count the matrix is allowed to report. Skip counts are
+# advisory because some skips depend on the host environment (qemu running on
+# Apple Silicon vs Linux, x86_64 fixtures present or not). When the runtime
+# advances, bump these counts in the same commit that changes behaviour so
+# reviewers see the new headline numbers explicitly.
 #
-# elfuse-x86_64 baseline (71) is the sum of the seven Rosetta sub-suites
-# in run_rosetta_x86_64_suites:
+# elfuse-x86_64 baseline (71) is the sum of the seven Rosetta sub-suites in
+# run_rosetta_x86_64_suites:
 #   test-rosetta-cli.sh            = 4
 #   test-rosetta-failure-modes.sh  = 3
 #   test-rosetta-statics.sh        = 20
@@ -958,29 +956,27 @@ run_suite()
 #   test-rosetta-audit.sh          = 2
 #   test-rosetta-jit.sh            = 2
 #   test-rosetta-glibc.sh          = 7
-# The full per-binary inventory and the per-host capture process live
-# in docs/testing.md "x86_64 Acceptance Inventory and Per-Host
-# Baselines". Bump these counts in the same commit that grows or trims
-# any sub-suite's Results line so the matrix gate stays in sync.
+# The full per-binary inventory and the per-host capture process live in
+# docs/testing.md "x86_64 Acceptance Inventory and Per-Host Baselines". Bump
+# these counts in the same commit that grows or trims any sub-suite's Results
+# line so the matrix gate stays in sync.
 #
 # Per-mode baseline gate. Encoded as "key|min_pass|max_fail" tuples in a
-# single indexed array so stock macOS bash 3.2 (which lacks 'declare -A')
-# works the same as bash 4+.
+# single indexed array so stock macOS bash 3.2 (which lacks 'declare -A') works
+# the same as bash 4+.
 #
-# The bareword-subscript hazard the prior 'declare -A' form had to dodge
-# (shfmt rewriting [a-b] into [a - b] inside subscripts) does not apply
-# to this encoding: keys live inside a quoted string, never as a
-# subscript expression.
+# The bareword-subscript hazard the prior 'declare -A' form had to dodge (shfmt
+# rewriting [a-b] into [a - b] inside subscripts) does not apply to this
+# encoding: keys live inside a quoted string, never as a subscript expression.
 #
-# Order: aarch64 baselines first, then x86_64 baselines keyed by detected
-# host SoC class. The two M-series classes diverge inside
-# sys_mmap_fixed_high_va on IPA width (apple-m1-m2 is 36-bit, the
-# overflow-segment path; apple-m3-plus is 40-bit, the bisected-slab
-# path on M5). The seven Rosetta sub-suites currently emit fixed pass
-# counts regardless of IPA width, so both rows start at 71; an operator
-# with M3+ hardware updates the apple-m3-plus row in place when their
-# observed counts diverge. apple-unknown is the fallback row for SoC
-# strings the detector does not recognize yet.
+# Order: aarch64 baselines first, then x86_64 baselines keyed by detected host
+# SoC class. The two M-series classes diverge inside sys_mmap_fixed_high_va on
+# IPA width (apple-m1-m2 is 36-bit, the overflow-segment path; apple-m3-plus is
+# 40-bit, the bisected-slab path on M5). The seven Rosetta sub-suites currently
+# emit fixed pass counts regardless of IPA width, so both rows start at 71; an
+# operator with M3+ hardware updates the apple-m3-plus row in place when their
+# observed counts diverge. apple-unknown is the fallback row for SoC strings the
+# detector does not recognize yet.
 EXPECTED_BASELINES=(
     "elfuse-aarch64|169|0"
     "qemu-aarch64|163|0"
@@ -989,15 +985,14 @@ EXPECTED_BASELINES=(
     "elfuse-x86_64:apple-unknown|71|0"
 )
 
-# Look up the (min_pass, max_fail) baseline for a mode key. Writes the
-# values into the named output variables and returns 0 on hit, 1 on
-# miss. Callers use the rc=1 path as "no recorded baseline for this key,
-# stay silent".
+# Look up the (min_pass, max_fail) baseline for a mode key. Writes the values
+# into the named output variables and returns 0 on hit, 1 on miss. Callers use
+# the rc=1 path as "no recorded baseline for this key, stay silent".
 #
-# Parses from the right so a key containing a literal '|' would still
-# split correctly (today the schema has none, but the right-anchored
-# form is no harder to read and removes the trap). printf -v sets the
-# named output without eval; printf -v exists in bash 3.1+.
+# Parses from the right so a key containing a literal '|' would still split
+# correctly (today the schema has none, but the right-anchored form is no harder
+# to read and removes the trap). printf -v sets the named output without eval;
+# printf -v exists in bash 3.1+.
 expected_baseline_get()
 {
     local target="$1"
@@ -1019,18 +1014,16 @@ expected_baseline_get()
 }
 
 # Host SoC class detector for x86_64 baseline selection. Reads
-# machdep.cpu.brand_string (sysctl), which Apple Silicon Macs publish
-# as "Apple M1", "Apple M2 Pro", "Apple M3 Max", etc. The MATRIX_HOST
-# _CLASS_OVERRIDE env var exists so the M3+ row can be exercised from
-# an M1/M2 host (and vice versa) without modifying the detector. The
-# detector intentionally returns a stable apple-unknown rather than
-# guessing on never-seen brand strings so new SoCs do not silently
-# graft onto an existing row.
-# Validate MATRIX_HOST_CLASS_OVERRIDE at script entry. The detector is
-# invoked from $(...) inside verify_expected_counts, where an exit only
-# terminates the subshell and the parent silently sees an empty class.
-# Pre-validating here makes a typo (e.g. "apple-m3" missing -plus)
-# fail loudly before any sub-suite runs.
+# machdep.cpu.brand_string (sysctl), which Apple Silicon Macs publish as "Apple
+# M1", "Apple M2 Pro", "Apple M3 Max", etc. The MATRIX_HOST _CLASS_OVERRIDE env
+# var exists so the M3+ row can be exercised from an M1/M2 host (and vice versa)
+# without modifying the detector. The detector intentionally returns a stable
+# apple-unknown rather than guessing on never-seen brand strings so new SoCs do
+# not silently graft onto an existing row. Validate MATRIX_HOST_CLASS_OVERRIDE
+# at script entry. The detector is invoked from $(...) inside
+# verify_expected_counts, where an exit only terminates the subshell and the
+# parent silently sees an empty class. Pre-validating here makes a typo (e.g.
+# "apple-m3" missing -plus) fail loudly before any sub-suite runs.
 if [ -n "${MATRIX_HOST_CLASS_OVERRIDE:-}" ]; then
     case "$MATRIX_HOST_CLASS_OVERRIDE" in
         apple-m1-m2 | apple-m3-plus | apple-unknown) ;;
@@ -1058,23 +1051,22 @@ detect_x86_64_host_class()
     esac
 }
 
-# Known-failure annotations. These are tests that fail by design under a
-# given mode and are tracked here so the matrix runner can distinguish them
-# from real regressions in surface output. The matrix does not yet rewrite
-# their pass/fail accounting (the underlying drivers would need richer
-# reporting), but this list is the canonical reference for "expected to
-# fail" in code review and CI triage.
+# Known-failure annotations. These are tests that fail by design under a given
+# mode and are tracked here so the matrix runner can distinguish them from real
+# regressions in surface output. The matrix does not yet rewrite their pass/fail
+# accounting (the underlying drivers would need richer reporting), but this list
+# is the canonical reference for "expected to fail" in code review and CI
+# triage.
 #
-# qemu-aarch64: none. test-poll used to diverge inside the qemu reference
-# VM but now passes there (observed on the self-hosted runner and in local
-# captures); the qemu row in EXPECTED_BASELINES therefore pins exactly
-# zero failures.
+# qemu-aarch64: none. test-poll used to diverge inside the qemu reference VM but
+# now passes there (observed on the self-hosted runner and in local captures);
+# the qemu row in EXPECTED_BASELINES therefore pins exactly zero failures.
 KNOWN_FAILURES_QEMU_AARCH64=""
 # elfuse-x86_64: rosetta limitations documented in the upstream hyper-linux
 # audit. test-signal-thread fails because rosetta shadows signal state
 # internally (SA_RESETHAND not reset); test-thread / test-stress hang on
 # rosetta's TLS=0 corner case.
-KNOWN_FAILURES_ELFUSE_X86_64="test-signal-thread test-thread test-stress"
+KNOWN_FAILURES_ELFUSE_X86_64="test-signal-thread test-tgkill-directed test-thread test-stress"
 
 verify_expected_counts()
 {
@@ -1088,17 +1080,17 @@ verify_expected_counts()
 
     local exp_min="" exp_fail=""
     if ! expected_baseline_get "$key" exp_min exp_fail; then
-        # No recorded baseline for this key (experimental local mode, or
-        # an x86_64 host class the detector did not classify). Stay
-        # silent so the matrix runner remains usable as a smoke probe.
+        # No recorded baseline for this key (experimental local mode, or an
+        # x86_64 host class the detector did not classify). Stay silent so the
+        # matrix runner remains usable as a smoke probe.
         return 0
     fi
 
-    # Uncaptured rows: apple-m3-plus inherits the M1/M2 numbers pending
-    # operator capture on real M3+ hardware; apple-unknown means the SoC
-    # brand string did not match a known class at all. In both cases
-    # surface that the baseline is not authoritative for this host so a
-    # genuine M3+ divergence is not silently absorbed.
+    # Uncaptured rows: apple-m3-plus inherits the M1/M2 numbers pending operator
+    # capture on real M3+ hardware; apple-unknown means the SoC brand string did
+    # not match a known class at all. In both cases surface that the baseline is
+    # not authoritative for this host so a genuine M3+ divergence is not
+    # silently absorbed.
     if [ "$mode" = "elfuse-x86_64" ]; then
         case "$host_class" in
             apple-m3-plus)
@@ -1139,9 +1131,9 @@ verify_expected_counts()
 }
 
 # Main entry point. The aarch64 fixture fetch only matters for modes that
-# actually consume those binaries; running elfuse-x86_64 in isolation lets
-# the user iterate before the x86_64 corpus exists, without pulling the
-# aarch64 musl rootfs and qemu kernel they will not use.
+# actually consume those binaries; running elfuse-x86_64 in isolation lets the
+# user iterate before the x86_64 corpus exists, without pulling the aarch64 musl
+# rootfs and qemu kernel they will not use.
 case "$MODE" in
     elfuse-x86_64)
         ensure_x86_fixtures

--- a/tests/test-signalfd-hardening.c
+++ b/tests/test-signalfd-hardening.c
@@ -21,6 +21,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -741,6 +742,103 @@ static void *tid_worker(void *arg)
     return NULL;
 }
 
+/* The target thread's own signalfd must wake when it receives a blocked,
+ * thread-directed signal -- the standard "block SIGxxx, drain it via signalfd"
+ * pattern. Regression guard for the routing fix (issue #152): a directed signal
+ * has to reach the target's signalfd wait, not just process-directed kills.
+ * Linux wakes the one shared sighand wait queue, so the target's poll must fire
+ * and its read must return the directed signal.
+ */
+typedef struct {
+    pthread_mutex_t mtx;
+    pthread_cond_t ready_cv;
+    bool ready;
+    int result; /* 1 = signalfd delivered SIGUSR1, 0 = did not, -1 = setup err
+                 */
+} sfd_target_t;
+
+static void *signalfd_target_worker(void *arg)
+{
+    sfd_target_t *s = arg;
+    sigset_t block;
+    sigemptyset(&block);
+    sigaddset(&block, SIGUSR1);
+    pthread_sigmask(SIG_BLOCK, &block, NULL);
+
+    int fd = signalfd(-1, &block, 0); /* blocking; poll gates the read */
+
+    pthread_mutex_lock(&s->mtx);
+    s->ready = true;
+    s->result = (fd < 0) ? -1 : 0;
+    pthread_cond_signal(&s->ready_cv);
+    pthread_mutex_unlock(&s->mtx);
+    if (fd < 0)
+        return NULL;
+
+    /* Park in poll waiting for the directed signal; the wake proves notify ran
+     * for the thread-directed path.
+     */
+    struct pollfd pfd = {.fd = fd, .events = POLLIN};
+    int pr = poll(&pfd, 1, 2000);
+    if (pr == 1 && (pfd.revents & POLLIN)) {
+        struct signalfd_siginfo si;
+        ssize_t n = read(fd, &si, sizeof(si));
+        s->result =
+            (n == (ssize_t) sizeof(si) && si.ssi_signo == (uint32_t) SIGUSR1)
+                ? 1
+                : 0;
+    }
+    close(fd);
+    return NULL;
+}
+
+static void test_directed_signal_wakes_target_signalfd(void)
+{
+    TEST("directed signal wakes the target's signalfd");
+
+    sfd_target_t s;
+    pthread_mutex_init(&s.mtx, NULL);
+    pthread_cond_init(&s.ready_cv, NULL);
+    s.ready = false;
+    s.result = 0;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, signalfd_target_worker, &s) != 0) {
+        FAIL("pthread_create");
+        return;
+    }
+
+    pthread_mutex_lock(&s.mtx);
+    while (!s.ready)
+        pthread_cond_wait(&s.ready_cv, &s.mtx);
+    int setup = s.result;
+    pthread_mutex_unlock(&s.mtx);
+
+    if (setup == -1) {
+        pthread_join(th, NULL);
+        pthread_mutex_destroy(&s.mtx);
+        pthread_cond_destroy(&s.ready_cv);
+        FAIL("signalfd");
+        return;
+    }
+
+    usleep(100000); /* let the worker reach poll() */
+    pthread_kill(th, SIGUSR1);
+    pthread_join(th, NULL);
+    pthread_mutex_destroy(&s.mtx);
+    pthread_cond_destroy(&s.ready_cv);
+
+    if (s.result != 1) {
+        printf(
+            "FAIL: target signalfd did not deliver the directed signal "
+            "(result=%d)\n",
+            s.result);
+        fails++;
+        return;
+    }
+    PASS();
+}
+
 static void test_rt_sigqueueinfo_thread_tid_routes_to_tgid(void)
 {
     /* Linux is permissive: rt_sigqueueinfo(tid_of_any_thread, ...) succeeds and
@@ -862,6 +960,7 @@ int main(void)
     test_partial_fault_returns_partial_bytes();
     test_rt_sigqueueinfo_bad_pointer_efault();
     test_rt_sigqueueinfo_rejects_foreign_pid();
+    test_directed_signal_wakes_target_signalfd();
     test_rt_sigqueueinfo_thread_tid_routes_to_tgid();
 
     SUMMARY("test-signalfd-hardening");

--- a/tests/test-tgkill-directed.c
+++ b/tests/test-tgkill-directed.c
@@ -1,0 +1,255 @@
+/*
+ * Thread-directed signal routing (tgkill / pthread_kill)
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A thread-directed signal must be consumed by the target thread only, not by
+ * whichever thread reaches a delivery point first. Regression test for the bug
+ * where sc_tgkill validated the target tid then dropped it into the single
+ * process-wide pending set, so pthread_kill(worker, SIGUSR1) could be handled
+ * on the main thread while the worker slept on in a blocking read.
+ *
+ * Also checks the anti-coalescing property: N tgkills of the same standard
+ * signal to N distinct threads deliver N times, once per target, instead of
+ * collapsing into a single pending bit.
+ *
+ * Syscalls exercised: tgkill(131), rt_sigaction(134), gettid(178),
+ *                     clone(220, via pthread_create)
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_tkill
+#define SYS_tkill 130
+#endif
+
+#include "test-harness.h"
+#include "raw-syscall.h"
+
+int passes = 0, fails = 0;
+
+/* Test 1: pthread_kill targets the specific thread, not the process. */
+
+static volatile sig_atomic_t got_sig = 0;
+static volatile int handler_tid = 0;
+static int worker_tid = 0;
+static volatile sig_atomic_t worker_ready = 0;
+static int wake_pipe[2];
+
+static void usr1_handler(int sig)
+{
+    (void) sig;
+    handler_tid = (int) raw_gettid();
+    got_sig = 1;
+}
+
+static void *blocking_worker(void *arg)
+{
+    (void) arg;
+    worker_tid = (int) raw_gettid();
+    worker_ready = 1;
+    /* Block in read() on an empty pipe. A thread-directed signal must land here
+     * and interrupt this read with EINTR; a byte written by the parent is the
+     * fallback that unblocks the worker if the signal was misdelivered.
+     */
+    char c;
+    while (!got_sig) {
+        ssize_t r = read(wake_pipe[0], &c, 1);
+        if (r > 0)
+            break; /* Parent unblocked us (misdelivery path) */
+        if (r < 0 && errno == EINTR)
+            continue; /* Signal handler ran; loop re-checks got_sig */
+    }
+    return NULL;
+}
+
+static void test_pthread_kill_targets_thread(void)
+{
+    TEST("pthread_kill targets the named thread");
+
+    got_sig = 0;
+    handler_tid = 0;
+    worker_tid = 0;
+    worker_ready = 0;
+
+    if (pipe(wake_pipe) != 0) {
+        FAIL("pipe");
+        return;
+    }
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = usr1_handler;
+    sigemptyset(&sa.sa_mask);
+    /* No SA_RESTART: the worker's read() should return EINTR after delivery. */
+    sigaction(SIGUSR1, &sa, NULL);
+
+    pthread_t worker;
+    if (pthread_create(&worker, NULL, blocking_worker, NULL) != 0) {
+        FAIL("pthread_create");
+        return;
+    }
+
+    /* Wait for the worker to publish its tid and park in read(). */
+    while (!worker_ready)
+        usleep(1000);
+    usleep(100000); /* 100ms: ensure the worker is inside read() */
+
+    pthread_kill(worker, SIGUSR1);
+
+    /* Spin in usleep so the main thread hits nanosleep epilogues -- under the
+     * old process-wide routing the main thread would steal the signal here.
+     */
+    for (int i = 0; i < 2000 && !got_sig; i++)
+        usleep(1000);
+
+    /* Unblock the worker unconditionally so join() cannot hang, then join. */
+    (void) !write(wake_pipe[1], "x", 1);
+    pthread_join(worker, NULL);
+    close(wake_pipe[0]);
+    close(wake_pipe[1]);
+
+    EXPECT_TRUE(got_sig && handler_tid == worker_tid,
+                "signal handled on the wrong thread (process-wide routing)");
+}
+
+/* Test 2: standard signals to distinct threads do not coalesce. Each of N
+ * worker threads blocks SIGUSR2, is sent one tgkill(SIGUSR2), then unblocks and
+ * counts its own delivery. Coalescing into one process-wide bit would deliver
+ * to at most one thread.
+ */
+
+#define N_WORKERS 4
+
+static pthread_barrier_t sent_barrier; /* main signalled all workers */
+/* Incremented from handlers running concurrently on the N worker threads, so
+ * the update must be inter-thread atomic; a plain volatile RMW would lose
+ * counts and make the coalescing assertion flaky on multi-core hosts. Reset
+ * before the workers start and read after they join, so those accesses need no
+ * atomics.
+ */
+static int usr2_hits = 0;
+
+static void usr2_handler(int sig)
+{
+    (void) sig;
+    __atomic_add_fetch(&usr2_hits, 1, __ATOMIC_SEQ_CST);
+}
+
+static void *counting_worker(void *arg)
+{
+    (void) arg;
+
+    sigset_t block;
+    sigemptyset(&block);
+    sigaddset(&block, SIGUSR2);
+    /* Per-thread block so the pending signal stays queued on this thread until
+     * it unblocks -- no thread can consume another's instance.
+     */
+    pthread_sigmask(SIG_BLOCK, &block, NULL);
+
+    /* Publish that this worker exists and is blocking SIGUSR2. */
+    pthread_barrier_wait(&sent_barrier);
+
+    /* Wait until the main thread has issued every tgkill, then unblock and let
+     * this thread's own pending instance deliver.
+     */
+    pthread_barrier_wait(&sent_barrier);
+    pthread_sigmask(SIG_UNBLOCK, &block, NULL);
+    /* Give delivery a moment on the next syscall epilogue. */
+    usleep(50000);
+    return NULL;
+}
+
+static void test_directed_no_coalesce(void)
+{
+    TEST("standard signals to N threads do not coalesce");
+
+    usr2_hits = 0;
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = usr2_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR2, &sa, NULL);
+
+    /* Block SIGUSR2 on the main thread so it is not an eligible consumer: each
+     * tgkill's syscall epilogue must not steal the delivery. Under process-wide
+     * routing the four sends then coalesce into one shared pending bit and only
+     * one worker fires; per-thread routing keeps four distinct instances.
+     */
+    sigset_t block_main;
+    sigemptyset(&block_main);
+    sigaddset(&block_main, SIGUSR2);
+    pthread_sigmask(SIG_BLOCK, &block_main, NULL);
+
+    pthread_barrier_init(&sent_barrier, NULL, N_WORKERS + 1);
+
+    pthread_t workers[N_WORKERS];
+    int tids[N_WORKERS];
+    for (int i = 0; i < N_WORKERS; i++)
+        pthread_create(&workers[i], NULL, counting_worker, NULL);
+
+    /* Wait for all workers to block SIGUSR2 and publish existence. */
+    pthread_barrier_wait(&sent_barrier);
+
+    /* Collect worker tids and send one directed SIGUSR2 to each. */
+    for (int i = 0; i < N_WORKERS; i++) {
+        /* pthread_kill needs the pthread_t; the handler counts globally, so we
+         * only need to reach each distinct target thread.
+         */
+        pthread_kill(workers[i], SIGUSR2);
+        (void) tids;
+    }
+
+    /* Release the workers to unblock and drain their private pending sets. */
+    pthread_barrier_wait(&sent_barrier);
+
+    for (int i = 0; i < N_WORKERS; i++)
+        pthread_join(workers[i], NULL);
+    pthread_barrier_destroy(&sent_barrier);
+
+    EXPECT_TRUE(usr2_hits == N_WORKERS,
+                "not every thread received its own signal instance");
+}
+
+/* Test 3: legacy tkill(2) delivers a thread-directed signal to self. */
+
+static void test_tkill_self(void)
+{
+    TEST("tkill delivers to self");
+
+    got_sig = 0;
+    handler_tid = 0;
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = usr1_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    int tid = (int) raw_gettid();
+    long ret = syscall(SYS_tkill, tid, SIGUSR1);
+
+    EXPECT_TRUE(ret == 0 && got_sig && handler_tid == tid,
+                "tkill(self) did not deliver to the caller");
+}
+
+int main(void)
+{
+    printf("test-tgkill-directed: thread-directed signal routing\n");
+
+    test_pthread_kill_targets_thread();
+    test_directed_no_coalesce();
+    test_tkill_self();
+
+    SUMMARY("test-tgkill-directed");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
{tg,t}kill, rt_tgsigqueueinfo, and thus pthread_kill validated the target tid then queued the signal into the single process-wide pending set, so whichever thread reached a delivery point first consumed it and standard signals coalesced across threads. Go async preemption, pthread_cancel, and glibc setxid / musl __synccall all interrupted the wrong thread; interruptible blocking I/O made the gap load-bearing.

Model Linux's 2 pending sets. Extract signal_pending_t (pending bitmask, coalesced standard siginfo, per-signal RT queues); signal_state now holds one shared instance (signal->shared_pending, hit by kill) and each thread_entry_t holds its own private tpending (task->pending, hit by tgkill/tkill). signal_deliver drains the current thread's private set before the shared set, matching dequeue_signal; signal_pending, sigsuspend, rt_sigprocmask unblock, and rt_sigpending union the two.

Resolve the target under thread_lock and enqueue into its tpending under sig_lock then thread_lock so a concurrent exit cannot misroute; kill and rt_sigqueueinfo stay process-directed. Add tkill (syscall 130), which was ENOSYS. Both directed senders validate tgid/tid and treat sig 0 as an existence probe.

signalfd reads the caller's private set then the shared set with a per-entry source tag so peek and take consume from the same set; a queued directed signal wakes signalfd waiters (Linux wakes the shared sighand queue) and a blocking read re-waits on a false wake. The pending hint becomes shared.pending OR the union of every active thread's private set, recomputed on thread exit so a departed thread's unconsumed directed signal stops pinning the identity-syscall fast path off.

Close #152

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route thread-directed signals to the exact target thread and match Linux delivery semantics. Adds `SYS_tkill`, corrects `tgkill`/`rt_tgsigqueueinfo` routing, and hardens signalfd to handle per-thread vs shared pending sets.

- **New Features**
  - Two pending sets: shared (process-directed) and per-thread (`tpending`). Delivery drains the thread’s private set before the shared set; `signal_pending`, `rt_sigpending`, `rt_sigsuspend`, and `rt_sigprocmask` union the two.
  - Add `SYS_tkill` (130). Route `tgkill`/`rt_tgsigqueueinfo` to the target thread with `tgid` validation; treat `sig==0` as an existence probe. Keep `kill`/`rt_sigqueueinfo` process-directed and accept a thread TID as the PID; also honor `sig==0`.
  - `signalfd`: read private then shared with a per-entry source tag so take consumes from the same set; re-wait on false wakes; wake signalfd on directed signals so target readers unblock while non-targets see `EAGAIN`.

- **Bug Fixes**
  - Fix thread-directed signals being handled by the wrong thread and stop standard-signal coalescing across threads.
  - Resolve target under `thread_lock` and enqueue into its private set under `sig_lock`→`thread_lock` to avoid misrouting during concurrent thread exit.
  - Recompute the global pending hint as (shared.pending OR union of all threads’ private masks) and refresh on thread slot deactivation/exit so stale bits do not pin fast paths off.
  - Tests: add `test-tgkill-directed` and a signalfd case ensuring a directed signal wakes the target’s signalfd.

<sup>Written for commit 217bb85cc20c900b9c6d531a5080e4a53ca602b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

