### PR TITLE
Report guest path for /proc/self/exe under Rosetta

### DIFF
--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -3667,6 +3667,50 @@ int proc_intercept_stat(const char *path, struct stat *st)
     return PROC_NOT_INTERCEPTED;
 }
 
+/* Resolve /proc/self/exe to the guest binary path in buf. Strips the sysroot
+ * prefix so a guest running under --sysroot=/opt/sr sees /bin/ls rather than
+ * /opt/sr/bin/ls, matching the chroot-like abstraction the rest of the path
+ * layer presents.
+ *
+ * Returns bytes written, or -1 with errno set. Under rosetta this still returns
+ * the real guest binary: the rosetta translator is an implementation detail,
+ * and guest apps (coreutils multi-call dispatch) expect the true path just as
+ * native binfmt_misc + rosetta exposes it.
+ */
+static int proc_readlink_self_exe(char *buf, size_t bufsiz)
+{
+    char exe_buf[LINUX_PATH_MAX];
+    if (!proc_elf_path_snapshot(exe_buf, sizeof(exe_buf))) {
+        errno = ENOENT;
+        return -1;
+    }
+    const char *exe = exe_buf;
+    char exe_real[LINUX_PATH_MAX];
+    char sysroot_snap[LINUX_PATH_MAX];
+    if (proc_sysroot_snapshot(sysroot_snap, sizeof(sysroot_snap))) {
+        /* proc_set_sysroot stores a realpath()-canonicalized form, so
+         * canonicalize exe before the prefix check or the strip fails when /var
+         * -> /private/var (and similar macOS symlinks) make the two strings
+         * diverge.
+         */
+        const char *exe_cmp = exe;
+        if (realpath(exe, exe_real))
+            exe_cmp = exe_real;
+        size_t sr_len = strlen(sysroot_snap);
+        if (sr_len > 0 && !strncmp(exe_cmp, sysroot_snap, sr_len) &&
+            (exe_cmp[sr_len] == '/' || exe_cmp[sr_len] == '\0')) {
+            exe = exe_cmp + sr_len;
+            if (*exe == '\0')
+                exe = "/";
+        }
+    }
+    size_t len = strlen(exe);
+    if (len > bufsiz)
+        len = bufsiz;
+    memcpy(buf, exe, len);
+    return (int) len;
+}
+
 int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz)
 {
     {
@@ -3678,54 +3722,8 @@ int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz)
             return proc_intercept_readlink(alias, buf, bufsiz);
     }
 
-    /* /proc/self/exe -> path of current ELF binary. Strip the sysroot prefix so
-     * a guest running under --sysroot=/opt/sr sees /bin/ls rather than
-     * /opt/sr/bin/ls, matching the chroot-like abstraction the rest of the path
-     * layer presents.
-     */
-    if (!strcmp(path, "/proc/self/exe")) {
-        /* Under rosetta, readlink("/proc/self/exe") points at the rosetta
-         * translator (the binfmt_misc interpreter). Matches the behavior Linux
-         * exposes when binfmt_misc dispatch is active.
-         */
-        if (proc_rosetta_active()) {
-            size_t len = strlen(ROSETTA_PATH);
-            if (len > bufsiz)
-                len = bufsiz;
-            memcpy(buf, ROSETTA_PATH, len);
-            return (int) len;
-        }
-        char exe_buf[LINUX_PATH_MAX];
-        if (!proc_elf_path_snapshot(exe_buf, sizeof(exe_buf))) {
-            errno = ENOENT;
-            return -1;
-        }
-        const char *exe = exe_buf;
-        char exe_real[LINUX_PATH_MAX];
-        char sysroot_snap[LINUX_PATH_MAX];
-        if (proc_sysroot_snapshot(sysroot_snap, sizeof(sysroot_snap))) {
-            /* proc_set_sysroot stores a realpath()-canonicalized form, so
-             * canonicalize exe before the prefix check or the strip fails when
-             * /var -> /private/var (and similar macOS symlinks) make the two
-             * strings diverge.
-             */
-            const char *exe_cmp = exe;
-            if (realpath(exe, exe_real))
-                exe_cmp = exe_real;
-            size_t sr_len = strlen(sysroot_snap);
-            if (sr_len > 0 && !strncmp(exe_cmp, sysroot_snap, sr_len) &&
-                (exe_cmp[sr_len] == '/' || exe_cmp[sr_len] == '\0')) {
-                exe = exe_cmp + sr_len;
-                if (*exe == '\0')
-                    exe = "/";
-            }
-        }
-        size_t len = strlen(exe);
-        if (len > bufsiz)
-            len = bufsiz;
-        memcpy(buf, exe, len);
-        return (int) len;
-    }
+    if (!strcmp(path, "/proc/self/exe"))
+        return proc_readlink_self_exe(buf, bufsiz);
 
     /* /proc/self/cwd -> getcwd() */
     if (!strcmp(path, "/proc/self/cwd")) {
@@ -3760,6 +3758,14 @@ int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz)
             errno = ENOENT;
             return -1;
         }
