### PR TITLE
De-dup write_rusage_to_guest code

### DIFF
--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1074,9 +1074,7 @@ int64_t sys_ptrace(guest_t *g,
 _Static_assert(sizeof(struct rusage) == sizeof(linux_rusage_t),
                "host and guest rusage layouts must match on LP64");
 
-static int write_rusage_to_guest(guest_t *g,
-                                 uint64_t gva,
-                                 const struct rusage *ru)
+int write_rusage_to_guest(guest_t *g, uint64_t gva, const struct rusage *ru)
 {
     linux_rusage_t lru;
     memcpy(&lru, ru, sizeof(lru));

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -323,6 +323,13 @@ void proc_children_cpu_add(const struct rusage *ru);
 /* Read the accumulated guest-children CPU time, in microseconds. */
 void proc_children_cpu_us(uint64_t *utime_us, uint64_t *stime_us);
 
+/* Write a macOS struct rusage to guest memory as linux_rusage_t. The field
+ * layout matches on LP64; ru_maxrss is converted from macOS bytes to Linux
+ * kilobytes. Returns the guest_write_small result (0 on success, negative on
+ * fault).
+ */
+int write_rusage_to_guest(guest_t *g, uint64_t gva, const struct rusage *ru);
+
 /* Collect host PIDs of active (non-exited) fork children. Writes up to max_pids
  * entries into out[].
  *

--- a/src/syscall/sys.c
+++ b/src/syscall/sys.c
@@ -74,8 +74,9 @@ static linux_rlimit64_t guest_nofile_limit = {
 };
 #define RLIMIT_CACHE_SIZE ((int) (ARRAY_SIZE(cached_linux_rlimits)))
 
-_Static_assert(sizeof(struct rusage) == sizeof(linux_rusage_t),
-               "host and guest rusage layouts must match on LP64");
+/* The full-size assertion lives with write_rusage_to_guest() in proc.c; this
+ * offset check guards the fast memcpy translation done there.
+ */
 _Static_assert(offsetof(struct rusage, ru_maxrss) ==
                    offsetof(linux_rusage_t, ru_maxrss),
                "ru_maxrss offset must stay aligned for fast translation");
@@ -529,12 +530,7 @@ int64_t sys_getrusage(guest_t *g, int who, uint64_t usage_gva)
     if (getrusage(who, &mac_usage) < 0)
         return linux_errno();
 
-    linux_rusage_t lin_usage;
-    memcpy(&lin_usage, &mac_usage, sizeof(lin_usage));
-    lin_usage.ru_maxrss =
-        mac_usage.ru_maxrss / 1024; /* macOS: bytes -> Linux: KB */
-
-    if (guest_write_small(g, usage_gva, &lin_usage, sizeof(lin_usage)) < 0)
+    if (write_rusage_to_guest(g, usage_gva, &mac_usage) < 0)
         return -LINUX_EFAULT;
 
     return 0;


### PR DESCRIPTION
Stacked on https://github.com/sysprog21/elfuse/pull/220


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated timespec validation/conversion and rusage write logic across syscalls to unify behavior and reduce drift. Ensures consistent EINVAL handling, overflow saturation, and getrusage translation.

- **Refactors**
  - Added `linux_timespec_valid` and `linux_timespec_to_ns_sat`; used in `ppoll`, `pselect6`, and `rt_sigtimedwait`.
  - Exposed `write_rusage_to_guest` via `proc.h` and called it from `sys_getrusage`; handles `ru_maxrss` bytes→KB conversion.
  - Moved the full-size rusage layout assertion next to `write_rusage_to_guest` in `proc.c`; kept only the `ru_maxrss` offset assert in `sys.c` to guard the fast memcpy path.

<sup>Written for commit 874d9283682b99e20173270e06b5ab2841af4dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



