### PR TITLE
Align PI-futex dead-owner and unaligned UNLOCK_PI to Linux

### DIFF
--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -1114,18 +1114,29 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
         if ((expected & FUTEX_TID_MASK) == tid)
             return -LINUX_EDEADLK;
 
-        /* Check if the owner thread has exited without releasing the lock.
-         * Linux kernel handles this via PI futex cleanup on thread exit; futex
-         * emulation detects it lazily here since guest memory does not track PI
-         * ownership per-thread. Clear the futex word and retry acquisition.
+        /* Robust owner death: the robust-list walk sets FUTEX_OWNER_DIED and
+         * clears the TID field on thread exit (see robust_list_walk), so the
+         * word is nonzero (OWNER_DIED set) with an empty TID -- the CAS(0->TID)
+         * fast path above cannot acquire it. Recover by clearing the word and
+         * retrying. This must run before the nonzero-TID dead-owner test below,
+         * which never sees a robust-cleaned word (TID == 0) and would otherwise
+         * spin forever.
          */
-        uint32_t owner_tid = expected & FUTEX_TID_MASK;
-        if (owner_tid != 0 && !thread_find((int64_t) owner_tid)) {
+        if (expected & FUTEX_OWNER_DIED) {
             __atomic_compare_exchange_n(word, &expected, 0,
                                         /*weak=*/0, __ATOMIC_SEQ_CST,
                                         __ATOMIC_SEQ_CST);
             continue; /* Retry acquisition */
         }
+
+        /* Owner thread has exited without releasing the lock and without robust
+         * cleanup (no OWNER_DIED). Linux does not recover such a lock:
+         * FUTEX_LOCK_PI returns -ESRCH (attach_to_pi_owner ->
+         * handle_exit_race).
+         */
+        uint32_t owner_tid = expected & FUTEX_TID_MASK;
+        if (owner_tid != 0 && !thread_find((int64_t) owner_tid))
+            return -LINUX_ESRCH;
 
         /* Set the WAITERS bit so the owner takes the kernel-mediated unlock
          * path. Retry the CAS in a loop since the owner may release
@@ -1222,16 +1233,28 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
                 }
 
                 /* Check if the owner thread has died while the waiter was
-                 * waiting. If so, clear the lock and retry. Use
-                 * thread_tid_alive (lock-free) instead of thread_find to avoid
-                 * lock order inversion: bucket lock(7) is held here, and
-                 * thread_find acquires thread_lock(5).
+                 * waiting. Use thread_tid_alive (lock-free) instead of
+                 * thread_find to avoid lock order inversion: bucket lock(7) is
+                 * held here, and thread_find acquires thread_lock(5).
+                 *
+                 * As in the fast path, Linux only recovers a PI lock whose
+                 * owner died if the robust-list walk marked it
+                 * FUTEX_OWNER_DIED. A robust death clears the TID field, so
+                 * test OWNER_DIED first (recover via the clear-and-retry path
+                 * below); a non-robust dead owner keeps its TID but has no
+                 * OWNER_DIED, and Linux yields -ESRCH.
                  */
                 uint32_t check = __atomic_load_n(word, __ATOMIC_SEQ_CST);
-                uint32_t check_tid = check & FUTEX_TID_MASK;
-                if (check_tid != 0 && !thread_tid_alive((int64_t) check_tid)) {
+                if (check & FUTEX_OWNER_DIED) {
                     owner_died = true;
                     break;
+                }
+                uint32_t check_tid = check & FUTEX_TID_MASK;
+                if (check_tid != 0 && !thread_tid_alive((int64_t) check_tid)) {
+                    bucket_unlink_locked(b, &waiter);
+                    pthread_mutex_unlock(&b->lock);
+                    pthread_cond_destroy(&waiter.cond);
+                    return -LINUX_ESRCH;
                 }
             }
         }
