### PR TITLE
Run test-osync-requeue in the qemu reference lane

### DIFF
--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -251,7 +251,6 @@ unstage_sysroot_fixtures()
 # which a real kernel does not honor. All listed tests still run in
 # elfuse-aarch64 mode and in 'make check'; the qemu reference run skips them.
 QEMU_SKIP="
-test-osync-requeue
 test-io-opt
 test-sysfs-cpu
 "


### PR DESCRIPTION
`test-osync-requeue` was in `QEMU_SKIP` next to the raw-clone / thread-stress tests that actually hang under `qemu-system-aarch64` on Apple Silicon — but it doesn't belong there. Run natively on the Alpine `linux-virt` guest kernel (6.12.95, aarch64) under HVF it completes in well under a second and passes (`1 passed, 0 failed`) with no hang.

Dropping it from `QEMU_SKIP` lets the qemu reference lane exercise the musl-style `FUTEX_REQUEUE` wake path instead of skipping it, so the lane actually cross-checks elfuse's requeue behavior against the real kernel.

**Effect:** qemu-aarch64 rises to 170 passed / 9 skipped (of 179); the mode's baseline is a ≥163 pass / exactly 0 fail floor, so the gate stays green without a floor bump.

**Verified:** `test-osync-requeue` on the qemu Linux guest → `1 passed, 0 failed` (rc=0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `test-osync-requeue` in the qemu reference lane by dropping it from `QEMU_SKIP`, so the musl-style `FUTEX_REQUEUE` wake path is exercised and elfuse’s requeue behavior is cross-checked against the guest kernel. On Alpine `linux-virt` (aarch64, HVF) it completes in under a second with 1 passed; qemu-aarch64 now shows 170 passed / 9 skipped (of 179) with 0 fails, staying above the ≥163 floor.

<sup>Written for commit 5571bda1448d9e610dd3052cb915db85b919e0c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