+        /* Under rosetta, open("/proc/self/exe") returns a host fd pointing at
+         * the rosetta translator (needed by the VZ ioctl gate). readlink on
+         * that fd must still report the guest binary, not the translator, or
+         * coreutils multi-call dispatch reads back "rosetta" as the applet name
+         * and aborts.
+         */
+        if (proc_rosetta_active() && !strcmp(fdpath, ROSETTA_PATH))
+            return proc_readlink_self_exe(buf, bufsiz);
         size_t len = strlen(fdpath);
         if (len > bufsiz)
             len = bufsiz;

--- a/tests/test-rosetta-alpine.sh
+++ b/tests/test-rosetta-alpine.sh
@@ -4,21 +4,21 @@
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Extends test-rosetta-statics.sh with workloads that exercise the
-# Alpine static-binary suite end-to-end:
+# Extends test-rosetta-statics.sh with workloads that exercise the Alpine
+# static-binary suite end-to-end:
 #   - file I/O against a real on-disk corpus (read, hash, sort, find)
 #   - text-processing pipelines stitched through the host shell
 #   - exit-code propagation through pipe chains
 #   - filesystem readback (ls, find, du, wc)
 #
-# Each test runs an Alpine x86_64 static binary (busybox or applet) under
-# elfuse + Rosetta. The host shell stitches multi-step pipelines so each
-# stage is a separate elfuse invocation - that catches per-launch
-# regressions (bootstrap, /proc/self/exe, vDSO) on every step.
+# Each test runs an Alpine x86_64 static binary (busybox or applet) under elfuse
+# + Rosetta. The host shell stitches multi-step pipelines so each stage is a
+# separate elfuse invocation - that catches per-launch regressions (bootstrap,
+# /proc/self/exe, vDSO) on every step.
 #
-# Fixture: tests/fetch-fixtures.sh INCLUDE_X86_64=1.
-# Path cap: stages a /tmp/elfuse-ra/ symlink farm so paths stay inside
-# rosetta's 42-byte ROSETTA_CAPS_BINARY_PATH_LEN.
+# Fixture: tests/fetch-fixtures.sh INCLUDE_X86_64=1. Path cap: stages a
+# /tmp/elfuse-ra/ symlink farm so paths stay inside rosetta's 42-byte
+# ROSETTA_CAPS_BINARY_PATH_LEN.
 #
 # Usage: tests/test-rosetta-alpine.sh [path/to/elfuse]
 
@@ -39,9 +39,9 @@ SHORTDIR=/tmp/elfuse-ra
 STATICBIN="${SHORTDIR}/bin"
 DATA="${SHORTDIR}/data"
 
-# Shared report_pass / report_fail / report_skip + Results: summary
-# emitter. Matches the matrix runner's aarch64 per-binary format so
-# tests/test-matrix.sh elfuse-x86_64 output reads uniformly.
+# Shared report_pass / report_fail / report_skip + Results: summary emitter.
+# Matches the matrix runner's aarch64 per-binary format so tests/test-matrix.sh
+# elfuse-x86_64 output reads uniformly.
 # shellcheck source=tests/lib/rosetta-test.sh
 . "$(dirname "$0")/lib/rosetta-test.sh"
 
