### PR TITLE
Split oom-proc subtests out of test-io-opt

### DIFF
--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -49,6 +49,7 @@ test-file-ops
 test-flock
 test-sysinfo
 test-io-opt
+test-oom-proc
 test-syscall-smoke
 test-vdso
 test-shim-identity

--- a/tests/test-io-opt.c
+++ b/tests/test-io-opt.c
@@ -17,15 +17,6 @@
 
 #include "test-harness.h"
 
-static void reset_oom_score_adj(void)
-{
-    int fd = open("/proc/self/oom_score_adj", O_RDWR);
-    if (fd >= 0) {
-        write(fd, "0\n", 2);
-        close(fd);
-    }
-}
-
 int main(void)
 {
     int passes = 0, fails = 0;
@@ -87,52 +78,6 @@ int main(void)
                 close(out_fd);
             FAIL("open failed");
         }
-    }
-
-    TEST("sendfile rereads synthetic oom proc source");
-    {
-        const char *proc_dst = "/tmp/elfuse-test-proc-sendfile.txt";
-        unlink(proc_dst);
-        reset_oom_score_adj();
-
-        int in_fd = open("/proc/self/oom_adj", O_RDONLY);
-        int score_fd = open("/proc/self/oom_score_adj", O_RDWR);
-        int out_fd = open(proc_dst, O_CREAT | O_WRONLY | O_TRUNC, 0644);
-        if (in_fd >= 0 && score_fd >= 0 && out_fd >= 0) {
-            char buf[32] = {0};
-            off_t offset = 0;
-            ssize_t wrote = write(score_fd, "1000\n", 5);
-            ssize_t copied =
-                wrote == 5 ? sendfile(out_fd, in_fd, &offset, 32) : -1;
-            close(out_fd);
-            close(score_fd);
-            close(in_fd);
-
-            int verify_fd = open(proc_dst, O_RDONLY);
-            if (copied >= 0 && verify_fd >= 0) {
-                ssize_t n = read(verify_fd, buf, sizeof(buf) - 1);
-                close(verify_fd);
-                if (copied == 3 && offset == 3 && n == 3 &&
-                    memcmp(buf, "15\n", 3) == 0)
-                    PASS();
-                else
-                    FAIL("unexpected sendfile proc content");
-            } else {
-                if (verify_fd >= 0)
-                    close(verify_fd);
-                FAIL("proc sendfile setup failed");
-            }
-        } else {
-            if (in_fd >= 0)
-                close(in_fd);
-            if (score_fd >= 0)
-                close(score_fd);
-            if (out_fd >= 0)
-                close(out_fd);
-            PASS();
-        }
-        reset_oom_score_adj();
-        unlink(proc_dst);
     }
 
     /* Test fsync */
@@ -236,54 +181,6 @@ int main(void)
             FAIL("open failed");
         }
         unlink(cfr_dst);
-    }
-
-    TEST("copy_file_range rereads synthetic oom proc source");
-    {
-        const char *proc_dst = "/tmp/elfuse-test-proc-cfr.txt";
-        unlink(proc_dst);
-        reset_oom_score_adj();
-
-        int in_fd = open("/proc/self/oom_adj", O_RDONLY);
-        int score_fd = open("/proc/self/oom_score_adj", O_RDWR);
-        int out_fd = open(proc_dst, O_CREAT | O_WRONLY | O_TRUNC, 0644);
-        if (in_fd >= 0 && score_fd >= 0 && out_fd >= 0) {
-            char buf[32] = {0};
-            off_t off_in = 0, off_out = 0;
-            ssize_t wrote = write(score_fd, "1000\n", 5);
-            ssize_t copied =
-                wrote == 5
-                    ? copy_file_range(in_fd, &off_in, out_fd, &off_out, 32, 0)
-                    : -1;
-            close(out_fd);
-            close(score_fd);
-            close(in_fd);
-
-            int verify_fd = open(proc_dst, O_RDONLY);
-            if (copied >= 0 && verify_fd >= 0) {
-                ssize_t n = read(verify_fd, buf, sizeof(buf) - 1);
-                close(verify_fd);
-                if (copied == 3 && off_in == 3 && off_out == 3 && n == 3 &&
-                    memcmp(buf, "15\n", 3) == 0)
-                    PASS();
-                else
-                    FAIL("unexpected copy_file_range proc content");
-            } else {
-                if (verify_fd >= 0)
-                    close(verify_fd);
-                FAIL("proc copy_file_range setup failed");
-            }
-        } else {
-            if (in_fd >= 0)
-                close(in_fd);
-            if (score_fd >= 0)
-                close(score_fd);
-            if (out_fd >= 0)
-                close(out_fd);
-            PASS();
-        }
-        reset_oom_score_adj();
-        unlink(proc_dst);
     }
 
     /* Cleanup */

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -244,13 +244,19 @@ unstage_sysroot_fixtures()
 # Generic test helpers.
 
 # Tests that either hang under qemu-system-aarch64 on Apple Silicon (raw clone /
