### PR TITLE
Restrict sysroot fallback to exclude system paths

### DIFF
--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -24,6 +24,7 @@
 #include "syscall/internal.h"
 #include "syscall/proc.h"
 #include "syscall/proc-state.h"
+#include "syscall/path.h"
 
 /* Shim blob reference (set by startup/bootstrap) */
 static const unsigned char *shim_blob_ptr = NULL;
@@ -521,6 +522,93 @@ static bool sysroot_path_exists(const char *resolved_path, bool follow_final)
  * enforced only when the path actually resolves under sysroot, to prevent
  * symlink escape from a tree the caller intended to stay inside.
  */
+static bool lexical_normalize_absolute_path(char *dest,
+                                            const char *src,
+                                            size_t dest_sz)
+{
+    if (!src || src[0] != '/' || dest_sz == 0)
+        return false;
+    dest[0] = '/';
+    dest[1] = '\0';
+    size_t dest_len = 1;
+
+    const char *scan = src;
+    const char *comp;
+    size_t len;
+    while (path_next_component(&scan, &comp, &len)) {
+        if (len == 1 && comp[0] == '.') {
+            /* Do nothing */
+        } else if (len == 2 && comp[0] == '.' && comp[1] == '.') {
+            /* Pop the last component */
+            if (dest_len > 1) {
+                while (dest_len > 1 && dest[dest_len - 1] == '/')
+                    dest[--dest_len] = '\0';
+                while (dest_len > 1 && dest[dest_len - 1] != '/')
+                    dest[--dest_len] = '\0';
+                if (dest_len > 1 && dest[dest_len - 1] == '/')
+                    dest[--dest_len] = '\0';
+                if (dest_len == 0) {
+                    dest[0] = '/';
+                    dest[1] = '\0';
+                    dest_len = 1;
+                }
+            }
+        } else {
+            /* Push the component */
+            if (dest_len > 1 && dest[dest_len - 1] != '/') {
+                if (dest_len + 1 >= dest_sz)
+                    return false;
+                dest[dest_len++] = '/';
+            }
+            if (dest_len + len >= dest_sz)
+                return false;
+            memcpy(dest + dest_len, comp, len);
+            dest_len += len;
+            dest[dest_len] = '\0';
+        }
+    }
+    if (dest_len == 0) {
+        dest[0] = '/';
+        dest[1] = '\0';
+    } else {
+        while (dest_len > 1 && dest[dest_len - 1] == '/')
+            dest[--dest_len] = '\0';
+    }
+    return true;
+}
+
+static bool is_guest_system_path(const char *path)
+{
+    if (!path || path[0] != '/')
+        return false;
+
+    /* Check prefix patterns (path/...) and exact root matches (path) */
+    static const char *const dirs[] = {
+        "/usr/", "/bin/",  "/sbin/", "/lib/",  "/lib64/",
+        "/opt/", "/boot/", "/srv/",  "/root/", "/home/",
+    };
+    for (size_t i = 0; i < sizeof(dirs) / sizeof(dirs[0]); i++) {
+        size_t n = strlen(dirs[i]);
+        if (strncmp(path, dirs[i], n) == 0)
+            return true;
+        /* Also match the bare directory name (e.g., "/usr") */
+        if (strncmp(path, dirs[i], n - 1) == 0 && path[n - 1] == '\0')
+            return true;
+    }
+    if (strncmp(path, "/var/", 5) == 0 || !strcmp(path, "/var")) {
+        if (strncmp(path, "/var/folders/", 13) == 0 ||
+            !strcmp(path, "/var/folders"))
+            return false;
+        return true;
+    }
+    if (strncmp(path, "/etc/", 5) == 0 || !strcmp(path, "/etc")) {
+        if (!strcmp(path, "/etc/resolv.conf") || !strcmp(path, "/etc/hosts"))
+            return false;
+        return true;
+    }
+    return false;
+}
+
 static const char *proc_resolve_sysroot_path_flags(const char *path,
                                                    char *buf,
                                                    size_t bufsz,
@@ -553,6 +641,16 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
         errno = ENAMETOOLONG;
         return NULL;
     }
