### PR TITLE
Improve test-matrix coverage

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,10 +86,17 @@ make clean
 What they do:
 
 - `make elfuse`: build and sign `build/elfuse`
-- `make check`: the recommended pre-commit gate. Runs, in order:
+- `make check`: fast elfuse-internal gate. Runs, in order:
   - `scripts/check-syscall-coverage.py` so any new `dispatch.tbl`
     entry without a direct or aliased test reference fails the build
-  - the unit suite from `tests/manifest.txt`
+  - the unit suite from `tests/manifest.txt` -- deliberately narrow: only
+    tests that assert elfuse-internal implementation details with no real
+    Linux counterpart (the EL1 shim fast-path suite, `test-mremap-infra`,
+    `test-oom-proc`), plus whatever `mk/tests.mk`'s `SANITIZER_SECTIONS`
+    needs for the `check-{asan,ubsan,tsan}` lanes. Everything that is
+    meaningful to cross-check against a real Linux kernel lives exclusively
+    in `tests/test-matrix.sh`'s `run_unit_tests` instead (see Test Matrix
+    below) -- `make check` alone is *not* a substitute for it
   - the TLBI RVAE1IS encoder unit test
   - the proctitle argv-tail and low-stack regressions
   - the BusyBox applet smoke suite (auto-resolved from
@@ -115,19 +122,27 @@ What they do:
 
 ## Quick Iteration
 
-For normal code changes:
+For normal code changes touching syscall or runtime logic:
 
 ```sh
 make elfuse
 make check
+make test-matrix-elfuse-aarch64
 ```
 
-For changes that touch procfs, path handling, `/dev`, FUSE, networking, dynamic
-linking, or guest process semantics, run the matrix as well:
+`make check` alone only covers elfuse-internal plumbing and the sanitizer
+subset now; `test-matrix-elfuse-aarch64` is what actually exercises the full
+unit-test surface against `build/elfuse` (no qemu boot needed, so it is about
+as fast to iterate with as `make check` was before the split). For changes
+that touch procfs, path handling, `/dev`, FUSE, networking, dynamic linking,
+or guest process semantics, also cross-check against the qemu reference
+kernel:
 
 ```sh
-make test-matrix
+make test-matrix-qemu-aarch64
 ```
+
+or run all matrix modes back-to-back with `make test-matrix`.
 
 `make check` already runs the BusyBox applet suite as a second stage, so a
 green `make check` covers BusyBox validation. Use `make test-busybox` to
@@ -147,6 +162,22 @@ execution modes:
 The goal is not to compare performance. The goal is to compare guest-observable
 behavior against a ground-truth Linux AArch64 environment so that any divergence
 in syscall translation, procfs emulation, or process semantics is caught early.
+
+`run_unit_tests` in `tests/test-matrix.sh` is the full aarch64 unit-test
+surface -- every binary that is meaningful to run against a real kernel, which
+is almost everything. It deliberately excludes only the handful of tests that
+assert elfuse-internal implementation details with no meaningful counterpart
+on a real kernel (the EL1 shim fast-path suite, `test-mremap-infra`,
+`test-oom-proc` -- these live solely in `tests/manifest.txt` / `make check`,
+see that file's header for the full split rationale). There is no separate
+"core" vs "extended" test set inside the matrix; a test that has a real,
+understood divergence from the qemu reference kernel is listed in
+`QEMU_SKIP` with a comment explaining why instead -- see that variable in
+`tests/test-matrix.sh` for the current list and rationale. `run_unit_tests`
+runs in both `elfuse-aarch64` and `qemu-aarch64` modes, so most tests are
+exercised twice per matrix run: once against `build/elfuse`, once against the
+real kernel.
+
 The x86_64 mode is narrower: it aggregates the Rosetta-specific acceptance
 scripts and their per-binary summaries into the same matrix runner, including
 the Rosetta thread/signal audit smoke, the LuaJIT guest-JIT probe, and the
@@ -327,8 +358,8 @@ Suggested minimum validation:
 | Change area | Recommended validation |
 |-------------|------------------------|
 | CLI, logging, docs-only build rules | `make elfuse` |
-| General syscall or runtime logic | `make elfuse && make check` |
-| `/proc`, `/dev`, path, or BusyBox-sensitive behavior | `make elfuse && make check` |
+| General syscall or runtime logic | `make elfuse && make check && make test-matrix-elfuse-aarch64` |
+| `/proc`, `/dev`, path, or BusyBox-sensitive behavior | `make elfuse && make check && make test-matrix-elfuse-aarch64` |
 | Rosetta hosting, x86_64 dispatch, VZ ioctls, AOT cache | `make elfuse && make test-rosetta-all` |
 | Broad behavioral changes | `make elfuse && make check && make test-matrix` |
 | Debugger or ptrace flow | `make elfuse && make test-gdbstub` |

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -10,6 +10,21 @@
 #
 # BINARY is resolved relative to TESTDIR (default: build/).
 # Lines starting with # are comments. Blank lines are ignored.
+#
+# Scope: this file only lists tests that make check needs directly --
+# elfuse-internal implementation tests with no meaningful counterpart on a
+# real kernel (they can only ever be exercised against elfuse itself), plus
+# whatever mk/tests.mk's SANITIZER_SECTIONS regex selects for the
+# check-{asan,ubsan,tsan} lanes (those need a *sanitizer-instrumented elfuse
+# binary*, which only driver.sh -e can point at; qemu-aarch64 runs an
+# uninstrumented real kernel and cannot substitute for them). Every other
+# aarch64 test -- anything that is meaningful to cross-check against a real
+# Linux kernel -- lives exclusively in tests/test-matrix.sh's run_unit_tests,
+# which is a superset: it runs every one of these binaries too (via
+# elfuse-aarch64 mode), plus everything that used to be duplicated here.
+# Don't add a portable/cross-checkable test here; add it to test-matrix.sh
+# instead. Only add a test here if it is genuinely elfuse-internal, or if a
+# SANITIZER_SECTIONS section needs it.
 
 [section] Assembly tests
 test-hello
@@ -28,31 +43,12 @@ test-ls tests/
 test-roundtrip
 test-comprehensive
 
-[section] Process tests
-test-exec $TESTDIR/echo-test exec-works
-test-exec-limits
-test-fork
-test-session
-test-pidfd                         # diff=skip
-
-[section] Signal tests
-test-signal
-test-kill-broadcast
-test-kill-pgroup
-test-sigio                         # diff=skip
-
-[section] Socket tests
-test-socket
-
-[section] Syscall coverage tests
-test-file-ops
-test-flock
-test-sysinfo
-test-times
-test-io-opt
+[section] elfuse-internal implementation tests
+# These probe elfuse's own EL1 shim fast paths (identity cache, urandom
+# ring, shim_data privilege) and procfs sendfile/copy_file_range
+# interception -- plumbing with no Linux-kernel counterpart, so they are
+# never part of test-matrix.sh (see each file's own header comment).
 test-oom-proc
-test-syscall-smoke
-test-vdso
 test-shim-identity
 test-shim-identity-attention
 test-shim-verbose-trace
@@ -60,7 +56,6 @@ test-shim-data-el1
 test-shim-urandom-smp
 test-shim-urandom-toctou
 test-shim-urandom-wrap
-test-poll                      # diff=skip
 
 [section] I/O subsystem tests
 test-eventfd
@@ -81,15 +76,6 @@ test-pty
 test-ioctl-fioasync
 test-getdents-refcount
 
-[section] /proc and /dev emulation tests
-test-proc
-test-sysfs-cpu
-
-[section] Network tests
-test-net
-test-netstat
-test-netlink
-
 [section] Threading tests
 test-thread                    # diff=skip
 test-pthread
@@ -99,9 +85,6 @@ test-simd-clone                # diff=skip
 [section] Stress tests
 test-stress                    # diff=skip
 test-mprotect-mt               # diff=skip
-
-[section] Negative / error-path tests
-test-negative                  # diff=skip
 
 [section] Signal + thread tests
 test-signal-thread
@@ -118,22 +101,9 @@ test-fork-lowbase
 test-cow-fork
 test-fork-synthetic-fd
 
-[section] O_CLOEXEC tests
-test-cloexec
-
-[section] O_PATH semantics tests
-test-opath
-
-[section] xattr semantics tests
-test-xattr
-
 [section] Guard page / mmap edge cases
 test-guard-page
 test-mmap-hint
-
-[section] Low-base ET_EXEC memory regression tests
-test-lowbase-mem-200000
-test-lowbase-mem-300000
 
 [section] mremap tests
 test-mremap
@@ -152,81 +122,23 @@ test-cross-fork-mapshared          # diff=skip
 [section] madvise MADV_DONTNEED tests
 test-madvise
 
-[section] Scatter-gather I/O tests
-test-readv-writev
-
-[section] inotify emulation tests
-test-inotify
-
 [section] PI futex + EINTR regression tests
 test-futex-pi                  # diff=skip
 
 [section] futex_waitv (SYS 449) tests
 test-futex-waitv               # diff=skip
 
-[section] SIGILL / null guard tests
-test-sigill
-
-[section] X11 raw protocol tests
-test-x11
-
 [section] Robust futex tests
 test-robust-futex
-
-[section] /proc completeness tests
-test-procfs
-test-procfs-exec
-test-proc-limits
 
 [section] FD table race tests
 test-fd-race
 
-[section] FD lifecycle tests
-test-fd-lifecycle
-
 [section] Multithreaded fork tests
 test-mt-fork
-
-[section] Exit-group teardown reachability tests
-test-exit-group-teardown wait     # expected_rc=42
-test-exit-group-teardown stop     # expected_rc=42
-test-exit-group-teardown fork     # expected_rc=42
 
 [section] SysV shared memory tests
 test-sysv-shm
 
-[section] Credential/identity emulation tests
-test-credentials                   # diff=skip
-
-[section] Scheduler policy stub tests
-test-sched-policy
-
 [section] membarrier tests
 test-membarrier
-
-[section] rseq registration tests
-test-rseq                          # diff=skip
-
-[section] Abstract Unix socket tests
-test-abstract-socket
-
-[section] Ancillary data (SCM_RIGHTS/MSG_CTRUNC) tests
-test-ancillary
-
-[section] Tier A compatibility tests
-test-tier-a                        # diff=skip
-
-[section] /proc fidelity tests
-test-proc-fidelity                 # diff=skip
-
-[section] Linux syscall fidelity tests
-test-syscall-fidelity              # diff=skip
-
-[section] fd-family tests
-test-fd-family                     # diff=skip
-
-[section] SCM_CREDENTIALS tests
-test-scm-creds                     # diff=skip
-
-[section] Virtual chown overlay tests
-test-chown-overlay                 # diff=skip

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -254,7 +254,100 @@ unstage_sysroot_fixtures()
 # see that file's header comment. test-io-opt itself is now pure portable
 # sendfile/fsync/fallocate/copy_file_range coverage and runs against qemu
 # like any other test.
-QEMU_SKIP=""
+#
+# The entries below were added when run_unit_tests grew to cover the rest of
+# tests/manifest.txt ("make check"). Each was verified against a live
+# qemu-aarch64 boot before being listed here -- see the per-entry comment for
+# the observed divergence. Do not add a test here just because it *might*
+# behave differently; confirm it first the same way.
+QEMU_SKIP="
+    test-session
+    test-pidfd
+    test-sigio
+    test-syscall-smoke
+    test-vdso
+    test-ioctl-cloexec
+    test-pty
+    test-mprotect-mt
+    test-clone3
+    test-fork-synthetic-fd
+    test-mmap-hint
+    test-msync
+    test-credentials
+    test-sched-policy
+    test-rseq
+    test-tier-a
+    test-syscall-fidelity
+    test-fd-family
+    test-scm-creds
+    test-proc-fidelity
+"
+# test-session: getpgid/getsid/setsid assume the test is its own session and
+#   process-group leader, true when elfuse launches it directly but not when
+#   sshd execs it non-interactively -- a launcher artifact, not an elfuse
+#   syscall bug.
+# test-pidfd: pins pidfd_getfd(2) at elfuse's not-yet-implemented ENOSYS stub;
+#   a real kernel implements it and returns success.
+# test-sigio: the F_SETOWN pgrp round-trip inherits test-session's launcher
+#   artifact (own pgid assumption); F_SETOWN_EX with a negative pid also hits
+#   a real kernel ESRCH-after-lookup path where elfuse rejects up front --
+#   a minor validation-order gap worth a closer look separately.
+# test-syscall-smoke: tee() between two empty pipes is stubbed to an
+#   immediate EINVAL under elfuse; a real kernel attempts the real splice and
+#   blocks waiting for data that this test never writes, since the source
+#   pipe's write end is still held open.
+# test-vdso: pins the exact PT_NOTE/dynamic-section layout of elfuse's own
+#   hand-built vDSO image, which a real kernel's vDSO has no reason to match;
+#   also assumes getcpu() always reports cpu 0 (elfuse models one online CPU),
+#   which does not hold on the reference VM's 4 vCPUs.
+# test-ioctl-cloexec: ioctl(FIOCLEX/FIONCLEX) on an O_PATH fd succeeds under
+#   elfuse but returns EBADF on a real kernel -- elfuse is more permissive
+#   than Linux here.
+# test-pty: opening /dev/pts/N directly (and TIOCGPTPEER) fails with EIO on
+#   the qemu reference lane's minimal Alpine initramfs, most likely a devpts
+#   mount/config gap in that fixture rather than a syscall behavior gap.
+# test-mprotect-mt: the RVAE1IS race-window thresholds were tuned against
+#   elfuse's own vCPU/TLBI shootout timing; the qemu reference lane's nested
+#   virtualization has different scheduling latency and trips the same
+#   thresholds for real, unrelated races.
+# test-clone3: CLONE_NEWPID succeeds on a real kernel (PID namespaces) but
+#   elfuse has no namespace support and expects EINVAL; the mismatch derails
+#   the rest of the scenario into a hang instead of a clean FAIL.
+# test-fork-synthetic-fd: the first /dev/urandom read blocks -- the qemu
+#   reference lane boots without a virtio-rng device, so the guest CRNG may
+#   not be seeded yet this early after boot, while elfuse's urandom
+#   emulation never blocks.
+# test-mmap-hint / test-msync: pin mmap addresses against elfuse's own
+#   deterministic placement heuristics (2 MiB-aligned hint fallback, a fixed
+#   neighbor address); a real kernel's allocator places mappings differently.
+# test-credentials: pins elfuse's restricted "fakeroot" setuid/capset/
+#   getgroups model (deliberately narrower than real root); the qemu
+#   reference lane runs as genuine root, which has unrestricted privilege.
+# test-sched-policy: exercises elfuse's explicitly-a-stub scheduler policy
+#   layer (see the file's own header) -- RT class changes are always
+#   -EPERM'd regardless of privilege, whereas real root can set them.
+# test-rseq: the double-register and unregister-wrong-signature cases return
+#   different results on the real kernel; root cause not fully pinned down
+#   (possibly libc-level rseq interaction) -- flagged for follow-up rather
+#   than silently assumed.
+# test-tier-a: msgrcv(..., MSG_EXCEPT) is an elfuse ENOSYS stub; a real
+#   kernel implements it and blocks waiting for a non-matching message that
+#   this test never sends.
+# test-syscall-fidelity: shares test-vdso's getcpu==0 assumption; several
+#   openat2 RESOLVE_*/NO_MAGICLINKS cases targeting /dev/fd also return the
+#   wrong errno, most likely because the reference initramfs never creates a
+#   /dev/fd -> /proc/self/fd symlink (a fixture gap, not confirmed as an
+#   elfuse behavior bug).
+# test-fd-family: elfuse deliberately preserves a pending signal after an
+#   EFAULT signalfd read; the real kernel drops it -- an intentional
+#   improvement over a real Linux quirk, not a bug.
+# test-scm-creds: SO_PEERCRED/SCM_CREDENTIALS assert elfuse's default
+#   emulated guest identity (uid/gid 1000); the qemu reference lane runs as
+#   real root (uid/gid 0).
+# test-proc-fidelity: /proc/self/oom_score rejects a writable open outright
+#   under elfuse, while a real kernel allows the open and only rejects the
+#   write -- a genuine behavioral difference worth reviewing on its own,
+#   not just an environment artifact.
 
 is_qemu_skipped()
 {
@@ -469,6 +562,17 @@ test_pipe()
 }
 
 # Test suites.
+#
+# This is the full aarch64 unit-test surface: every tests/manifest.txt ("make
+# check") binary except the handful that assert elfuse-internal implementation
+# details with no meaningful counterpart on a real kernel (the EL1 shim
+# fast-path suite -- test-shim-* and test-shim-cred-race, which probe elfuse's
+# own shim_data block and identity cache -- test-mremap-infra, which guards
+# elfuse's guest-IPA infra reserve, and test-oom-proc, documented in its own
+# header). There is no "core" vs "extended" split here; everything below runs
+# in both elfuse-aarch64 and qemu-aarch64 modes, and genuine, understood
+# divergences from the qemu reference kernel are called out via QEMU_SKIP with
+# a comment rather than silently dropped from this list.
 run_unit_tests()
 {
     local runner="$1" bindir="$2"
@@ -496,6 +600,9 @@ run_unit_tests()
     test_check "$runner" "test-exec" "exec-works" "$bindir/test-exec" "$bindir/echo-test" exec-works
     test_check "$runner" "test-fork-exec" "PASS" "$bindir/test-fork-exec" "$bindir/echo-test"
     test_check "$runner" "test-cloexec" "PASS" "$bindir/test-cloexec"
+    test_rc "$runner" "test-exec-limits" 0 "$bindir/test-exec-limits"
+    test_rc "$runner" "test-session" 0 "$bindir/test-session"
+    test_rc "$runner" "test-pidfd" 0 "$bindir/test-pidfd"
 
     printf "\nSignal tests\n"
     test_check "$runner" "test-signal" "PASS|0 failed" "$bindir/test-signal"
@@ -506,6 +613,9 @@ run_unit_tests()
         "$bindir/test-kill-broadcast"
     test_check "$runner" "test-kill-pgroup" "0 failed" \
         "$bindir/test-kill-pgroup"
+    test_rc "$runner" "test-sigio" 0 "$bindir/test-sigio"
+    test_rc "$runner" "test-fault-signal-mt" 0 "$bindir/test-fault-signal-mt"
+    test_rc "$runner" "test-exit-group-worker" 0 "$bindir/test-exit-group-worker"
 
     printf "\nSocket tests\n"
     test_check "$runner" "test-socket" "PASS|0 failed" "$bindir/test-socket"
@@ -515,6 +625,10 @@ run_unit_tests()
     test_check "$runner" "test-sysinfo" "0 failed" "$bindir/test-sysinfo"
     test_check "$runner" "test-io-opt" "0 failed" "$bindir/test-io-opt"
     test_check "$runner" "test-poll" "0 failed" "$bindir/test-poll"
+    test_rc "$runner" "test-flock" 0 "$bindir/test-flock"
+    test_rc "$runner" "test-times" 0 "$bindir/test-times"
+    test_rc "$runner" "test-syscall-smoke" 0 "$bindir/test-syscall-smoke"
+    test_rc "$runner" "test-vdso" 0 "$bindir/test-vdso"
 
     printf "\nI/O subsystem\n"
     test_check "$runner" "test-eventfd" "0 failed" "$bindir/test-eventfd"
@@ -528,13 +642,27 @@ run_unit_tests()
     test_check "$runner" "test-epoll-refcount" "0 failed" \
         "$bindir/test-epoll-refcount"
     test_check "$runner" "test-timerfd" "0 failed" "$bindir/test-timerfd"
+    test_rc "$runner" "test-eventfd-dup" 0 "$bindir/test-eventfd-dup"
+    test_rc "$runner" "test-epoll-mt" 0 "$bindir/test-epoll-mt"
+    test_rc "$runner" "test-epoll-aba" 0 "$bindir/test-epoll-aba"
+    test_rc "$runner" "test-large-io-boundary" 0 "$bindir/test-large-io-boundary"
+    test_rc "$runner" "test-ioctl-cloexec" 0 "$bindir/test-ioctl-cloexec"
+    test_rc "$runner" "test-pty" 0 "$bindir/test-pty"
+    test_rc "$runner" "test-ioctl-fioasync" 0 "$bindir/test-ioctl-fioasync"
+    test_rc "$runner" "test-getdents-refcount" 0 "$bindir/test-getdents-refcount"
 
     printf "\n/proc and /dev\n"
     test_check "$runner" "test-proc" "0 failed" "$bindir/test-proc"
     test_check "$runner" "test-sysfs-cpu" "0 failed" "$bindir/test-sysfs-cpu"
+    test_rc "$runner" "test-procfs" 0 "$bindir/test-procfs"
+    test_rc "$runner" "test-procfs-exec" 0 "$bindir/test-procfs-exec"
+    test_rc "$runner" "test-proc-limits" 0 "$bindir/test-proc-limits"
+    test_rc "$runner" "test-proc-fidelity" 0 "$bindir/test-proc-fidelity"
 
     printf "\nNetwork\n"
     test_check "$runner" "test-net" "0 failed" "$bindir/test-net"
+    test_rc "$runner" "test-netstat" 0 "$bindir/test-netstat"
+    test_rc "$runner" "test-netlink" 0 "$bindir/test-netlink"
 
     printf "\nThreading\n"
     test_check "$runner" "test-thread" "0 failed" "$bindir/test-thread"
@@ -542,15 +670,48 @@ run_unit_tests()
     test_check "$runner" "test-osync-requeue" "0 failed" "$bindir/test-osync-requeue"
     test_check "$runner" "test-simd-clone" "0 failed" "$bindir/test-simd-clone"
     test_check "$runner" "test-stress" "0 failed" "$bindir/test-stress"
+    test_rc "$runner" "test-thread-churn" 0 "$bindir/test-thread-churn"
+    test_rc "$runner" "test-mprotect-mt" 0 "$bindir/test-mprotect-mt"
 
     printf "\nNegative tests\n"
     test_check "$runner" "test-negative" "0 failed" "$bindir/test-negative"
 
+    printf "\nFork edge cases\n"
+    test_rc "$runner" "test-clone3" 0 "$bindir/test-clone3"
+    test_rc "$runner" "test-fork-lowbase" 0 "$bindir/test-fork-lowbase"
+
     printf "\nCoW fork isolation\n"
     test_check "$runner" "test-cow-fork" "PASS" "$bindir/test-cow-fork"
+    test_rc "$runner" "test-fork-synthetic-fd" 0 "$bindir/test-fork-synthetic-fd"
+
+    printf "\nO_PATH semantics\n"
+    test_rc "$runner" "test-opath" 0 "$bindir/test-opath"
+
+    printf "\nxattr semantics\n"
+    test_rc "$runner" "test-xattr" 0 "$bindir/test-xattr"
 
     printf "\nGuard page / mmap edge cases\n"
     test_check "$runner" "test-guard-page" "PASS" "$bindir/test-guard-page"
+    test_rc "$runner" "test-mmap-hint" 0 "$bindir/test-mmap-hint"
+
+    printf "\nLow-base ET_EXEC memory regression\n"
+    test_rc "$runner" "test-lowbase-mem-200000" 0 "$bindir/test-lowbase-mem-200000"
+    test_rc "$runner" "test-lowbase-mem-300000" 0 "$bindir/test-lowbase-mem-300000"
+
+    printf "\nmremap\n"
+    test_rc "$runner" "test-mremap" 0 "$bindir/test-mremap"
+
+    printf "\nmsync MAP_SHARED\n"
+    test_rc "$runner" "test-msync" 0 "$bindir/test-msync"
+
+    printf "\nRead-only MAP_SHARED overlay\n"
+    test_rc "$runner" "test-mmap-shared-ro" 0 "$bindir/test-mmap-shared-ro"
+
+    printf "\nCross-fork MAP_SHARED coherence\n"
+    test_rc "$runner" "test-cross-fork-mapshared" 0 "$bindir/test-cross-fork-mapshared"
+
+    printf "\nmadvise MADV_DONTNEED\n"
+    test_rc "$runner" "test-madvise" 0 "$bindir/test-madvise"
 
     printf "\nScatter-gather I/O\n"
     test_check "$runner" "test-readv-writev" "PASS" "$bindir/test-readv-writev"
@@ -560,6 +721,61 @@ run_unit_tests()
 
     printf "\nPI futex + EINTR regression\n"
     test_check "$runner" "test-futex-pi" "0 failed" "$bindir/test-futex-pi"
+    test_rc "$runner" "test-futex-waitv" 0 "$bindir/test-futex-waitv"
+    test_rc "$runner" "test-robust-futex" 0 "$bindir/test-robust-futex"
+
+    printf "\nFD table race\n"
+    test_rc "$runner" "test-fd-race" 0 "$bindir/test-fd-race"
+
+    printf "\nFD lifecycle\n"
+    test_rc "$runner" "test-fd-lifecycle" 0 "$bindir/test-fd-lifecycle"
+
+    printf "\nMultithreaded fork\n"
+    test_rc "$runner" "test-mt-fork" 0 "$bindir/test-mt-fork"
+
+    printf "\nExit-group teardown reachability\n"
+    test_rc "$runner" "test-exit-group-teardown-wait" 42 \
+        "$bindir/test-exit-group-teardown" wait
+    test_rc "$runner" "test-exit-group-teardown-stop" 42 \
+        "$bindir/test-exit-group-teardown" stop
+    test_rc "$runner" "test-exit-group-teardown-fork" 42 \
+        "$bindir/test-exit-group-teardown" fork
+
+    printf "\nSysV shared memory\n"
+    test_rc "$runner" "test-sysv-shm" 0 "$bindir/test-sysv-shm"
+
+    printf "\nCredential/identity emulation\n"
+    test_rc "$runner" "test-credentials" 0 "$bindir/test-credentials"
+
+    printf "\nScheduler policy stub\n"
+    test_rc "$runner" "test-sched-policy" 0 "$bindir/test-sched-policy"
+
+    printf "\nmembarrier\n"
+    test_rc "$runner" "test-membarrier" 0 "$bindir/test-membarrier"
+
+    printf "\nrseq registration\n"
+    test_rc "$runner" "test-rseq" 0 "$bindir/test-rseq"
+
+    printf "\nAbstract Unix socket\n"
+    test_rc "$runner" "test-abstract-socket" 0 "$bindir/test-abstract-socket"
+
+    printf "\nAncillary data\n"
+    test_rc "$runner" "test-ancillary" 0 "$bindir/test-ancillary"
+
+    printf "\nTier A compatibility\n"
+    test_rc "$runner" "test-tier-a" 0 "$bindir/test-tier-a"
+
+    printf "\nLinux syscall fidelity\n"
+    test_rc "$runner" "test-syscall-fidelity" 0 "$bindir/test-syscall-fidelity"
+
+    printf "\nfd-family\n"
+    test_rc "$runner" "test-fd-family" 0 "$bindir/test-fd-family"
+
+    printf "\nSCM_CREDENTIALS\n"
+    test_rc "$runner" "test-scm-creds" 0 "$bindir/test-scm-creds"
+
+    printf "\nVirtual chown overlay\n"
+    test_rc "$runner" "test-chown-overlay" 0 "$bindir/test-chown-overlay"
 
     printf "\nX11 raw protocol\n"
     test_check "$runner" "test-x11" "0 failed" "$bindir/test-x11"
@@ -991,8 +1207,8 @@ run_suite()
 # observed counts diverge. apple-unknown is the fallback row for SoC strings the
 # detector does not recognize yet.
 EXPECTED_BASELINES=(
-    "elfuse-aarch64|169|0"
-    "qemu-aarch64|165|0"
+    "elfuse-aarch64|234|0"
+    "qemu-aarch64|214|0"
     "elfuse-x86_64:apple-m1-m2|71|0"
     "elfuse-x86_64:apple-m3-plus|71|0"
     "elfuse-x86_64:apple-unknown|71|0"


### PR DESCRIPTION
## Summary
- Trim `tests/manifest.txt` from 118 to 69 entries: keep only tests with no real-kernel equivalent (EL1 shim fast-path suite, `test-mremap-infra`, `test-oom-proc`) plus whatever `SANITIZER_SECTIONS` needs for the `check-{asan,ubsan,tsan}` lanes.
- `test-matrix.sh` now covers the full portable test surface against both `elfuse-aarch64` and `qemu-aarch64`.
- `make check` now owns only what it uniquely needs — elfuse-internal plumbing and sanitizer coverage — while `test-matrix.sh` is the sole, comprehensive cross-kernel gate.
- Update `docs/testing.md` to describe the new split and adjust the recommended dev workflow (`make check` alone no longer substitutes for `make test-matrix-elfuse-aarch64`).
-  The 24 skipped test for qemu-aarch64 needs to fix later


## Test
`make check`: 69/0, all stages green (busybox, sysroot, FUSE, Rosetta CLI gating, hot-syscall guardrail)
`driver.sh -l -s '<SANITIZER_SECTIONS>'` still matches the same 48 sanitizer-relevant tests
`bash tests/test-matrix.sh elfuse-aarch64`: 234 passed, 0 failed, 4 skipped
`bash tests/test-matrix.sh qemu-aarch64`: 214 passed, 0 failed, 24 skipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed `make check` to elfuse-internal and sanitizer-only tests, and moved all portable tests into the matrix runner to remove duplicate gates while keeping coverage the same. The matrix is now the single, comprehensive cross-kernel gate.

- **Refactors**
  - Trimmed `tests/manifest.txt` from 118 to 69 tests: keep EL1 shim fast-path, `test-mremap-infra`, `test-oom-proc`, plus sanitizer-selected tests.
  - Merged matrix runners into one `run_unit_tests` that exercises the full portable suite against `elfuse-aarch64` and `qemu-aarch64`.
  - Documented qemu-only divergences via `QEMU_SKIP`, updated expected baselines, and refreshed `docs/testing.md` to reflect the new split.

- **Migration**
  - For syscall/runtime changes: run `make elfuse && make check && make test-matrix-elfuse-aarch64`.
  - To cross-check with a real kernel: run `make test-matrix-qemu-aarch64` or `make test-matrix`.

<sup>Written for commit 4cab69b164d12507f5b8cb5d3a8703584a8c7232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

