### PR TITLE
Share one path component iterator across syscall/

### DIFF
--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -284,9 +284,7 @@ int path_translate_dirent_name(guest_fd_t dirfd,
     return 0;
 }
 
-static bool path_next_component(const char **pathp,
-                                const char **comp,
-                                size_t *len)
+bool path_next_component(const char **pathp, const char **comp, size_t *len)
 {
     const char *p = *pathp;
 

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -32,6 +32,13 @@ typedef struct {
     char host_buf[LINUX_PATH_MAX];
 } path_translation_t;
 
+/* Advance *pathp to the next '/'-separated component, skipping empty segments
+ * from repeated slashes. Returns true with the component (not NUL-terminated)
+ * reported through comp and len, leaving *pathp at its end; returns false once
+ * only slashes or the terminating NUL remain.
+ */
+bool path_next_component(const char **pathp, const char **comp, size_t *len);
+
 bool path_might_use_open_intercept(const char *path);
 bool path_might_use_stat_intercept(const char *path);
 int path_check_intercept_access(const struct stat *st, int mode, int flags);

--- a/src/syscall/sidecar.c
+++ b/src/syscall/sidecar.c
@@ -468,25 +468,6 @@ static const char *sidecar_lookup_token(const sidecar_index_t *index,
     return NULL;
 }
 
-static int sidecar_next_component(const char **pathp,
-                                  const char **comp,
-                                  size_t *len)
-{
-    const char *p = *pathp;
-    while (*p == '/')
-        p++;
-    if (*p == '\0') {
-        *pathp = p;
-        return 0;
-    }
-    *comp = p;
-    while (*p != '\0' && *p != '/')
-        p++;
-    *len = (size_t) (p - *comp);
-    *pathp = p;
-    return 1;
-}
-
 static int sidecar_append_component(char *out,
                                     size_t outsz,
                                     size_t *len_io,
@@ -693,7 +674,7 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
     size_t out_len = strlen(out);
     const char *comp;
     size_t comp_len;
-    while (sidecar_next_component(&scan, &comp, &comp_len)) {
+    while (path_next_component(&scan, &comp, &comp_len)) {
         char guest_comp[NAME_MAX + 1];
         if (comp_len >= sizeof(guest_comp)) {
             close(cur_fd);
@@ -826,7 +807,7 @@ int sidecar_translate_lookup_at(guest_fd_t dirfd,
              * components translate to themselves; the caller's syscall then
              * reports ENOENT against the translated path.
              */
-            while (sidecar_next_component(&scan, &comp, &comp_len)) {
+            while (path_next_component(&scan, &comp, &comp_len)) {
                 char rest_comp[NAME_MAX + 1];
                 if (comp_len >= sizeof(rest_comp)) {
                     errno = ENAMETOOLONG;


### PR DESCRIPTION
path.c and sidecar.c each carry a private copy of the same '/'-separated component walk, differing only in name and return type.

Promote path.c's path_next_component to external linkage and switch sidecar.c to it so the syscall layer keeps a single walker and future path predicates do not grow another copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated path component iteration in the syscall layer by exporting `path_next_component` and switching `sidecar.c` to use it. This keeps one '/'-component walker and aligns behavior across callers with no functional changes.

- **Refactors**
  - Exposed `path_next_component(const char **pathp, const char **comp, size_t *len)` in `path.c` and declared it in `path.h` with docs.
  - Removed `sidecar_next_component` and updated call sites in `sidecar_translate_lookup_at` to use the shared helper.
  - Preserved semantics: skips repeated slashes and returns false at end of path.

<sup>Written for commit 3451457be71c69896c6d7894477ef3a5a03d7112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

