### PR TITLE
Fire SIGIO synchronously on FUSE request enqueue

### DIFF
--- a/src/syscall/asyncio.c
+++ b/src/syscall/asyncio.c
@@ -113,6 +113,18 @@ static void async_deliver(void *udata, int signum)
     signal_queue(signum);
 }
 
+void asyncio_fire(int guest_fd)
+{
+    fd_entry_t snap;
+    if (!fd_snapshot(guest_fd, &snap))
+        return;
+    if (!(snap.linux_flags & LINUX_O_ASYNC))
+        return;
+    if (!async_owner_is_local(snap.fasync_owner_type, snap.fasync_owner))
+        return;
+    signal_queue(LINUX_SIGIO);
+}
+
 static void *async_watcher(void *arg)
 {
     (void) arg;

--- a/src/syscall/asyncio.h
+++ b/src/syscall/asyncio.h
@@ -63,6 +63,18 @@ void asyncio_arm(int guest_fd, uint64_t generation, int host_fd, int fd_type);
  */
 void asyncio_disarm(int host_fd);
 
+/* Synchronously deliver SIGIO for a readiness edge the caller just produced on
+ * guest_fd, without going through the kqueue watcher. Needed where the ready
+ * state can be consumed again before the watcher's kevent() collection
+ * revalidates the knote: the FUSE device's daemon can dequeue the request and
+ * drain the notify pipe first, which drops the edge -- and with it the only
+ * SIGIO a one-shot request like FUSE_INIT will ever produce. Linux fires
+ * kill_fasync synchronously at enqueue time for the same reason. Revalidates
+ * O_ASYNC and the owner against the live slot; a duplicate delivery against
+ * the watcher's coalesces in the pending mask like any standard signal.
+ */
+void asyncio_fire(int guest_fd);
+
 /* Store the SIGIO/SIGURG owner for guest_fd under fd_lock, guarded by the
  * caller's snapshot generation so a close+reopen in the race window is a no-op.
  * owner_type is a FASYNC_OWNER_* value.

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -474,15 +474,18 @@ static fuse_session_t *fuse_unbind_dev_fd_locked(int guest_fd)
     return NULL;
 }
 
-static int fuse_dev_alias_count_locked(fuse_session_t *session)
+/* First guest fd still bound to session, or -1 when none remain. Doubles as
+ * the alias-count > 0 test and names the surviving alias so the close path can
+ * repoint session->guest_fd (the synchronous SIGIO target) at a live slot.
+ */
+static int fuse_dev_alias_fd_locked(fuse_session_t *session)
 {
-    int count = 0;
     for (int i = 0; i < FD_TABLE_SIZE; i++) {
         if (fuse_dev_bindings[i].used &&
             fuse_dev_bindings[i].session == session)
-            count++;
+            return fuse_dev_bindings[i].guest_fd;
     }
-    return count;
+    return -1;
 }
 
 /* Bump session reference under fuse_lock. Each live mount, each FUSE-backed
@@ -529,6 +532,11 @@ static void fuse_notify_readable_locked(fuse_session_t *session)
         return;
     uint8_t byte = 1;
     write(session->notify_wr, &byte, 1);
+    /* Fire SIGIO synchronously: a parked daemon can dequeue the request and
+     * drain the notify byte before the asyncio watcher's kevent() revalidates
+     * the readiness edge, silently losing the signal (FUSE_INIT is one-shot).
+     */
+    asyncio_fire(session->guest_fd);
 }
 
 static void fuse_notify_drain_fd_locked(int fd)
@@ -1235,7 +1243,18 @@ static void fuse_fd_cleanup(int guest_fd)
         return;
     }
 
