### PR TITLE
Add sanitizer CI lanes and fix the races

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,17 @@
 # Build elfuse and run the lint + analysis suites.
 #
-# Five jobs run in parallel:
-#   lint        : format/newline/security/cppcheck/dispatch on Linux
-#   build-macos : compile + entitlement check on macOS Apple Silicon
-#   tidy-macos  : clang-tidy via `make lint`
-#   scan-macos  : LLVM scan-build via `make analyze`
-#   infer-macos : Facebook Infer capture + analyze over the full build
+# Jobs run in parallel where runner capacity allows:
+#   lint          : format/newline/security/cppcheck/dispatch on Linux
+#   build-macos   : compile + entitlement check on macOS Apple Silicon
+#   tidy-macos    : clang-tidy via `make lint`
+#   scan-macos    : LLVM scan-build via `make analyze`
+#   infer-macos   : Facebook Infer capture + analyze over the full build
+#   runtime-macos : HVF runtime tests on self-hosted Apple Silicon,
+#                   including release, ASAN, UBSAN, and TSAN variants
 #
-# Runtime tests (test-hello, make check, test-multi-vcpu) require
-# Hypervisor.framework, which GitHub-hosted macOS runners do not expose
-# (the runner OS itself runs under a virtualization layer that withholds
-# HVF and returns HV_UNSUPPORTED from hv_vm_create). Those tests must run
-# on a self-hosted Apple Silicon runner; the hosted job stops at build.
+# Runtime and sanitizer tests require Hypervisor.framework, which
+# GitHub-hosted macOS runners do not expose. Those tests run on self-hosted
+# Apple Silicon runners; the hosted job stops at build.
 #
 # Within the lint job, all sub-checks run even if an earlier one fails so
 # the report shows every problem at once instead of stopping at the first.
@@ -335,13 +335,67 @@ jobs:
           if-no-files-found: warn
 
   runtime-macos:
-    name: Runtime (macOS Apple Silicon, HVF)
+    name: Runtime (${{ matrix.name }})
     needs: build-macos
     if: >
       github.repository == 'sysprog21/elfuse' &&
       (github.event_name == 'push' || github.event_name == 'pull_request')
     runs-on: [self-hosted, macOS, arm64]
