### PR TITLE
Order setpgid defaulting before validation like Linux

### DIFF
--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -607,16 +607,16 @@ static int64_t sc_setpgid(guest_t *g,
      * pid/pgid is seen as negative, not a large positive.
      */
     int pid = (int) x0, pgid = (int) x1;
-    /* Linux rejects a negative group id with EINVAL and a negative pid (no such
-     * process) with ESRCH before any group change.
+    /* Kernel order: default pid/pgid before validation, so setpgid(-9, 0)
+     * turns the pgid negative and fails EINVAL, not ESRCH.
      */
-    if (pgid < 0)
-        return -LINUX_EINVAL;
-    if (pid < 0)
-        return -LINUX_ESRCH;
     int64_t self = proc_get_pid();
     int64_t rpid = (pid == 0) ? self : pid;
     int64_t rpgid = (pgid == 0) ? rpid : pgid;
+    if (rpgid < 0)
+        return -LINUX_EINVAL;
+    if (rpid < 0)
+        return -LINUX_ESRCH;
     /* setpgid on a direct child records the group so kill(0) and kill(-pgid)
      * reach it. Kept in the syscall layer so proc-identity stays free of the
      * process-table dependency. Only POSIX-plausible targets are recorded: the

--- a/tests/test-kill-pgroup.c
+++ b/tests/test-kill-pgroup.c
@@ -168,13 +168,21 @@ int main(void)
     int failed = 0;
     install();
 
-    /* 0: setpgid rejects a negative group (EINVAL) and negative pid (ESRCH). */
+    /* 0: setpgid argument validation. The kernel defaults pgid==0 to pid
+     * before checking pgid < 0, so a negative pid with pgid==0 becomes a
+     * negative pgid and fails EINVAL, not ESRCH; ESRCH needs a valid pgid
+     * alongside the nonexistent pid.
+     */
     if (setpgid(0, -5) != -1 || errno != EINVAL) {
         fprintf(stderr, "FAIL: setpgid(0,-5) should be EINVAL\n");
         failed++;
     }
-    if (setpgid(-9, 0) != -1 || errno != ESRCH) {
-        fprintf(stderr, "FAIL: setpgid(-9,0) should be ESRCH\n");
+    if (setpgid(-9, 0) != -1 || errno != EINVAL) {
+        fprintf(stderr, "FAIL: setpgid(-9,0) should be EINVAL\n");
+        failed++;
+    }
+    if (setpgid(-9, getpgrp()) != -1 || errno != ESRCH) {
+        fprintf(stderr, "FAIL: setpgid(-9,self-pgid) should be ESRCH\n");
         failed++;
     }
 


### PR DESCRIPTION
PR #91's runtime job runs tests/test-matrix.sh against a qemu-aarch64 reference kernel, and that lane fails test-kill-pgroup: subtest 0 expects `setpgid(-9, 0)` to return ESRCH, but Linux returns EINVAL — the kernel defaults `pgid==0` to `pid` before the `pgid < 0` check, so the negative pid propagates into pgid. elfuse validated the raw arguments first and returned ESRCH, agreeing with the test but not with the kernel.

- `sc_setpgid`: default pid/pgid before validation, matching the kernel's ordering
- `test-kill-pgroup`: expect EINVAL for `setpgid(-9, 0)`; add a `setpgid(-9, valid-pgid)` case so the ESRCH path keeps coverage

Verified under both elfuse-aarch64 and qemu-aarch64 (Alpine linux-virt 6.12): make check and the full test matrix pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered setpgid argument handling to match Linux: default pid/pgid before validation so setpgid(-9, 0) returns EINVAL, not ESRCH. Updated tests to reflect kernel behavior and keep ESRCH coverage.

- **Bug Fixes**
  - sc_setpgid: default pid/pgid first, then validate. setpgid(-9, 0) now yields EINVAL; ESRCH is only returned with a valid pgid.
  - tests: expect EINVAL for setpgid(-9, 0); add setpgid(-9, getpgrp()) for ESRCH. Verified passing on elfuse-aarch64 and qemu-aarch64.

<sup>Written for commit 1b3d313543ec7b6a630c5ea361d314279ee82021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

