### PR TITLE
Reap terminated worker pthreads on slot reuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,11 @@ $(BUILD_DIR)/test-pthread: tests/test-pthread.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
 
+# test-thread-churn creates >64 threads to force thread-table slot reuse.
+$(BUILD_DIR)/test-thread-churn: tests/test-thread-churn.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $< -lpthread
+
 # test-poll uses pthread_kill to verify blocked read signal delivery.
 $(BUILD_DIR)/test-poll: tests/test-poll.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -642,6 +642,13 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         log_error("clone_thread: thread table full");
         return -LINUX_EAGAIN;
     }
+    /* Captured now, while the slot is guaranteed still ours (thread_alloc just
+     * marked it active, so no concurrent thread_alloc reuse-scan will touch
+     * it until our own worker deactivates it). Passed to
+     * thread_set_host_thread below so it can detect whether this exact slot
+     * got recycled to a different logical thread before that call runs.
+     */
+    uint64_t t_generation = t->generation;
 
     /* Inherit parent's signal mask (POSIX: clone inherits blocked mask) */
     if (current_thread)
@@ -711,7 +718,19 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_EAGAIN;
     }
 
-    thread_set_host_thread(t, host_thread, true);
+    /* If this returns false, the worker already hit its startup_failed path
+     * and thread_deactivate'd t fast enough for a concurrent clone to recycle
+     * the slot before this write -- t no longer refers to our worker, so the
+     * write is skipped rather than clobbering the new occupant (a race
+     * flagged by review: recording host_thread unconditionally could corrupt
+     * the recycled slot's real handle). A mismatch can only happen alongside
+     * a startup failure (thread_deactivate is the sole precondition for
+     * reuse, and nothing else calls it this early), so the failure branch
+     * below is guaranteed to run and is solely responsible for reaping
+     * host_thread in that case.
+     */
+    bool host_thread_recorded =
+        thread_set_host_thread(t, host_thread, true, t_generation);
 
     pthread_mutex_lock(&startup.lock);
     while (!startup.ready)
@@ -723,13 +742,26 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         /* Worker failed during HVF bring-up after the SETTID writes had already
          * populated the guest TID slots. Linux clone(2) does not leave a
          * live-looking TID behind for a thread that never started, so restore
-         * the slots before the parent sees the error. The worker deactivated
-         * its slot before signaling the handshake, so a concurrent clone may
-         * already have reused the slot and joined the handle at reuse time;
-         * claim the join to guarantee exactly one joiner.
+         * the slots before the parent sees the error.
          */
-        if (thread_claim_worker_join(t, host_thread))
+        if (host_thread_recorded) {
+            /* The worker deactivated its slot before signaling the handshake,
+             * so a concurrent clone may already have reused the slot and
+             * joined the handle at reuse time; claim the join to guarantee
+             * exactly one joiner.
+             */
+            if (thread_claim_worker_join(t, host_thread))
+                pthread_join(host_thread, NULL);
+        } else {
+            /* The write above was rejected: some other clone recycled t
+             * before we could record host_thread, so no table entry
+             * references it and nobody else will ever join it. We are the
+             * only owner. The worker's startup_failed path is a short,
+             * non-blocking sequence (no guest code ever ran), so this join
+             * returns promptly.
+             */
             pthread_join(host_thread, NULL);
+        }
         clone_rollback_tid_flags(g, &tid_rollback);
         return startup.startup_rc;
     }
@@ -968,6 +1000,7 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
         log_error("clone_vm: thread table full");
         return -LINUX_EAGAIN;
     }
+    uint64_t t_generation = t->generation;
 
     /* Mark as VM-clone child (waitable via wait4, not CLONE_THREAD) */
     t->is_vm_clone = true;
@@ -1033,9 +1066,13 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
     }
 
     /* Detached: the pthread runtime reclaims the thread on exit, so the handle
-     * must never be joined (host_thread_needs_join stays false).
+     * must never be joined (host_thread_needs_join stays false). The
+     * generation check always succeeds here: unlike sys_clone_thread's
+     * worker, a vm-clone worker that fails HVF bring-up
+     * (vm_clone_report_bringup_failure) keeps the slot active for wait4
+     * rather than deactivating it, so t cannot be recycled before this call.
      */
-    thread_set_host_thread(t, host_thread, false);
+    (void) thread_set_host_thread(t, host_thread, false, t_generation);
 
     log_debug(
         "clone_vm: child tid=%lld created "

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -685,8 +685,9 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_EFAULT;
     }
 