@@ -72,10 +72,10 @@ rm -rf "$SHORTDIR"
 mkdir -p "$STATICBIN" "$DATA"
 staticbin_abs="$(cd "$STATICBIN_LONG" && pwd)"
 
-# Point HOME at the per-run tmp so the rosettad AOT cache stays empty
-# across re-runs. Without this, the cache from a previous run can serve
-# the digest fast-path and silently bypass the path-publishing surface
-# the smoke probes are meant to exercise.
+# Point HOME at the per-run tmp so the rosettad AOT cache stays empty across
+# re-runs. Without this, the cache from a previous run can serve the digest
+# fast-path and silently bypass the path-publishing surface the smoke probes are
+# meant to exercise.
 export HOME="$SHORTDIR"
 
 ln -s "${staticbin_abs}/busybox" "${STATICBIN}/busybox"
@@ -90,31 +90,31 @@ done
 
 trap 'rm -rf "$SHORTDIR"' EXIT
 
-# Build a small data corpus the tests can chew on. Deterministic content
-# so hash and sort results are stable across runs. fruits-unsorted.txt is
-# deliberately out of order so sort + diff exercise the comparison paths.
+# Build a small data corpus the tests can chew on. Deterministic content so hash
+# and sort results are stable across runs. fruits-unsorted.txt is deliberately
+# out of order so sort + diff exercise the comparison paths.
 printf 'cherry\napple\ngrape\nbanana\nfig\ndurian\neggplant\n' \
     > "${DATA}/fruits-unsorted.txt"
 printf 'apple\nbanana\ncherry\ndurian\neggplant\nfig\ngrape\n' \
     > "${DATA}/fruits-sorted.txt"
 
-# 8 KiB of repeated ASCII (printable so wc/grep/sort don't choke). The
-# pattern is deterministic so the SHA-256 expectation below is stable.
+# 8 KiB of repeated ASCII (printable so wc/grep/sort don't choke). The pattern
+# is deterministic so the SHA-256 expectation below is stable.
 {
     for i in $(seq 1 256); do
         printf 'rosetta line %03d - the quick brown fox\n' "$i"
     done
 } > "${DATA}/lines.txt"
 
-# Capture an expected SHA-256 of lines.txt computed locally so the test
-# can compare without hardcoding a fragile constant.
+# Capture an expected SHA-256 of lines.txt computed locally so the test can
+# compare without hardcoding a fragile constant.
 expected_sha="$(shasum -a 256 "${DATA}/lines.txt" | awk '{print $1}')"
 
 # A pair of identical files for diff -q to confirm.
 cp "${DATA}/lines.txt" "${DATA}/lines-copy.txt"
 
-# Test helpers.
-# run_eq: command's stdout must equal expected exactly. rc must be 0.
+# Test helpers. run_eq: command's stdout must equal expected exactly. rc must be
+# 0.
 run_eq()
 {
     local label="$1" expected="$2"
@@ -161,10 +161,10 @@ run_re()
     report_pass "$label"
 }
 