@@ -1291,20 +1314,33 @@ static int64_t futex_trylock_pi(guest_t *g, uint64_t uaddr)
  */
 static int64_t futex_unlock_pi(guest_t *g, uint64_t uaddr)
 {
+    uint32_t tid = current_thread ? (uint32_t) current_thread->guest_tid
+                                  : (uint32_t) proc_get_pid();
+
+    /* Linux futex_unlock_pi() reads the word and rejects a non-owner with
+     * -EPERM *before* it validates alignment (get_user + owner check run ahead
+     * of get_futex_key, whose -EINVAL is never reached), so releasing a lock
+     * you do not own returns -EPERM even for an unaligned uaddr. Match that
+     * ordering. The word may be unaligned here, so read it with
+     * guest_read_small (boundary-safe, and avoids the aligned-atomic-load fault
+     * an unaligned __atomic_load_n would take on the arm64 host).
+     */
+    uint32_t cur;
+    if (guest_read_small(g, uaddr, &cur, sizeof(cur)) != 0)
+        return -LINUX_EFAULT;
+    if ((cur & FUTEX_TID_MASK) != tid)
+        return -LINUX_EPERM;
+
+    /* Only the owner reaches here, and an owned PI lock is always aligned
+     * (LOCK_PI/TRYLOCK_PI reject an unaligned uaddr up front). Validate before
+     * the atomic release path below, which requires a 4-byte-aligned word.
+     */
     if (!futex_uaddr_is_aligned(uaddr))
         return -LINUX_EINVAL;
 
     uint32_t *word = (uint32_t *) guest_ptr_w(g, uaddr);
     if (!word)
         return -LINUX_EFAULT;
-
-    uint32_t tid = current_thread ? (uint32_t) current_thread->guest_tid
-                                  : (uint32_t) proc_get_pid();
-
-    /* Verify the current thread owns the lock (TID field matches) */
-    uint32_t cur = __atomic_load_n(word, __ATOMIC_SEQ_CST);
-    if ((cur & FUTEX_TID_MASK) != tid)
-        return -LINUX_EPERM;
 
     /* Atomically release: set word to 0 (clear TID + WAITERS flag). Use CAS
      * loop in case another thread is concurrently setting WAITERS.

--- a/tests/test-futex-pi.c
+++ b/tests/test-futex-pi.c
@@ -6,9 +6,14 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Tests:
- *   1. PI futex dead-owner recovery (commit 64d21f2): child thread
- *      acquires a PI lock, exits without releasing it. Parent's
- *      FUTEX_LOCK_PI detects the dead owner and acquires the lock.
+ *   1. PI futex non-robust dead owner: a child thread acquires a PI lock
+ *      and exits without releasing it or registering a robust list, so no
+ *      FUTEX_OWNER_DIED is set. Linux does not recover such a lock -- the
+ *      parent's FUTEX_LOCK_PI returns -ESRCH -- so elfuse must too.
+ *
+ *   1b. Robust OWNER_DIED recovery: FUTEX_LOCK_PI on a word left in the
+ *      post-robust-walk state (FUTEX_OWNER_DIED set, TID cleared) must take
+ *      the lock over and return 0, not spin on the CAS(0->TID) fast path.
  *
  *   2. FUTEX_LOCK_PI + FUTEX_UNLOCK_PI round-trip: acquire and
  *      release a PI lock from the same thread.
@@ -41,6 +46,9 @@ int passes = 0, fails = 0;
 #endif
 #ifndef FUTEX_WAITERS
 #define FUTEX_WAITERS 0x80000000
+#endif
+#ifndef FUTEX_OWNER_DIED
+#define FUTEX_OWNER_DIED 0x40000000
 #endif
 
 /* Linux futex ops */
@@ -76,8 +84,8 @@ static long raw_futex_unlock_pi(uint32_t *addr)
 /* Stack for child thread (8KiB, 16-byte aligned) */
 static char child_stack_buf[8192] __attribute__((aligned(16)));
 
-/* Child: acquire PI lock, signal parent, exit WITHOUT releasing. This tests
- * elfuse's dead-owner detection in futex_lock_pi().
+/* Child: acquire PI lock, signal parent, exit WITHOUT releasing and WITHOUT a
+ * robust list. Exercises the non-robust dead-owner path in futex_lock_pi().
  */
 static void child_acquire_and_die(void)
 {
@@ -94,8 +102,9 @@ static void child_acquire_and_die(void)
     child_ready = 1;
     raw_futex_wake((int *) &child_ready, 1);
 
-    /* Exit WITHOUT calling FUTEX_UNLOCK_PI. This is the bug scenario: elfuse's
-     * futex_lock_pi must detect the current TID is dead and recover.
+    /* Exit WITHOUT calling FUTEX_UNLOCK_PI and WITHOUT a robust list, so no
+     * FUTEX_OWNER_DIED is set on pi_lock. The parent's FUTEX_LOCK_PI must then
+     * fail with -ESRCH, matching Linux's non-robust dead-owner behavior.
      */
     raw_exit(0);
 }
@@ -137,7 +146,7 @@ static void test_pi_lock_unlock(void)
 
 static void test_pi_dead_owner(void)
 {
-    TEST("PI dead-owner recovery");
+    TEST("PI non-robust dead owner returns ESRCH");
 
     /* Reset shared state */
     pi_lock = 0;
@@ -188,17 +197,57 @@ static void test_pi_dead_owner(void)
         usleep(10000); /* 10ms */
     }
 
-    /* Now try to acquire the PI lock. The child exited without releasing it, so
-     * elfuse's futex_lock_pi must detect the dead owner and let the waiter
-     * acquire.
+    /* Now try to acquire the PI lock. The child exited without releasing it and
+     * without registering a robust list, so no FUTEX_OWNER_DIED was set. Linux
+     * does NOT silently recover such a lock: FUTEX_LOCK_PI returns -ESRCH
+     * (attach_to_pi_owner sees the owner TID is dead with no OWNER_DIED mark).
+     * A guest that wants dead-owner recovery must use a robust futex list.
      */
     long r = raw_futex_lock_pi((uint32_t *) &pi_lock);
+    if (r != -3 /* -ESRCH */) {
+        printf(
+            "FAIL: LOCK_PI expected -ESRCH(-3) for non-robust dead owner, "
+            "got %ld\n",
+            r);
+        fails++;
+        return;
+    }
+    PASS();
+}
+
+/* Test: LOCK_PI recovers a robust OWNER_DIED word */
+
+static void test_pi_owner_died_recover(void)
+{
+    TEST("PI LOCK_PI recovers an OWNER_DIED word");
+
+    /* Reproduce the post-robust-walk state directly: the robust-list walk sets
+     * FUTEX_OWNER_DIED and clears the TID field on owner exit, leaving a
+     * nonzero word (OWNER_DIED set) with an empty TID. FUTEX_LOCK_PI must take
+     * over such a word -- Linux reacquires it and returns 0 -- rather than spin
+     * forever on the CAS(0->TID) fast path (which never matches OWNER_DIED) or
+     * fall through to the non-robust dead-owner -ESRCH path (TID is 0 here).
+     */
+    pi_lock = FUTEX_OWNER_DIED;
+
+    long r = raw_futex_lock_pi((uint32_t *) &pi_lock);
     if (r != 0) {
-        FAIL("LOCK_PI failed (dead-owner not recovered)");
+        printf(
+            "FAIL: LOCK_PI on OWNER_DIED word expected 0 (recovered), "
+            "got %ld\n",
+            r);
+        fails++;
         return;
     }
 
-    /* Clean up: release the lock */
+    /* We now own it; the low bits carry our TID. */
+    uint32_t tid = (uint32_t) raw_gettid();
+    uint32_t val = __atomic_load_n(&pi_lock, __ATOMIC_SEQ_CST);
+    if ((val & FUTEX_TID_MASK) != tid) {
+        FAIL("lock word doesn't contain our TID after recovery");
+        return;
+    }
+
     raw_futex_unlock_pi((uint32_t *) &pi_lock);
     PASS();
 }
