### PR TITLE
Add vcpu run loop hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,12 @@ $(BUILD_DIR)/test-fork-ipc-protocol-host: \
 	@echo "  LD      $@"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^
 
+## Build the vCPU run-loop hook API compile test (native macOS binary).
+$(BUILD_DIR)/test-vcpu-run-hooks-host: \
+		$(BUILD_DIR)/test-vcpu-run-hooks-host.o | $(BUILD_DIR)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(CFLAGS) -o $@ $^
+
 ## Build the identity override host test (native macOS binary)
 $(BUILD_DIR)/test-identity-override-host: \
 		$(BUILD_DIR)/test-identity-override-host.o \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -12,7 +12,8 @@
         test-full test-multi-vcpu test-rwx test-sysroot-rename \
         test-case-collision test-case-collision-fallback test-getdents64-overlong \
         test-sysroot-host-fallback test-sysroot-case-exact \
-        test-sysroot-create-paths test-fork-ipc-protocol-host test-identity-override-host \
+        test-sysroot-create-paths test-fork-ipc-protocol-host \
+        test-vcpu-run-hooks-host test-identity-override-host \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-timeout-disable test-fuse-alpine \
         test-sysroot-nofollow test-sysroot-chdir test-sysroot-symlink-escape \
@@ -77,12 +78,15 @@ SANITIZER_SECTIONS := Threading|Stress|Signal.*thread|Fork edge|CoW fork|Guard p
 check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) \
 		$(BUILD_DIR)/test-tlbi-encoder-host \
 		$(BUILD_DIR)/test-fork-ipc-protocol-host \
+		$(BUILD_DIR)/test-vcpu-run-hooks-host \
 		$(BUILD_DIR)/test-identity-override-host
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v -s '$(SANITIZER_SECTIONS)'
 	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-tlbi-encoder-host
 	@printf "\n$(BLUE)━━━ fork IPC protocol identity unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-fork-ipc-protocol-host
+	@printf "\n$(BLUE)━━━ vCPU run-loop hook API unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-vcpu-run-hooks-host
 	@printf "\n$(BLUE)━━━ identity override unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-identity-override-host
 
@@ -90,12 +94,15 @@ check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) \
 check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 		$(BUILD_DIR)/test-tlbi-encoder-host \
 		$(BUILD_DIR)/test-fork-ipc-protocol-host \
+		$(BUILD_DIR)/test-vcpu-run-hooks-host \
 		$(BUILD_DIR)/test-identity-override-host
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
 	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-tlbi-encoder-host
 	@printf "\n$(BLUE)━━━ fork IPC protocol identity unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-fork-ipc-protocol-host
+	@printf "\n$(BLUE)━━━ vCPU run-loop hook API unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-vcpu-run-hooks-host
 	@printf "\n$(BLUE)━━━ identity override unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-identity-override-host
 	@printf "\n$(BLUE)━━━ shebang parser unit test ━━━$(RESET)\n"
@@ -751,6 +758,11 @@ test-rwx: $(BUILD_DIR)/test-rwx
 ## Run the fork IPC protocol identity unit test
 test-fork-ipc-protocol-host: $(BUILD_DIR)/test-fork-ipc-protocol-host
 	$(BUILD_DIR)/test-fork-ipc-protocol-host
+
+# vCPU run-loop hook API regression
+## Run the vCPU run-loop hook API unit test
+test-vcpu-run-hooks-host: $(BUILD_DIR)/test-vcpu-run-hooks-host
+	$(BUILD_DIR)/test-vcpu-run-hooks-host
 
 # Proctitle argv-tail regression
 ## Run the deterministic argv-tail overshoot guard test

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -2962,12 +2962,13 @@ static const hv_sys_reg_t hvc4_sysregs[] = {
  * Both modes check proc_exit_group_requested so the main thread also reacts to
  * exit_group called by a worker.
  */
-int vcpu_run_loop(hv_vcpu_t vcpu,
-                  hv_vcpu_exit_t *vexit,
-                  guest_t *g,
-                  bool verbose,
-                  int timeout_sec,
-                  int *wait_status_out)
+int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
+                             hv_vcpu_exit_t *vexit,
+                             guest_t *g,
+                             bool verbose,
+                             int timeout_sec,
+                             int *wait_status_out,
+                             const vcpu_run_hooks_t *hooks)
 {
     int exit_code = 0;
     (void) signal_take_termination_wait_status();
@@ -2997,6 +2998,17 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
         if (proc_exit_group_requested()) {
             exit_code = proc_exit_group_code();
             break;
+        }
+        if (hooks && hooks->tick) {
+            int tick_ret = hooks->tick(g, hooks->opaque);
+            if (tick_ret != 0) {
+                exit_code = tick_ret;
+                break;
+            }
+            if (proc_exit_group_requested()) {
+                exit_code = proc_exit_group_code();
+                break;
+            }
         }
 
         if (verbose) {
@@ -4117,4 +4129,15 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
             signal_status != 0 ? signal_status : (exit_code & 0xff) << 8;
     }
     return exit_code;
+}
+
+int vcpu_run_loop(hv_vcpu_t vcpu,
+                  hv_vcpu_exit_t *vexit,
+                  guest_t *g,
+                  bool verbose,
+                  int timeout_sec,
+                  int *wait_status_out)
+{
+    return vcpu_run_loop_with_hooks(vcpu, vexit, g, verbose, timeout_sec,
+                                    wait_status_out, NULL);
 }

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -498,6 +498,34 @@ int proc_exit_group_requested(void);
  */
 void proc_request_hvc6_yield(void);
 
