### PR TITLE
Emulate Linux network identity probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ SRCS := \
     syscall/net.c \
     syscall/net-msg.c \
     syscall/net-abi.c \
+    syscall/net-identity.c \
     syscall/net-absock.c \
     syscall/net-sockopt.c \
     syscall/netlink.c \

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -57,6 +57,7 @@
 #include "syscall/fd.h"
 #include "syscall/fuse.h"
 #include "syscall/internal.h"
+#include "syscall/net-identity.h"
 #include "syscall/proc.h"
 #include "syscall/sys.h"
 
@@ -594,6 +595,47 @@ __attribute__((format(printf, 1, 2))) static int proc_emit_fmt(const char *fmt,
 static int proc_emit_literal(const char *s)
 {
     return proc_synthetic_fd(s, strlen(s));
+}
+
+static int proc_open_net_dev(void)
+{
+    linux_net_identity_t ident;
+    net_identity_snapshot(&ident);
+    linux_netdev_stats_t *lo = &ident.lo_stats;
+    linux_netdev_stats_t *eth0 = &ident.eth0_stats;
+
+    return proc_emit_fmt(
+        "Inter-|   Receive                                                |  "
+        "Transmit\n"
+        " face |bytes    packets errs drop fifo frame compressed "
+        "multicast|bytes    packets errs drop fifo colls carrier "
+        "compressed\n"
+        "    lo: %llu %llu %llu %llu %llu %llu %llu %llu "
+        "%llu %llu %llu %llu %llu %llu %llu %llu\n"
+        "  eth0: %llu %llu %llu %llu %llu %llu %llu %llu "
+        "%llu %llu %llu %llu %llu %llu %llu %llu\n",
+        (unsigned long long) lo->rx_bytes, (unsigned long long) lo->rx_packets,
+        (unsigned long long) lo->rx_errs, (unsigned long long) lo->rx_drop,
+        (unsigned long long) lo->rx_fifo, (unsigned long long) lo->rx_frame,
+        (unsigned long long) lo->rx_compressed,
+        (unsigned long long) lo->rx_multicast,
+        (unsigned long long) lo->tx_bytes, (unsigned long long) lo->tx_packets,
+        (unsigned long long) lo->tx_errs, (unsigned long long) lo->tx_drop,
+        (unsigned long long) lo->tx_fifo, (unsigned long long) lo->tx_colls,
+        (unsigned long long) lo->tx_carrier,
+        (unsigned long long) lo->tx_compressed,
+        (unsigned long long) eth0->rx_bytes,
+        (unsigned long long) eth0->rx_packets,
+        (unsigned long long) eth0->rx_errs, (unsigned long long) eth0->rx_drop,
+        (unsigned long long) eth0->rx_fifo, (unsigned long long) eth0->rx_frame,
+        (unsigned long long) eth0->rx_compressed,
+        (unsigned long long) eth0->rx_multicast,
+        (unsigned long long) eth0->tx_bytes,
+        (unsigned long long) eth0->tx_packets,
+        (unsigned long long) eth0->tx_errs, (unsigned long long) eth0->tx_drop,
+        (unsigned long long) eth0->tx_fifo, (unsigned long long) eth0->tx_colls,
+        (unsigned long long) eth0->tx_carrier,
+        (unsigned long long) eth0->tx_compressed);
 }
 
 /* Return the basename of the loaded ELF binary, falling back to "elfuse" when
@@ -1173,7 +1215,7 @@ static const char *ensure_proc_tmpdir(const guest_t *g)
     snprintf(netdir, sizeof(netdir), "%s/net", proc_tmpdir);
     if (mkdir(netdir, 0755) == 0 || errno == EEXIST) {
         static const char *net_files[] = {
-            "tcp", "tcp6", "udp", "udp6", "raw", "raw6", "unix", NULL,
+            "dev", "tcp", "tcp6", "udp", "udp6", "raw", "raw6", "unix", NULL,
         };
         for (const char **name = net_files; *name; name++)
             populate_proc_placeholder(netdir, *name);
@@ -3101,6 +3143,9 @@ int proc_intercept_open(const guest_t *g,
         free(buf);
         return fd;
     }
+    if (!strcmp(path, "/proc/net/dev")) {
+        return proc_open_net_dev();
+    }
 
     /* /proc/sys/vm/mmap_min_addr -> synthetic mmap minimum address. */
     if (!strcmp(path, "/proc/sys/vm/mmap_min_addr"))
@@ -3610,6 +3655,7 @@ int proc_intercept_stat(const char *path, struct stat *st)
         "/proc/net/raw",
         "/proc/net/raw6",
         "/proc/net/unix",
+        "/proc/net/dev",
         NULL,
     };
 