@@ -315,10 +364,14 @@ static void test_futex_unaligned(void)
         return;
     }
 
+    /* UNLOCK_PI checks ownership before alignment (Linux futex_unlock_pi runs
+     * get_user + owner check ahead of get_futex_key), so an unaligned word you
+     * do not own returns -EPERM, not -EINVAL.
+     */
     r = raw_syscall6(__NR_futex, (long) unaligned,
                      FUTEX_UNLOCK_PI | FUTEX_PRIVATE, 0, 0, 0, 0);
-    if (r != -22) {
-        printf("FAIL: UNLOCK_PI expected -EINVAL(-22) got %ld\n", r);
+    if (r != -1 /* -EPERM */) {
+        printf("FAIL: UNLOCK_PI expected -EPERM(-1) got %ld\n", r);
         fails++;
         return;
     }
@@ -335,6 +388,7 @@ int main(void)
     test_pi_lock_unlock();
     test_futex_eintr();
     test_futex_unaligned();
+    test_pi_owner_died_recover();
     test_pi_dead_owner(); /* Last: uses CLONE_THREAD which may hang on x64 */
 
     SUMMARY("test-futex-pi");

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -244,13 +244,13 @@ unstage_sysroot_fixtures()
 # Generic test helpers.
 
 # Tests that either hang under qemu-system-aarch64 on Apple Silicon (raw clone /
-# PI futex / massive thread+mmap stress) or currently diverge from the Alpine
-# linux-virt reference kernel on the deprecated oom_adj procfs compatibility
-# path exercised by test-io-opt. test-sysfs-cpu asserts the elfuse stub contract
+# massive thread+mmap stress) or currently diverge from the Alpine linux-virt
+# reference kernel on the deprecated oom_adj procfs compatibility path exercised
+# by test-io-opt. test-sysfs-cpu asserts the elfuse stub contract
 # (cache/topology subtree empty, possible == online, cpuN count == online count)
 # which a real kernel does not honor. All listed tests still run in
 # elfuse-aarch64 mode and in 'make check'; the qemu reference run skips them.
-QEMU_SKIP="test-thread test-stress test-futex-pi test-osync-requeue test-io-opt test-sysfs-cpu"
+QEMU_SKIP="test-thread test-stress test-osync-requeue test-io-opt test-sysfs-cpu"
 
 is_qemu_skipped()
 {


### PR DESCRIPTION
`test-futex-pi` asserted two PI-futex behaviors that elfuse implemented but real Linux does not, so it passed under elfuse and failed under the qemu reference lane (hence its `QEMU_SKIP` entry). This aligns elfuse with Linux and re-enables the test in the qemu lane. Verified on an Alpine `linux-virt` guest (6.12.95, aarch64) under HVF: elfuse and qemu now both pass 4/4 with identical expectations.

**1. Unaligned `FUTEX_UNLOCK_PI`:** elfuse returned `-EINVAL`, Linux returns `-EPERM` — `futex_unlock_pi()` does `get_user` + owner check before the alignment check. Fix: reject a non-owner with `-EPERM` before validating alignment (word read via `guest_read_small`, which is unaligned-safe on the arm64 host).

**2. Non-robust dead owner:** elfuse's `futex_lock_pi` silently recovered a PI lock whose owner exited without a robust list; Linux returns `-ESRCH` unless the robust walk set `FUTEX_OWNER_DIED`. Fix: fast path and waiter loop recover only when `OWNER_DIED` is set, else return `-ESRCH`. Robust recovery is unchanged (`test-robust-futex` stays green).

`test-futex-pi.c` now asserts the Linux values; `test-matrix.sh` drops `test-futex-pi` from `QEMU_SKIP`.

**Testing:** `make check` 112/112; `test-futex-pi` 4/4 under both elfuse and the qemu guest; clang-format clean.