-    timeout-minutes: 20
+    # Sanitizer builds run several times slower than the release build, so the
+    # job budget and the per-test TEST_TIMEOUT are widened per leg. Without
+    # that, a TSAN-slowed guest overruns the 10s default TEST_TIMEOUT and the
+    # 20-minute job budget, surfacing as TIMEOUT reds indistinguishable from a
+    # real hang.
+    timeout-minutes: ${{ matrix.job_timeout }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include:
+          - name: Release
+            sanitizer: release
+            extra_cflags: ''
+            asan_options: ''
+            ubsan_options: ''
+            tsan_options: ''
+            test_timeout: ''
+            job_timeout: 20
+            run_matrix: true
+            check_target: check
+            brew_pkgs: binutils qemu
+          - name: ASAN
+            sanitizer: asan
+            extra_cflags: -O1 -g -fsanitize=address -fno-omit-frame-pointer
+            asan_options: abort_on_error=1:detect_leaks=0
+            ubsan_options: ''
+            tsan_options: ''
+            test_timeout: '30'
+            job_timeout: 30
+            run_matrix: false
+            check_target: check-sanitizer
+            brew_pkgs: binutils
+          - name: UBSAN
+            sanitizer: ubsan
+            extra_cflags: -O1 -g -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer
+            asan_options: ''
+            ubsan_options: halt_on_error=1:print_stacktrace=1
+            tsan_options: ''
+            test_timeout: '30'
+            job_timeout: 30
+            run_matrix: false
+            check_target: check-sanitizer
+            brew_pkgs: binutils
+          - name: TSAN
+            sanitizer: tsan
+            extra_cflags: -O1 -g -fsanitize=thread -fno-omit-frame-pointer
+            asan_options: ''
+            ubsan_options: ''
+            tsan_options: halt_on_error=1
+            test_timeout: '60'
+            job_timeout: 45
+            run_matrix: false
+            check_target: check-sanitizer
+            brew_pkgs: binutils
 
     # contents: read for the checkout; pull-requests: read so the guard can
     # query the PR's current HEAD. (actions: write would let the guard
@@ -352,15 +406,26 @@ jobs:
       pull-requests: read
 
     concurrency:
-      group: runtime-macos-${{ github.ref }}
+      group: runtime-macos-${{ matrix.sanitizer }}-${{ github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     env:
       LINUX_TOOLCHAIN: /opt/toolchain/aarch64-linux-gnu
       GNU_OBJCOPY: /opt/homebrew/opt/binutils/bin/objcopy
+      EXTRA_CFLAGS: ${{ matrix.extra_cflags }}
+      ASAN_OPTIONS: ${{ matrix.asan_options }}
+      UBSAN_OPTIONS: ${{ matrix.ubsan_options }}
+      TSAN_OPTIONS: ${{ matrix.tsan_options }}
+      # Empty on the release leg falls back to test-runner.sh's 10s default.
+      TEST_TIMEOUT: ${{ matrix.test_timeout }}
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
-      BREW_PKGS: binutils qemu
+      # qemu is only needed by test-matrix (release leg); sanitizer legs run the
+      # fixture-free check-sanitizer subset and skip it.
+      BREW_PKGS: ${{ matrix.brew_pkgs }}
+      # Parallelize compilation; the guest-test cross-compile and elfuse build
+      # dominate the non-test wall time.
+      MAKEFLAGS: -j8
 
     steps:
       # Fail fast if this run targets a commit that is no longer the PR's
@@ -403,6 +468,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Restore cached test fixtures
+        # Only the release leg needs fixtures: the sanitizer legs run the
+        # fixture-free check-sanitizer subset.
+        if: ${{ matrix.run_matrix }}
         # actions/checkout's default clean:true runs `git clean -ffdx`, which
         # wipes externals/test-fixtures (gitignored) on this self-hosted
         # runner even though its disk otherwise persists across runs.
@@ -464,6 +532,9 @@ jobs:
           python3 --version
 
       - name: Check Rosetta for Linux
+        # Rosetta is exercised only by test-matrix (release leg); the
+        # check-sanitizer subset has no x86_64-via-Rosetta tests.
+        if: ${{ matrix.run_matrix }}
         run: |
           ROSETTA=/Library/Apple/usr/libexec/oah/RosettaLinux/rosetta
 
@@ -481,8 +552,13 @@ jobs:
           ls -l "$ROSETTA"
 
       - name: Build elfuse
+        # make does not track EXTRA_CFLAGS changes, so an object built for one
+        # sanitizer must not be reused for another. Checkout already wipes
+        # build/ (git clean -ffdx), but clean explicitly so the leg builds from
+        # scratch even on a workspace that was not freshly cleaned.
         run: |
-          make elfuse
+          make clean
+          make EXTRA_CFLAGS="$EXTRA_CFLAGS" elfuse
 
       - name: Verify HVF entitlement is embedded
         run: |
@@ -491,19 +567,32 @@ jobs:
 
       - name: test-hello
         run: |
-          make test-hello
+          make EXTRA_CFLAGS="$EXTRA_CFLAGS" test-hello
 
       - name: test-multi-vcpu
         run: |
-          make test-multi-vcpu
+          make EXTRA_CFLAGS="$EXTRA_CFLAGS" test-multi-vcpu
 
       - name: make check
+        # Release runs the full check suite; sanitizer legs run check-sanitizer,
+        # a representative internal-implementation subset (the release lane plus
+        # test-matrix already cover Linux syscall compatibility).
         run: |
-          make check
+          make EXTRA_CFLAGS="$EXTRA_CFLAGS" ${{ matrix.check_target }}
 
       - name: Test matrix
+        if: ${{ matrix.run_matrix }}
         run: |
           bash tests/test-matrix.sh all
+
+      - name: Upload runtime binary
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: elfuse-runtime-${{ matrix.sanitizer }}-${{ runner.os }}-${{ runner.arch }}
+          path: build/elfuse
+          retention-days: 7
+          if-no-files-found: warn
 
       - name: Save test fixtures cache
         # Persist externals/test-fixtures outside the workspace so the next
@@ -511,7 +600,7 @@ jobs:
         # unchanged Alpine packages. Runs even if an earlier step failed, as
         # long as the job wasn't cancelled, so a fixture-unrelated test
         # failure doesn't cost the next run its cache.
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.sanitizer == 'release' }}
         run: |
           if [ -d externals/test-fixtures ]; then
             cache="$HOME/.cache/elfuse-ci/test-fixtures"

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -56,6 +56,7 @@ CFLAGS := -O2 -Wall -Wextra -Wpedantic \
           -Wshadow -Wstrict-prototypes -Wmissing-prototypes \
           -Wformat=2 -Wimplicit-fallthrough -Wundef \
           -Wnull-dereference -Wno-unused-parameter
+CFLAGS += $(EXTRA_CFLAGS)
 
 ifneq ($(strip $(ELFUSE_NR_EMBEDDER_HVC6)),)
 CFLAGS += -DELFUSE_NR_EMBEDDER_HVC6=$(ELFUSE_NR_EMBEDDER_HVC6)

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -37,6 +37,54 @@ define RUN_OPTIONAL_SKIP77
 	fi
 endef
 
+.PHONY: check-asan check-ubsan check-tsan check-sanitizer
+
+# Sanitizer builds target elfuse's own internals, not Linux syscall
+# compatibility -- the release lane already covers that via test-matrix. So the
+# check-{asan,ubsan,tsan} entry points run check-sanitizer, a representative
+# subset of manifest sections that stress concurrency, memory, fork, and signal
+# machinery (where ASAN/UBSAN/TSAN actually find bugs) instead of the full
+# check suite.
+#
+# Sanitized guests run several times slower, so widen the per-test timeout
+# (test-runner.sh defaults to 10s) to keep the slowdown from surfacing as a
+# spurious TIMEOUT. TEST_TIMEOUT is only overridden if the caller has not
+# already set one.
+
+## Run the sanitizer subset with AddressSanitizer (ASAN)
+check-asan: clean
+	ASAN_OPTIONS="abort_on_error=1:detect_leaks=0" TEST_TIMEOUT="$${TEST_TIMEOUT:-30}" $(MAKE) EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer" check-sanitizer
+
+## Run the sanitizer subset with UndefinedBehaviorSanitizer (UBSAN)
+check-ubsan: clean
+	UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" TEST_TIMEOUT="$${TEST_TIMEOUT:-30}" $(MAKE) EXTRA_CFLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer" check-sanitizer
+
+## Run the sanitizer subset with ThreadSanitizer (TSAN)
+check-tsan: clean
+	TSAN_OPTIONS="halt_on_error=1" TEST_TIMEOUT="$${TEST_TIMEOUT:-60}" $(MAKE) EXTRA_CFLAGS="-fsanitize=thread -fno-omit-frame-pointer" check-sanitizer
+
+# Manifest sections that exercise elfuse-internal concurrency, memory, fork,
+# and signal machinery -- the highest-signal targets for ASAN/UBSAN/TSAN.
+# Selected by tests/driver.sh -s; see tests/manifest.txt for the full list.
+# Kept deliberately tight so a TSAN leg (~5s per guest spawn) stays inside the
+# CI budget. "I/O subsystem" is included for its fd-table refcount/ABA races
+# (epoll-mt/aba/refcount, getdents-refcount) now that fd_entry_t.type is atomic;
+# the remaining compat sections (rseq, /proc, sockets) stay on the release lane.
+SANITIZER_SECTIONS := Threading|Stress|Signal.*thread|Fork edge|CoW fork|Guard page|mremap|MAP_SHARED|madvise|futex|FD table race|Multithreaded|SysV shared|membarrier|I/O subsystem
+
+## Run the representative internal-implementation subset (for sanitizer builds)
+check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) \
+		$(BUILD_DIR)/test-tlbi-encoder-host \
+		$(BUILD_DIR)/test-fork-ipc-protocol-host \
+		$(BUILD_DIR)/test-identity-override-host
+	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v -s '$(SANITIZER_SECTIONS)'
+	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-tlbi-encoder-host
+	@printf "\n$(BLUE)━━━ fork IPC protocol identity unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-fork-ipc-protocol-host
+	@printf "\n$(BLUE)━━━ identity override unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-identity-override-host
+
 ## Run the unit test suite plus busybox applet validation
 check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 		$(BUILD_DIR)/test-tlbi-encoder-host \

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -643,10 +643,10 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_EAGAIN;
     }
     /* Captured now, while the slot is guaranteed still ours (thread_alloc just
-     * marked it active, so no concurrent thread_alloc reuse-scan will touch
-     * it until our own worker deactivates it). Passed to
-     * thread_set_host_thread below so it can detect whether this exact slot
-     * got recycled to a different logical thread before that call runs.
+     * marked it active, so no concurrent thread_alloc reuse-scan will touch it
+     * until our own worker deactivates it). Passed to thread_set_host_thread
+     * below so it can detect whether this exact slot got recycled to a
+     * different logical thread before that call runs.
      */
     uint64_t t_generation = t->generation;
 
