### PR TITLE
De-dup {digest_to_hex,gdb_hex_encode} code

### DIFF
--- a/src/core/rosetta.c
+++ b/src/core/rosetta.c
@@ -573,17 +573,6 @@ static int compute_fd_sha256(int fd, uint8_t digest[ROSETTAD_DIGEST_SIZE])
     return 0;
 }
 
-static void digest_to_hex(const uint8_t digest[ROSETTAD_DIGEST_SIZE],
-                          char hex[ROSETTAD_DIGEST_HEX_LEN])
-{
-    static const char hex_chars[] = "0123456789abcdef";
-    for (int i = 0; i < ROSETTAD_DIGEST_SIZE; i++) {
-        hex[i * 2 + 0] = hex_chars[(digest[i] >> 4) & 0xf];
-        hex[i * 2 + 1] = hex_chars[digest[i] & 0xf];
-    }
-    hex[ROSETTAD_DIGEST_SIZE * 2] = '\0';
-}
-
 /* AOT cache paths */
 
 /* Build <HOME>/.cache/elfuse-rosettad[/suffix] into out. When suffix is NULL,
@@ -631,7 +620,7 @@ static int aot_cache_path_for_digest(const uint8_t digest[ROSETTAD_DIGEST_SIZE],
                                      size_t outsz)
 {
     char hex[ROSETTAD_DIGEST_HEX_LEN];
-    digest_to_hex(digest, hex);
+    bytes_to_hex(hex, digest, ROSETTAD_DIGEST_SIZE);
     char leaf[ROSETTAD_DIGEST_HEX_LEN + 32];
     int ln = snprintf(leaf, sizeof(leaf), "%s%s", hex, suffix ? suffix : "");
     if (ln < 0 || (size_t) ln >= sizeof(leaf))

--- a/src/debug/gdbstub-rsp.c
+++ b/src/debug/gdbstub-rsp.c
@@ -12,6 +12,8 @@
 #include <unistd.h>
 #include <errno.h>
 
+#include "utils.h"
+
 #include "debug/gdbstub-rsp.h"
 
 static const char hex_chars[] = "0123456789abcdef";
@@ -29,12 +31,7 @@ static int hex_val(char c)
 
 int gdb_hex_encode(char *dst, const uint8_t *src, size_t len)
 {
-    for (size_t i = 0; i < len; i++) {
-        dst[i * 2] = hex_chars[(src[i] >> 4) & 0xF];
-        dst[i * 2 + 1] = hex_chars[src[i] & 0xF];
-    }
-    dst[len * 2] = '\0';
-    return (int) (len * 2);
+    return (int) bytes_to_hex(dst, src, len);
 }
 
 int gdb_hex_decode(uint8_t *dst, const char *src, size_t len)

--- a/src/utils.h
+++ b/src/utils.h
@@ -112,6 +112,21 @@ static inline void close_keep_errno(int fd)
     errno = saved;
 }
 
+/* Encode @len bytes of @src as lowercase hex into @dst, writing len*2 hex
+ * characters followed by a terminating NUL. @dst must hold at least len*2+1
+ * bytes. Returns the number of hex characters written (len*2).
+ */
+static inline size_t bytes_to_hex(char *dst, const uint8_t *src, size_t len)
+{
+    static const char hex_chars[] = "0123456789abcdef";
+    for (size_t i = 0; i < len; i++) {
+        dst[i * 2] = hex_chars[(src[i] >> 4) & 0xf];
+        dst[i * 2 + 1] = hex_chars[src[i] & 0xf];
+    }
+    dst[len * 2] = '\0';
+    return len * 2;
+}
+
 /* Create a private per-user scratch directory. mkdir(path, 0700), then tolerate
  * an already-existing entry only if it is a real directory, owned by the
  * current uid, with no group/other access bits. That rejects a symlink, a


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized byte-to-hex encoding by adding `bytes_to_hex` in `src/utils.h` and deduplicating logic in Rosetta and the GDB stub. Behavior is unchanged: lowercase hex with a trailing NUL.

- **Refactors**
  - Added inline `bytes_to_hex(char *dst, const uint8_t *src, size_t len)` in `src/utils.h` (writes len*2 hex chars + NUL; returns len*2).
  - Removed Rosetta’s `digest_to_hex`; `gdb_hex_encode` now wraps `bytes_to_hex`, and `gdbstub-rsp.c` includes `utils.h`.

<sup>Written for commit 2946f97b54b5ccd93e6a4bfd5bfd4a75dc5f763f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