--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -376,6 +376,11 @@ typedef struct {
 #define LINUX_TIOCGPTN 0x80045430   /* _IOR('T', 0x30, unsigned int) */
 #define LINUX_TIOCSPTLCK 0x40045431 /* _IOW('T', 0x31, int) */
 #define LINUX_TIOCGPTPEER 0x5441    /* _IO('T', 0x41); arg is open flags */
+/* Linux network interface ioctls. */
+#define LINUX_SIOCGIFHWADDR 0x8927 /* get hardware address (struct ifreq) */
+#define LINUX_IFNAMSIZ 16
+#define LINUX_ARPHRD_ETHER 1
+#define LINUX_ARPHRD_LOOPBACK 772
 
 /* Linux open flags. */
 #define LINUX_O_RDONLY 0x0000

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -45,6 +45,7 @@
 #include "syscall/inotify.h"
 #include "syscall/io.h"
 #include "syscall/net.h"
+#include "syscall/net-identity.h"
 #include "syscall/poll.h"
 #include "syscall/proc.h"
 #include "syscall/signal.h"
@@ -66,6 +67,16 @@ typedef struct {
     uint8_t c_line;
     uint8_t c_cc[19];
 } linux_termios_t;
+
+typedef struct {
+    uint16_t sa_family;
+    char sa_data[14];
+} linux_sockaddr_t;
+
+typedef struct {
+    char ifr_name[LINUX_IFNAMSIZ];
+    linux_sockaddr_t ifr_hwaddr;
+} linux_ifreq_hwaddr_t;
 
 /* Per-fd lock embedded in the cache so a urandom read on fd A does not
  * serialize behind a concurrent urandom read on fd B. The previous design used
@@ -148,6 +159,32 @@ static int termios_action_for(unsigned long request)
 static int64_t io_return_zero(host_fd_ref_t *host_ref)
 {
     host_fd_ref_close(host_ref);
+    return 0;
+}
+
+static int64_t linux_siocgifhwaddr(guest_t *g, uint64_t arg)
+{
+    char raw_name[LINUX_IFNAMSIZ];
+    if (guest_read_small(g, arg, raw_name, sizeof(raw_name)) < 0)
+        return -LINUX_EFAULT;
+
+    char name[LINUX_IFNAMSIZ + 1];
+    memcpy(name, raw_name, LINUX_IFNAMSIZ);
+    name[LINUX_IFNAMSIZ] = '\0';
+
+    linux_ifreq_hwaddr_t ifr = {0};
+    memcpy(ifr.ifr_name, raw_name, sizeof(ifr.ifr_name));
+
+    uint16_t family = 0;
+    uint8_t mac[NET_IDENTITY_MAC_LEN];
+    if (net_identity_hwaddr(name, &family, mac) < 0)
+        return -LINUX_ENODEV;
+
+    ifr.ifr_hwaddr.sa_family = family;
+    memcpy(ifr.ifr_hwaddr.sa_data, mac, sizeof(mac));
+
+    if (guest_write_small(g, arg, &ifr, sizeof(ifr)) < 0)
+        return -LINUX_EFAULT;
     return 0;
 }
 
@@ -1723,6 +1760,17 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
             fd_table[fd].linux_flags &= ~LINUX_O_CLOEXEC;
         pthread_mutex_unlock(&fd_lock);
         return 0;
+    }
+
+    if (request == LINUX_SIOCGIFHWADDR) {
+        fd_entry_t snap;
+        if (!fd_snapshot(fd, &snap))
+            return -LINUX_EBADF;
+        if (snap.type == FD_PATH)
+            return -LINUX_EBADF;
+        if (snap.type != FD_SOCKET)
+            return -LINUX_ENOTTY;
+        return linux_siocgifhwaddr(g, arg);
     }
 
     host_fd_ref_t host_ref;

--- a/src/syscall/net-identity.c
+++ b/src/syscall/net-identity.c
@@ -1,0 +1,197 @@
+/*
+ * Host-backed network identity helpers
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <net/if_var.h>
+#include <ifaddrs.h>
+#include <sys/socket.h>
+
+#include "syscall/abi.h"
+#include "syscall/net-identity.h"
+#include "utils.h"
+
+static const uint8_t fallback_eth0_mac[NET_IDENTITY_MAC_LEN] = {0x02, 0, 0,
+                                                                0,    0, 1};
+
+static bool mac_valid(const uint8_t mac[NET_IDENTITY_MAC_LEN])
+{
+    bool any = false;
+    bool all_ff = true;
+
+    for (int i = 0; i < NET_IDENTITY_MAC_LEN; i++) {
+        any |= mac[i] != 0;
+        all_ff &= mac[i] == 0xff;
+    }
+    return any && !all_ff;
+}
+
+static bool sockaddr_dl_mac(const struct sockaddr *sa,
+                            uint8_t mac[NET_IDENTITY_MAC_LEN])
+{
+    if (!sa || sa->sa_family != AF_LINK)
+        return false;
+
+    const struct sockaddr_dl *sdl = (const struct sockaddr_dl *) sa;
+    if (sdl->sdl_alen != NET_IDENTITY_MAC_LEN)
+        return false;
+
+    memcpy(mac, LLADDR(sdl), NET_IDENTITY_MAC_LEN);
+    return mac_valid(mac);
+}
+
+static bool ifname_skipped_as_eth0(const char *name)
+{
+    return !strncmp(name, "awdl", 4) || !strncmp(name, "llw", 3) ||
+           !strncmp(name, "utun", 4) || !strncmp(name, "bridge", 6) ||
+           !strncmp(name, "vmenet", 6) || !strncmp(name, "anpi", 4) ||
+           !strncmp(name, "ap", 2);
+}
+
+static bool ifa_has_ip(const struct ifaddrs *ifalist, const char *name)
+{
+    for (const struct ifaddrs *ifa = ifalist; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr || strcmp(ifa->ifa_name, name))
+            continue;
+        if (ifa->ifa_addr->sa_family == AF_INET ||
+            ifa->ifa_addr->sa_family == AF_INET6)
+            return true;
+    }
+    return false;
+}
+
+static int eth0_candidate_score(const struct ifaddrs *ifalist,
+                                const struct ifaddrs *ifa)
+{
+    if (!ifa || !ifa->ifa_name || !ifa->ifa_addr ||
+        ifa->ifa_addr->sa_family != AF_LINK ||
+        (ifa->ifa_flags & IFF_LOOPBACK) ||
+        ifname_skipped_as_eth0(ifa->ifa_name))
+        return -1;
+
+    uint8_t mac[NET_IDENTITY_MAC_LEN];
+    if (!sockaddr_dl_mac(ifa->ifa_addr, mac))
+        return -1;
+
+    int score = 0;
+    if (ifa->ifa_flags & IFF_UP)
+        score += 1000;
+    if (ifa->ifa_flags & IFF_RUNNING)
+        score += 1000;
+    if (ifa_has_ip(ifalist, ifa->ifa_name))
+        score += 500;
+    if (!strcmp(ifa->ifa_name, "en0"))
+        score += 300;
+    else if (!strncmp(ifa->ifa_name, "en", 2))
+        score += 200;
+    return score;
+}
+
+static void stats_from_if_data(linux_netdev_stats_t *out, const void *data)
+{
+    if (!out || !data)
+        return;
+
+    const struct if_data *ifd = data;
+    out->rx_bytes = ifd->ifi_ibytes;
+    out->rx_packets = ifd->ifi_ipackets;
+    out->rx_errs = ifd->ifi_ierrors;
+    out->rx_drop = ifd->ifi_iqdrops;
+    out->rx_multicast = ifd->ifi_imcasts;
+    out->tx_bytes = ifd->ifi_obytes;
+    out->tx_packets = ifd->ifi_opackets;
+    out->tx_errs = ifd->ifi_oerrors;
+    out->tx_colls = ifd->ifi_collisions;
+}
+
+static bool copy_exact_host_hwaddr(const char *ifname,
+                                   uint16_t *family_out,
+                                   uint8_t mac_out[NET_IDENTITY_MAC_LEN])
+{
+    struct ifaddrs *ifalist;
+    if (getifaddrs(&ifalist) < 0)
+        return false;
+
+    bool found = false;
+    for (const struct ifaddrs *ifa = ifalist; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_name || strcmp(ifa->ifa_name, ifname))
+            continue;
+        if (!sockaddr_dl_mac(ifa->ifa_addr, mac_out))
+            continue;
+        *family_out = (ifa->ifa_flags & IFF_LOOPBACK) ? LINUX_ARPHRD_LOOPBACK
+                                                      : LINUX_ARPHRD_ETHER;
+        found = true;
+        break;
+    }
+
+    freeifaddrs(ifalist);
+    return found;
+}
+
+void net_identity_snapshot(linux_net_identity_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    memcpy(out->eth0_mac, fallback_eth0_mac, sizeof(out->eth0_mac));
+
+    struct ifaddrs *ifalist;
+    if (getifaddrs(&ifalist) < 0)
+        return;
+
+    int best_score = -1;
+    for (const struct ifaddrs *ifa = ifalist; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_name || !ifa->ifa_addr)
+            continue;
+
+        if (!strcmp(ifa->ifa_name, "lo0") &&
+            ifa->ifa_addr->sa_family == AF_LINK)
+            stats_from_if_data(&out->lo_stats, ifa->ifa_data);
+
+        int score = eth0_candidate_score(ifalist, ifa);
+        if (score < 0 || score <= best_score)
+            continue;
+
+        uint8_t mac[NET_IDENTITY_MAC_LEN];
+        if (!sockaddr_dl_mac(ifa->ifa_addr, mac))
+            continue;
+
+        best_score = score;
+        out->eth0_from_host = true;
+        str_copy_trunc(out->eth0_host_name, ifa->ifa_name,
+                       sizeof(out->eth0_host_name));
+        memcpy(out->eth0_mac, mac, sizeof(out->eth0_mac));
+        stats_from_if_data(&out->eth0_stats, ifa->ifa_data);
+    }
+
+    freeifaddrs(ifalist);
+}
+
+int net_identity_hwaddr(const char *ifname,
+                        uint16_t *family_out,
+                        uint8_t mac_out[NET_IDENTITY_MAC_LEN])
+{
+    if (!ifname || !family_out || !mac_out)
+        return -1;
+
+    memset(mac_out, 0, NET_IDENTITY_MAC_LEN);
+    if (!strcmp(ifname, "lo") || !strcmp(ifname, "lo0")) {
+        *family_out = LINUX_ARPHRD_LOOPBACK;
+        return 0;
+    }
+
+    if (!strcmp(ifname, "eth0")) {
+        linux_net_identity_t ident;
+        net_identity_snapshot(&ident);
+        *family_out = LINUX_ARPHRD_ETHER;
+        memcpy(mac_out, ident.eth0_mac, NET_IDENTITY_MAC_LEN);
+        return 0;
+    }
+
+    return copy_exact_host_hwaddr(ifname, family_out, mac_out) ? 0 : -1;
+}

--- a/src/syscall/net-identity.h
+++ b/src/syscall/net-identity.h
@@ -1,0 +1,46 @@
+/*
+ * Host-backed network identity helpers
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define NET_IDENTITY_MAC_LEN 6
+#define NET_IDENTITY_IFNAME_MAX 16
+
+typedef struct {
+    uint64_t rx_bytes;
+    uint64_t rx_packets;
+    uint64_t rx_errs;
+    uint64_t rx_drop;
+    uint64_t rx_fifo;
+    uint64_t rx_frame;
+    uint64_t rx_compressed;
+    uint64_t rx_multicast;
+    uint64_t tx_bytes;
+    uint64_t tx_packets;
+    uint64_t tx_errs;
+    uint64_t tx_drop;
+    uint64_t tx_fifo;
+    uint64_t tx_colls;
+    uint64_t tx_carrier;
+    uint64_t tx_compressed;
+} linux_netdev_stats_t;
+
+typedef struct {
+    bool eth0_from_host;
+    char eth0_host_name[NET_IDENTITY_IFNAME_MAX];
+    uint8_t eth0_mac[NET_IDENTITY_MAC_LEN];
+    linux_netdev_stats_t lo_stats;
+    linux_netdev_stats_t eth0_stats;
+} linux_net_identity_t;
+
+void net_identity_snapshot(linux_net_identity_t *out);
+int net_identity_hwaddr(const char *ifname,
+                        uint16_t *family_out,
+                        uint8_t mac_out[NET_IDENTITY_MAC_LEN]);

--- a/tests/test-netstat.c
+++ b/tests/test-netstat.c
@@ -21,6 +21,21 @@
 #include <errno.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+
+#ifndef SIOCGIFHWADDR
+#define SIOCGIFHWADDR 0x8927
+#endif
+
+#ifndef ARPHRD_ETHER
+#define ARPHRD_ETHER 1
+#endif
+
+#ifndef ARPHRD_LOOPBACK
+#define ARPHRD_LOOPBACK 772
+#endif
 
 static int read_proc_file(const char *path, char *buf, size_t bufsz)
 {
@@ -39,26 +54,63 @@ static int read_proc_file(const char *path, char *buf, size_t bufsz)
     return 0;
 }
 
+static int hwaddr_all_zero(const unsigned char *addr)
+{
+    for (int i = 0; i < 6; i++) {
+        if (addr[i] != 0)
+            return 0;
+    }
+    return 1;
+}
+
+static int check_hwaddr(int sock_fd,
+                        const char *ifname,
+                        int expected_family,
+                        int require_nonzero)
+{
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+
+    if (ioctl(sock_fd, SIOCGIFHWADDR, &ifr) < 0) {
+        printf("FAIL: ioctl(SIOCGIFHWADDR, %s): %s\n", ifname, strerror(errno));
+        return 0;
+    }
+    if (ifr.ifr_hwaddr.sa_family != expected_family) {
+        printf("FAIL: %s hwaddr family got %d expected %d\n", ifname,
+               ifr.ifr_hwaddr.sa_family, expected_family);
+        return 0;
+    }
+    if (require_nonzero &&
+        hwaddr_all_zero((const unsigned char *) ifr.ifr_hwaddr.sa_data)) {
+        printf("FAIL: %s hwaddr is all zero\n", ifname);
+        return 0;
+    }
+    return 1;
+}
+
 int main(void)
 {
     int pass = 0, fail = 0;
     char buf[8192];
+    int found_eth0 = 0;
 
     /* 0. Verify /proc/net exists as a directory with expected children. */
     struct stat st;
     if (stat("/proc/net", &st) == 0 && S_ISDIR(st.st_mode)) {
         DIR *dir = opendir("/proc/net");
         if (dir) {
-            int found_tcp = 0, found_udp = 0, found_unix = 0;
+            int found_dev = 0, found_tcp = 0, found_udp = 0, found_unix = 0;
             struct dirent *de;
             while ((de = readdir(dir))) {
+                found_dev |= !strcmp(de->d_name, "dev");
                 found_tcp |= !strcmp(de->d_name, "tcp");
                 found_udp |= !strcmp(de->d_name, "udp");
                 found_unix |= !strcmp(de->d_name, "unix");
             }
             closedir(dir);
-            if (found_tcp && found_udp && found_unix) {
-                printf("PASS: /proc/net enumerates synthetic socket tables\n");
+            if (found_dev && found_tcp && found_udp && found_unix) {
+                printf("PASS: /proc/net enumerates synthetic network files\n");
                 pass++;
             } else {
                 printf("FAIL: /proc/net missing expected entries\n");
@@ -73,7 +125,42 @@ int main(void)
         fail++;
     }
 
-    /* 1. TCP listener on 127.0.0.1:7777 */
+    /* 1. Verify /proc/net/dev exposes Linux-style interface rows. */
+    if (read_proc_file("/proc/net/dev", buf, sizeof(buf)) == 0) {
+        found_eth0 = strstr(buf, "eth0:") != NULL;
+        if (strstr(buf, "Inter-|") && strstr(buf, "lo:") && found_eth0) {
+            printf("PASS: /proc/net/dev shows interface rows\n");
+            pass++;
+        } else {
+            printf("FAIL: /proc/net/dev missing expected rows\n  got: %s", buf);
+            fail++;
+        }
+    } else {
+        fail++;
+    }
+
+    int ioctl_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (ioctl_fd < 0) {
+        perror("socket(ioctl)");
+        return 1;
+    }
+    if (check_hwaddr(ioctl_fd, "lo", ARPHRD_LOOPBACK, 0)) {
+        printf("PASS: SIOCGIFHWADDR returns loopback identity for lo\n");
+        pass++;
+    } else {
+        fail++;
+    }
+    if (found_eth0) {
+        if (check_hwaddr(ioctl_fd, "eth0", ARPHRD_ETHER, 1)) {
+            printf("PASS: SIOCGIFHWADDR returns Ethernet identity for eth0\n");
+            pass++;
+        } else {
+            fail++;
+        }
+    }
+    close(ioctl_fd);
+
+    /* 2. Synthesize live TCP/UDP sockets for socket table checks. */
     int tcp_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (tcp_fd < 0) {
         perror("socket(TCP)");
@@ -92,7 +179,7 @@ int main(void)
         return 1;
     }
 
-    /* 2. UDP socket on 0.0.0.0:8888 */
+    /* UDP socket on 0.0.0.0:8888 */
     int udp_fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (udp_fd < 0) {
         perror("socket(UDP)");


### PR DESCRIPTION
## Summary
- Add a host-backed network identity helper for Linux-style interface probes.
- Implement SIOCGIFHWADDR for socket fds using the Linux ifreq layout.
- Synthesize /proc/net/dev with loopback and eth0 rows backed by host data.
- Extend test-netstat coverage for /proc/net/dev and SIOCGIFHWADDR.

## Notes
- eth0 maps to the primary macOS link interface, preferring en0 when available.
- A locally administered fallback MAC is used only when no host MAC is available.
- times(2) is intentionally left to PR #162.

## Validation
- make elfuse
- make build/test-netstat build/test-net build/test-netlink && tests/driver.sh -e build/elfuse -d build -v test-net test-netstat test-netlink
- build/elfuse build/test-netstat
- clang-format --dry-run --Werror src/syscall/net-identity.c src/syscall/net-identity.h src/runtime/procemu.c src/syscall/io.c src/syscall/abi.h tests/test-netstat.c
- git diff --check
- make check-syscall-coverage

Fixes #163.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emulates Linux network identity probes so guests can read MAC addresses and interface stats. Adds SIOCGIFHWADDR and a host-backed `/proc/net/dev` to unblock FlexLM-style license checks.

- New Features
  - Implemented Linux SIOCGIFHWADDR for socket fds using the Linux `ifreq` layout; returns loopback/Ethernet families, maps `eth0` to the primary macOS link (prefers `en0`), and uses a locally administered fallback MAC only if no host MAC is available.
  - Synthesized `/proc/net/dev` with a Linux-style header plus `lo` and `eth0` rows backed by host counters; `/proc/net` now lists `dev`. Tests cover `/proc/net/dev` rows and SIOCGIFHWADDR family/MAC checks.

<sup>Written for commit c401775f29ed2c90a03f9eda4e0633a524070cb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

