### PR TITLE
Silence not-an-ELF log on shebang script exec

### DIFF
--- a/src/core/elf.h
+++ b/src/core/elf.h
@@ -137,6 +137,12 @@ void elf_resolve_interp(const char *sysroot,
                         char *out,
                         size_t out_sz);
 
+/* Maximum shebang resolutions before a chain is rejected with -ELOOP. Both the
+ * execve path and startup honor this so a max-depth chain ending in a real ELF
+ * still loads, matching the Linux kernel exec_binprm recursion limit.
+ */
+#define ELF_SHEBANG_MAX_DEPTH 5
+
 /* Read, probe, and parse a shebang script header from host_path. Writes
  * interpreter path to interp_out and the single optional argument (if present)
  * to arg_out. arg_out will be set to an empty string if there is no optional

--- a/src/main.c
+++ b/src/main.c
@@ -466,9 +466,8 @@ int main(int argc, char **argv)
     proc_set_sysroot(sysroot);
 
     int shebang_depth = 0;
-    const int max_shebang_depth = 5;
 
-    while (shebang_depth < max_shebang_depth) {
+    while (true) {
         if (resolve_guest_elf_host_path(elf_path, elf_host_path,
                                         sizeof(elf_host_path),
                                         &elf_host_temp) < 0) {
@@ -502,6 +501,22 @@ int main(int argc, char **argv)
             return 1;
         }
 
+        /* The current path is a script. Bound the resolution chain only once a
+         * further shebang is confirmed, so a max-depth chain ending in a real
+         * ELF still boots (matches sys_execve and the Linux kernel).
+         */
+        if (shebang_depth >= ELF_SHEBANG_MAX_DEPTH) {
+            log_error(
+                "too many levels of shebang recursion (max %d) "
+                "resolving %s",
+                ELF_SHEBANG_MAX_DEPTH, argv[arg_start]);
+            cleanup_main_resources(&g, guest_initialized, &sysroot_mount,
+                                   have_host_cwd ? host_cwd : NULL, guest_argv,
+                                   guest_argc, elf_path, sysroot_path);
+            if (elf_host_temp)
+                unlink(elf_host_path);
+            return 1;
+        }
         shebang_depth++;
 
         /* Prepend interpreter (and argument if present) to guest_argv */
@@ -575,15 +590,6 @@ int main(int argc, char **argv)
             unlink(elf_host_path);
             elf_host_temp = false;
         }
-    }
-
-    if (shebang_depth >= max_shebang_depth) {
-        log_error("too many levels of shebang recursion (max %d) resolving %s",
-                  max_shebang_depth, argv[arg_start]);
-        cleanup_main_resources(&g, guest_initialized, &sysroot_mount,
-                               have_host_cwd ? host_cwd : NULL, guest_argv,
-                               guest_argc, elf_path, sysroot_path);
-        return 1;
     }
 
     if (gdb_port > 0) {

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -89,11 +89,11 @@ static void exec_stage_mmu_off_reentry(hv_vcpu_t vcpu, guest_t *g)
     uint64_t sctlr =
         SCTLR_RES1 | SCTLR_C | SCTLR_I | SCTLR_DZE | SCTLR_UCT | SCTLR_UCI;
 
-    /* The old syscall frame on the EL1 stack is dead; _start never pops it,
-     * so reset SP_EL1 to the stack top as cold boot does. HV_CHECK on every
-     * write for parity with guest_bootstrap_create_vcpu: past the point of no
-     * return a silent HVF failure would resume the vCPU on half-staged
-     * register state, so abort instead.
+    /* The old syscall frame on the EL1 stack is dead; _start never pops it, so
+     * reset SP_EL1 to the stack top as cold boot does. HV_CHECK on every write
+     * for parity with guest_bootstrap_create_vcpu: past the point of no return
+     * a silent HVF failure would resume the vCPU on half-staged register state,
+     * so abort instead.
      */
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SP_EL1, el1_sp));
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_SCTLR_EL1, sctlr));
@@ -415,20 +415,13 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         goto fail;
     }
 
