### PR TITLE
Emulate linkat on macOS symlinks and escape logs

### DIFF
--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -2301,7 +2301,7 @@ int64_t sys_linkat(guest_t *g,
          * directory entry that resolves identically, even though it is a
          * distinct inode rather than a second link to the original.
          */
-        if ((errno != EPERM && errno != ENOTSUP) ||
+        if ((errno != EPERM && errno != ENOTSUP && errno != EINVAL) ||
             (flags & LINUX_AT_SYMLINK_FOLLOW)) {
             host_fd_ref_close(&olddir_ref);
             host_fd_ref_close(&newdir_ref);

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -2334,6 +2334,45 @@ static int fast_scalar_syscall_result(int nr, uint64_t x0, int64_t *result)
     }
 }
 
+static void escape_log_string(char *dest, const char *src, size_t dest_sz)
+{
+    size_t d = 0;
+    for (size_t s = 0; src[s] != '\0'; s++) {
+        unsigned char c = (unsigned char) src[s];
+        if (c < 32 || c >= 127) {
+            if (d + 4 >= dest_sz)
+                break;
+            switch (c) {
+            case '\n':
+                dest[d++] = '\\';
+                dest[d++] = 'n';
+                break;
+            case '\r':
+                dest[d++] = '\\';
+                dest[d++] = 'r';
+                break;
+            case '\t':
+                dest[d++] = '\\';
+                dest[d++] = 't';
+                break;
+            case '\x1b':
+                dest[d++] = '\\';
+                dest[d++] = 'e';
+                break;
+            default:
+                snprintf(&dest[d], dest_sz - d, "\\x%02x", c);
+                d += 4;
+                break;
+            }
+        } else {
+            if (d + 1 >= dest_sz)
+                break;
+            dest[d++] = src[s];
+        }
+    }
+    dest[d] = '\0';
+}
+
 int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
 {
     uint64_t x0, x1, x2, x3, x4, x5, x8;
@@ -2572,12 +2611,26 @@ fast_done:
         if (verbose) {
             log_debug("  -> %lld (0x%llx)", (long long) result,
                       (unsigned long long) (uint64_t) result);
-            /* Log file paths for openat/readlinkat */
             if ((int) x8 == SYS_openat || (int) x8 == SYS_readlinkat ||
                 (int) x8 == SYS_faccessat) {
-                char pathbuf[256];
-                if (guest_read_str(g, x1, pathbuf, sizeof(pathbuf)) >= 0)
-                    log_debug("  path=\"%s\"", pathbuf);
+                char pathbuf[256], escaped_path[512];
+                if (guest_read_str(g, x1, pathbuf, sizeof(pathbuf)) >= 0) {
+                    escape_log_string(escaped_path, pathbuf,
+                                      sizeof(escaped_path));
+                    log_debug("  path=\"%s\"", escaped_path);
+                }
+            } else if ((int) x8 == SYS_symlinkat) {
+                char target[256], linkpath[256];
+                char escaped_target[512], escaped_linkpath[512];
+                if (guest_read_str(g, x0, target, sizeof(target)) >= 0 &&
+                    guest_read_str(g, x2, linkpath, sizeof(linkpath)) >= 0) {
+                    escape_log_string(escaped_target, target,
+                                      sizeof(escaped_target));
+                    escape_log_string(escaped_linkpath, linkpath,
+                                      sizeof(escaped_linkpath));
+                    log_debug("  symlink target=\"%s\" linkpath=\"%s\"",
+                              escaped_target, escaped_linkpath);
+                }
             }
         }
         /* Write result back to X0 */


### PR DESCRIPTION
On macOS, linkat(2) fails with EINVAL when attempting to hard-link a
symbolic link itself. Fall back to creating a new symlink to the same
target when host linkat returns EINVAL.

In addition, sanitize verbose tracing logs by escaping control
characters in guest-provided path strings. This prevents guests
from injecting terminal escape sequences into the operator's
terminal.

Fix #237

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop falling back to host paths for system directories when a guest path is missing in the sysroot. Prevents guest writes to the host and avoids SIP-related EPERM/EACCES on macOS.

- **Bug Fixes**
  - Block fallback for /usr, /bin, /lib, /sbin, /var, /opt, and /etc.
  - Keep fallback for /etc/resolv.conf to preserve DNS.
  - Treat `EINVAL` in `linkat` as non-fallback to avoid host writes.
  - Escape control/non-ASCII in debug logs: paths for `openat`/`readlinkat`/`faccessat`, and target+linkpath for `symlinkat`.

<sup>Written for commit c40996c77d432faee4d38b8ea02ef04038d447a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

