### PR TITLE
Fix getdents64 use-after-free on concurrent close

### DIFF
--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -437,19 +437,40 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
 
             if (fd_entries[i].type != FD_DIR)
                 continue;
+            /* Rebuild the directory stream. Every failure below must close
+             * the slot rather than leave it published as FD_DIR with
+             * dir=NULL: such a slot never faults, but sys_getdents64 would
+             * report ENOTDIR on it for the child's whole lifetime, masking
+             * the restore failure as a valid-but-broken fd. A closed slot
+             * yields EBADF, an honest signal that the fd did not survive
+             * the fork.
+             */
             int dir_fd = dup(host_fds[i]);
             if (dir_fd < 0) {
                 log_error("fork-child: dup failed for DIR gfd %d: %s", gfd,
                           strerror(errno));
+                close(host_fds[i]);
+                fd_mark_closed(gfd);
                 continue;
             }
             DIR *dir = fdopendir(dir_fd);
             if (!dir) {
                 close(dir_fd);
                 log_error("fork-child: fdopendir failed for gfd %d", gfd);
+                close(host_fds[i]);
+                fd_mark_closed(gfd);
                 continue;
             }
-            fd_table[gfd].dir = dir;
+            void *ds = dir_stream_create(dir);
+            if (!ds) {
+                closedir(dir);
+                log_error("fork-child: dir_stream_create failed for gfd %d",
+                          gfd);
+                close(host_fds[i]);
+                fd_mark_closed(gfd);
+                continue;
+            }
+            fd_table[gfd].dir = ds;
         }
     }
 

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -738,7 +738,8 @@ typedef struct {
                           * detect a close+reopen ABA where the slot now holds a
                           * different open file. */
     int linux_flags;     /* Linux open flags (for CLOEXEC tracking) */
-    void *dir;           /* DIR* for FD_DIR entries (NULL otherwise) */
+    void *dir;           /* dir_stream_t* for FD_DIR entries, opaque instance
+                          * pointer for FD_EPOLL entries (NULL otherwise) */
     char proc_path[FD_VIRTUAL_PATH_MAX]; /* Virtual /proc dir root for *at */
     int seals;      /* F_SEAL_* bits (non-zero only for memfd_create fds) */
     bool can_block; /* host read/write on this fd may block (pipe, socket, fifo,

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -568,10 +568,10 @@ int fd_to_host_dup(int guest_fd)
  */
 void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
 {
-    /* DIR* / epoll_instance_t stored in the dir field */
+    /* dir_stream_t / epoll_instance_t stored in the dir field */
     if (snap->dir) {
         if (snap->type == FD_DIR)
-            closedir((DIR *) snap->dir);
+            dir_stream_release(snap->dir);
         else if (snap->type == FD_EPOLL)
             free(snap->dir);
     }

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -215,6 +215,102 @@ static const char *proc_virtual_dir_path(const char *path,
     return virt;
 }
 
+/* Reference-counted wrapper around a directory stream. See the declaration in
+ * syscall/internal.h for why this exists: a raw DIR* stored in
+ * fd_table[fd].dir would let a sibling close()/dup2()/fork-restore free it via
+ * closedir() while sys_getdents64() is still mid-loop reading it. The struct
+ * itself is private to this file; every other module only ever sees the
+ * opaque void* that fd_table[].dir already stores.
+ */
+typedef struct {
+    DIR *dir;
+    pthread_mutex_t lock; /* Serializes the telldir/readdir/seekdir walk in
+                           * sys_getdents64. The refcount below only pins the
+                           * wrapper's lifetime; two guest threads issuing
+                           * getdents64 on the same fd would otherwise
+                           * interleave their walks on the shared DIR* and see
+                           * an undefined entry split (Linux serializes
+                           * getdents64 through the struct file's f_pos_lock).
+                           * Only ever taken by reference holders, so it is
+                           * never destroyed while held.
+                           */
+    int refcount;         /* Guarded by fd_lock. Starts at 1 (the fd-table's
+                           * own reference) and gains one per in-flight
+                           * sys_getdents64 that pinned it via
+                           * dir_stream_acquire(). Freed only when the count
+                           * reaches zero.
+                           */
+} dir_stream_t;
+
+/* Wrap an already-open DIR* for storage in fd_table[].dir. Takes ownership of
+ * dir on success. Returns NULL on allocation failure, in which case the
+ * caller still owns dir and must closedir() it.
+ */
+void *dir_stream_create(DIR *dir)
+{
+    dir_stream_t *ds = malloc(sizeof(*ds));
+    if (!ds)
+        return NULL;
+    ds->dir = dir;
+    pthread_mutex_init(&ds->lock, NULL);
+    ds->refcount = 1;
+    return ds;
+}
+
+/* Tear down a wrapper that was never published to fd_table (an allocation or
+ * install failure between dir_stream_create() and the point the pointer would
+ * have been written to fd_table[].dir). No other thread can have acquired a
+ * reference yet, so this always closes and frees unconditionally.
+ */
+static void dir_stream_discard(void *ds_ptr)
+{
+    dir_stream_t *ds = ds_ptr;
+    closedir(ds->dir);
+    pthread_mutex_destroy(&ds->lock);
+    free(ds);
+}
+
+/* Pin fd's directory stream against a concurrent close()/dup2() so
+ * sys_getdents64 can safely walk it. Returns the pinned wrapper, or NULL if
+ * fd is not (or no longer) an open FD_DIR. Balance every non-NULL return with
+ * dir_stream_release().
+ */
+static dir_stream_t *dir_stream_acquire(int fd)
+{
+    if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
+        return NULL;
+    pthread_mutex_lock(&fd_lock);
+    dir_stream_t *ds = NULL;
+    if (fd_table[fd].type == FD_DIR) {
+        ds = (dir_stream_t *) fd_table[fd].dir;
+        if (ds)
+            ds->refcount++;
+    }
+    pthread_mutex_unlock(&fd_lock);
+    return ds;
+}
+
+/* Drop a reference taken by dir_stream_acquire(), or the fd-table's own
+ * reference from fd_cleanup_entry(). No-op when passed NULL. The decrement
+ * happens under fd_lock; the actual closedir()/free() runs after releasing
+ * it, matching fd_cleanup_entry's own "do not hold fd_lock across slow
+ * syscalls" convention.
+ */
+void dir_stream_release(void *ds_ptr)
+{
+    dir_stream_t *ds = ds_ptr;
+    if (!ds)
+        return;
+    pthread_mutex_lock(&fd_lock);
+    bool last = --ds->refcount == 0;
+    pthread_mutex_unlock(&fd_lock);
+    if (last) {
+        closedir(ds->dir);
+        pthread_mutex_destroy(&ds->lock);
+        free(ds);
+    }
+}
+
 static int fd_alloc_opened_host(int host_fd,
                                 int type,
                                 int linux_flags,
@@ -222,16 +318,23 @@ static int fd_alloc_opened_host(int host_fd,
                                 void (*cleanup)(int),
                                 const char *virtual_path)
 {
-    DIR *dir = NULL;
+    dir_stream_t *ds = NULL;
 
     if (type == FD_DIR) {
         int dup_fd = dup(host_fd);
         if (dup_fd < 0)
             return -1;
 
-        dir = fdopendir(dup_fd);
+        DIR *dir = fdopendir(dup_fd);
         if (!dir) {
             close_keep_errno(dup_fd);
+            return -1;
+        }
+        ds = dir_stream_create(dir);
+        if (!ds) {
+            int saved_errno = errno;
+            closedir(dir);
+            errno = saved_errno;
             return -1;
         }
     }
@@ -242,8 +345,8 @@ static int fd_alloc_opened_host(int host_fd,
             : fd_alloc_from_relaxed(0, type, host_fd, cleanup);
     if (guest_fd < 0) {
         int saved_errno = errno;
-        if (dir)
-            closedir(dir);
+        if (ds)
+            dir_stream_discard(ds);
         errno = saved_errno;
         return -1;
     }
@@ -263,16 +366,16 @@ static int fd_alloc_opened_host(int host_fd,
      * tuple still matches what just got allocated; if it does not, the slot
      * belongs to a different file now and any install would clobber the
      * sibling's entry. The sibling's close path already cleaned up the host_fd
-     * of this side via fd_cleanup_entry, so this side only owns dir, which gets
-     * closed below.
+     * of this side via fd_cleanup_entry, so this side only owns ds, which gets
+     * discarded below.
      */
     bool installed = false;
     pthread_mutex_lock(&fd_lock);
     if (fd_table[guest_fd].type == type &&
         fd_table[guest_fd].host_fd == host_fd) {
         fd_table[guest_fd].linux_flags = linux_flags;
-        if (dir)
-            fd_table[guest_fd].dir = dir;
+        if (ds)
+            fd_table[guest_fd].dir = ds;
         if (have_proc_path)
             memcpy(fd_table[guest_fd].proc_path, proc_path_buf,
                    sizeof(proc_path_buf));
@@ -284,8 +387,8 @@ static int fd_alloc_opened_host(int host_fd,
     }
     pthread_mutex_unlock(&fd_lock);
 
-    if (!installed && dir)
-        closedir(dir);
+    if (!installed && ds)
+        dir_stream_discard(ds);
 
     return guest_fd;
 }
@@ -635,13 +738,13 @@ static void discard_allocated_fd(int guest_fd)
 /* Open a DIR stream over a dup of dst_host_fd if the source was an FD_DIR.
  *
  * Returns NULL on success-but-no-stream-needed (non-dir source) or on
- * dup/fdopendir failure with errno preserved. Pulled out of the critical
- * section in install_fd_alias_metadata_atomic because dup and fdopendir are
- * slow syscalls that must not hold fd_lock.
+ * dup/fdopendir/allocation failure with errno preserved. Pulled out of the
+ * critical section in install_fd_alias_metadata_atomic because dup and
+ * fdopendir are slow syscalls that must not hold fd_lock.
  */
-static DIR *clone_dir_stream(const fd_entry_t *src_snap,
-                             int dst_host_fd,
-                             bool *out_failed)
+static dir_stream_t *clone_dir_stream(const fd_entry_t *src_snap,
+                                      int dst_host_fd,
+                                      bool *out_failed)
 {
     *out_failed = false;
     if (src_snap->type != FD_DIR)
@@ -660,7 +763,15 @@ static DIR *clone_dir_stream(const fd_entry_t *src_snap,
         *out_failed = true;
         return NULL;
     }
-    return dir;
+    dir_stream_t *ds = dir_stream_create(dir);
+    if (!ds) {
+        int saved_errno = errno;
+        closedir(dir);
+        errno = saved_errno;
+        *out_failed = true;
+        return NULL;
+    }
+    return ds;
 }
 
 /* Install dup-alias metadata atomically with the slot identity. Uses the (type,
@@ -669,14 +780,14 @@ static DIR *clone_dir_stream(const fd_entry_t *src_snap,
  * the relaxed allocator's lock release and this call could otherwise clobber
  * the sibling's freshly-installed entry.
  * Returns true on successful install, false if the slot was reallocated (caller
- * must closedir any cloned dir to avoid a leak).
+ * must dir_stream_discard() any cloned ds to avoid a leak).
  */
 static bool install_fd_alias_metadata_atomic(int dst_fd,
                                              int expected_type,
                                              int expected_host_fd,
                                              const fd_entry_t *src_snap,
                                              int linux_flags,
-                                             DIR *dir)
+                                             dir_stream_t *ds)
 {
     /* LINUX_O_NONBLOCK is a file-status flag preserved by dup(2)/dup2(2).
      * Required for FD_TIMERFD (and any other type that stores NONBLOCK in
@@ -697,8 +808,8 @@ static bool install_fd_alias_metadata_atomic(int dst_fd,
         fd_table[dst_fd].seals = src_snap->seals;
         memcpy(fd_table[dst_fd].proc_path, src_snap->proc_path,
                sizeof(fd_table[dst_fd].proc_path));
-        if (dir)
-            fd_table[dst_fd].dir = dir;
+        if (ds)
+            fd_table[dst_fd].dir = ds;
         bool readable_urandom =
             expected_type == FD_URANDOM &&
             (final_flags & LINUX_O_ACCMODE) != LINUX_O_WRONLY;
@@ -795,7 +906,8 @@ static int duplicate_guest_fd(int src_fd,
      * this install land on an unrelated slot.
      */
     bool dir_clone_failed = false;
-    DIR *dir = clone_dir_stream(&src_snap, new_host_fd, &dir_clone_failed);
+    dir_stream_t *ds =
+        clone_dir_stream(&src_snap, new_host_fd, &dir_clone_failed);
     if (dir_clone_failed) {
         int saved_errno = errno;
         discard_allocated_fd(guest_fd);
@@ -804,14 +916,14 @@ static int duplicate_guest_fd(int src_fd,
     }
 
     if (!install_fd_alias_metadata_atomic(guest_fd, new_type, new_host_fd,
-                                          &src_snap, linux_flags, dir)) {
+                                          &src_snap, linux_flags, ds)) {
         /* Slot was reallocated by a sibling while metadata install was pending;
          * the sibling's close path already cleaned up new_host_fd via
          * fd_cleanup_entry, so the only resource this side still owns is the
          * cloned DIR stream.
          */
-        if (dir)
-            closedir(dir);
+        if (ds)
+            dir_stream_discard(ds);
     }
 
     return guest_fd;
@@ -1249,12 +1361,25 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
     if (fd_table[fd].type == FD_PATH)
         return -LINUX_EBADF;
 
-    DIR *dir = (DIR *) fd_table[fd].dir;
-    if (!dir)
+    /* Pin the directory stream so a concurrent close()/dup2() cannot free it
+     * while this call is still walking it -- see dir_stream_t in fs.c.
+     */
+    dir_stream_t *ds = dir_stream_acquire(fd);
+    if (!ds)
         return -LINUX_ENOTDIR;
+    DIR *dir = ds->dir;
 
-    if (!guest_ptr(g, buf_gva))
-        return -LINUX_EFAULT;
+    /* Serialize the walk against a concurrent getdents64 pinning the same
+     * stream -- see the lock field in dir_stream_t.
+     */
+    pthread_mutex_lock(&ds->lock);
+
+    int64_t ret;
+
+    if (!guest_ptr(g, buf_gva)) {
+        ret = -LINUX_EFAULT;
+        goto out;
+    }
 
     size_t guest_pos = 0;
     struct dirent *de;
@@ -1306,7 +1431,8 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
                         NAME_MAX, strlen(de->d_name), fd);
                 continue;
             }
-            return guest_pos > 0 ? (int64_t) guest_pos : linux_errno();
+            ret = guest_pos > 0 ? (int64_t) guest_pos : linux_errno();
+            goto out;
         }
 
         size_t name_len = strlen(guest_name);
@@ -1334,13 +1460,20 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         if (pad_start < reclen)
             memset(entry_buf + pad_start, 0, reclen - pad_start);
 
-        if (guest_write(g, buf_gva + guest_pos, entry_buf, reclen) < 0)
-            return guest_pos > 0 ? (int64_t) guest_pos : -LINUX_EFAULT;
+        if (guest_write(g, buf_gva + guest_pos, entry_buf, reclen) < 0) {
+            ret = guest_pos > 0 ? (int64_t) guest_pos : -LINUX_EFAULT;
+            goto out;
+        }
 
         guest_pos += reclen;
     }
 
-    return (int64_t) guest_pos;
+    ret = (int64_t) guest_pos;
+
+out:
+    pthread_mutex_unlock(&ds->lock);
+    dir_stream_release(ds);
+    return ret;
 }
 
 int64_t sys_chdir(guest_t *g, uint64_t path_gva)

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -214,6 +215,21 @@ bool fd_close_regular_relaxed(int fd, int *host_fd_out);
  * already removed the entry from fd_table.
  */
 void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap);
