### PR TITLE
run test-thread, test-stress in qemu matrix

### DIFF
--- a/tests/raw-syscall.h
+++ b/tests/raw-syscall.h
@@ -246,6 +246,15 @@ static inline long raw_futex_wait(int *addr, int val)
                         FUTEX_WAIT | FUTEX_PRIVATE_FLAG, (long) val, 0, 0, 0);
 }
 
+static inline long raw_futex_wait_cleartid(int *addr, int val)
+{
+    /* Linux's CLONE_CHILD_CLEARTID exit wake is a plain futex wake. Match it
+     * with plain FUTEX_WAIT rather than FUTEX_WAIT_PRIVATE.
+     */
+    return raw_syscall6(__NR_futex, (long) addr, FUTEX_WAIT, (long) val, 0, 0,
+                        0);
+}
+
 static inline long raw_futex_wake(int *addr, int count)
 {
     return raw_syscall6(__NR_futex, (long) addr,

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -243,22 +243,27 @@ unstage_sysroot_fixtures()
 
 # Generic test helpers.
 
-# Tests that either hang under qemu-system-aarch64 on Apple Silicon (raw clone /
-# massive thread+mmap stress) or currently diverge from the Alpine linux-virt
-# reference kernel on the deprecated oom_adj procfs compatibility path exercised
-# by test-io-opt. test-sysfs-cpu asserts the elfuse stub contract
+# Tests that either hang under qemu-system-aarch64 on Apple Silicon or currently
+# diverge from the Alpine linux-virt reference kernel on the deprecated
+# oom_adj procfs compatibility path exercised by test-io-opt. test-sysfs-cpu
+# asserts the elfuse stub contract
 # (cache/topology subtree empty, possible == online, cpuN count == online count)
 # which a real kernel does not honor. All listed tests still run in
 # elfuse-aarch64 mode and in 'make check'; the qemu reference run skips them.
-QEMU_SKIP="test-thread test-stress test-osync-requeue test-io-opt test-sysfs-cpu"
+QEMU_SKIP="
+test-osync-requeue
+test-io-opt
+test-sysfs-cpu
+"
 
 is_qemu_skipped()
 {
     local label="$1"
-    case " $QEMU_SKIP " in
-        *" $label "*) return 0 ;;
-        *) return 1 ;;
-    esac
+    local skipped
+    for skipped in $QEMU_SKIP; do
+        [ "$skipped" = "$label" ] && return 0
+    done
+    return 1
 }
 
 # Honor QEMU_SKIP across all test_* wrappers.
@@ -987,7 +992,7 @@ run_suite()
 # detector does not recognize yet.
 EXPECTED_BASELINES=(
     "elfuse-aarch64|169|0"
-    "qemu-aarch64|163|0"
+    "qemu-aarch64|165|0"
     "elfuse-x86_64:apple-m1-m2|71|0"
     "elfuse-x86_64:apple-m3-plus|71|0"
     "elfuse-x86_64:apple-unknown|71|0"

--- a/tests/test-stress.c
+++ b/tests/test-stress.c
@@ -74,7 +74,7 @@ static void test_max_threads(void)
     /* Wait for all children to exit via CLONE_CHILD_CLEARTID */
     for (int i = 0; i < STRESS_THREADS; i++) {
         while (thread_tids[i] != 0) {
-            raw_futex_wait((int *) &thread_tids[i], thread_tids[i]);
+            raw_futex_wait_cleartid((int *) &thread_tids[i], thread_tids[i]);
         }
     }
 

--- a/tests/test-thread.c
+++ b/tests/test-thread.c
@@ -135,7 +135,7 @@ static void test_parent_settid(void)
      * child to fully exit (CLONE_CHILD_CLEARTID clears it)
      */
     while (child_tid != 0) {
-        raw_futex_wait((int *) &child_tid, child_tid);
+        raw_futex_wait_cleartid((int *) &child_tid, child_tid);
     }
 
     /* If execution reaches this point, CHILD_CLEARTID cleared it and FUTEX_WAKE
@@ -146,7 +146,7 @@ static void test_parent_settid(void)
 
 static void test_settid_failure_preserves_slots(void)
 {
-    TEST("failed SETTID preserves slots");
+    TEST("failed SETTID behavior");
 
     int parent_tid = 12345;
     unsigned long flags = 0x7d0f00 | 0x01000000; /* + CLONE_CHILD_SETTID */
@@ -159,6 +159,8 @@ static void test_settid_failure_preserves_slots(void)
     }
 
     if (ret == -EFAULT && parent_tid == 12345) {
+        PASS();
+    } else if (ret > 0 && parent_tid == (int) ret) {
         PASS();
     } else {
         FAIL("failed clone changed parent TID slot");
@@ -211,7 +213,7 @@ static void test_multi_thread(void)
     /* Wait for all children to complete (CHILD_CLEARTID clears tids) */
     for (int i = 0; i < N_THREADS; i++) {
         while (mt_tids[i] != 0) {
-            raw_futex_wait((int *) &mt_tids[i], mt_tids[i]);
+            raw_futex_wait_cleartid((int *) &mt_tids[i], mt_tids[i]);
         }
     }
 
@@ -281,7 +283,7 @@ static void test_clone_stack_unmap_reuse(void)
     raw_futex_wake((int *) &parked_state, 1);
 
     while (child_tid != 0)
-        raw_futex_wait((int *) &child_tid, child_tid);
+        raw_futex_wait_cleartid((int *) &child_tid, child_tid);
 
     void *reuse =
         mmap(stack, stack_size, PROT_READ | PROT_WRITE,


### PR DESCRIPTION
## Summary

- Make clear-tid joins use a plain futex wait, matching the kernel's `CLONE_CHILD_CLEARTID` wake path.
- Relax the SETTID fault subtest to accept both elfuse's preflight `-EFAULT` behavior and Linux/qemu's parent-success behavior.
- Remove `test-thread` and `test-stress` from the qemu matrix skip list and bump the qemu baseline.

## Root Cause

`test-thread` and `test-stress` waited for `CLONE_CHILD_CLEARTID` with `FUTEX_WAIT_PRIVATE`, but Linux's clear-tid exit wake matches a plain futex wait. Under qemu/Linux, the child TID was cleared but the parent remained asleep on the private futex queue. The SETTID failure probe also assumed elfuse's rollback behavior, while Linux/qemu can return the child TID to the parent and update `parent_tid`.

## Validation

- `make build/test-thread build/test-stress`
- Direct qemu run of `build/test-thread`: `5 passed, 0 failed`
- Direct qemu run of `build/test-stress`: `6 passed, 0 failed`
- Direct elfuse run of `build/test-thread`: `5 passed, 0 failed`
- `bash -n tests/test-matrix.sh`
- `make test-matrix-qemu-aarch64`: `171 passed, 0 failed, 8 skipped (of 179)`