-    /* Create the host pthread (joinable; exit_group joins all workers via
-     * thread_join_workers_cb before process exit). Threads clean up their TID
+    /* Create the host pthread (joinable; teardown joins live workers via
+     * thread_join_workers, and a worker that exits on its own is joined when
+     * its table slot is reused by thread_alloc). Threads clean up their TID
      * address via CLONE_CHILD_CLEARTID + futex wake.
      */
     pthread_t host_thread;
@@ -710,7 +711,7 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_EAGAIN;
     }
 
-    t->host_thread = host_thread;
+    thread_set_host_thread(t, host_thread, true);
 
     pthread_mutex_lock(&startup.lock);
     while (!startup.ready)
@@ -722,9 +723,13 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         /* Worker failed during HVF bring-up after the SETTID writes had already
          * populated the guest TID slots. Linux clone(2) does not leave a
          * live-looking TID behind for a thread that never started, so restore
-         * the slots before the parent sees the error.
+         * the slots before the parent sees the error. The worker deactivated
+         * its slot before signaling the handshake, so a concurrent clone may
+         * already have reused the slot and joined the handle at reuse time;
+         * claim the join to guarantee exactly one joiner.
          */
-        pthread_join(host_thread, NULL);
+        if (thread_claim_worker_join(t, host_thread))
+            pthread_join(host_thread, NULL);
         clone_rollback_tid_flags(g, &tid_rollback);
         return startup.startup_rc;
     }
@@ -1027,7 +1032,10 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
         return -LINUX_EAGAIN;
     }
 
-    t->host_thread = host_thread;
+    /* Detached: the pthread runtime reclaims the thread on exit, so the handle
+     * must never be joined (host_thread_needs_join stays false).
+     */
+    thread_set_host_thread(t, host_thread, false);
 
     log_debug(
         "clone_vm: child tid=%lld created "

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -175,7 +175,15 @@ rescan:
             pthread_cond_destroy(&t->ptrace_cond);
             pthread_cond_destroy(&t->resume_cond);
         }
+        /* Bump generation across the memset so a caller still holding this
+         * slot's pointer from before reuse (e.g. a clone parent racing its
+         * own worker's startup-failure path) can detect the recycle via
+         * thread_set_host_thread's generation check instead of writing into
+         * what is now a different logical thread.
+         */
+        uint64_t next_generation = t->generation + 1;
         memset(t, 0, sizeof(*t));
+        t->generation = next_generation;
         t->sp_el1_slot = -1; /* No SP_EL1 yet; thread_alloc_sp_el1 fills this */
         t->guest_tid = tid;
         if (stack_start < stack_end) {
@@ -221,12 +229,20 @@ static void thread_ptrace_cleanup_locked(thread_entry_t *t)
     t->ptrace_cleanup_pending = false;
 }
 
-void thread_set_host_thread(thread_entry_t *t, pthread_t thr, bool joinable)
+bool thread_set_host_thread(thread_entry_t *t,
+                            pthread_t thr,
+                            bool joinable,
+                            uint64_t generation)
 {
     pthread_mutex_lock(&thread_lock);
-    t->host_thread = thr;
-    t->host_thread_needs_join = joinable;
+    bool recorded = (t->generation == generation);
+    if (recorded) {
+        t->host_thread = thr;
+        t->host_thread_needs_join = joinable;
+    }
     pthread_mutex_unlock(&thread_lock);
+
+    return recorded;
 }
 
 bool thread_claim_worker_join(thread_entry_t *t, pthread_t thr)
@@ -411,6 +427,7 @@ void thread_join_workers(void)
     struct {
         pthread_t thr;
         thread_entry_t *t;
+        uint64_t generation;
         bool claimed;
     } workers[MAX_THREADS];
     int nworkers = 0;
@@ -424,10 +441,12 @@ void thread_join_workers(void)
          * slot was never reused. Its pthread has terminated (or is in final
          * wind-down), so the join below is immediate.
          */
-        if (!t->active && !t->host_thread_needs_join)
+        if (!__atomic_load_n(&t->active, __ATOMIC_RELAXED) &&
+            !t->host_thread_needs_join)
             continue;
         workers[nworkers].thr = t->host_thread;
         workers[nworkers].t = t;
+        workers[nworkers].generation = t->generation;
         workers[nworkers].claimed = t->host_thread_needs_join;
         t->host_thread_needs_join = false;
         nworkers++;