@@ -718,16 +718,16 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_EAGAIN;
     }
 
-    /* If this returns false, the worker already hit its startup_failed path
-     * and thread_deactivate'd t fast enough for a concurrent clone to recycle
-     * the slot before this write -- t no longer refers to our worker, so the
-     * write is skipped rather than clobbering the new occupant (a race
-     * flagged by review: recording host_thread unconditionally could corrupt
-     * the recycled slot's real handle). A mismatch can only happen alongside
-     * a startup failure (thread_deactivate is the sole precondition for
-     * reuse, and nothing else calls it this early), so the failure branch
-     * below is guaranteed to run and is solely responsible for reaping
-     * host_thread in that case.
+    /* If this returns false, the worker already hit its startup_failed path and
+     * thread_deactivate'd t fast enough for a concurrent clone to recycle the
+     * slot before this write -- t no longer refers to our worker, so the write
+     * is skipped rather than clobbering the new occupant (a race flagged by
+     * review: recording host_thread unconditionally could corrupt the recycled
+     * slot's real handle). A mismatch can only happen alongside a startup
+     * failure (thread_deactivate is the sole precondition for reuse, and
+     * nothing else calls it this early), so the failure branch below is
+     * guaranteed to run and is solely responsible for reaping host_thread in
+     * that case.
      */
     bool host_thread_recorded =
         thread_set_host_thread(t, host_thread, true, t_generation);
@@ -746,19 +746,18 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
          */
         if (host_thread_recorded) {
             /* The worker deactivated its slot before signaling the handshake,
-             * so a concurrent clone may already have reused the slot and
-             * joined the handle at reuse time; claim the join to guarantee
-             * exactly one joiner.
+             * so a concurrent clone may already have reused the slot and joined
+             * the handle at reuse time; claim the join to guarantee exactly one
+             * joiner.
              */
             if (thread_claim_worker_join(t, host_thread))
                 pthread_join(host_thread, NULL);
         } else {
-            /* The write above was rejected: some other clone recycled t
-             * before we could record host_thread, so no table entry
-             * references it and nobody else will ever join it. We are the
-             * only owner. The worker's startup_failed path is a short,
-             * non-blocking sequence (no guest code ever ran), so this join
-             * returns promptly.
+            /* The write above was rejected: some other clone recycled t before
+             * we could record host_thread, so no table entry references it and
+             * nobody else will ever join it. We are the only owner. The
+             * worker's startup_failed path is a short, non-blocking sequence
+             * (no guest code ever ran), so this join returns promptly.
              */
             pthread_join(host_thread, NULL);
         }
@@ -800,8 +799,29 @@ static void *thread_create_and_run(void *arg)
         return NULL;
     }
 
+    /* Publish the vCPU handle under the thread lock. The slot is already active
+     * (thread_alloc set active before pthread_create), so thread_interrupt_all,
+     * thread_quiesce_siblings, and thread_destroy_all_vcpus can scan it
+     * concurrently; they read t->vcpu under thread_lock, so an unlocked store
+     * here is a data race (flagged by ThreadSanitizer). Until this store the
+     * scanners observe the zeroed handle and skip the slot; the startup_failed
+     * path below deactivates before destroying, so a scan that does observe the
+     * handle only ever hands HVF a live vCPU.
+     */
+    pthread_mutex_t *tlock = thread_get_lock();
+    pthread_mutex_lock(tlock);
     t->vcpu = vcpu;
     t->vexit = vexit;
+    /* A PTRACE_INTERRUPT that raced this bring-up (arrived before the handle
+     * was published) recorded a pending request it could not deliver via
+     * hv_vcpus_exit. Consume it under the same lock and self-kick below so the
+     * first hv_vcpu_run returns CANCELED into the ptrace-stop path.
+     */
+    bool ptrace_interrupt = t->ptrace_interrupt_pending;
+    t->ptrace_interrupt_pending = false;
+    pthread_mutex_unlock(tlock);
+    if (ptrace_interrupt)
+        hv_vcpus_exit(&vcpu, 1);
 
     /* Sysreg setup uses checked calls instead of HV_CHECK so the parent's
      * startup handshake can roll back cleanly rather than tearing down the
@@ -877,7 +897,12 @@ static void *thread_create_and_run(void *arg)
     bool verbose = tca->verbose;
     free(tca);
 
-    /* Set per-thread TLS pointer and enter worker run loop */
+    /* Set per-thread TLS pointer. The fork-quiesce barrier is checked at
+     * startup_ok (right before guest entry), not here: signaling startup
+     * readiness first lets the clone parent return and reach the barrier via
+     * the normal kick path, instead of stalling the fork snapshot until this
+     * worker's parent unblocks.
+     */
     current_thread = t;
 
     pthread_mutex_lock(&startup->lock);
@@ -890,13 +915,14 @@ static void *thread_create_and_run(void *arg)
 
 startup_failed:
     /* HVF sysreg/GPR setup failed after vCPU creation. Drop the thread slot
-     * before tearing the vCPU down: thread_interrupt_all() scans the active set
-     * and calls hv_vcpus_exit() on each t->vcpu without a null check, so
-     * clearing t->vcpu while the slot is still active would let a concurrent
-     * exit_group hand a zero handle to HVF. Deactivating first removes the slot
-     * from iteration. Then destroy the vCPU on its owning thread (the only
-     * thread allowed to do so), free args, and finally signal the parent so it
-     * observes a fully torn-down state.
+     * before tearing the vCPU down: the vCPU handle was already published under
+     * thread_lock, so a concurrent thread_interrupt_all /
+     * thread_destroy_all_vcpus / exit_group could otherwise observe it.
+     * Deactivating first removes the slot from THREAD_FOR_EACH_ACTIVE iteration
+     * so subsequent scans skip it before the handle is destroyed. Then destroy
+     * the vCPU on its owning thread (the only thread allowed to do so), free
+     * args, and finally signal the parent so it observes a fully torn-down
+     * state.
      */
     thread_deactivate(t);
     hv_vcpu_destroy(vcpu);