-    /* Try loading as ELF; if that fails, emulate Linux binfmt_script for
-     * shebang files. Linux kernel handles shebangs transparently in
-     * binfmt_script.
+    /* Resolve binfmt_script before probing ELF. elf_load() logs parse errors,
+     * and a script is an expected non-ELF input here.
      */
     elf_info_t elf_info;
     int shebang_depth = 0;
-    const int max_shebang_depth = 5;
 
-    while (elf_load(path_host, &elf_info) < 0) {
-        if (shebang_depth >= max_shebang_depth) {
-            err = -LINUX_ELOOP;
-            goto fail;
-        }
-
+    while (true) {
         char interp_start[256];
         char interp_arg[256];
         int rc = elf_read_shebang(path_host, interp_start, sizeof(interp_start),
@@ -438,11 +431,17 @@ int64_t sys_execve(hv_vcpu_t vcpu,
             err = linux_errno();
             goto fail;
         }
-        if (rc == 0) {
-            err = -LINUX_ENOEXEC;
+        if (rc == 0)
+            break;
+
+        /* The current path is a script. Bound the resolution chain only once a
+         * further shebang is confirmed, so a max-depth chain ending in a real
+         * ELF still loads (matches the prior elf_load-first loop).
+         */
+        if (shebang_depth >= ELF_SHEBANG_MAX_DEPTH) {
+            err = -LINUX_ELOOP;
             goto fail;
         }
-
         shebang_depth++;
 
         bool has_arg = (interp_arg[0] != '\0');
@@ -545,6 +544,11 @@ int64_t sys_execve(hv_vcpu_t vcpu,
                            sizeof(path_host_buf));
             path_host = path_host_buf;
         }
+    }
+
+    if (elf_load(path_host, &elf_info) < 0) {
+        err = -LINUX_ENOEXEC;
+        goto fail;
     }
 
     /* Pre-PNR validation. All checks that can fail gracefully MUST happen

--- a/tests/test-shebang-host.c
+++ b/tests/test-shebang-host.c
@@ -106,6 +106,10 @@ int main(void)
     const char case3[] = "#!/bin/bash -e\rline2\n";
     test_case(case3, sizeof(case3) - 1, 1, "/bin/bash", "-e");
 
+    /* 3b. Linux passes the whole optional suffix as one interpreter argument */
+    const char case3b[] = "#!/usr/bin/env -S python3 -O\n";
+    test_case(case3b, sizeof(case3b) - 1, 1, "/usr/bin/env", "-S python3 -O");
+
     /* 4. No trailing newline (EOF) */
     const char case4[] = "#!/bin/sh";
     test_case(case4, sizeof(case4) - 1, 1, "/bin/sh", "");


### PR DESCRIPTION
elf_load() was called as a probe before shebang resolution, so it logged "not an ELF file" on every script exec. A shebang script is an expected non-ELF input at that point, not an error.

Reorder sys_execve to resolve binfmt_script first via elf_read_shebang and call elf_load exactly once after the loop, mirroring what the startup path in main.c already does. The error log now fires only on a genuine non-ELF, non-script exec.

Align the recursion depth limit across both entry points. The prior elf_load-first loop allowed a max-depth chain ending in a real ELF to load; main.c capped one level shorter and rejected such a chain. Check the limit only after a further shebang is confirmed, and share the bound via ELF_SHEBANG_MAX_DEPTH so the two paths cannot drift. Both now match the Linux exec_binprm recursion limit: five script resolutions followed by a real ELF load, a sixth returns ELOOP.

Add a shebang parser case for "env -S python3 -O" single-argument suffixes.

Close #166

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the “not an ELF file” log when executing shebang scripts by resolving the shebang before probing ELF, and aligns recursion limits with Linux. Also adds support for `/usr/bin/env -S` single-argument suffixes.

- **Bug Fixes**
  - Resolve shebang via elf_read_shebang first and call elf_load once after the loop, so we only log on true non-ELF, non-script execs.
  - Align recursion depth across startup and execve using ELF_SHEBANG_MAX_DEPTH; check the limit only after confirming another shebang. Now allows 5 script resolutions followed by a real ELF; a 6th returns ELOOP.

- **New Features**
  - Shebang parser now supports `/usr/bin/env -S python3 -O` (passes the suffix as a single argument).

<sup>Written for commit b708ca1d280096e08d70c192b038188b76d326a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

