### PR TITLE
proc-identity fix saved-set-ID update in setreuid and setregid

### DIFF
--- a/src/syscall/proc-identity.c
+++ b/src/syscall/proc-identity.c
@@ -131,22 +131,28 @@ int64_t proc_sys_setgid(uint32_t gid)
     return 0;
 }
 
-#define DEFINE_SETRE(suffix, real, eff, saved, perm_fn)    \
-    int64_t proc_sys_setre##suffix(uint32_t r, uint32_t e) \
-    {                                                      \
-        uint32_t old_real = real;                          \
-        if (r != (uint32_t) -1 && r != real && r != eff)   \
-            return -LINUX_EPERM;                           \
-        if (e != (uint32_t) -1 && !perm_fn(e))             \
-            return -LINUX_EPERM;                           \
-        if (r != (uint32_t) -1)                            \
-            real = r;                                      \
-        if (e != (uint32_t) -1) {                          \
-            eff = e;                                       \
-            if (r != (uint32_t) -1 || e != old_real)       \
-                saved = e;                                 \
-        }                                                  \
-        return 0;                                          \
+#define DEFINE_SETRE(suffix, real, eff, saved, perm_fn)                    \
+    int64_t proc_sys_setre##suffix(uint32_t r, uint32_t e)                 \
+    {                                                                      \
+        uint32_t old_real = real;                                          \
+        if (r != (uint32_t) -1 && r != real && r != eff)                   \
+            return -LINUX_EPERM;                                           \
+        if (e != (uint32_t) -1 && !perm_fn(e))                             \
+            return -LINUX_EPERM;                                           \
+        if (r != (uint32_t) -1)                                            \
+            real = r;                                                      \
+        if (e != (uint32_t) -1)                                            \
+            eff = e;                                                       \
+        /* Linux setreuid(2): saved-set-ID is updated to                   \
+         * the new effective ID when the real ID is set                    \
+         * (r != -1) OR when the new effective ID differs                  \
+         * from the old real ID.  Both conditions use the                  \
+         * *new* effective value (eff, which may be                        \
+         * unchanged if e == -1).                                          \
+         */                                                                \
+        if (r != (uint32_t) -1 || (e != (uint32_t) -1 && eff != old_real)) \
+            saved = eff;                                                   \
+        return 0;                                                          \
     }
 
 DEFINE_SETRE(uid, emu_uid, emu_euid, emu_suid, uid_is_permitted)


### PR DESCRIPTION
sys: guard saved ID update in setreuid/setregid with euid/egid != -1

Modify DEFINE_SETRE macro to ensure that the saved-set-ID is only
updated by the effective ID change check when the new effective ID
is actually being set (i.e. e != -1).

This prevents setreuid(-1, -1) and setregid(-1, -1) from spuriously
clobbering the saved-set-ID when the current effective ID differs
from the real ID, matching Linux behavior.

Fix #140 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix saved-set-ID handling in setreuid(2) and setregid(2) to match Linux rules. The saved ID now updates from the new effective ID after applying real/effective changes, including when only the real ID is set.

- **Bug Fixes**
  - Updated `DEFINE_SETRE` to compute `saved` from the final `eff` after independently applying `r` and `e`.
  - Fixes the missed setreuid(r, -1) path; same change applies to setregid. Fixes #140.

<sup>Written for commit a6d01d9d4bfc060bd0122488aa8b9408c32c8581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

