### PR TITLE
De-dup timespec validation and conversion code

### DIFF
--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -31,6 +31,7 @@
 #include "syscall/poll.h"
 #include "syscall/proc.h" /* proc_exit_group_requested */
 #include "syscall/signal.h"
+#include "syscall/time.h" /* linux_timespec_valid */
 
 /* Global wakeup pipe: write end signals exit_group/futex_interrupt/guest
  * signals to threads blocked in host poll/select/kevent. The read end is added
@@ -178,7 +179,7 @@ int64_t sys_ppoll(guest_t *g,
             return -LINUX_EFAULT;
         }
         /* Linux returns EINVAL for negative timeout values */
-        if (lts.tv_sec < 0 || !RANGE_CHECK(lts.tv_nsec, 0, 1000000000LL)) {
+        if (!linux_timespec_valid(&lts)) {
             host_fd_refs_close(host_refs, nfds);
             return -LINUX_EINVAL;
         }
@@ -321,7 +322,7 @@ int64_t sys_pselect6(guest_t *g,
         linux_timespec_t lts;
         if (guest_read_small(g, timeout_gva, &lts, sizeof(lts)) < 0)
             return -LINUX_EFAULT;
-        if (lts.tv_sec < 0 || !RANGE_CHECK(lts.tv_nsec, 0, 1000000000LL))
+        if (!linux_timespec_valid(&lts))
             return -LINUX_EINVAL;
         if (lts.tv_sec == 0 && lts.tv_nsec == 0)
             return 0;
@@ -443,7 +444,7 @@ int64_t sys_pselect6(guest_t *g,
         if (guest_read_small(g, timeout_gva, &lts, sizeof(lts)) < 0)
             goto pselect_fault;
         /* Linux returns EINVAL for negative or out-of-range timeout values */
-        if (lts.tv_sec < 0 || !RANGE_CHECK(lts.tv_nsec, 0, 1000000000LL))
+        if (!linux_timespec_valid(&lts))
             goto pselect_inval;
         ts.tv_sec = lts.tv_sec;
         ts.tv_nsec = lts.tv_nsec;

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -39,6 +39,7 @@
 #include "syscall/poll.h" /* wakeup_pipe_signal */
 #include "syscall/proc.h" /* proc_get_pid, proc_get_uid, SYSCALL_EXEC_HAPPENED */
 #include "syscall/signal.h"
+#include "syscall/time.h" /* linux_timespec_valid, linux_timespec_to_ns_sat */
 
 /* Signal state (module-level, process-wide). */
 static signal_state_t sig_state;
@@ -1409,17 +1410,9 @@ int64_t signal_rt_sigtimedwait(guest_t *g,
         linux_timespec_t lts;
         if (guest_read_small(g, timeout_gva, &lts, sizeof(lts)) < 0)
             return -LINUX_EFAULT;
-        /* Negative tv_sec is invalid (matches kernel hrtimer validation). */
-        if (lts.tv_sec < 0 || lts.tv_nsec < 0 || lts.tv_nsec >= 1000000000LL)
+        if (!linux_timespec_valid(&lts))
             return -LINUX_EINVAL;
-        /* Saturate to INT64_MAX to avoid overflow. */
-        if (lts.tv_sec > (INT64_MAX / 1000000000LL) ||
-            (lts.tv_sec == (INT64_MAX / 1000000000LL) &&
-             lts.tv_nsec > (INT64_MAX % 1000000000LL))) {
-            remaining_ns = INT64_MAX;
-        } else {
-            remaining_ns = lts.tv_sec * 1000000000LL + lts.tv_nsec;
-        }
+        remaining_ns = linux_timespec_to_ns_sat(&lts);
     }
 
     /* Poll/wait loop. */

--- a/src/syscall/time.c
+++ b/src/syscall/time.c
@@ -60,14 +60,14 @@ _Static_assert(sizeof(struct timespec) == sizeof(linux_timespec_t),
 _Static_assert(sizeof(struct timeval) == sizeof(linux_timeval_t),
                "host and guest timeval must match on LP64");
 
-static bool linux_timespec_valid(const linux_timespec_t *ts)
+bool linux_timespec_valid(const linux_timespec_t *ts)
 {
     if (ts->tv_sec < 0)
         return false;
     return ts->tv_nsec >= 0 && ts->tv_nsec < NSEC_PER_SEC;
 }
 
-static int64_t linux_timespec_to_ns_sat(const linux_timespec_t *ts)
+int64_t linux_timespec_to_ns_sat(const linux_timespec_t *ts)
 {
     if (ts->tv_sec < 0)
         return 0;

--- a/src/syscall/time.h
+++ b/src/syscall/time.h
@@ -11,8 +11,21 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "core/guest.h"
+#include "syscall/abi.h"
+
+/* Return true when a guest-supplied timespec is well-formed: non-negative
+ * seconds and a nanosecond field in [0, NSEC_PER_SEC). Mirrors the kernel
+ * hrtimer validation shared by the timeout-bearing syscalls.
+ */
+bool linux_timespec_valid(const linux_timespec_t *ts);
+
+/* Convert a validated guest timespec to a nanosecond count, saturating to
+ * INT64_MAX on overflow rather than wrapping. A negative tv_sec yields 0.
+ */
+int64_t linux_timespec_to_ns_sat(const linux_timespec_t *ts);
 
 /* Time/timer syscall handlers. */
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deduplicated Linux timespec validation and nanosecond conversion via shared helpers. Replaced open-coded logic in `ppoll`, `pselect6`, and `rt_sigtimedwait` for consistent `EINVAL` handling and saturated conversion (no behavior change).

- **Refactors**
  - Exported `linux_timespec_valid` and `linux_timespec_to_ns_sat` from `time.c` and declared them in `time.h`.
  - Updated `sys_ppoll`, both `sys_pselect6` validation paths, and `signal_rt_sigtimedwait` to use the helpers; added `syscall/time.h` includes where needed.

<sup>Written for commit 2c24204d622303fffdf47a9117a2e8cf1dc2ce5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