@@ -909,6 +935,16 @@ startup_failed:
     return NULL;
 
 startup_ok:;
+
+    /* If a sibling armed a fork snapshot while this worker was still in
+     * bring-up, thread_quiesce_siblings could not kick a not-yet-published
+     * vCPU, but it still counted this slot in fork_target_count. Check the
+     * barrier before touching guest memory so the snapshot cannot be torn by a
+     * freshly-created thread. thread_lock serializes this check against the
+     * quiesce scan+arm, so the worker was either kicked (it published in time)
+     * or observes the armed barrier here and blocks until the fork completes.
+     */
+    thread_fork_barrier_check();
 
     log_debug("thread tid=%lld starting on vCPU", (long long) t->guest_tid);
 
@@ -1066,11 +1102,11 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
     }
 
     /* Detached: the pthread runtime reclaims the thread on exit, so the handle
-     * must never be joined (host_thread_needs_join stays false). The
-     * generation check always succeeds here: unlike sys_clone_thread's
-     * worker, a vm-clone worker that fails HVF bring-up
-     * (vm_clone_report_bringup_failure) keeps the slot active for wait4
-     * rather than deactivating it, so t cannot be recycled before this call.
+     * must never be joined (host_thread_needs_join stays false). The generation
+     * check always succeeds here: unlike sys_clone_thread's worker, a vm-clone
+     * worker that fails HVF bring-up (vm_clone_report_bringup_failure) keeps
+     * the slot active for wait4 rather than deactivating it, so t cannot be
+     * recycled before this call.
      */
     (void) thread_set_host_thread(t, host_thread, false, t_generation);
 
@@ -1101,6 +1137,12 @@ static void vm_clone_report_bringup_failure(thread_entry_t *t)
     t->vcpu = 0;
     t->vm_exited = true;
     t->vm_exit_status = LINUX_SIGKILL; /* WIFSIGNALED, WTERMSIG == SIGKILL */
+    /* The slot stays active for wait4 rather than deactivating, so the fork
+     * barrier hand-back that thread_deactivate would otherwise perform must be
+     * done here -- else a fork racing this bring-up failure waits the full
+     * quiesce timeout for a child that never reaches the barrier.
+     */
+    thread_fork_release_counted_locked(t);
     pthread_cond_broadcast(&t->ptrace_cond);
     pthread_mutex_unlock(lock);
     if (dying)
@@ -1128,8 +1170,22 @@ static void *vm_clone_thread_run(void *arg)
         return NULL;
     }
 
+    /* Publish under the thread lock; see thread_create_and_run for the race
+     * this closes (concurrent thread_interrupt_all / thread_destroy_all_vcpus
+     * read t->vcpu under thread_lock).
+     */
+    pthread_mutex_t *tlock = thread_get_lock();
+    pthread_mutex_lock(tlock);
     t->vcpu = vcpu;
     t->vexit = vexit;
+    /* Deliver a PTRACE_INTERRUPT that raced bring-up; see
+     * thread_create_and_run. vm-clone children are the usual ptrace targets.
+     */
+    bool ptrace_interrupt = t->ptrace_interrupt_pending;
+    t->ptrace_interrupt_pending = false;
+    pthread_mutex_unlock(tlock);
+    if (ptrace_interrupt)
+        hv_vcpus_exit(&vcpu, 1);
 
     /* Copy system registers from parent */
     HV_CHECK(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_VBAR_EL1, tca->vbar));
@@ -1172,6 +1228,7 @@ static void *vm_clone_thread_run(void *arg)
 
     /* Set per-thread TLS pointer and enter worker run loop */
     current_thread = t;
+    thread_fork_barrier_check();
 
     log_debug("vm_clone tid=%lld starting on vCPU", (long long) t->guest_tid);
 

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -3481,9 +3481,14 @@ int proc_intercept_stat(const char *path, struct stat *st)
         /* macOS dev_t = (major << 24) | minor; the fs-stat translation layer
          * (mac_to_linux_dev) re-encodes that into Linux's split major/minor
          * layout, so storing 136 in the macOS-major slot makes glibc's
-         * major(rdev) yield UNIX98_PTY_SLAVE_MAJOR.
+         * major(rdev) yield UNIX98_PTY_SLAVE_MAJOR. Build the value in
+         * uint32_t: dev_t is a signed 32-bit int here, so 136 << 24
+         * (0x88000000) would overflow it -- undefined behavior flagged by
+         * UBSAN. The unsigned shift is well-defined and the conversion to dev_t
+         * keeps the same bit pattern.
          */
-        st->st_rdev = ((dev_t) 136u << 24) | (dev_t) (n & 0xFFFFFFu);
+        st->st_rdev =
+            (dev_t) (((uint32_t) 136u << 24) | (uint32_t) (n & 0xFFFFFFu));
         st->st_size = 0;
         st->st_blksize = 1024;
         st->st_blocks = 0;

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -56,6 +56,16 @@ static pthread_mutex_t thread_lock =
     PTHREAD_MUTEX_INITIALIZER; /* Lock order: 5 */
 static _Atomic int active_thread_count = 0;
 
+/* Fork barrier state. Protected by thread_lock. Declared here (rather than
+ * beside thread_quiesce_siblings) because thread_deactivate, earlier in the
+ * file, hands its count back when a counted sibling exits before the barrier.
+ */
+static bool fork_quiesce_active = false; /* True while a fork is in progress */
+static int fork_quiesced_count = 0;      /* Siblings blocked on barrier */
+static int fork_target_count = 0;        /* Number of siblings to quiesce */
+static pthread_cond_t fork_cond = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t fork_all_quiesced_cond = PTHREAD_COND_INITIALIZER;
+
 /* Iterate every slot. */
 #define THREAD_FOR_EACH(t) \
     for (thread_entry_t *t = thread_table; t < thread_table + MAX_THREADS; t++)
