### PR TITLE
Align zero-length socket receives with Linux readiness

### DIFF
--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -442,13 +442,12 @@ int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
                 len = (size_t) avail;
         }
 
-        if (len > 0) {
-            int64_t waited =
-                net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
-            if (waited < 0) {
-                host_fd_ref_close(&host_ref);
-                return waited;
-            }
+        int64_t waited =
+            len > 0 ? net_wait_or_interrupted(host_ref.fd, POLLIN, flags)
+                    : net_recv_zero_payload_gate(host_ref.fd, flags);
+        if (waited < 0) {
+            host_fd_ref_close(&host_ref);
+            return waited;
         }
 
         struct iovec host_iov = {
@@ -494,13 +493,13 @@ int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
         host_fd_ref_close(&host_ref);
         return iov_err;
     }
-    if (host_iov_has_payload(&host_iov, recv_iovcnt)) {
-        int64_t waited = net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
-        if (waited < 0) {
-            host_iov_free(&host_iov);
-            host_fd_ref_close(&host_ref);
-            return waited;
-        }
+    int64_t waited = host_iov_has_payload(&host_iov, recv_iovcnt)
+                         ? net_wait_or_interrupted(host_ref.fd, POLLIN, flags)
+                         : net_recv_zero_payload_gate(host_ref.fd, flags);
+    if (waited < 0) {
+        host_iov_free(&host_iov);
+        host_fd_ref_close(&host_ref);
+        return waited;
     }
 
     struct sockaddr_storage mac_sa;
@@ -952,13 +951,12 @@ int64_t sys_recvmmsg(guest_t *g,
                 .msg_iov = &host_iov,
                 .msg_iovlen = 1,
             };
-            if (len > 0) {
-                int64_t waited =
-                    net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
-                if (waited < 0) {
-                    host_fd_ref_close(&host_ref);
-                    return waited;
-                }
+            int64_t waited =
+                len > 0 ? net_wait_or_interrupted(host_ref.fd, POLLIN, flags)
+                        : net_recv_zero_payload_gate(host_ref.fd, flags);
+            if (waited < 0) {
+                host_fd_ref_close(&host_ref);
+                return waited;
             }
             ssize_t ret = recvmsg(host_ref.fd, &host_msg, mac_flags);
             if (ret < 0) {

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -43,6 +43,8 @@
 #include "syscall/io.h"
 #include "syscall/signal.h"
 
+/* Linux MSG_OOB: urgent-data receive, never gated on readiness. */
+#define LINUX_MSG_OOB 0x01
 /* Linux MSG_DONTWAIT: recv/send skip the interruptible wait when set. */
 #define LINUX_MSG_DONTWAIT 0x40
 
@@ -62,6 +64,37 @@ int64_t net_wait_or_interrupted(int host_fd, short events, int msg_flags)
     if (fl < 0 || (fl & O_NONBLOCK))
         return 0;
     return io_wait_fd_or_interrupted(host_fd, events);
+}
+
+/* Linux clamps a socket receive's low-water target to one byte (sock_rcvlowat
+ * returns v ?: 1), so a zero-payload recv/recvfrom/recvmsg on an empty socket
+ * blocks -- or fails EAGAIN when nonblocking -- instead of returning 0 the way
+ * the macOS host call does. (read() is the exception: sock_read_iter returns 0
+ * for a zero count, so sys_read stays untouched.) Gate the host call on
+ * readability: an interruptible wait for blocking callers, a zero-timeout
+ * readiness probe for nonblocking ones. EOF counts as readable in both, and
+ * the host call then returns 0 like Linux.
+ *
+ * Returns 0 to proceed or a negative Linux errno (EINTR/EAGAIN).
+ */
+int64_t net_recv_zero_payload_gate(int host_fd, int msg_flags)
+{
+    /* Linux's urgent-data receive path never waits for readiness: with no
+     * urgent data queued, recv(MSG_OOB) fails EINVAL immediately whether the
+     * socket blocks or not (tcp_recv_urg, unix_stream_recv_urg; verified on
+     * 6.12). Pass straight to the host call, which fails the same way.
+     */
+    if (msg_flags & LINUX_MSG_OOB)
+        return 0;
+    if (sock_op_should_block(host_fd, msg_flags))
+        return io_wait_fd_or_interrupted(host_fd, POLLIN);
+    struct pollfd pfd = {.fd = host_fd, .events = POLLIN};
+    int ready = poll(&pfd, 1, 0);
+    if (ready < 0)
+        return linux_errno();
+    if (ready == 0)
+        return -LINUX_EAGAIN;
+    return 0;
 }
 
 /* True when a socket send/recv should wait interruptibly and retry rather than
@@ -877,17 +910,17 @@ int64_t sys_recvfrom(guest_t *g,
 
     int mac_flags = translate_msg_flags(flags);
 
-    /* A zero-length recv returns 0 without blocking on Linux; only wait when
-     * there is a buffer to fill. A single interruptible wait (not a
-     * MSG_DONTWAIT probe loop) preserves MSG_WAITALL semantics; the tiny
-     * ready-then-stolen window can still block, matching sys_read.
+    /* A single interruptible wait (not a MSG_DONTWAIT probe loop) preserves
+     * MSG_WAITALL semantics; the tiny ready-then-stolen window can still
+     * block, matching sys_read. A zero-length recv takes the readiness gate
+     * instead: unlike read(), Linux blocks it on an empty socket.
      */
-    if (len > 0) {
-        int64_t waited = net_wait_or_interrupted(host_ref.fd, POLLIN, flags);
-        if (waited < 0) {
-            host_fd_ref_close(&host_ref);
-            return waited;
-        }
+    int64_t waited = len > 0
+                         ? net_wait_or_interrupted(host_ref.fd, POLLIN, flags)
+                         : net_recv_zero_payload_gate(host_ref.fd, flags);
+    if (waited < 0) {
+        host_fd_ref_close(&host_ref);
+        return waited;
     }
 
     struct sockaddr_storage mac_sa;

--- a/src/syscall/net.h
+++ b/src/syscall/net.h
@@ -165,6 +165,16 @@ int64_t sys_shutdown(int fd, int how);
  */
 int64_t net_wait_or_interrupted(int host_fd, short events, int msg_flags);
 
+/* Readiness gate for a zero-payload recv/recvfrom/recvmsg: Linux clamps the
+ * receive low-water target to one byte, so an empty socket blocks (EINTR on
+ * guest signal) or fails EAGAIN when nonblocking, rather than returning 0
+ * like the macOS host call. Call before the host receive when the resolved
+ * payload length is zero.
+ *
+ * Returns 0 to proceed or a negative Linux errno (EINTR/EAGAIN).
+ */
+int64_t net_recv_zero_payload_gate(int host_fd, int msg_flags);
+
 /* True when a socket send/recv should wait interruptibly and retry on EAGAIN
  * rather than surface it (guest wants blocking semantics: no MSG_DONTWAIT, fd
  * not O_NONBLOCK). Send/recv paths pair this with a per-call MSG_DONTWAIT probe

--- a/tests/test-socket.c
+++ b/tests/test-socket.c
@@ -22,19 +22,28 @@
  * 11. shutdown(SHUT_WR) causes read to return 0 (EOF)
  * 12. socketpair(AF_UNIX, SOCK_SEQPACKET)
  * 13. socket(AF_UNIX, SOCK_SEQPACKET)
- * 14. zero-length recvmsg returns immediately
+ * 14. zero-length recvmsg follows receive-readiness semantics (EAGAIN when
+ *     nonblocking and empty, blocks when empty, 0 without consuming when
+ *     data is pending)
  * 15. invalid recvmsg iov returns EFAULT immediately
  */
 
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/un.h>
 #include <sys/uio.h>
 #include <netinet/in.h>
+
+static void alarm_noop(int sig)
+{
+    (void) sig;
+}
 
 int main(void)
 {
@@ -388,8 +397,14 @@ int main(void)
         failures++;
     }
 
-    /* Test 14: zero-length recvmsg returns immediately */
-    printf("test-socket: 14. zero-length recvmsg returns immediately... ");
+    /* Test 14: zero-length recvmsg follows receive-readiness semantics. Linux
+     * clamps the receive low-water target to one byte (sock_rcvlowat returns
+     * v ?: 1), so a zero-length recvmsg behaves like a one-byte receive for
+     * readiness: EAGAIN on an empty nonblocking socket, blocks on an empty
+     * blocking socket (observed here as EINTR via alarm), and returns 0
+     * without consuming anything once data is pending.
+     */
+    printf("test-socket: 14. zero-length recvmsg readiness semantics... ");
     {
         int zsv[2];
         if (socketpair(AF_UNIX, SOCK_STREAM, 0, zsv) < 0) {
@@ -402,13 +417,63 @@ int main(void)
                 {.iov_base = &dummy, .iov_len = 0},
             };
             struct msghdr zmsg = {.msg_iov = ziov, .msg_iovlen = 2};
-            n = recvmsg(zsv[1], &zmsg, 0);
-            if (n == 0)
-                printf("PASS\n");
-            else {
-                printf("FAIL (recvmsg returned %zd errno=%d)\n", n, errno);
-                failures++;
+            int zfail = 0;
+
+            /* Empty socket, nonblocking: EAGAIN, not 0. */
+            errno = 0;
+            n = recvmsg(zsv[1], &zmsg, MSG_DONTWAIT);
+            if (n != -1 || errno != EAGAIN) {
+                printf("FAIL (empty dontwait: n=%zd errno=%d)\n", n, errno);
+                zfail++;
             }
+
+            /* Empty socket, blocking: parks until the timer interrupts. A
+             * repeating interval (not a one-shot alarm) closes the race where
+             * the first SIGALRM lands before recvmsg enters the kernel and
+             * the call then blocks with no interrupt left.
+             */
+            struct sigaction zsa, old_zsa;
+            memset(&zsa, 0, sizeof(zsa));
+            zsa.sa_handler = alarm_noop; /* no SA_RESTART */
+            sigaction(SIGALRM, &zsa, &old_zsa);
+            struct itimerval zit = {
+                .it_value = {.tv_sec = 1, .tv_usec = 0},
+                .it_interval = {.tv_sec = 1, .tv_usec = 0},
+            };
+            struct itimerval zit_off = {{0, 0}, {0, 0}};
+            setitimer(ITIMER_REAL, &zit, NULL);
+            errno = 0;
+            n = recvmsg(zsv[1], &zmsg, 0);
+            int zerrno = errno;
+            setitimer(ITIMER_REAL, &zit_off, NULL);
+            sigaction(SIGALRM, &old_zsa, NULL);
+            if (n != -1 || zerrno != EINTR) {
+                printf("FAIL (empty blocking: n=%zd errno=%d)\n", n, zerrno);
+                zfail++;
+            }
+
+            /* Data pending: returns 0 and leaves the byte queued. */
+            char kept = 0;
+            ssize_t klen = -1;
+            if (write(zsv[0], "X", 1) != 1) {
+                printf("FAIL (write: %m)\n");
+                zfail++;
+            } else {
+                errno = 0;
+                n = recvmsg(zsv[1], &zmsg, 0);
+                klen = read(zsv[1], &kept, 1);
+                if (n != 0 || klen != 1 || kept != 'X') {
+                    printf(
+                        "FAIL (pending: recvmsg=%zd read=%zd byte=0x%02x "
+                        "errno=%d)\n",
+                        n, klen, (unsigned char) kept, errno);
+                    zfail++;
+                }
+            }
+
+            if (zfail == 0)
+                printf("PASS\n");
+            failures += zfail;
             close(zsv[0]);
             close(zsv[1]);
         }


### PR DESCRIPTION
PR #91's runtime test-matrix qemu-aarch64 reference lane hangs in test-socket subtest 14 until the 60s harness timeout: the subtest asserted that a zero-length recvmsg on an empty socket returns 0 immediately, which is macOS host behavior leaking through. Linux clamps the receive low-water target to one byte (sock_rcvlowat returns `v ?: 1`), so a zero-length recv/recvfrom/recvmsg on an empty socket blocks — or fails EAGAIN when nonblocking. Only read() is exempt (sock_read_iter returns 0 for a zero count).

- add `net_recv_zero_payload_gate()`: interruptible POLLIN wait for blocking callers, zero-timeout readiness probe (EAGAIN when empty) for nonblocking ones
- wire it at the four zero-payload receive sites: recvfrom, both recvmsg paths, and the recvmmsg single-message fast path (the general recvmmsg loop inherits it by delegation)
- rewrite subtest 14 to assert the Linux semantics: EAGAIN on an empty nonblocking socket, EINTR via alarm on an empty blocking socket, 0 without consuming the queued byte once data is pending

Probed blocking/nonblocking × empty/pending/EOF × stream/dgram plus read()-vs-recv() on both kernels; elfuse now matches Linux on all cases (a pending datagram was already consumed with MSG_TRUNC by the host call, as on Linux).

Depends on #169: the subtest's blocking case needs alarm() to interrupt the parked wait. Verified with both applied under elfuse-aarch64 and qemu-aarch64 (make check and the full test matrix pass).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align zero-length socket receives with Linux readiness to prevent hangs and match Linux behavior. Zero-length recv/recvfrom/recvmsg now block or return EAGAIN on empty sockets; read() is unchanged.

- **Bug Fixes**
  - Added net_recv_zero_payload_gate() to gate zero-length receives. Blocking waits; nonblocking returns EAGAIN; EOF still returns 0; MSG_OOB bypasses the gate.
  - Wired into recvfrom, both recvmsg paths, and the recvmmsg single-message fast path.
  - Updated test-socket subtest 14 to assert Linux behavior: EAGAIN when empty and nonblocking, EINTR when empty and blocking, and 0 without consuming when data is pending.

<sup>Written for commit 7a4d19975183692a4626076cb03f92d6bb9e06d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

