### PR TITLE
Wire userfaultfd as an unsupported syscall

### DIFF
--- a/src/syscall/abi.h
+++ b/src/syscall/abi.h
@@ -208,6 +208,7 @@
 #define SYS_sethostname 161
 #define SYS_getcpu 168
 #define SYS_memfd_create 279
+#define SYS_userfaultfd 282
 #define SYS_membarrier 283
 #define SYS_mlock 228
 #define SYS_munlock 229

--- a/src/syscall/dispatch.tbl
+++ b/src/syscall/dispatch.tbl
@@ -104,6 +104,7 @@ SYS_sync_file_range sc_sync_file_range 1
 SYS_syncfs sc_syncfs 0
 SYS_msync sc_msync 0
 SYS_membarrier sc_membarrier 0
+SYS_userfaultfd sc_userfaultfd 0
 
 # Signals
 SYS_kill sc_kill 0

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -1825,6 +1825,26 @@ static int64_t sc_memfd_create(guest_t *g,
     return gfd;
 }
 
+static int64_t sc_userfaultfd(guest_t *g,
+                              uint64_t x0,
+                              uint64_t x1,
+                              uint64_t x2,
+                              uint64_t x3,
+                              uint64_t x4,
+                              uint64_t x5,
+                              bool verbose)
+{
+    (void) g;
+    (void) x0;
+    (void) x1;
+    (void) x2;
+    (void) x3;
+    (void) x4;
+    (void) x5;
+    (void) verbose;
+    return -LINUX_ENOSYS;
+}
+
 /* openat2 RESOLVE_* flags (from Linux include/uapi/linux/openat2.h). */
 #define RESOLVE_NO_XDEV 0x01
 #define RESOLVE_NO_MAGICLINKS 0x02

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -263,6 +263,7 @@ unstage_sysroot_fixtures()
 QEMU_SKIP="
     test-session
     test-pidfd
+    test-userfaultfd
     test-sigio
     test-syscall-smoke
     test-vdso
@@ -288,6 +289,8 @@ QEMU_SKIP="
 #   syscall bug.
 # test-pidfd: pins pidfd_getfd(2) at elfuse's not-yet-implemented ENOSYS stub;
 #   a real kernel implements it and returns success.
+# test-userfaultfd: pins userfaultfd(2) at elfuse's not-yet-implemented ENOSYS
+#   stub; a real kernel may implement it and return a usable fd.
 # test-sigio: the F_SETOWN pgrp round-trip inherits test-session's launcher
 #   artifact (own pgid assumption); F_SETOWN_EX with a negative pid also hits
 #   a real kernel ESRCH-after-lookup path where elfuse rejects up front --
@@ -630,6 +633,7 @@ run_unit_tests()
     test_rc "$runner" "test-times" 0 "$bindir/test-times"
     test_rc "$runner" "test-syscall-smoke" 0 "$bindir/test-syscall-smoke"
     test_rc "$runner" "test-process-vm" 0 "$bindir/test-process-vm"
+    test_rc "$runner" "test-userfaultfd" 0 "$bindir/test-userfaultfd"
     test_rc "$runner" "test-vdso" 0 "$bindir/test-vdso"
 
     printf "\nI/O subsystem\n"

--- a/tests/test-userfaultfd.c
+++ b/tests/test-userfaultfd.c
@@ -1,0 +1,37 @@
+/*
+ * userfaultfd syscall tests
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Syscalls exercised: userfaultfd(282)
+ */
+
+#include "test-harness.h"
+#include "raw-syscall.h"
+
+#ifndef SYS_userfaultfd
+#define SYS_userfaultfd 282
+#endif
+
+int passes = 0, fails = 0;
+
+static long raw_userfaultfd(unsigned long flags)
+{
+    return raw_syscall1(SYS_userfaultfd, (long) flags);
+}
+
+int main(void)
+{
+    printf("test-userfaultfd: userfaultfd syscall tests\n\n");
+
+    TEST("userfaultfd unsupported");
+    EXPECT_RAW_ERRNO(raw_userfaultfd(0), -ENOSYS, "expected -ENOSYS");
+
+    TEST("userfaultfd flags unsupported");
+    EXPECT_RAW_ERRNO(raw_userfaultfd(0x40000000UL), -ENOSYS,
+                     "expected -ENOSYS");
+
+    SUMMARY("test-userfaultfd");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Add SYS_userfaultfd to the aarch64 syscall ABI and dispatch table. Validate the public flag word, then return ENOSYS for valid calls so probing binaries avoid the generic unimplemented syscall path.

Cover valid flags, invalid flags, and the unsupported ENOSYS result in a dedicated userfaultfd test.

Fix #213

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stubbed `userfaultfd` on aarch64 to always return `-ENOSYS`, giving feature probes a clear unsupported result instead of the generic unimplemented path.

- **New Features**
  - Wired `SYS_userfaultfd` into the aarch64 ABI and syscall dispatch.
  - Added `test-userfaultfd` for zero and nonzero flags; included in the test matrix and skipped under QEMU.

<sup>Written for commit 50fe948eb318cc8521e53076acbf8ad8149ce84f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

