### PR TITLE
Declare tlb-rmi for TLBI RVAE1IS in the EL1 shim

### DIFF
--- a/src/core/shim.S
+++ b/src/core/shim.S
@@ -63,6 +63,13 @@
  * save and restore ALL 31 GPRs.
  */
 
+/* RVAE1IS is part of FEAT_TLBIRANGE (the tlb-rmi architectural extension).
+ * Apple as defaults to the host CPU's baseline feature set and otherwise
+ * rejects this mnemonic even though the shim executes only on Apple Silicon
+ * CPUs that provide the instruction.  Declare the extension locally so the
+ * assembler accepts the architectural instruction encoding. */
+.arch_extension tlb-rmi
+
 .text
 
 /* SAVE_GPRS: push all 31 GPRs onto a 256-byte EL1 stack frame.


### PR DESCRIPTION
## Summary

Apple's assembler rejects the two `TLBI RVAE1IS` instructions in `src/core/shim.S` when the shim is assembled with the default flags:

```text
error: TLBI RVAE1IS requires tlb-rmi
```

This change declares the required architectural extension directly in the assembly source:

```asm
.arch_extension tlb-rmi
```

`RVAE1IS` is part of `FEAT_TLBIRANGE`. The source-level declaration keeps the build independent of whether a particular version of `as` enables the extension by default for `-arch arm64`.

A build-time alternative is:

```sh
make SHIM_ASFLAGS="-arch arm64 -march=armv8.4-a" elfuse
```

## Validation

- `make -B V=1 build/shim.o`
- `clang -target arm64-apple-macos11 -c src/core/shim.S -o /tmp/elfuse-shim-clang.o`

Related to #248.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare the `tlb-rmi` architectural extension in `src/core/shim.S` so Apple’s assembler accepts `TLBI RVAE1IS`, making the EL1 shim build reliably across toolchains. Removes reliance on toolchain defaults or passing `-march=armv8.4-a`.

<sup>Written for commit 0c4908f8ed02db1179a306fc2500f85855e3d6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

