### PR TITLE
Show full failing-test output in the driver

### DIFF
--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -276,13 +276,13 @@ report_case()
     esac
 }
 
-print_output_excerpt()
+print_failure_output()
 {
     local output="$1"
-    local lines="$2"
+    local prefix="$2"
 
     [ "$VERBOSE" -eq 1 ] && [ -n "$output" ] || return 0
-    printf "%s\n" "$output" | head -"$lines" | sed 's/^/    /'
+    printf '%s\n' "$output" | sed "s/^/${prefix}/"
 }
 
 total=${#filtered_idx[@]}
@@ -380,9 +380,7 @@ for i in "${filtered_idx[@]}"; do
             fail=$((fail + 1))
         else
             echo "not ok $test_num - $name # exit code $rc"
-            if [ "$VERBOSE" -eq 1 ] && [ -n "$output" ]; then
-                printf "%s\n" "$output" | head -10 | sed 's/^/  # /'
-            fi
+            print_failure_output "$output" "  # "
             fail=$((fail + 1))
         fi
     else
@@ -398,7 +396,7 @@ for i in "${filtered_idx[@]}"; do
             fail=$((fail + 1))
         else
             report_case fail "$name" " (exit $rc)"
-            print_output_excerpt "$output" 8
+            print_failure_output "$output" "    "
             fail=$((fail + 1))
         fi
     fi


### PR DESCRIPTION
driver.sh capped a failing test's captured output at the first 8 lines (10 in TAP mode). For a test that prints many passing sub-checks before the failure, and for sanitizer legs whose UBSAN/ASAN report is emitted last, that cap hid the actual failing check and the diagnostic entirely, leaving only a wall of leading OK lines.

The full stdout and stderr are already captured into $output, so print all of it on failure instead of a head-truncated excerpt. Fold both the plain and TAP paths onto one print_failure_output helper that indents every line with a caller-supplied prefix. Output still only appears under -v, so non-verbose runs are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show full failing-test output in the test driver instead of truncating to 8–10 lines, so real failures and sanitizer diagnostics are visible. Output remains gated behind -v.

- **Bug Fixes**
  - Print full captured stdout/stderr for failing tests (no head truncation), including UBSAN/ASAN reports. Works in both plain and TAP modes.

- **Refactors**
  - Replace `print_output_excerpt` with `print_failure_output`, which indents each line with a caller-supplied prefix.

<sup>Written for commit 97cdf9d580bb60aeb86863fb95668dd676764959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

