### PR TITLE
De-dup {read,write}-all code

### DIFF
--- a/src/core/rosetta.c
+++ b/src/core/rosetta.c
@@ -1012,51 +1012,9 @@ bool rosettad_wait_for_idle(unsigned int max_ms)
            -1;
 }
 
-static ssize_t rosettad_read_full(int fd, void *buf, size_t len)
-{
-    uint8_t *p = buf;
-    size_t got = 0;
-    while (got < len) {
-        ssize_t n = read(fd, p + got, len - got);
-        if (n == 0)
-            return (ssize_t) got;
-        if (n < 0) {
-            if (errno == EINTR)
-                continue;
-            return -1;
-        }
-        got += (size_t) n;
-    }
-    return (ssize_t) got;
-}
-
 static int rosettad_write_byte(int fd, uint8_t b)
 {
-    for (;;) {
-        ssize_t n = write(fd, &b, 1);
-        if (n == 1)
-            return 0;
-        if (n < 0 && errno == EINTR)
-            continue;
-        return -1;
-    }
-}
-
-static int rosettad_write_full(int fd, const void *buf, size_t len)
-{
-    const uint8_t *p = buf;
-    size_t sent = 0;
-    while (sent < len) {
-        ssize_t n = write(fd, p + sent, len - sent);
-        if (n > 0) {
-            sent += (size_t) n;
-            continue;
-        }
-        if (n < 0 && errno == EINTR)
-            continue;
-        return -1;
-    }
-    return 0;
+    return write_all(fd, &b, 1);
 }
 
 /* Send the success reply for a TRANSLATE or DIGEST command: {HIT byte, optional
@@ -1068,7 +1026,7 @@ static int rosettad_send_aot(int fd, const uint8_t *digest, int aot_fd)
 {
     if (rosettad_write_byte(fd, ROSETTAD_RESP_HIT) < 0)
         return -1;
-    if (digest && rosettad_write_full(fd, digest, ROSETTAD_DIGEST_SIZE) < 0)
+    if (digest && write_all(fd, digest, ROSETTAD_DIGEST_SIZE) < 0)
         return -1;
     if (rosettad_send_fd(fd, 0, aot_fd) < 0)
         return -1;
@@ -1149,7 +1107,7 @@ static void *rosettad_handler_thread(void *arg)
              * request.
              */
             uint8_t digest[ROSETTAD_DIGEST_SIZE];
-            if (rosettad_read_full(fd, digest, sizeof(digest)) !=
+            if (read_all(fd, digest, sizeof(digest), false) !=
                 (ssize_t) sizeof(digest))
                 goto done;
             int cached = aot_cache_lookup(digest);

--- a/src/debug/gdbstub-rsp.c
+++ b/src/debug/gdbstub-rsp.c
@@ -70,18 +70,7 @@ static uint8_t rsp_checksum(const char *data, size_t len)
 
 static int rsp_send_byte(int fd, char value)
 {
-    while (1) {
-        ssize_t n = write(fd, &value, 1);
-        if (n < 0) {
-            if (errno == EINTR)
-                continue;
-            return -1;
-        }
-        if (n == 1)
-            return 0;
-        errno = EIO;
-        return -1;
-    }
+    return write_all(fd, &value, 1);
 }
 
 int gdb_rsp_send(int fd, const char *data, size_t len)

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -30,44 +30,15 @@
 
 int fork_ipc_write_all(int fd, const void *buf, size_t len)
 {
-    const uint8_t *p = buf;
-    while (len > 0) {
-        ssize_t n = write(fd, p, len);
-        if (n < 0) {
-            if (errno == EINTR)
-                continue;
-            return -1;
-        }
-
-        if (n == 0) {
-            /* Defensive: an unexpected zero return on a blocking socket would
-             * otherwise spin forever, since p and len stay at the same offset.
-             * Treat it as an IO failure so the parent and child both bail
-             * rather than wedge.
-             */
-            errno = EIO;
-            return -1;
-        }
-        p += n;
-        len -= n;
-    }
-    return 0;
+    return write_all(fd, buf, len);
 }
 
 int fork_ipc_read_all(int fd, void *buf, size_t len)
 {
-    uint8_t *p = buf;
-    while (len > 0) {
-        ssize_t n = read(fd, p, len);
-        if (n <= 0) {
-            if (n < 0 && errno == EINTR)
-                continue;
-            return -1;
-        }
-        p += n;
-        len -= n;
-    }
-    return 0;
+    /* A truncated exchange (EOF before len) is a protocol failure here, so the
+     * parent and child both bail rather than act on a partial message.
+     */
+    return read_all(fd, buf, len, true) < 0 ? -1 : 0;
 }
 
 /* macOS rejects overly large SCM_RIGHTS payloads with EINVAL. Keep each control

--- a/src/utils.h
+++ b/src/utils.h
@@ -127,6 +127,60 @@ static inline size_t bytes_to_hex(char *dst, const uint8_t *src, size_t len)
     return len * 2;
 }
 
+/* Write exactly @len bytes to a blocking @fd, resuming across short writes and
+ * EINTR. Returns 0 once every byte is written, or -1 with errno set on error.
+ * An unexpected zero-byte return is treated as EIO rather than spun on, since
+ * the offset would otherwise never advance. A zero-length request returns 0.
+ */
+static inline int write_all(int fd, const void *buf, size_t len)
+{
+    const uint8_t *p = buf;
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = write(fd, p + sent, len - sent);
+        if (n > 0) {
+            sent += (size_t) n;
+            continue;
+        }
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        errno = EIO;
+        return -1;
+    }
+    return 0;
+}
+
+/* Read exactly @len bytes from a blocking @fd into @buf, resuming across short
+ * reads and EINTR. On error returns -1 with errno set. On a premature EOF the
+ * result depends on @eof_is_error: when true the call returns -1, when false it
+ * returns the count of bytes read before EOF so the caller can detect a clean
+ * end of stream. Otherwise returns @len.
+ */
+static inline ssize_t read_all(int fd, void *buf, size_t len, bool eof_is_error)
+{
+    uint8_t *p = buf;
+    size_t got = 0;
+    while (got < len) {
+        ssize_t n = read(fd, p + got, len - got);
+        if (n > 0) {
+            got += (size_t) n;
+            continue;
+        }
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        if (eof_is_error)
+            return -1;
+        break;
+    }
+    return (ssize_t) got;
+}
+
 /* Create a private per-user scratch directory. mkdir(path, 0700), then tolerate
  * an already-existing entry only if it is a real directory, owned by the
  * current uid, with no group/other access bits. That rejects a symlink, a


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Consolidates read/write loops into `write_all` and `read_all` in `src/utils.h` and adopts them across the codebase for consistent blocking I/O. Unifies EINTR, short I/O, zero-write, and EOF handling.

- **Refactors**
  - Added `write_all`/`read_all`: resumes on EINTR/short I/O; `write_all` treats zero write as EIO; `read_all` returns -1 on EOF when `eof_is_error=true`, else returns bytes read.
  - Replaced custom loops in `src/core/rosetta.c` (digest read uses `read_all(..., false)`), `src/debug/gdbstub-rsp.c` (byte send uses `write_all`), and `src/runtime/fork-state.c` (IPC read uses `read_all(..., true)`); write paths now use `write_all`.
  - Removed duplicated helpers (`rosettad_*_full`); behavior stays the same with unified zero-write and EOF semantics.

<sup>Written for commit 0dec58ae07f31f4860524ddc46b6f101172e9df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