-# run_pipe: two-stage pipeline. Stage A produces stdout, piped to stage
-# B which is also a guest binary under elfuse. Final stdout must equal
-# expected. Each stage is its own elfuse invocation, so bootstrap +
-# /proc/self/exe + vDSO run twice per test.
+# run_pipe: two-stage pipeline. Stage A produces stdout, piped to stage B which
+# is also a guest binary under elfuse. Final stdout must equal expected. Each
+# stage is its own elfuse invocation, so bootstrap + /proc/self/exe + vDSO run
+# twice per test.
 run_pipe()
 {
     local label="$1" expected="$2"
@@ -190,9 +190,9 @@ run_pipe()
     fi
     local out rc
     set +e
-    # set -o pipefail inside the subshell so the captured $? reflects the
-    # first non-zero stage exit, not just the last. Without this a producer
-    # that fails after emitting matching text would silently pass.
+    # set -o pipefail inside the subshell so the captured $? reflects the first
+    # non-zero stage exit, not just the last. Without this a producer that fails
+    # after emitting matching text would silently pass.
     out="$(
         set -o pipefail
         "$TIMEOUT" 15 "$ELFUSE" ${args_a[@]+"${args_a[@]}"} 2> /dev/null \
@@ -217,18 +217,16 @@ printf 'elfuse:    %s\n' "$ELFUSE"
 printf 'fixtures:  %s -> %s\n' "$STATICBIN" "$staticbin_abs"
 printf 'rosetta:   %s\n\n' "$ROSETTA_PATH"
 
-# ---------------------------------------------------------------------------
 # Filesystem readback
-# ---------------------------------------------------------------------------
 
 # cat: openat + read + write + close. Read the first line of fruits.
-# fruits-unsorted.txt starts with "cherry" by construction (deliberately
-# out of order so sort + diff exercise the comparison paths).
+# fruits-unsorted.txt starts with "cherry" by construction (deliberately out of
+# order so sort + diff exercise the comparison paths).
 run_re "cat-fruits-first-line" "^cherry$" \
     "${STATICBIN}/head" "-n1" "${DATA}/fruits-unsorted.txt"
 
-# wc -l counts lines via read syscall over a file. The fixture file is
-# 7 fruit names; lines.txt has 256 lines of 39 bytes each (256*39 = 9984).
+# wc -l counts lines via read syscall over a file. The fixture file is 7 fruit
+# names; lines.txt has 256 lines of 39 bytes each (256*39 = 9984).
 run_re "wc-l-fruits" "^[[:space:]]*7 .*fruits-unsorted.txt$" \
     "${STATICBIN}/wc" "-l" "${DATA}/fruits-unsorted.txt"
 run_re "wc-l-lines" "^[[:space:]]*256 .*lines.txt$" \
@@ -248,14 +246,19 @@ run_re "stat-data" "regular file" \
 run_re "find-by-name" "lines.txt" \
     "${STATICBIN}/find" "$DATA" "-name" "lines.txt"
 
-# du -s: stat aggregation; output is "<size>\t<path>". Just sanity-check
-# that a non-zero size is reported.
+# du -s: stat aggregation; output is "<size>\t<path>". Just sanity-check that a
+# non-zero size is reported.
 run_re "du-sk-data" "^[1-9][0-9]*[[:space:]]" \
     "${STATICBIN}/du" "-sk" "$DATA"
 
-# ---------------------------------------------------------------------------
+# readlink /proc/self/exe must resolve to the guest binary, not the rosetta
+# translator (issue #107). A regression returns .../RosettaLinux/rosetta, so pin
+# the basename to busybox. Guards both readlink code paths: rosetta maps
+# readlink("/proc/self/exe") onto open + readlink("/proc/self/fd/N").
+run_re "readlink-self-exe-not-rosetta" "/busybox$" \
+    "${STATICBIN}/busybox" "readlink" "/proc/self/exe"
+
 # Hashing - libc per-byte loops + per-iteration computation
-# ---------------------------------------------------------------------------
 
 run_re "sha256-fruits" "^[0-9a-f]{64}  " \
     "${STATICBIN}/sha256sum" "${DATA}/fruits-sorted.txt"
@@ -274,9 +277,7 @@ run_re "md5-fruits" "^[0-9a-f]{32}  " \
 run_re "cksum-fruits" "^[0-9]+ [0-9]+ " \
     "${STATICBIN}/cksum" "${DATA}/fruits-sorted.txt"
 
-# ---------------------------------------------------------------------------
 # Text processing
-# ---------------------------------------------------------------------------
 
 # sort: in-place tmpfile + qsort + write back. Verify first and last lines.
 run_re "sort-first" "^apple$" \
@@ -284,8 +285,8 @@ run_re "sort-first" "^apple$" \
 run_re "sort-reverse-first" "^grape$" \
     "${STATICBIN}/sort" "-r" "${DATA}/fruits-unsorted.txt"
 
-# Sort + count via two-stage pipeline. busybox wc on stdin does not pad
-# the count, so the expected output is the bare "7".
+# Sort + count via two-stage pipeline. busybox wc on stdin does not pad the
+# count, so the expected output is the bare "7".
 run_pipe "pipe-sort-wc" "7" \
     "${STATICBIN}/sort" "${DATA}/fruits-unsorted.txt" \
     -- \
@@ -340,14 +341,12 @@ run_pipe "pipe-rev" "olleh" \
     -- \
     "${STATICBIN}/rev"
 
-# tac: reverse line order on a file. The fruits-sorted.txt corpus starts
-# with "apple" and ends with "grape"; after tac the first line is "grape".
+# tac: reverse line order on a file. The fruits-sorted.txt corpus starts with
+# "apple" and ends with "grape"; after tac the first line is "grape".
 run_re "tac-reverse-first-line" "^grape$" \
     "${STATICBIN}/tac" "${DATA}/fruits-sorted.txt"
 
-# ---------------------------------------------------------------------------
 # Arithmetic and number generation
-# ---------------------------------------------------------------------------
 
 run_eq "seq-1-5" "$(printf '1\n2\n3\n4\n5')" \
     "${STATICBIN}/seq" "1" "5"
@@ -361,9 +360,7 @@ run_re "factor-prime" "^999983: 999983$" \
 run_re "factor-composite" "^60: 2 2 3 5$" \
     "${STATICBIN}/factor" "60"
 
-# ---------------------------------------------------------------------------
 # File comparison + base64 round-trip
-# ---------------------------------------------------------------------------
 
 # diff -q on identical files: rc=0 and no stdout.
 total=$((total + 1))
@@ -392,17 +389,15 @@ else
     report_fail "diff-differs: rc=$diff_rc (want 1)"
 fi
 
-# base64 decode of a pre-encoded constant. Verifies the encoder + decoder
-# share the same alphabet and padding rules. The encoded form below is the
-# canonical base64 of "rosetta-bridge".
+# base64 decode of a pre-encoded constant. Verifies the encoder + decoder share
+# the same alphabet and padding rules. The encoded form below is the canonical
+# base64 of "rosetta-bridge".
 run_pipe "pipe-base64-decode" "rosetta-bridge" \
     "${STATICBIN}/echo" "cm9zZXR0YS1icmlkZ2U=" \
     -- \
     "${STATICBIN}/base64" "-d"
 
-# ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
 
 report_summary "$total"
 


### PR DESCRIPTION
On x86_64 guests, readlink("/proc/self/exe") and
readlink("/proc/self/fd/N") (with N from opening /proc/self/exe) returned the Rosetta translator path (ROSETTA_PATH) instead of the running guest binary. GNU coreutils ships a multi-call binary whose applets self-identify by reading /proc/self/exe, opening it, then readlink-ing /proc/self/fd/N and matching the basename. Getting "rosetta" back made every applet abort with "unknown program 'rosetta'", which broke Debian/Ubuntu maintainer scripts under apt upgrade and dpkg -i.

Factor the /proc/self/exe resolution (ELF-path snapshot plus sysroot-prefix strip) into proc_readlink_self_exe. Drop the Rosetta early-return from the direct /proc/self/exe branch, and in the /proc/self/fd/N branch substitute the guest binary when the host fd resolves to ROSETTA_PATH.

proc_intercept_open("/proc/self/exe") still hands back an fd to ROSETTA_PATH so the VZ ioctl gate (rosetta_ioctl_target_fd) keeps recognising Rosetta's own self-identification; only the guest-visible readlink string changed.

Close #107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong /proc/self/exe reporting under Rosetta. `readlink("/proc/self/exe")` and `readlink("/proc/self/fd/N")` now return the guest binary path (sysroot-stripped) so multi-call binaries no longer abort.

- **Bug Fixes**
  - Return the guest binary for `readlink("/proc/self/exe")` and `readlink("/proc/self/fd/N")` on x86_64 under Rosetta, with sysroot prefix stripped.
  - Keep `open("/proc/self/exe")` returning a host fd to `ROSETTA_PATH` so the VZ ioctl gate still recognizes Rosetta.
  - Add a regression test asserting `/proc/self/exe` resolves to the guest (basename `busybox`), not Rosetta.

- **Refactors**
  - Extract `proc_readlink_self_exe()` to resolve the ELF path and strip the sysroot; reuse in both readlink paths.
  - Remove the Rosetta early-return for `/proc/self/exe` and substitute the guest path when an fd resolves to `ROSETTA_PATH`.

<sup>Written for commit ebd6d26baa794078398a7532fbcc4b3bd0d3d39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