-# PI futex / massive thread+mmap stress) or currently diverge from the Alpine
-# linux-virt reference kernel on the deprecated oom_adj procfs compatibility
-# path exercised by test-io-opt. test-sysfs-cpu asserts the elfuse stub contract
-# (cache/topology subtree empty, possible == online, cpuN count == online count)
-# which a real kernel does not honor. All listed tests still run in
-# elfuse-aarch64 mode and in 'make check'; the qemu reference run skips them.
-QEMU_SKIP="test-thread test-stress test-futex-pi test-osync-requeue test-io-opt test-sysfs-cpu"
+# PI futex / massive thread+mmap stress) or assert an elfuse-specific stub
+# contract a real kernel does not honor: test-sysfs-cpu checks cache/topology
+# subtree empty, possible == online, cpuN count == online count. All listed
+# tests still run in elfuse-aarch64 mode and in 'make check'; the qemu
+# reference run skips them.
+#
+# The two oom_adj/oom_score_adj sendfile-and-copy_file_range-interception
+# subtests that used to make test-io-opt diverge here were split out into
+# tests/test-oom-proc.c (make check only, not part of this matrix at all) --
+# see that file's header comment. test-io-opt itself is now pure portable
+# sendfile/fsync/fallocate/copy_file_range coverage and runs against qemu
+# like any other test.
+QEMU_SKIP="test-thread test-stress test-futex-pi test-osync-requeue test-sysfs-cpu"
 
 is_qemu_skipped()
 {

--- a/tests/test-oom-proc.c
+++ b/tests/test-oom-proc.c
@@ -1,0 +1,146 @@
+/*
+ * Test synthetic /proc/self/oom_* sendfile/copy_file_range interception
+ *
+ * Copyright 2026 elfuse contributors
+ * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * elfuse backs /proc/self/oom_adj, oom_score_adj, and oom_score with a
+ * per-open host temp file materialized at open() time, plus a separate
+ * read-intercept path (proc_intercept_read) that serves live atomic state
+ * to guest read/pread/readv so a write through a sibling fd is visible
+ * without reopening. sendfile(2) and copy_file_range(2) do not go through
+ * that read path -- they go through copy_fd_range's own, independently
+ * wired proc_try_chunk_read_intercept call. These tests pin that second
+ * wiring: open the source fd, mutate the value through a sibling fd, then
+ * sendfile/copy_file_range from the already-open fd and require the fresh
+ * value, not the stale open-time snapshot.
+ *
+ * This is elfuse-internal plumbing with no Linux-kernel counterpart -- no
+ * real program sendfile()s or copy_file_range()s out of procfs -- so unlike
+ * test-io-opt this suite is not run against the QEMU reference kernel; see
+ * tests/test-matrix.sh.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/sendfile.h>
+
+#include "test-harness.h"
+
+static void reset_oom_score_adj(void)
+{
+    int fd = open("/proc/self/oom_score_adj", O_RDWR);
+    if (fd >= 0) {
+        write(fd, "0\n", 2);
+        close(fd);
+    }
+}
+
+int main(void)
+{
+    int passes = 0, fails = 0;
+
+    printf(
+        "test-oom-proc: synthetic oom proc source sendfile/copy_file_range "
+        "interception\n");
+
+    TEST("sendfile rereads synthetic oom proc source");
+    {
+        const char *proc_dst = "/tmp/elfuse-test-proc-sendfile.txt";
+        unlink(proc_dst);
+        reset_oom_score_adj();
+
+        int in_fd = open("/proc/self/oom_adj", O_RDONLY);
+        int score_fd = open("/proc/self/oom_score_adj", O_RDWR);
+        int out_fd = open(proc_dst, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (in_fd >= 0 && score_fd >= 0 && out_fd >= 0) {
+            char buf[32] = {0};
+            off_t offset = 0;
+            ssize_t wrote = write(score_fd, "1000\n", 5);
+            ssize_t copied =
+                wrote == 5 ? sendfile(out_fd, in_fd, &offset, 32) : -1;
+            close(out_fd);
+            close(score_fd);
+            close(in_fd);
+
+            int verify_fd = open(proc_dst, O_RDONLY);
+            if (copied >= 0 && verify_fd >= 0) {
+                ssize_t n = read(verify_fd, buf, sizeof(buf) - 1);
+                close(verify_fd);
+                if (copied == 3 && offset == 3 && n == 3 &&
+                    memcmp(buf, "15\n", 3) == 0)
+                    PASS();
+                else
+                    FAIL("unexpected sendfile proc content");
+            } else {
+                if (verify_fd >= 0)
+                    close(verify_fd);
+                FAIL("proc sendfile setup failed");
+            }
+        } else {
+            if (in_fd >= 0)
+                close(in_fd);
+            if (score_fd >= 0)
+                close(score_fd);
+            if (out_fd >= 0)
+                close(out_fd);
+            FAIL("open failed");
+        }
+        reset_oom_score_adj();
+        unlink(proc_dst);
+    }
+
+    TEST("copy_file_range rereads synthetic oom proc source");
+    {
+        const char *proc_dst = "/tmp/elfuse-test-proc-cfr.txt";
+        unlink(proc_dst);
+        reset_oom_score_adj();
+
+        int in_fd = open("/proc/self/oom_adj", O_RDONLY);
+        int score_fd = open("/proc/self/oom_score_adj", O_RDWR);
+        int out_fd = open(proc_dst, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (in_fd >= 0 && score_fd >= 0 && out_fd >= 0) {
+            char buf[32] = {0};
+            off_t off_in = 0, off_out = 0;
+            ssize_t wrote = write(score_fd, "1000\n", 5);
+            ssize_t copied =
+                wrote == 5
+                    ? copy_file_range(in_fd, &off_in, out_fd, &off_out, 32, 0)
+                    : -1;
+            close(out_fd);
+            close(score_fd);
+            close(in_fd);
+
+            int verify_fd = open(proc_dst, O_RDONLY);
+            if (copied >= 0 && verify_fd >= 0) {
+                ssize_t n = read(verify_fd, buf, sizeof(buf) - 1);
+                close(verify_fd);
+                if (copied == 3 && off_in == 3 && off_out == 3 && n == 3 &&
+                    memcmp(buf, "15\n", 3) == 0)
+                    PASS();
+                else
+                    FAIL("unexpected copy_file_range proc content");
+            } else {
+                if (verify_fd >= 0)
+                    close(verify_fd);
+                FAIL("proc copy_file_range setup failed");
+            }
+        } else {
+            if (in_fd >= 0)
+                close(in_fd);
+            if (score_fd >= 0)
+                close(score_fd);
+            if (out_fd >= 0)
+                close(out_fd);
+            FAIL("open failed");
+        }
+        reset_oom_score_adj();
+        unlink(proc_dst);
+    }
+
+    SUMMARY("test-oom-proc");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- `test-io-opt`'s two "rereads synthetic oom proc source" subtests exercise `copy_fd_range`'s own proc-source read-intercept wiring (sendfile/copy_file_range reading a mutated-after-open `/proc/self/oom_adj` fd) -- elfuse-internal plumbing with no Linux-kernel counterpart, since no real program `sendfile()`s or `copy_file_range()`s out of procfs.
- Their presence forced the *entire* `test-io-opt` binary into `tests/test-matrix.sh`'s `QEMU_SKIP` list, silently withholding the other 5 portable subtests (sendfile, fsync, fallocate x2, copy_file_range) from ever being checked against the real Alpine `linux-virt` reference kernel.
- Moved the two subtests into a new `tests/test-oom-proc.c` (added to `tests/manifest.txt`, i.e. `make check` only; never invoked from `test-matrix.sh`), and dropped `test-io-opt` from `QEMU_SKIP`.

`make check` -- 81 passed, 0 failed, 3 skipped; `test-io-opt` and `test-oom-proc` both `[ OK ]`
`bash tests/test-matrix.sh elfuse-aarch64` -- 175 passed, 0 failed
`bash tests/test-matrix.sh qemu-aarch64` -- 170 passed, 0 failed; `test-io-opt` now passes against the real kernel for the first time


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split elfuse-only OOM proc interception subtests out of `test-io-opt` into a new `test-oom-proc`. This restores `test-io-opt` to the QEMU matrix and improves portable I/O coverage against the reference kernel.

- **Refactors**
  - Moved the two "rereads synthetic oom proc source" subtests to `tests/test-oom-proc.c`; added to `tests/manifest.txt` (make check only; not in `test-matrix.sh`); fixed open-failure handling to `FAIL` instead of `PASS`.
  - Updated `tests/test-matrix.sh`: removed `test-io-opt` from `QEMU_SKIP`; `test-io-opt` now only covers portable sendfile/fsync/fallocate/copy_file_range; kept `test-oom-proc` out of the matrix.

<sup>Written for commit fc44281a902da7f3ed5d08871b169a35e1a30b20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