@@ -152,16 +162,16 @@ rescan:
          */
         if (t->ptrace_conds_inited && t->ptrace_waiters > 0)
             continue;
-        /* Reap the previous occupant's pthread before reusing the slot.
-         * Workers that exit on their own are joinable but never joined
+        /* Reap the previous occupant's pthread before reusing the slot. Workers
+         * that exit on their own are joinable but never joined
          * (thread_join_workers snapshots active entries only), so dropping the
-         * handle in the memset below would leak its pthread bookkeeping for
-         * the process lifetime. active == 0 means the pthread is already past
-         * thread_deactivate, so the join blocks at most for its final
-         * wind-down -- but that wind-down can take thread_lock (the
-         * last-worker wakeup calls thread_interrupt_all), so the join must run
-         * with the lock dropped. Claim the handle first so no one else joins
-         * it, then rescan: the table may have changed while unlocked.
+         * handle in the memset below would leak its pthread bookkeeping for the
+         * process lifetime. active == 0 means the pthread is already past
+         * thread_deactivate, so the join blocks at most for its final wind-down
+         * -- but that wind-down can take thread_lock (the last-worker wakeup
+         * calls thread_interrupt_all), so the join must run with the lock
+         * dropped. Claim the handle first so no one else joins it, then rescan:
+         * the table may have changed while unlocked.
          */
         if (t->host_thread_needs_join) {
             pthread_t stale = t->host_thread;
@@ -176,8 +186,8 @@ rescan:
             pthread_cond_destroy(&t->resume_cond);
         }
         /* Bump generation across the memset so a caller still holding this
-         * slot's pointer from before reuse (e.g. a clone parent racing its
-         * own worker's startup-failure path) can detect the recycle via
+         * slot's pointer from before reuse (e.g. a clone parent racing its own
+         * worker's startup-failure path) can detect the recycle via
          * thread_set_host_thread's generation check instead of writing into
          * what is now a different logical thread.
          */
@@ -257,6 +267,23 @@ bool thread_claim_worker_join(thread_entry_t *t, pthread_t thr)
     return claimed;
 }
 