+
+    /* Prevent escaping guest system paths to macOS host paths, which leads
+     * to host contamination and permission failures (e.g. SIP/EPERM).
+     */
+    char norm_path[LINUX_PATH_MAX];
+    bool has_norm =
+        lexical_normalize_absolute_path(norm_path, path, sizeof(norm_path));
+    if (is_guest_system_path(has_norm ? norm_path : path))
+        return buf;
+
     return path;
 }
 
@@ -634,9 +732,17 @@ const char *proc_resolve_sysroot_create_path(const char *path,
     /* Parent doesn't exist in sysroot. Only /tmp, /var/tmp, and ccache get
      * forcefully redirected to the sysroot to avoid host case-collisions;
      * everything else falls back to the host literal.
+     * Guest system directories must also be forced to resolve to the sysroot.
      */
-    if (strncmp(path, "/tmp/", 5) && strncmp(path, "/var/tmp/", 9) &&
-        !strstr(path, "/.ccache/"))
+    char norm_path[LINUX_PATH_MAX];
+    bool has_norm =
+        lexical_normalize_absolute_path(norm_path, path, sizeof(norm_path));
+    const char *path_to_check = has_norm ? norm_path : path;
+
+    if (strncmp(path_to_check, "/tmp/", 5) &&
+        strncmp(path_to_check, "/var/tmp/", 9) &&
+        !strstr(path_to_check, "/.ccache/") &&
+        !is_guest_system_path(path_to_check))
         return path;
 
     if (!create_parents) {

--- a/tests/test-sysroot-host-fallback.c
+++ b/tests/test-sysroot-host-fallback.c
@@ -149,6 +149,40 @@ int main(int argc, char **argv)
     else
         PASS();
 
+    TEST("blocked guest system path does not fall back to host");
+    {
+        int fd = open("/usr/bin/env", O_RDONLY);
+        if (fd < 0 && errno == ENOENT)
+            PASS();
+        else {
+            if (fd >= 0)
+                close(fd);
+            FAIL("guest system path fell back to host");
+        }
+    }
+
+    TEST("dot-component guest system path does not fall back to host");
+    {
+        int fd = open("/tmp/../usr/bin/env", O_RDONLY);
+        if (fd < 0 && errno == ENOENT)
+            PASS();
+        else {
+            if (fd >= 0)
+                close(fd);
+            FAIL("dot-component system path fell back to host");
+        }
+    }
+
+    TEST("allowed guest network configuration falls back to host");
+    {
+        int fd = open("/etc/hosts", O_RDONLY);
+        if (fd >= 0) {
+            close(fd);
+            PASS();
+        } else
+            FAIL("allowed network config did not fall back to host");
+    }
+
     SUMMARY("test-sysroot-host-fallback");
     return fails > 0 ? 1 : 0;
 }


### PR DESCRIPTION
When absolute paths do not exist in the guest sysroot, translation falls back to the host literal path. For standard system directories (such as /usr, /bin, /lib, /sbin, /var, /opt, and /etc), this fallback leaks guest actions to the host.

On macOS, system directories are protected by System Integrity Protection (SIP) and root ownership, causing permission failures (EPERM/EACCES) when guest tools attempt writes or backups.

Prevent fallback for system paths. Keep fallback for network configurations like /etc/resolv.conf to support DNS resolution.

Fix #238

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts sysroot fallback so guest paths under system directories never escape to the host, including dot/dot-dot variants. Fixes #238 and avoids SIP permission errors on macOS while keeping DNS working.

- **Bug Fixes**
  - Block fallback for system dirs (/usr, /bin, /sbin, /lib, /lib64, /var, /opt, /boot, /srv, /root, /home) and /etc except /etc/resolv.conf and /etc/hosts; allow macOS /var/folders. Normalize absolute paths to catch cases like "/tmp/../usr".
  - Enforce the system-path check in both resolve and create flows; add tests for blocked /usr and dot-component paths, and allowed /etc/hosts.

<sup>Written for commit b1e4a21c873f5e690855126c779c40a2eb510731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

