### PR TITLE
Materialize guest itimers inside interruptible I/O waits

### DIFF
--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -164,6 +164,13 @@ int64_t io_wait_fd_or_interrupted(int host_fd, short events)
     };
 
     for (;;) {
+        /* Materialize expired guest interval timers first: ITIMER_REAL is
+         * virtual and only converted to a pending SIGALRM by the syscall
+         * epilogue, which cannot run while this thread is parked here. The
+         * futex wait loops do the same.
+         */
+        signal_check_timer();
+
         /* Ignored/default-ignore signals do not interrupt; restartable handlers
          * still need to run promptly through the syscall epilogue.
          */

--- a/tests/test-signal.c
+++ b/tests/test-signal.c
@@ -6,14 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Verifies:
- * 1. rt_sigaction installs a handler for SIGUSR1
- * 2. kill(getpid(), SIGUSR1) delivers the signal
- * 3. Handler fires with correct signum
- * 4. rt_sigreturn restores all callee-saved registers
+ * 1. Basic delivery: rt_sigaction installs a handler for SIGUSR1,
+ *    kill(getpid(), SIGUSR1) fires it with the correct signum
+ * 2. rt_sigreturn restores all callee-saved registers
  *    (aarch64: X19-X28, x86_64: rbx/r12-r15)
- * 5. sigprocmask blocks/unblocks signals correctly
+ * 3. sigprocmask blocks/unblocks signals correctly
+ * 4. SA_RESETHAND resets the handler to SIG_DFL after delivery
+ * 5. alarm() interrupts a blocking read with EINTR
  */
 
+#include <errno.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -184,6 +186,41 @@ int main(void)
         } else {
             printf("FAIL (handler not reset to SIG_DFL)\n");
             failures++;
+        }
+    }
+
+    /* Test 5: alarm() interrupts a blocking read. The guest ITIMER_REAL is
+     * virtual, so the expiry must be materialized while the thread is parked
+     * inside the interruptible wait, not only in the syscall epilogue.
+     */
+    printf("test-signal: 5. alarm interrupts blocking read (EINTR)... ");
+    {
+        int p[2];
+        if (pipe(p) != 0) {
+            printf("FAIL (pipe: %m)\n");
+            failures++;
+        } else {
+            memset(&sa, 0, sizeof(sa));
+            sa.sa_handler = sigusr1_handler; /* no SA_RESTART */
+            sigemptyset(&sa.sa_mask);
+            sigaction(SIGALRM, &sa, NULL);
+            handler_called = 0;
+            char c;
+            alarm(1);
+            errno = 0;
+            ssize_t n = read(p[0], &c, 1);
+            int read_errno = errno;
+            alarm(0);
+            if (n == -1 && read_errno == EINTR && handler_called &&
+                handler_signum == SIGALRM) {
+                printf("PASS\n");
+            } else {
+                printf("FAIL (n=%zd errno=%d handler=%d signum=%d)\n", n,
+                       read_errno, (int) handler_called, handler_signum);
+                failures++;
+            }
+            close(p[0]);
+            close(p[1]);
         }
     }
 


### PR DESCRIPTION
Found while fixing PR #91's runtime test-matrix failures: alarm() cannot interrupt any blocking I/O. Guest ITIMER_REAL is virtual — expiry only becomes a pending SIGALRM when signal_check_timer() runs in the syscall epilogue, which never happens while a vCPU is parked in io_wait_fd_or_interrupted. `alarm(1)` + a blocking read/recv therefore hangs forever, exactly the calls alarm is most used to bound. The futex wait loops already call signal_check_timer(); the I/O wait loop was the gap.

- `io_wait_fd_or_interrupted`: materialize expired guest itimers at the top of the wait loop, so the existing pending-signal check aborts with EINTR like Linux
- `test-signal`: new case arming `alarm(1)` against a blocking pipe read, expecting EINTR with the handler fired; hangs without the fix

Verified under both elfuse-aarch64 and qemu-aarch64 (make check and the full test matrix pass).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `alarm()` could not interrupt blocking I/O. Expired guest `ITIMER_REAL` timers are now materialized during I/O waits so blocking reads/recvs return `EINTR`, matching Linux behavior.

- **Bug Fixes**
  - Call `signal_check_timer()` at the start of `io_wait_fd_or_interrupted` to convert expired timers into pending `SIGALRM` and break the wait with `EINTR`.
  - Add/extend test: arm `alarm(1)` against a blocking pipe `read`; expect `EINTR` and the `SIGALRM` handler to run.

<sup>Written for commit d96b3d2eb758bdd451724b9159e850f7a840e3a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