+/* Optional embedder hook. Called on the vCPU owner thread at host boundaries
+ * (before each hv_vcpu_run() entry or re-entry).
+ *
+ * Stop semantics:
+ * Return nonzero to stop the loop. A nonzero tick return is propagated
+ * and returned as the run loop's exit code.
+ *
+ * Cooperative-only timing:
+ * The tick is only checked at host boundaries, not during guest execution.
+ * A guest spinning entirely in EL0 without VM-exiting will never trigger
+ * the tick, meaning a tick-initiated hook cannot interrupt a runaway guest.
+ * To force interruption of a runaway guest, use hv_vcpus_exit().
+ *
+ * Concurrency and lifetime:
+ * When a single vcpu_run_hooks_t and its opaque data are shared across
+ * multiple vCPUs, the tick function will be invoked concurrently from
+ * multiple host threads and must be thread-safe. The run loop does not keep
+ * a copy of the hooks structure and dereferences it every iteration; the
+ * caller must ensure the hooks structure and opaque lifetime extend until
+ * all run loops return.
+ */
+typedef int (*vcpu_run_loop_tick_fn)(guest_t *g, void *opaque);
+
+typedef struct vcpu_run_hooks {
+    vcpu_run_loop_tick_fn tick;
+    void *opaque;
+} vcpu_run_hooks_t;
+
 /* Run the vCPU execution loop.
  *
  * Returns the exit code.
@@ -513,3 +541,10 @@ int vcpu_run_loop(hv_vcpu_t vcpu,
                   bool verbose,
                   int timeout_sec,
                   int *wait_status_out);
+int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
+                             hv_vcpu_exit_t *vexit,
+                             guest_t *g,
+                             bool verbose,
+                             int timeout_sec,
+                             int *wait_status_out,
+                             const vcpu_run_hooks_t *hooks);

--- a/tests/test-vcpu-run-hooks-host.c
+++ b/tests/test-vcpu-run-hooks-host.c
@@ -1,0 +1,62 @@
+/*
+ * Native-host compile test for vcpu_run_loop hook API compatibility.
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "syscall/proc.h"
+
+typedef int vcpu_run_loop_sig(hv_vcpu_t vcpu,
+                              hv_vcpu_exit_t *vexit,
+                              guest_t *g,
+                              bool verbose,
+                              int timeout_sec,
+                              int *wait_status_out);
+
+typedef int vcpu_run_loop_with_hooks_sig(hv_vcpu_t vcpu,
+                                         hv_vcpu_exit_t *vexit,
+                                         guest_t *g,
+                                         bool verbose,
+                                         int timeout_sec,
+                                         int *wait_status_out,
+                                         const vcpu_run_hooks_t *hooks);
+
+_Static_assert(__builtin_types_compatible_p(__typeof__(vcpu_run_loop),
+                                            vcpu_run_loop_sig),
+               "vcpu_run_loop compatibility signature changed");
+_Static_assert(
+    __builtin_types_compatible_p(__typeof__(vcpu_run_loop_with_hooks),
+                                 vcpu_run_loop_with_hooks_sig),
+    "vcpu_run_loop_with_hooks signature changed");
+
+static int tick(guest_t *g, void *opaque)
+{
+    return g != NULL && opaque != NULL;
+}
+
+int main(void)
+{
+    vcpu_run_hooks_t hooks = {
+        .tick = tick,
+        .opaque = (void *) 0x1,
+    };
+
+    if (hooks.tick == NULL || hooks.opaque == NULL) {
+        fprintf(stderr, "test-vcpu-run-hooks-host: API wiring failed\n");
+        return 1;
+    }
+
+    /* Verify tick actually functions with non-NULL and NULL parameters */
+    assert(hooks.tick((guest_t *) 0x1234, hooks.opaque) == 1);
+    assert(hooks.tick(NULL, hooks.opaque) == 0);
+    assert(hooks.tick((guest_t *) 0x1234, NULL) == 0);
+    assert(hooks.tick(NULL, NULL) == 0);
+
+    printf("test-vcpu-run-hooks-host: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
Add an optional hook API for embedders that need to run host-side work before re-entering hv_vcpu_run on the vCPU owner thread.

Keep the existing vcpu_run_loop signature as a compatibility wrapper around the extended entry point with no hooks installed.

Add a host-side compile test that pins the public signatures and verifies the hook structure can be initialized. Run it from the normal host test paths used by check and check-sanitizer.

Fix #244

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `vcpu_run_loop_with_hooks` to let embedders run host work before each `hv_vcpu_run` re-entry. Keep `vcpu_run_loop` as a wrapper and add a host compile test.

- **New Features**
  - New `vcpu_run_loop_with_hooks(..., const vcpu_run_hooks_t *hooks)` and `vcpu_run_hooks_t` with an optional `tick`.
  - `tick` runs on the vCPU owner thread before `hv_vcpu_run()`, checked only at host boundaries; nonzero return stops the loop.
  - `vcpu_run_loop` remains as a no-hook wrapper for API compatibility.
  - Added host compile test `test-vcpu-run-hooks-host`; wired into `check`, `check-sanitizer`, and `make test-vcpu-run-hooks-host`.

<sup>Written for commit e19686a88fd1677c8dfc6dd0b7cb11754b4f1dbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

