### PR TITLE
Fix openat2 ENOTDIR/ENOENT errno mismatches

### DIFF
--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -875,8 +875,13 @@ static int dirfd_guest_base_path(guest_fd_t dirfd, char *out, size_t outsz)
     if (path_openat2_dirfd_host_path(dirfd, host_path, sizeof(host_path)) == 0)
         return host_path_to_guest_path(host_path, out, outsz);
 
+    /* fd_snapshot already proved dirfd is open, so a valid-but-wrong-type fd
+     * (pipe, socket, epoll, ...) belongs here, not in the "bad fd" case: Linux
+     * resolves a relative path against such a dirfd with ENOTDIR, reserving
+     * EBADF for a closed or out-of-range descriptor.
+     */
     if (snap.type != FD_DIR) {
-        errno = EBADF;
+        errno = ENOTDIR;
         return -1;
     }
 

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -1944,6 +1944,14 @@ static int64_t sc_openat2(guest_t *g,
         if (guest_read_str(g, x1, path, sizeof(path)) < 0)
             return -LINUX_EFAULT;
 
+        /* openat2() has no AT_EMPTY_PATH equivalent in how.flags, so an empty
+         * pathname is always ENOENT. Without this, RESOLVE_IN_ROOT's "."
+         * substitution for an empty path (see path_openat2_normalize_in_root)
+         * would resolve to dirfd itself and let the open succeed.
+         */
+        if (path[0] == '\0')
+            return -LINUX_ENOENT;
+
         if ((resolve & (RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS)) &&
             path_openat2_is_fd_magiclink_anchor((int) x0, path))
             return -LINUX_ELOOP;

--- a/tests/test-syscall-fidelity.c
+++ b/tests/test-syscall-fidelity.c
@@ -1289,6 +1289,58 @@ static void test_mmap_low_hint_exact(void)
     munmap(p, len);
 }
 
+/* A dirfd that is open but not a directory (and has no host-nameable path,
+ * e.g. a pipe) must resolve a relative path with ENOTDIR, not EBADF: the fd
+ * itself is valid, it just cannot anchor a lookup. Issue #133.
+ */
+static void test_openat2_resolve_no_xdev_non_directory_dirfd_rejects_enotdir(
+    void)
+{
+    TEST("openat2 RESOLVE_NO_XDEV non-directory dirfd rejects ENOTDIR");
+    int pipefd[2];
+    if (pipe(pipefd) < 0) {
+        FAIL("pipe");
+        return;
+    }
+    close(pipefd[1]);
+
+    struct open_how how = {
+        .flags = O_RDONLY, .mode = 0, .resolve = RESOLVE_NO_XDEV};
+    long fd = syscall(SYS_openat2, pipefd[0], "relative", &how, sizeof(how));
+    close(pipefd[0]);
+    if (fd >= 0) {
+        close((int) fd);
+        FAIL("expected ENOTDIR, openat2 unexpectedly succeeded");
+        return;
+    }
+    EXPECT_TRUE(errno == ENOTDIR, "wrong errno");
+}
+
+/* openat2() has no AT_EMPTY_PATH equivalent, so an empty pathname must always
+ * fail ENOENT -- even under RESOLVE_IN_ROOT, whose "." substitution for the
+ * empty-path case could otherwise resolve to dirfd itself. Issue #133.
+ */
+static void test_openat2_empty_path_rejects_enoent(void)
+{
+    TEST("openat2 empty path rejects ENOENT under RESOLVE_IN_ROOT");
+    int dirfd = open("/tmp", O_RDONLY | O_DIRECTORY);
+    if (dirfd < 0) {
+        FAIL("open /tmp");
+        return;
+    }
+
+    struct open_how how = {
+        .flags = O_RDONLY, .mode = 0, .resolve = RESOLVE_IN_ROOT};
+    long fd = syscall(SYS_openat2, dirfd, "", &how, sizeof(how));
+    close(dirfd);
+    if (fd >= 0) {
+        close((int) fd);
+        FAIL("expected ENOENT, openat2 unexpectedly succeeded");
+        return;
+    }
+    EXPECT_TRUE(errno == ENOENT, "wrong errno");
+}
+
 int main(void)
 {
     printf("Linux syscall fidelity tests:\n");
@@ -1332,6 +1384,8 @@ int main(void)
     test_openat2_resolve_no_xdev_rejects_dev_fd_magiclink();
     test_openat2_rejects_dev_fd_magiclink_variants();
     test_openat2_resolve_no_xdev_rejects_normalized_proc_fd_magiclink();
+    test_openat2_resolve_no_xdev_non_directory_dirfd_rejects_enotdir();
+    test_openat2_empty_path_rejects_enoent();
 
     /* O_PATH */
     test_opath_read_fails();


### PR DESCRIPTION
## Summary
- `dirfd_guest_base_path()` returned EBADF instead of ENOTDIR for a valid but non-directory dirfd with no host-nameable path (pipes, sockets, etc.), surfacing through openat2()'s RESOLVE_NO_XDEV precheck.
- `sc_openat2()` let an empty pathname succeed under RESOLVE_IN_ROOT, since `path_openat2_normalize_in_root()` substitutes "." for "" and resolves to dirfd itself. openat2() has no AT_EMPTY_PATH equivalent, so empty paths now fail ENOENT up front.

Fixes #133.

## Test
Added two regression tests to `tests/test-syscall-fidelity.c`
`make check` — 120/120 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix errno handling in openat2 path resolution: valid non-directory dirfds now return ENOTDIR (not EBADF), and empty pathnames return ENOENT even under RESOLVE_IN_ROOT. Added two regression tests to confirm Linux-compatible behavior.

<sup>Written for commit 9b99624c0743269ebd1fba821f12283e75284158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