+void thread_fork_release_counted_locked(thread_entry_t *t)
+{
+    /* Caller holds thread_lock. If a fork snapshot counted this slot but it is
+     * exiting or failing bring-up before it could reach
+     * thread_fork_barrier_check, hand its count back so thread_quiesce_siblings
+     * is not stalled the full timeout waiting for a thread that will never
+     * arrive. Guarded by fork_counted so a slot created after the barrier armed
+     * (never counted) does not over-decrement. No-op when no barrier is armed.
+     */
+    if (fork_quiesce_active && t->fork_counted) {
+        t->fork_counted = false;
+        fork_target_count--;
+        if (fork_quiesced_count >= fork_target_count)
+            pthread_cond_signal(&fork_all_quiesced_cond);
+    }
+}
+
 void thread_deactivate(thread_entry_t *t)
 {
     if (!t)
@@ -284,6 +311,8 @@ void thread_deactivate(thread_entry_t *t)
 
     __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
     atomic_fetch_sub(&active_thread_count, 1);
+
+    thread_fork_release_counted_locked(t);
 
     /* Destroy condvars once no waiters still reference them. A tracer woken by
      * the broadcast above may still be re-acquiring thread_lock.
@@ -471,9 +500,9 @@ void thread_join_workers(void)
              * polled: thread_alloc only recycles a slot once its previous
              * occupant is inactive, so a generation bump here proves our
              * snapshotted worker already deactivated even though the slot now
-             * reads active == 1 again for the replacement thread. Stop
-             * polling immediately rather than tracking the wrong thread's
-             * active bit for the rest of the loop.
+             * reads active == 1 again for the replacement thread. Stop polling
+             * immediately rather than tracking the wrong thread's active bit
+             * for the rest of the loop.
              */
             if (workers[w].t->generation != workers[w].generation) {
                 recycled = true;
@@ -485,8 +514,8 @@ void thread_join_workers(void)
         if (!workers[w].claimed)
             continue;
         /* recycled short-circuits before the active re-check: once recycled,
-         * that bit belongs to the replacement thread and must not influence
-         * the join-vs-detach decision for our (already-terminated) handle.
+         * that bit belongs to the replacement thread and must not influence the
+         * join-vs-detach decision for our (already-terminated) handle.
          */
         if (recycled ||
             !__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
@@ -554,27 +583,32 @@ int thread_signal_deliverable(uint64_t sigbit)
 
 /* Fork quiesce. */
 
-/* Fork barrier state. Protected by thread_lock. */
-static bool fork_quiesce_active = false; /* True while a fork is in progress */
-static int fork_quiesced_count = 0;      /* Siblings blocked on barrier */
-static int fork_target_count = 0;        /* Number of siblings to quiesce */
-static pthread_cond_t fork_cond = PTHREAD_COND_INITIALIZER;
-static pthread_cond_t fork_all_quiesced_cond = PTHREAD_COND_INITIALIZER;
 static pthread_cond_t deferred_stack_unmap_cond = PTHREAD_COND_INITIALIZER;
 
 void thread_quiesce_siblings(void)
 {
     hv_vcpu_t vcpus[MAX_THREADS];
     int count = 0;
+    int targets = 0;
 
     pthread_mutex_lock(&thread_lock);
 
-    /* Collect sibling vCPUs (all active threads except caller). */
-    THREAD_FOR_EACH_ACTIVE (t)
-        if (t != current_thread)
+    /* Count every active sibling. Startup siblings may not have published a
+     * vCPU yet, but once they do they check the barrier before guest entry.
+     * fork_counted marks the slots that owe the barrier a response, so a
+     * sibling that exits before arriving can hand its count back (see
+     * thread_deactivate) instead of stalling the forker the full timeout.
+     */
+    THREAD_FOR_EACH_ACTIVE (t) {
+        if (t == current_thread)
+            continue;
+        t->fork_counted = true;
+        targets++;
+        if (t->vcpu)
             vcpus[count++] = t->vcpu;
+    }
 
-    if (count == 0) {
+    if (targets == 0) {
         pthread_mutex_unlock(&thread_lock);
         return;
     }
@@ -582,12 +616,13 @@ void thread_quiesce_siblings(void)
     /* Arm the barrier */
     fork_quiesce_active = true;
     fork_quiesced_count = 0;
-    fork_target_count = count;
+    fork_target_count = targets;
 
     pthread_mutex_unlock(&thread_lock);
 
     /* Force siblings out of hv_vcpu_run */
-    hv_vcpus_exit(vcpus, (uint32_t) count);
+    if (count > 0)
+        hv_vcpus_exit(vcpus, (uint32_t) count);
 
     /* Wait until all siblings have blocked on the barrier. Use a bounded wait:
      * siblings in long-running host syscalls (poll, read, accept) may not reach
@@ -615,6 +650,12 @@ void thread_resume_siblings(void)
     fork_quiesce_active = false;
     fork_quiesced_count = 0;
     fork_target_count = 0;
+    /* Clear any fork_counted still set on siblings that never reached the
+     * barrier (blocked in a host syscall and released by the timeout) so the
+     * next barrier generation starts from a clean slate.
+     */
+    THREAD_FOR_EACH (t)
+        t->fork_counted = false;
     pthread_cond_broadcast(&fork_cond);
     pthread_mutex_unlock(&thread_lock);
 }
@@ -627,10 +668,18 @@ int thread_fork_barrier_check(void)
         return 0;
     }
 
-    /* Signal that the current thread has reached the barrier */
-    fork_quiesced_count++;
-    if (fork_quiesced_count >= fork_target_count)
-        pthread_cond_signal(&fork_all_quiesced_cond);
+    /* Only a thread that thread_quiesce_siblings counted contributes to the
+     * quiesced tally, and only once. A thread created after the barrier armed
+     * (fork_counted == false) still blocks below so it cannot run guest code
+     * during the snapshot, but must not inflate fork_quiesced_count past
+     * fork_target_count and let the forker proceed before a real sibling has
+     * stopped.
+     */
+    if (current_thread && current_thread->fork_counted) {
+        current_thread->fork_counted = false;
+        if (++fork_quiesced_count >= fork_target_count)
+            pthread_cond_signal(&fork_all_quiesced_cond);
+    }
 
     /* Block until fork is complete */
     while (fork_quiesce_active)

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -46,7 +46,8 @@ typedef struct thread_entry {
                                   * teardown in thread_join_workers, or the
                                   * clone startup-failure rollback. Never set
                                   * for the main thread or vm-clone children
-                                  * (the latter are created detached). */
+                                  * (the latter are created detached).
+                                  */
     uint64_t clear_child_tid;    /* GVA for CLONE_CHILD_CLEARTID (0=none) */
     uint64_t sp_el1;             /* Per-thread EL1 stack top (IPA) */
     int sp_el1_slot;             /* Slot index in sp_el1_allocated (-1 = none).
@@ -105,6 +106,15 @@ typedef struct thread_entry {
     uint32_t rseq_len;       /* Length from registration */
     uint32_t rseq_signature; /* Abort signature from registration */
 
+    /* Fork-quiesce barrier accounting. Set by thread_quiesce_siblings for each
+     * sibling it counted into fork_target_count; cleared when the thread either
+     * reaches thread_fork_barrier_check (contributing to fork_quiesced_count)
+     * or deactivates first (decrementing fork_target_count so the forker is not
+     * stalled). Guards both sides so a thread created after the barrier armed
+     * neither inflates nor deflates the tally. Written under thread_lock.
+     */
+    bool fork_counted;
+
     /* ptrace state. Used by two-process JIT architectures: the tracer attaches
      * via PTRACE_SEIZE, then uses BRK-triggered SIGTRAP + wait4 to discover
      * untranslated code on-demand. The tracee snapshots its own vCPU registers
@@ -121,6 +131,12 @@ typedef struct thread_entry {
     int ptrace_waiters;          /* Tracers currently blocked on ptrace_cond */
     bool ptrace_cleanup_pending; /* Destroy condvars after last waiter leaves */
     int ptrace_cont_sig;         /* Signal to inject on resume (0=none) */
+    bool ptrace_interrupt_pending;    /* PTRACE_INTERRUPT arrived while the vCPU
+                                       * was still in bring-up (t->vcpu == 0), so
+                                       * it could not be delivered via
+                                       * hv_vcpus_exit; the worker self-kicks at
+                                       * publish to deliver it. Under thread_lock.
+                                       */
     linux_user_pt_regs_t ptrace_regs; /* snapshot for cross-thread access */
     bool ptrace_regs_dirty;           /* Tracer modified registers */
 
@@ -201,25 +217,28 @@ void thread_deactivate(thread_entry_t *t);
 
 /* Record the host pthread backing this entry, under thread_lock so concurrent
  * table readers (thread_join_workers snapshot, thread_alloc slot reuse) see a
- * consistent handle. joinable marks the handle as needing a pthread_join
- * before its slot can be reused; pass false for detached pthreads (vm-clone
- * children). generation must be the value of t->generation the caller
- * observed when it obtained t from thread_alloc: if the slot was recycled to
- * a different logical thread in the meantime (the calling worker failed
- * startup and deactivated before this call ran), the current generation no
- * longer matches and the write is rejected -- the caller then owns thr
- * exclusively and must join or detach it itself. Returns true if recorded.
+ * consistent handle. joinable marks the handle as needing a pthread_join before
+ * its slot can be reused; pass false for detached pthreads (vm-clone children).
+ * generation must be the value of t->generation the caller observed when it
+ * obtained t from thread_alloc: if the slot was recycled to a different logical
+ * thread in the meantime (the calling worker failed startup and deactivated
+ * before this call ran), the current generation no longer matches and the write
+ * is rejected -- the caller then owns thr exclusively and must join or detach
+ * it itself.
+ *
+ * Returns true if recorded.
  */
 bool thread_set_host_thread(thread_entry_t *t,
                             pthread_t thr,
                             bool joinable,
                             uint64_t generation);
 
-/* Atomically claim the right to pthread_join a worker's handle. Returns true
- * when the caller must join thr; false when someone else (slot reuse in
- * thread_alloc) already claimed it, or the slot no longer holds thr. Used by
- * the clone startup-failure rollback so the parent's join cannot race with a
- * concurrent slot reuse joining the same terminated pthread.
+/* Atomically claim the right to pthread_join a worker's handle.
+ *
+ * Returns true when the caller must join thr; false when someone else (slot
+ * reuse in thread_alloc) already claimed it, or the slot no longer holds thr.
+ * Used by the clone startup-failure rollback so the parent's join cannot race
+ * with a concurrent slot reuse joining the same terminated pthread.
  */
 bool thread_claim_worker_join(thread_entry_t *t, pthread_t thr);
 
@@ -322,6 +341,14 @@ void thread_resume_siblings(void);
  * Returns 0 if no quiesce is active.
  */
 int thread_fork_barrier_check(void);
+
+/* Hand a counted sibling's slot back to an armed fork barrier when it exits or
+ * fails bring-up before reaching thread_fork_barrier_check. Caller must hold
+ * the thread lock (thread_get_lock()). No-op if no barrier is armed or the slot
+ * was not counted. thread_deactivate calls this; paths that keep a failed slot
+ * active for wait4 (vm-clone bring-up failure) must call it explicitly.
+ */
+void thread_fork_release_counted_locked(thread_entry_t *t);
 
 /* Ptrace helpers. */
 

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -737,9 +737,16 @@ typedef struct {
 } sock_opt_cache_t;
 
 typedef struct {
-    int type;        /* FD_CLOSED, FD_STDIO, FD_REGULAR, FD_DIR */
-    int host_fd;     /* Underlying macOS file descriptor */
-    uint64_t ofd_id; /* Shared by dup aliases of one open file description */
+    /* Read lock-free in per-syscall validity gates (e.g. type == FD_CLOSED) and
+     * written under fd_lock at open/close. _Atomic makes those lock-free reads
+     * well-defined against the locked writes (a plain int would be a data race,
+     * flagged by ThreadSanitizer); plain read/write syntax stays atomic under
+     * C11. A stale read only affects a guest racing open/close/op on the same
+     * fd number, which is a guest-level bug.
+     */
+    _Atomic int type; /* FD_CLOSED, FD_STDIO, FD_REGULAR, FD_DIR */
+    int host_fd;      /* Underlying macOS file descriptor */
+    uint64_t ofd_id;  /* Shared by dup aliases of one open file description */
     uint64_t generation; /* Bumped each time this guest fd slot is reused. Lets
                           * long-lived references (e.g. epoll registrations)
                           * detect a close+reopen ABA where the slot now holds a
@@ -747,7 +754,8 @@ typedef struct {
                           */
     int linux_flags;     /* Linux open flags (for CLOEXEC tracking) */
     void *dir;           /* dir_stream_t* for FD_DIR entries, opaque instance
-                          * pointer for FD_EPOLL entries (NULL otherwise) */
+                          * pointer for FD_EPOLL entries (NULL otherwise)
+                          */
     char proc_path[FD_VIRTUAL_PATH_MAX]; /* Virtual /proc dir root for *at */
     int seals;      /* F_SEAL_* bits (non-zero only for memfd_create fds) */
     bool can_block; /* host read/write on this fd may block (pipe, socket, fifo,

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -861,14 +861,38 @@ int64_t sys_ptrace(guest_t *g,
         /* Force a running tracee into ptrace-stop. Uses hv_vcpus_exit to break
          * the tracee out of hv_vcpu_run; the tracee will then enter ptrace-stop
          * in its HV_EXIT_REASON_CANCELED handler.
+         *
+         * Read the vCPU handle under thread_lock: thread_find drops the lock
+         * before returning, so touching target->vcpu afterwards would race a
+         * concurrent teardown/recycle. Snapshot the handle while locked, then
+         * call HVF outside the lock (framework calls must not run under it).
          */
-        thread_entry_t *target = thread_find(pid);
-        if (!target || !target->ptraced)
+        pthread_mutex_t *tlock = thread_get_lock();
+        pthread_mutex_lock(tlock);
+        thread_entry_t *target = thread_find_locked(pid);
+        if (!target || !target->ptraced) {
+            pthread_mutex_unlock(tlock);
             return -LINUX_ESRCH;
-        if (target->ptrace_stopped)
+        }
+        if (target->ptrace_stopped) {
+            pthread_mutex_unlock(tlock);
             return 0; /* Already stopped */
+        }
+        hv_vcpu_t vcpu = target->vcpu;
+        /* If the tracee is still in vCPU bring-up (handle not yet published),
+         * hv_vcpus_exit cannot reach it, and dropping the interrupt would lose
+         * it silently. Record it under thread_lock: the worker checks this flag
+         * at publish and self-kicks so the interrupt is delivered before it
+         * runs any guest code. This serializes against the worker's publish
+         * (also under thread_lock), so exactly one of the two paths delivers
+         * it.
+         */
+        if (!vcpu)
+            target->ptrace_interrupt_pending = true;
+        pthread_mutex_unlock(tlock);
 
-        hv_vcpus_exit(&target->vcpu, 1);
+        if (vcpu)
+            hv_vcpus_exit(&vcpu, 1);
         return 0;
     }
 

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -607,8 +607,8 @@ static int64_t sc_setpgid(guest_t *g,
      * pid/pgid is seen as negative, not a large positive.
      */
     int pid = (int) x0, pgid = (int) x1;
-    /* Kernel order: default pid/pgid before validation, so setpgid(-9, 0)
-     * turns the pgid negative and fails EINVAL, not ESRCH.
+    /* Kernel order: default pid/pgid before validation, so setpgid(-9, 0) turns
+     * the pgid negative and fails EINVAL, not ESRCH.
      */
     int64_t self = proc_get_pid();
     int64_t rpid = (pid == 0) ? self : pid;
@@ -810,6 +810,14 @@ static void thread_force_exit_cb(thread_entry_t *t, void *ctx)
 {
     (void) ctx;
     if (t == current_thread)
+        return;
+    /* Skip a slot that is active but has not yet published its vCPU (a sibling
+     * still in thread_create_and_run bring-up): it is not in hv_vcpu_run, and
+     * handing hv_vcpus_exit a zero handle is invalid. Runs under thread_lock
+     * via thread_for_each, so this read is race-free. Same guard as
+     * thread_interrupt_all / thread_quiesce_siblings.
+     */
+    if (!t->vcpu)
         return;
     hv_vcpus_exit(&t->vcpu, 1);
 }

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -22,8 +22,9 @@ set -uo pipefail
 
 ELFUSE="${ELFUSE:-build/elfuse}"
 TESTDIR="${TESTDIR:-build}"
-TIMEOUT=60
+TIMEOUT="${TEST_TIMEOUT:-60}"
 FILTER=""
+SECTION=""
 LIST_ONLY=0
 VERBOSE=0
 TAP=0
@@ -38,7 +39,7 @@ ALLOW_MISSING_BINARIES="${ALLOW_MISSING_BINARIES:-0}"
 
 usage()
 {
-    echo "Usage: $0 [-e elfuse] [-d testdir] [-t timeout] [-f filter] [-l] [-v] [-T] [test ...]" >&2
+    echo "Usage: $0 [-e elfuse] [-d testdir] [-t timeout] [-f filter] [-s section] [-l] [-v] [-T] [test ...]" >&2
 }
 
 while [ $# -gt 0 ]; do
@@ -53,6 +54,10 @@ while [ $# -gt 0 ]; do
             ;;
         -t)
             TIMEOUT="${2:?missing argument for -t}"
+            shift 2
+            ;;
+        -s)
+            SECTION="${2:?missing argument for -s}"
             shift 2
             ;;
         -f)
@@ -196,20 +201,24 @@ if [ $# -gt 0 ]; then
         echo "error: no tests matched: $*" >&2
         exit 1
     fi
-elif [ -n "$FILTER" ]; then
-    for i in "${!test_names[@]}"; do
-        if printf "%s\n" "${test_names[$i]}" | grep -q "$FILTER"; then
-            filtered_idx+=("$i")
-        fi
-    done
-    if [ ${#filtered_idx[@]} -eq 0 ]; then
-        echo "error: no tests matched filter: $FILTER" >&2
-        exit 1
-    fi
 else
+    # -f (name) and -s (section) are independent constraints; when both are
+    # set a test must match both. Neither set selects everything.
     for i in "${!test_names[@]}"; do
+        if [ -n "$FILTER" ] && ! printf "%s\n" "${test_names[$i]}" | grep -Eq "$FILTER"; then
+            continue
+        fi
+        if [ -n "$SECTION" ] && ! printf "%s\n" "${test_sections[$i]}" | grep -Eq "$SECTION"; then
+            continue
+        fi
         filtered_idx+=("$i")
     done
+    if [ ${#filtered_idx[@]} -eq 0 ] && {
+        [ -n "$FILTER" ] || [ -n "$SECTION" ]
+    }; then
+        echo "error: no tests matched${FILTER:+ filter: $FILTER}${SECTION:+ section: $SECTION}" >&2
+        exit 1
+    fi
 fi
 
 if [ "$LIST_ONLY" -eq 1 ]; then


### PR DESCRIPTION
dd ASAN, UBSAN, and TSAN runtime legs to the self-hosted macOS runtime job via a build matrix. The sanitizer legs run check-sanitizer, a representative internal-implementation subset selected from the manifest (concurrency, memory, fork, signal, and fd-table machinery) rather than the full compatibility suite, which the release leg plus test-matrix already cover. EXTRA_CFLAGS plumbs the sanitizer flags to both compile and link; the freestanding EL1 shim and the cross-compiled guest binaries stay uninstrumented. Per-leg job and per-test timeouts absorb the sanitizer slowdown, and an explicit make clean guards against reusing objects built for a different sanitizer.

Fix the defects the lanes expose:
- Data race on thread_entry_t.vcpu: worker threads published the handle without thread_lock while thread_interrupt_all, thread_quiesce_siblings, and thread_destroy_all_vcpus read it under the lock. Publish under the lock in both the clone and vm-clone worker paths.
- Torn fork snapshot from a sibling still in bring-up: count every active sibling in the quiesce barrier, have each worker check the barrier before guest entry, and hand a counted slot back when it exits or fails bring-up before arriving, via a per-thread fork_counted flag guarding both the increment and the decrement.
- Guard the remaining hv_vcpus_exit call sites (exit_group, membarrier, ptrace interrupt) against a not-yet-published vCPU, and snapshot the ptrace target handle under thread_lock.
- Make fd_entry_t.type _Atomic so the lock-free validity-gate reads are well-defined against the fd_lock-held writes at open and close.
- Fix signed-overflow undefined behavior in the pty rdev encoding, where 136 << 24 overflowed a 32-bit signed dev_t.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ASAN/UBSAN/TSAN CI lanes for the self-hosted macOS HVF runtime, run a focused sanitizer test subset, and fix the races and UB they exposed (vCPU publish, fork-quiesce, ptrace interrupts, fd-table atomicity, PTY dev_t overflow). This expands CI coverage and hardens cloning, ptrace, and fd-table paths.

- **New Features**
  - Add runtime matrix legs for Release, ASAN, UBSAN, and TSAN on Apple Silicon with per-leg job and test timeouts; upload the runtime as an artifact.
  - Run `check-sanitizer` (focused internal sections) on sanitizer legs; keep full `check` and `test-matrix` on Release only; skip fixtures and `qemu` off sanitizer legs.
  - Plumb `EXTRA_CFLAGS` through builds; add `check-{asan,ubsan,tsan}` and `check-sanitizer` targets; test driver adds `-s` section filter and honors `TEST_TIMEOUT`.
  - Key concurrency groups per sanitizer; gate fixture cache and Rosetta checks to Release; build in parallel with `MAKEFLAGS=-j8`.

- **Bug Fixes**
  - Publish `t->vcpu` and `vexit` under `thread_lock`; deliver a pending `PTRACE_INTERRUPT` at publish if it arrived during bring-up.
  - Make the fork barrier robust: count all active siblings (even pre-publish), have workers call `thread_fork_barrier_check()` before guest entry, and use per-thread `fork_counted` to hand counts back on early exit or bring-up failure (including vm-clone).
  - Guard all `hv_vcpus_exit` call sites against zero handles and snapshot ptrace targets under `thread_lock`.
  - Make `fd_entry_t.type` `_Atomic` for lock-free validity checks against `fd_lock` writes.
  - Fix signed-overflow UB in PTY `st_rdev` encoding by building the major in `uint32_t`.

<sup>Written for commit 652bc2da4394749dfc9dbe4234056dbcf8d8a6c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