-    if (fuse_dev_alias_count_locked(session) > 0) {
+    int alias_fd = fuse_dev_alias_fd_locked(session);
+    if (alias_fd >= 0) {
+        /* The closing fd may be the one fuse_notify_readable_locked fires
+         * synchronous SIGIO on; repoint delivery at a surviving alias so a
+         * dup+close of the original /dev/fuse fd keeps signal-driven I/O
+         * working (the armed bit and owner are per open-file description and
+         * already mirrored on every alias).
+         */
+        pthread_mutex_lock(&session->lock);
+        if (session->guest_fd == guest_fd)
+            session->guest_fd = alias_fd;
+        pthread_mutex_unlock(&session->lock);
         fuse_session_put_locked(session);
         pthread_mutex_unlock(&fuse_lock);
         return;

--- a/tests/test-fuse-basic.c
+++ b/tests/test-fuse-basic.c
@@ -530,6 +530,15 @@ int main(void)
     if (fuse_fl < 0 || fcntl(fusefd, F_SETFL, fuse_fl | O_ASYNC) < 0)
         die("fcntl(F_SETFL O_ASYNC fusefd)");
 
+    /* Route the daemon and the mount through a dup of the device fd: the
+     * original is closed after INIT below, and SIGIO must keep flowing since
+     * O_ASYNC and the owner live on the shared open-file description.
+     */
+    int sigio_origfd = fusefd;
+    fusefd = dup(sigio_origfd);
+    if (fusefd < 0)
+        die("dup(/dev/fuse)");
+
     daemon_ctx_t ctx = {.fusefd = fusefd};
     pthread_t tid;
     if (pthread_create(&tid, NULL, daemon_main, &ctx) != 0) {
@@ -554,6 +563,29 @@ int main(void)
         fprintf(stderr, "mountpoint is not a directory\n");
         return 1;
     }
+
+    /* Close the original device fd: the session must repoint synchronous
+     * SIGIO delivery at the surviving dup, so the next request still raises
+     * the signal.
+     */
+    if (close(sigio_origfd) < 0)
+        die("close(original /dev/fuse fd)");
+    got_sigio = 0;
+    if (stat(mount_dir, &st) < 0)
+        die("stat(mountpoint after close)");
+    for (int i = 0; i < 2000 && !got_sigio; i++)
+        usleep(1000);
+    if (!got_sigio) {
+        fprintf(stderr, "no SIGIO after closing the original /dev/fuse fd\n");
+        return 1;
+    }
+    /* Disarm O_ASYNC: every later FUSE request would otherwise raise SIGIO,
+     * and a non-SA_RESTART handler firing mid-syscall surfaces spurious EINTR
+     * in the unrelated tests below.
+     */
+    fuse_fl = fcntl(fusefd, F_GETFL);
+    if (fuse_fl < 0 || fcntl(fusefd, F_SETFL, fuse_fl & ~O_ASYNC) < 0)
+        die("fcntl(F_SETFL clear O_ASYNC)");
 
     expect_contains("/proc/self/mountinfo", mount_dir);
     expect_contains("/proc/self/mountinfo", " - fuse ");


### PR DESCRIPTION
PR #91's self-hosted runtime job is the first CI that actually runs make check (hosted runners lack HVF), and it fails test-fuse-basic with "no SIGIO on FUSE device readiness" — a race in the O_ASYNC delivery added by #147, reproducible on main at roughly 1 run in 15 locally.

A FUSE request enqueue writes one byte to the device's notify pipe and relies on the asyncio kqueue watcher to observe the readable edge and inject SIGIO. kevent() revalidates the filter at collection time, and the daemon drains the notify byte as soon as it dequeues the request: if the daemon wins, the edge vanishes and the signal is never delivered. FUSE_INIT is one-shot per mount, so there is no second chance.

Linux fires kill_fasync synchronously at request enqueue; do the same. asyncio_fire() revalidates O_ASYNC and the owner against the live fd slot and queues SIGIO directly from fuse_notify_readable_locked. The watcher stays as a backstop — a duplicate delivery coalesces in the pending mask like any standard signal.

Verified: test-fuse-basic 100/100 stress iterations against the Alpine rootfs sysroot (2 failures + 1 hang in 30 before the fix); make check green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deliver SIGIO synchronously on FUSE request enqueue to remove a race that could drop the only signal for one‑shot events like FUSE_INIT, and keep delivery working after dup+close. Fixes intermittent “no SIGIO on FUSE device readiness” failures and matches Linux behavior.

- **Bug Fixes**
  - Added `asyncio_fire()` to revalidate `O_ASYNC`/owner and queue `SIGIO` directly.
  - Call from `fuse_notify_readable_locked` after the notify byte; keep kqueue watcher as a backstop.
  - Repoint synchronous `SIGIO` target to a surviving dup when the original `/dev/fuse` fd closes.
  - Extended `test-fuse-basic` to verify dup+close and to clear `O_ASYNC`; 100/100 stress passes, make check green.

<sup>Written for commit dcd0d5f6a1f186366c0e357e2c2e6e18206c7a64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