+
+/* Reference-counted wrapper around a directory stream, stored in
+ * fd_table[].dir for FD_DIR entries (see syscall/fs.c). A raw DIR* would let a
+ * sibling's close()/dup2()/fork-restore free it via closedir() while
+ * sys_getdents64() is still mid-loop reading it; the wrapper defers the
+ * closedir() until every acquirer -- the fd-table's own reference, plus any
+ * in-flight sys_getdents64 -- has released it. Guarded by fd_lock, mirroring
+ * poll.c's epoll_instance_t refcount.
+ *
+ * dir_stream_create() takes ownership of dir and returns the wrapper, or NULL
+ * on allocation failure (caller still owns dir and must closedir() it itself).
+ * dir_stream_release() drops a reference and is a no-op when passed NULL.
+ */
+void *dir_stream_create(DIR *dir);
+void dir_stream_release(void *ds);
 
 /* Translation helpers. */
 

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -71,6 +71,7 @@ test-large-io-boundary
 test-ioctl-cloexec
 test-pty
 test-ioctl-fioasync
+test-getdents-refcount
 
 [section] /proc and /dev emulation tests
 test-proc

--- a/tests/test-getdents-refcount.c
+++ b/tests/test-getdents-refcount.c
@@ -1,0 +1,208 @@
+/*
+ * getdents64 directory-stream lifetime stress: close(fd) racing a sibling's
+ * getdents64
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Companion to test-getdents64-overlong.c. That test drives sys_getdents64's
+ * dirent-translation edge cases. This one pins a different invariant: a
+ * directory fd's DIR* stream must survive a concurrent close()/dup2() while
+ * sys_getdents64() is still mid-loop reading it (src/syscall/fs.c
+ * dir_stream_t / dir_stream_acquire / dir_stream_release).
+ *
+ * fd_table[fd].dir is a bare pointer for FD_DIR entries. Before this fix,
+ * sys_getdents64() read it with no lock and no pin, then looped
+ * readdir()/telldir()/seekdir() on it; a sibling's close(fd) ran
+ * fd_cleanup_entry() -> closedir() outside fd_lock and freed the stream out
+ * from under the in-flight loop -- the exact same use-after-free class the
+ * companion epoll fix (src/syscall/poll.c epoll_instance_acquire/_release)
+ * addresses for FD_EPOLL. dir_stream_acquire()/_release() close the gap by
+ * refcounting the wrapper instead of freeing it the instant the fd-table's
+ * own reference goes away.
+ *
+ * This test hammers that window: a long-lived sibling spins raw getdents64()
+ * on a directory fd the main thread keeps recreating, publishing, and
+ * retiring -- once via close(), once via dup2() overwriting the slot (the
+ * fd_alloc_at path, which also funnels through fd_cleanup_entry). Racing
+ * close()/dup2() with getdents64() on the same fd is guest-undefined, so the
+ * sibling's return value is not asserted; the contract under test is that
+ * elfuse never faults or double-frees. Survival across all iterations with a
+ * clean exit is the pass condition.
+ *
+ * Raw syscalls in the sibling (a CLONE_THREAD child has no libc TLS).
+ *
+ * Syscalls exercised: clone(220), openat(56), getdents64(61), close(57),
+ *                     dup3(24), nanosleep(101), futex(98), exit(93)
+ */
+
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include "test-harness.h"
+#include "raw-syscall.h"
+
+int passes = 0, fails = 0;
+
+/* Shared with the clone sibling; atomic because both threads touch them. */
+static _Atomic int shared_fd = -1;
+static _Atomic int sibling_stop = 0;
+static char sibling_stack[32768] __attribute__((aligned(16)));
+
+#define STRESS_DIR "/tmp/test-getdents-refcount.d"
+#define STRESS_FILE_COUNT 800
+
+/* Populate a directory with enough entries that a single getdents64() call
+ * cannot drain it in one host readdir() burst, widening the window a sibling
+ * close()/dup2() has to land mid-loop.
+ */
+static int make_stress_dir(void)
+{
+    if (mkdir(STRESS_DIR, 0755) < 0 && errno != EEXIST)
+        return -1;
+    for (int i = 0; i < STRESS_FILE_COUNT; i++) {
+        char path[128];
+        snprintf(path, sizeof(path), STRESS_DIR "/f%d", i);
+        int fd = open(path, O_CREAT | O_WRONLY, 0644);
+        if (fd < 0)
+            return -1;
+        close(fd);
+    }
+    return 0;
+}
+
+/* Spin raw getdents64() on whatever directory fd the main thread has
+ * published. The fd may be closed (or reused) concurrently; a raw syscall
+ * just returns an error, which is exactly the window the refcount must make
+ * memory-safe.
+ */
+static int sibling_fn(void *arg)
+{
+    (void) arg;
+    static char buf[65536];
+    while (!sibling_stop) {
+        int fd = shared_fd;
+        if (fd >= 0) {
+            raw_syscall3(__NR_getdents64, (long) fd, (long) buf, sizeof(buf));
+        } else {
+            struct {
+                long tv_sec, tv_nsec;
+            } ts = {0, 5000}; /* 5us -- react fast to a freshly published fd */
+            raw_syscall2(__NR_nanosleep, (long) &ts, 0);
+        }
+    }
+    raw_syscall1(__NR_exit, 0);
+    return 0;
+}
+
+int main(void)
+{
+    printf("test-getdents-refcount: close(fd)/dup2 vs concurrent getdents64\n");
+
+    TEST("stress directory fixture");
+    EXPECT_TRUE(make_stress_dir() == 0, "failed to create stress directory");
+
+    long flags = 0x00000100 | 0x00000200 | 0x00000400 | 0x00000800 |
+                 0x00010000 | 0x00200000; /* CLONE_VM|FS|FILES|SIGHAND|THREAD|
+                                             CHILD_CLEARTID */
+    volatile uint32_t child_tid = 1;
+    long ret = raw_syscall5(__NR_clone, flags,
+                            (long) (sibling_stack + sizeof(sibling_stack)), 0,
+                            0, (long) &child_tid);
+    if (ret == 0) {
+        sibling_fn(NULL);
+        return 0; /* unreachable */
+    }
+
+    TEST("clone sibling reader");
+    EXPECT_TRUE(ret > 0, "clone failed");
+
+    const int iterations = 4000;
+    int completed = 0;
+    for (int i = 0; i < iterations; i++) {
+        int fd = open(STRESS_DIR, O_RDONLY | O_DIRECTORY);
+        if (fd < 0)
+            break;
+
+        /* Publish to the sibling with no synchronization delay: getdents64
+         * (unlike epoll_pwait) never blocks, so there is no multi-millisecond
+         * window to sleep into -- racing as tightly as possible and repeating
+         * thousands of times is what actually lands the close()/dup2() inside
+         * an in-flight readdir() loop often enough to matter.
+         */
+        shared_fd = fd;
+
+        if (i % 2 == 0) {
+            /* Retract, then close under the sibling's in-flight getdents64.
+             * Fires the close hook (fd_cleanup_entry -> dir_stream_release)
+             * on the stream the sibling is still reading.
+             */
+            shared_fd = -1;
+            close(fd);
+        } else {
+            /* dup2 a fresh directory fd over the same slot number: retires the
+             * old open file description via fd_alloc_at -> fd_cleanup_entry
+             * without a close() syscall on fd itself -- the second chokepoint
+             * dir_stream_release() must also cover.
+             */
+            int replacement = open(STRESS_DIR, O_RDONLY | O_DIRECTORY);
+            if (replacement >= 0) {
+                shared_fd = -1;
+                dup3(replacement, fd, 0);
+                close(replacement);
+                close(fd);
+            } else {
+                shared_fd = -1;
+                close(fd);
+            }
+        }
+        completed++;
+    }
+
+    TEST("all iterations survived close/dup2 vs getdents64 race");
+    EXPECT_EQ(completed, iterations, "did not complete every iteration");
+
+    /* A fresh directory fd still reads correctly after the churn (no
+     * leaked/corrupt state, refcount returned to a clean baseline).
+     */
+    TEST("getdents64 still functional after churn");
+    {
+        int fd = open(STRESS_DIR, O_RDONLY | O_DIRECTORY);
+        int seen = 0;
+        bool ok = fd >= 0;
+        if (ok) {
+            char buf[512];
+            for (;;) {
+                long n = raw_syscall3(__NR_getdents64, (long) fd, (long) buf,
+                                      sizeof(buf));
+                if (n <= 0)
+                    break;
+                seen++;
+                if (seen > 4 * STRESS_FILE_COUNT)
+                    break; /* corrupt stream would loop forever; bail out */
+            }
+            close(fd);
+        }
+        EXPECT_TRUE(ok && seen > 0, "getdents64 broken after stress");
+    }
+
+    /* Release the sibling and join via the CLONE_CHILD_CLEARTID futex. */
+    sibling_stop = 1;
+    for (int i = 0; i < 200 && child_tid != 0; i++) {
+        struct {
+            long tv_sec, tv_nsec;
+        } ts = {0, 10000000}; /* 10ms */
+        raw_syscall6(__NR_futex, (long) &child_tid, 0 /* FUTEX_WAIT */,
+                     child_tid, (long) &ts, 0, 0);
+    }
+
+    SUMMARY("test-getdents-refcount");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
sys_getdents64 read fd_table[fd].dir with no lock and no lifetime pin,
then looped readdir()/telldir()/seekdir() on it. A sibling close() or
dup2()-overwrite of the same fd runs fd_cleanup_entry() -> closedir()
outside fd_lock and frees the stream while the read loop is still
using it -- the same use-after-free class PR #146 fixes for
FD_EPOLL's epoll_instance_t, left unaddressed for FD_DIR.

Wrap the DIR* in a refcounted dir_stream_t (fd-table's own reference
plus one per in-flight sys_getdents64, mirroring epoll_instance_t's
acquire/release), so a concurrent close/dup2/fork-restore only drops
its own reference instead of unconditionally freeing the stream.

Reproduced pre-fix under ASAN (double-free in readdir() racing
closedir() from a concurrent dup3) and confirmed clean post-fix with
tests/test-getdents-refcount.c, added to the unit suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a getdents64 use-after-free and concurrent-walk races by refcounting and serializing directory streams. Closing, dup2/dup3, or fork-restore no longer frees a stream in use; failed restores now close the fd and return EBADF.

- **Bug Fixes**
  - Wrapped directory `DIR*` in refcounted `dir_stream_t`; `fd_table[].dir` stores the wrapper and frees on last ref.
  - `sys_getdents64` now pins the stream and holds a per-stream mutex across the readdir/telldir/seekdir walk.
  - Close/dup/fork paths updated: `fd_cleanup_entry` calls `dir_stream_release`; dup/aliasing clones the wrapper; on restore failure (dup/fdopendir/create), the child closes the slot instead of publishing `FD_DIR` with `dir=NULL`.
  - Added stress test `tests/test-getdents-refcount.c` (in `tests/manifest.txt`) that reproduced the race pre-fix and now passes.

<sup>Written for commit a900f6b634acd4c88d84785fa13793f4dd3c7350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