@@ -443,15 +462,34 @@ void thread_join_workers(void)
      * is unsafe.
      */
     for (int w = 0; w < nworkers; w++) {
+        bool recycled = false;
+
         for (int i = 0; i < 20; i++) {
             if (!__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
                 break;
+            /* The slot may have been reused for a new logical thread while we
+             * polled: thread_alloc only recycles a slot once its previous
+             * occupant is inactive, so a generation bump here proves our
+             * snapshotted worker already deactivated even though the slot now
+             * reads active == 1 again for the replacement thread. Stop
+             * polling immediately rather than tracking the wrong thread's
+             * active bit for the rest of the loop.
+             */
+            if (workers[w].t->generation != workers[w].generation) {
+                recycled = true;
+                break;
+            }
             usleep(5000);
         }
 
         if (!workers[w].claimed)
             continue;
-        if (!__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
+        /* recycled short-circuits before the active re-check: once recycled,
+         * that bit belongs to the replacement thread and must not influence
+         * the join-vs-detach decision for our (already-terminated) handle.
+         */
+        if (recycled ||
+            !__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
             pthread_join(workers[w].thr, NULL);
         else
             pthread_detach(workers[w].thr);

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -113,6 +113,7 @@ void thread_register_main(hv_vcpu_t vcpu,
     t->vcpu = vcpu;
     t->vexit = vexit;
     t->host_thread = pthread_self();
+    t->host_thread_needs_join = false; /* Never join the process main thread */
     t->clear_child_tid = 0;
     t->sp_el1 = sp_el1;
     t->sp_el1_slot = 0; /* Main thread always owns slot 0 */
@@ -142,6 +143,7 @@ thread_entry_t *thread_alloc(int64_t tid,
     thread_entry_t *result = NULL;
 
     pthread_mutex_lock(&thread_lock);
+rescan:
     THREAD_FOR_EACH (t) {
         if (__atomic_load_n(&t->active, __ATOMIC_RELAXED))
             continue;
@@ -150,6 +152,25 @@ thread_entry_t *thread_alloc(int64_t tid,
          */
         if (t->ptrace_conds_inited && t->ptrace_waiters > 0)
             continue;
+        /* Reap the previous occupant's pthread before reusing the slot.
+         * Workers that exit on their own are joinable but never joined
+         * (thread_join_workers snapshots active entries only), so dropping the
+         * handle in the memset below would leak its pthread bookkeeping for
+         * the process lifetime. active == 0 means the pthread is already past
+         * thread_deactivate, so the join blocks at most for its final
+         * wind-down -- but that wind-down can take thread_lock (the
+         * last-worker wakeup calls thread_interrupt_all), so the join must run
+         * with the lock dropped. Claim the handle first so no one else joins
+         * it, then rescan: the table may have changed while unlocked.
+         */
+        if (t->host_thread_needs_join) {
+            pthread_t stale = t->host_thread;
+            t->host_thread_needs_join = false;
+            pthread_mutex_unlock(&thread_lock);
+            pthread_join(stale, NULL);
+            pthread_mutex_lock(&thread_lock);
+            goto rescan;
+        }
         if (t->ptrace_conds_inited) {
             pthread_cond_destroy(&t->ptrace_cond);
             pthread_cond_destroy(&t->resume_cond);
@@ -198,6 +219,26 @@ static void thread_ptrace_cleanup_locked(thread_entry_t *t)
     pthread_cond_destroy(&t->resume_cond);
     t->ptrace_conds_inited = false;
     t->ptrace_cleanup_pending = false;
+}
+
+void thread_set_host_thread(thread_entry_t *t, pthread_t thr, bool joinable)
+{
+    pthread_mutex_lock(&thread_lock);
+    t->host_thread = thr;
+    t->host_thread_needs_join = joinable;
+    pthread_mutex_unlock(&thread_lock);
+}
+
+bool thread_claim_worker_join(thread_entry_t *t, pthread_t thr)
+{
+    pthread_mutex_lock(&thread_lock);
+    bool claimed =
+        t->host_thread_needs_join && pthread_equal(t->host_thread, thr);
+    if (claimed)
+        t->host_thread_needs_join = false;
+    pthread_mutex_unlock(&thread_lock);
+
+    return claimed;
 }
 
 void thread_deactivate(thread_entry_t *t)
@@ -359,20 +400,36 @@ void thread_join_workers(void)
 {
     /* Snapshot worker threads under the lock. The code needs the host_thread
      * handle and a way to check the active flag without re-locking. Storing the
-     * table entry pointer lets the loop use __atomic_load on active.
+     * table entry pointer lets the loop use __atomic_load on active. Claim each
+     * joinable handle here (clear host_thread_needs_join) so a concurrent slot
+     * reuse in thread_alloc cannot join the same pthread twice. Unclaimed
+     * entries -- vm-clone children (created detached) and the main thread's
+     * slot when a worker drives teardown -- are still polled below so teardown
+     * waits for them to leave the guest, but their handle is never joined or
+     * detached.
      */
     struct {
         pthread_t thr;
         thread_entry_t *t;
+        bool claimed;
     } workers[MAX_THREADS];
     int nworkers = 0;
 
     pthread_mutex_lock(&thread_lock);
-    THREAD_FOR_EACH_ACTIVE (t) {
+    THREAD_FOR_EACH (t) {
         if (t == current_thread)
+            continue;
+        /* Inactive slots are included when they still hold an unjoined handle:
+         * a worker that exited on its own shortly before teardown and whose
+         * slot was never reused. Its pthread has terminated (or is in final
+         * wind-down), so the join below is immediate.
+         */
+        if (!t->active && !t->host_thread_needs_join)
             continue;
         workers[nworkers].thr = t->host_thread;
         workers[nworkers].t = t;
+        workers[nworkers].claimed = t->host_thread_needs_join;
+        t->host_thread_needs_join = false;
         nworkers++;
     }
     pthread_mutex_unlock(&thread_lock);
@@ -392,6 +449,8 @@ void thread_join_workers(void)
             usleep(5000);
         }
 
+        if (!workers[w].claimed)
+            continue;
         if (!__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
             pthread_join(workers[w].thr, NULL);
         else

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -35,10 +35,10 @@
  * signal API without an include cycle.
  */
 typedef struct thread_entry {
-    int64_t guest_tid;        /* Linux TID (unique per thread) */
-    hv_vcpu_t vcpu;           /* HVF vCPU handle for this thread */
-    hv_vcpu_exit_t *vexit;    /* vCPU exit info pointer */
-    pthread_t host_thread;    /* macOS host thread running this vCPU */
+    int64_t guest_tid;           /* Linux TID (unique per thread) */
+    hv_vcpu_t vcpu;              /* HVF vCPU handle for this thread */
+    hv_vcpu_exit_t *vexit;       /* vCPU exit info pointer */
+    pthread_t host_thread;       /* macOS host thread running this vCPU */
     bool host_thread_needs_join; /* host_thread was created joinable and nobody
                                   * has joined it yet. Exactly one claimer
                                   * clears the flag under thread_lock before
@@ -47,19 +47,19 @@ typedef struct thread_entry {
                                   * clone startup-failure rollback. Never set
                                   * for the main thread or vm-clone children
                                   * (the latter are created detached). */
-    uint64_t clear_child_tid; /* GVA for CLONE_CHILD_CLEARTID (0=none) */
-    uint64_t sp_el1;          /* Per-thread EL1 stack top (IPA) */
-    int sp_el1_slot;          /* Slot index in sp_el1_allocated (-1 = none).
-                               * Stored at alloc time so the free path does
-                               * not need to recompute (top - sp) / 4096; the
-                               * shim data block is now at high IPA and only
-                               * known via guest_t.
-                               */
-    int active;               /* Non-zero while thread is running.
-                               * Stays int (not bool) because lock-free paths in thread.c
-                               * use __atomic_load_n on this field; the 32-bit width keeps
-                               * the access pattern predictable across architectures.
-                               */
+    uint64_t clear_child_tid;    /* GVA for CLONE_CHILD_CLEARTID (0=none) */
+    uint64_t sp_el1;             /* Per-thread EL1 stack top (IPA) */
+    int sp_el1_slot;             /* Slot index in sp_el1_allocated (-1 = none).
+                                  * Stored at alloc time so the free path does
+                                  * not need to recompute (top - sp) / 4096; the
+                                  * shim data block is now at high IPA and only
+                                  * known via guest_t.
+                                  */
+    int active;                  /* Non-zero while thread is running.
+                                  * Stays int (not bool) because lock-free paths in thread.c
+                                  * use __atomic_load_n on this field; the 32-bit width keeps
+                                  * the access pattern predictable across architectures.
+                                  */
     uint64_t generation; /* Bumped by thread_alloc each time this slot is
                           * reused. Lets a caller holding a t pointer detect
                           * that its slot was recycled to a different logical
@@ -203,9 +203,17 @@ void thread_deactivate(thread_entry_t *t);
  * table readers (thread_join_workers snapshot, thread_alloc slot reuse) see a
  * consistent handle. joinable marks the handle as needing a pthread_join
  * before its slot can be reused; pass false for detached pthreads (vm-clone
- * children).
+ * children). generation must be the value of t->generation the caller
+ * observed when it obtained t from thread_alloc: if the slot was recycled to
+ * a different logical thread in the meantime (the calling worker failed
+ * startup and deactivated before this call ran), the current generation no
+ * longer matches and the write is rejected -- the caller then owns thr
+ * exclusively and must join or detach it itself. Returns true if recorded.
  */
-void thread_set_host_thread(thread_entry_t *t, pthread_t thr, bool joinable);
+bool thread_set_host_thread(thread_entry_t *t,
+                            pthread_t thr,
+                            bool joinable,
+                            uint64_t generation);
 
 /* Atomically claim the right to pthread_join a worker's handle. Returns true
  * when the caller must join thr; false when someone else (slot reuse in

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -60,6 +60,17 @@ typedef struct thread_entry {
                                * use __atomic_load_n on this field; the 32-bit width keeps
                                * the access pattern predictable across architectures.
                                */
+    uint64_t generation; /* Bumped by thread_alloc each time this slot is
+                          * reused. Lets a caller holding a t pointer detect
+                          * that its slot was recycled to a different logical
+                          * thread while it was not looking (e.g. a clone
+                          * parent that raced with a starting-up worker's own
+                          * failure path). Read/written under thread_lock,
+                          * except for the lock-free comparison in
+                          * thread_join_workers' teardown poll, which uses
+                          * acquire/release ordering against thread_alloc's
+                          * release-store.
+                          */
     /* Per-thread signal mask (POSIX requires each thread to have its own).
      * Initialized to the parent's mask on clone, modified via rt_sigprocmask.
      */

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -39,6 +39,14 @@ typedef struct thread_entry {
     hv_vcpu_t vcpu;           /* HVF vCPU handle for this thread */
     hv_vcpu_exit_t *vexit;    /* vCPU exit info pointer */
     pthread_t host_thread;    /* macOS host thread running this vCPU */
+    bool host_thread_needs_join; /* host_thread was created joinable and nobody
+                                  * has joined it yet. Exactly one claimer
+                                  * clears the flag under thread_lock before
+                                  * joining: slot reuse in thread_alloc,
+                                  * teardown in thread_join_workers, or the
+                                  * clone startup-failure rollback. Never set
+                                  * for the main thread or vm-clone children
+                                  * (the latter are created detached). */
     uint64_t clear_child_tid; /* GVA for CLONE_CHILD_CLEARTID (0=none) */
     uint64_t sp_el1;          /* Per-thread EL1 stack top (IPA) */
     int sp_el1_slot;          /* Slot index in sp_el1_allocated (-1 = none).
@@ -179,6 +187,22 @@ thread_entry_t *thread_alloc(int64_t tid,
 
 /* Mark a thread as inactive and release its table slot. */
 void thread_deactivate(thread_entry_t *t);
+
+/* Record the host pthread backing this entry, under thread_lock so concurrent
+ * table readers (thread_join_workers snapshot, thread_alloc slot reuse) see a
+ * consistent handle. joinable marks the handle as needing a pthread_join
+ * before its slot can be reused; pass false for detached pthreads (vm-clone
+ * children).
+ */
+void thread_set_host_thread(thread_entry_t *t, pthread_t thr, bool joinable);
+
+/* Atomically claim the right to pthread_join a worker's handle. Returns true
+ * when the caller must join thr; false when someone else (slot reuse in
+ * thread_alloc) already claimed it, or the slot no longer holds thr. Used by
+ * the clone startup-failure rollback so the parent's join cannot race with a
+ * concurrent slot reuse joining the same terminated pthread.
+ */
+bool thread_claim_worker_join(thread_entry_t *t, pthread_t thr);
 
 /* Find a thread by guest TID. Returns NULL if not found. */
 thread_entry_t *thread_find(int64_t tid);

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -91,6 +91,7 @@ test-netlink
 [section] Threading tests
 test-thread                    # diff=skip
 test-pthread
+test-thread-churn
 test-simd-clone                # diff=skip
 
 [section] Stress tests

--- a/tests/test-thread-churn.c
+++ b/tests/test-thread-churn.c
@@ -1,0 +1,115 @@
+/*
+ * Thread churn: force thread-table slot reuse
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * elfuse keeps one thread-table slot per guest thread (MAX_THREADS = 64).
+ * Creating well over 64 threads across the test's lifetime forces later
+ * clones to reuse slots whose previous occupant already exited on its own,
+ * which is the only path that reaps the terminated worker's host pthread
+ * (issue #157: stale joinable handles leaked on slot reuse).
+ *
+ * The sequential phase is the sharpest probe: each worker is the last one
+ * alive when it exits, so its wind-down runs the last-worker wakeup that
+ * takes the thread-table lock AFTER the slot is released. The next clone
+ * joins that same pthread at slot-reuse time; joining under the table lock
+ * would deadlock here deterministically.
+ */
+
+#include <pthread.h>
+#include <stdbool.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define SEQUENTIAL_ROUNDS 150
+#define BATCH_SIZE 32
+#define BATCH_ROUNDS 6
+
+static void *churn_fn(void *arg)
+{
+    int *out = (int *) arg;
+    *out = 1;
+    return NULL;
+}
+
+/* Phase 1: sequential create+join, one live worker at a time. Every round
+ * past the table size reuses the slot freed by the previous round.
+ */
+static void test_sequential_churn(void)
+{
+    TEST("sequential churn (150 threads)");
+
+    for (int i = 0; i < SEQUENTIAL_ROUNDS; i++) {
+        int ran = 0;
+        pthread_t t;
+        if (pthread_create(&t, NULL, churn_fn, &ran) != 0) {
+            FAIL("pthread_create failed");
+            return;
+        }
+        if (pthread_join(t, NULL) != 0) {
+            FAIL("pthread_join failed");
+            return;
+        }
+        if (!ran) {
+            FAIL("thread did not run");
+            return;
+        }
+    }
+    PASS();
+}
+
+/* Phase 2: batches of concurrent workers. Slot reuse happens while other
+ * workers are still live, so the reaping clone and unrelated guest threads
+ * contend on the thread table.
+ */
+static void test_batch_churn(void)
+{
+    TEST("batch churn (6x32 threads)");
+
+    for (int round = 0; round < BATCH_ROUNDS; round++) {
+        pthread_t threads[BATCH_SIZE];
+        int ran[BATCH_SIZE];
+        int created = 0;
+        bool ok = true;
+
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            ran[i] = 0;
+            if (pthread_create(&threads[i], NULL, churn_fn, &ran[i]) != 0) {
+                ok = false;
+                break;
+            }
+            created++;
+        }
+
+        for (int i = 0; i < created; i++) {
+            if (pthread_join(threads[i], NULL) != 0)
+                ok = false;
+        }
+
+        if (!ok || created != BATCH_SIZE) {
+            FAIL("batch create/join failed");
+            return;
+        }
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            if (!ran[i]) {
+                FAIL("worker did not run");
+                return;
+            }
+        }
+    }
+    PASS();
+}
+
+int main(void)
+{
+    printf("test-thread-churn: thread-table slot reuse\n");
+
+    test_sequential_churn();
+    test_batch_churn();
+
+    SUMMARY("test-thread-churn");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Worker pthreads are created joinable so `thread_join_workers` can join them at teardown, but a worker that exits on its own is never joined — the teardown snapshot only sees active entries, and slot reuse in `thread_alloc` drops `host_thread` without join or detach. Each reaped thread under churn leaks one pthread handle (JVM/Go-style workloads); TSan reports 342 leaks on a 342-thread churn test.

Add a `host_thread_needs_join` flag, cleared by exactly one claimer under `thread_lock` before joining:
- `thread_alloc` joins the stale handle before reusing a slot (drops the lock during the join, since the dying worker's own wind-down can retake `thread_lock`).
- `thread_join_workers` claims at snapshot time so it can't double-join a concurrently-reused slot, and no longer joins/detaches handles it doesn't own (it previously touched detached vm-clone and main-thread handles too).
- The clone startup-failure rollback claims via `thread_claim_worker_join`, since a concurrent clone may have already reaped the slot.

Added `test-thread-churn` (150 sequential + 6×32 batched threads) to force slot reuse past the 64-entry table. TSan: 342 leaks → 0. Driver suite 107/107, churn test stable over 20 runs.

Closes #157