### PR TITLE
Fix host panic from cross-thread hv_vcpu_destroy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,17 @@ $(BUILD_DIR)/test-shebang-host: $(BUILD_DIR)/test-shebang-host.o \
 	@echo "  LD      $@"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^
 
+## Build the teardown live-worker accounting host unit test (native macOS binary)
+# Links the in-tree thread.o so the real thread_destroy_all_vcpus logic runs.
+# It drives only the worker branches (main vCPU passed as not-valid), so no
+# hv_vcpu_destroy is ever called and no HVF entitlement is needed; the framework
+# is linked only to resolve thread.o's hv_* references.
+$(BUILD_DIR)/test-teardown-live-vcpu-host: \
+		$(BUILD_DIR)/test-teardown-live-vcpu-host.o \
+		$(BUILD_DIR)/runtime/thread.o | $(BUILD_DIR)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(CFLAGS) -o $@ $^ $(HVF_LDFLAGS)
+
 
 # Guest test binaries (cross-compiled, aarch64-linux)
 # Only used when GUEST_TEST_BINARIES is not set.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -79,7 +79,8 @@ check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) \
 		$(BUILD_DIR)/test-tlbi-encoder-host \
 		$(BUILD_DIR)/test-fork-ipc-protocol-host \
 		$(BUILD_DIR)/test-vcpu-run-hooks-host \
-		$(BUILD_DIR)/test-identity-override-host
+		$(BUILD_DIR)/test-identity-override-host \
+		$(BUILD_DIR)/test-teardown-live-vcpu-host
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v -s '$(SANITIZER_SECTIONS)'
 	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-tlbi-encoder-host
@@ -89,13 +90,16 @@ check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) \
 	@$(BUILD_DIR)/test-vcpu-run-hooks-host
 	@printf "\n$(BLUE)━━━ identity override unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-identity-override-host
+	@printf "\n$(BLUE)━━━ teardown live-worker accounting unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-teardown-live-vcpu-host
 
 ## Run the unit test suite plus busybox applet validation
 check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 		$(BUILD_DIR)/test-tlbi-encoder-host \
 		$(BUILD_DIR)/test-fork-ipc-protocol-host \
 		$(BUILD_DIR)/test-vcpu-run-hooks-host \
-		$(BUILD_DIR)/test-identity-override-host
+		$(BUILD_DIR)/test-identity-override-host \
+		$(BUILD_DIR)/test-teardown-live-vcpu-host
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
 	@printf "\n$(BLUE)━━━ TLBI RVAE1IS encoder unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-tlbi-encoder-host
@@ -105,6 +109,8 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 	@$(BUILD_DIR)/test-vcpu-run-hooks-host
 	@printf "\n$(BLUE)━━━ identity override unit test ━━━$(RESET)\n"
 	@$(BUILD_DIR)/test-identity-override-host
+	@printf "\n$(BLUE)━━━ teardown live-worker accounting unit test ━━━$(RESET)\n"
+	@$(BUILD_DIR)/test-teardown-live-vcpu-host
 	@printf "\n$(BLUE)━━━ shebang parser unit test ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-shebang-host
 	@printf "\n$(BLUE)━━━ proctitle argv-tail regression ━━━$(RESET)\n"

--- a/src/core/guest.c
+++ b/src/core/guest.c
@@ -218,9 +218,9 @@ static uint64_t *pt_at(const guest_t *g, uint64_t gpa)
  * gva_translate_perm() walks L0->L3 lock-free on every guest-pointer
  * translation, from every vCPU thread, while the runtime mutators
  * (guest_update_perms, guest_invalidate_ptes, split_l2_block, ...) rewrite
- * descriptors under the caller's mmap lock. The lock serializes mutator
- * against mutator only -- it provides no happens-before edge to the lock-free
- * walker, so the descriptor accesses themselves must carry the ordering:
+ * descriptors under the caller's mmap lock. The lock serializes mutator against
+ * mutator only -- it provides no happens-before edge to the lock-free walker,
+ * so the descriptor accesses themselves must carry the ordering:
  *
  *   - pte_store_release publishes a descriptor so that everything written
  *     before it -- most critically the 512 L3 fills of split_l2_block and the
@@ -233,14 +233,14 @@ static uint64_t *pt_at(const guest_t *g, uint64_t gpa)
  *     from that one value, never re-read per field, so a concurrent rewrite
  *     cannot make the walker mix two generations of the same entry.
  *
- * Table pages come from a bump allocator (pt_alloc_page) that is only reset
- * on execve while all vCPU threads are quiesced, so a not-yet-published table
- * can never be reached through a stale pointer; filling it with plain stores
- * before the release-flip is sound. Boot-time construction also keeps plain
- * stores -- guest_build_page_tables, guest_init_kbuf, and the rosetta kbuf
- * user-alias install (guest_install_kbuf_user_alias /
- * populate_kbuf_l2_blocks) all run single-threaded before any vCPU thread
- * exists, and pthread_create provides the happens-before edge.
+ * Table pages come from a bump allocator (pt_alloc_page) that is only reset on
+ * execve while all vCPU threads are quiesced, so a not-yet-published table can
+ * never be reached through a stale pointer; filling it with plain stores before
+ * the release-flip is sound. Boot-time construction also keeps plain stores --
+ * guest_build_page_tables, guest_init_kbuf, and the rosetta kbuf user-alias
+ * install (guest_install_kbuf_user_alias / populate_kbuf_l2_blocks) all run
+ * single-threaded before any vCPU thread exists, and pthread_create provides
+ * the happens-before edge.
  */
 static inline uint64_t pte_load_acquire(const uint64_t *entry)
 {
@@ -385,6 +385,7 @@ int guest_init(guest_t *g, uint64_t size, uint32_t ipa_bits)
             continue;
 
         uint64_t try_size = 1ULL << bits;
+
         /* Respect a caller-supplied size cap (size > 0 means "no larger than
          * this"). Skip slab attempts that exceed the cap.
          */
@@ -655,8 +656,8 @@ void guest_destroy(guest_t *g)
      * off the shared pipe, and thread_wake_exit_waiters broadcasts the internal
      * condvars (fork barrier, ptrace stop/wait). Without them, host-blocked
      * workers miss the hv_vcpus_exit kick (which only affects threads inside
-     * hv_vcpu_run) and the 100ms join cap in thread_join_workers detaches
-     * them, leaving live pthreads to crash on the imminent munmap.
+     * hv_vcpu_run) and the 100ms join cap in thread_join_workers detaches them,
+     * leaving live pthreads to crash on the imminent munmap.
      */
     if (!proc_exit_group_requested())
         proc_request_exit_group(0);
@@ -665,15 +666,43 @@ void guest_destroy(guest_t *g)
     thread_interrupt_all();
     thread_wake_exit_waiters();
     thread_join_workers();
-    /* Destroy all remaining worker vCPUs (thread table) before tearing down the
-     * VM. This prevents hv_vm_destroy from racing with active vCPUs that may
-     * still be running if thread join timed out during exit_group.
+
+    /* Destroy the main vCPU (owned by this thread) before tearing down the VM.
+     * Worker vCPUs are never destroyed cross-thread here; if thread join timed
+     * out and one is still live, thread_destroy_all_vcpus reports it via
+     * live_workers so teardown is deferred to process exit.
      */
-    bool main_vcpu_destroyed = thread_destroy_all_vcpus(g->vcpu, g->vcpu_valid);
+    bool live_workers = false;
+    bool main_vcpu_destroyed =
+        thread_destroy_all_vcpus(g->vcpu, g->vcpu_valid, &live_workers);
+    if (live_workers) {
+        /* A worker did not stop within the join cap and is still live on its
+         * own thread. HVF vCPUs are thread-affine, so neither a cross-thread
+         * hv_vcpu_destroy nor hv_vm_destroy / munmap of the slab may run while
+         * that worker holds a live vCPU without corrupting kernel state and
+         * panicking the host. guest_destroy is always terminal -- main() and
+         * the fork-child return straight into process exit after it -- so leave
+         * the VM, its vCPUs, and the slab in place and let process teardown
+         * reclaim them atomically, the one operation that safely stops a
+         * foreign vCPU. The leaked fds and heap are reclaimed the same way.
+         */
+        log_warn(
+            "guest_destroy: worker vCPU still live past join cap; "
+            "deferring HVF teardown to process exit");
+
+        /* thread_destroy_all_vcpus already destroyed the main vCPU (owned by
+         * this thread); clear the handle so no stale g->vcpu_valid survives the
+         * early return even though the rest of teardown is deferred.
+         */
+        g->vcpu_valid = false;
+        g->vcpu = 0;
+        return;
+    }
     if (g->vcpu_valid && !main_vcpu_destroyed)
         hv_vcpu_destroy(g->vcpu);
     g->vcpu_valid = false;
     g->vcpu = 0;
+
     /* Unmap each HVF segment. hv_vm_destroy releases all stage-2 state
      * regardless, but unmapping explicitly keeps invariants clean for
      * downstream tools (Instruments, leak detectors).
@@ -728,6 +757,7 @@ static bool guest_mapping_overlaps(const guest_t *g, uint64_t gpa, size_t size)
         if (gpa < m->gpa + m->size && m->gpa < end)
             return true;
     }
+
     /* Overflow segments occupy IPA ranges stacked above guest_size on a
      * first-come basis. An explicit mapping added later must not silently land
      * on top of an already-allocated overflow segment; HVF would accept the
@@ -752,6 +782,7 @@ int guest_add_mapping(guest_t *g,
         return -1;
     if ((gpa & (PAGE_SIZE - 1)) || (size & (PAGE_SIZE - 1)))
         return -1;
+
     /* If the caller supplied a host VA, it must be page-aligned. NULL means
      * callee-allocate-and-own; non-NULL means caller-owned, mapped as-is into
      * Stage-2 without taking ownership.
@@ -913,6 +944,7 @@ uint64_t guest_overflow_alloc(guest_t *g)
                   (unsigned long long) seg_ipa);
         return UINT64_MAX;
     }
+
     /* Skip past every extra mapping that overlaps the candidate placement. Each
      * skip moves seg_ipa forward, so the scan must restart to catch any mapping
      * the new position now overlaps. The loop is bounded by n_mappings -- each
@@ -989,6 +1021,7 @@ int guest_init_kbuf(guest_t *g, uint64_t kbuf_gpa)
 {
     if (!g)
         return -1;
+
     /* Scrub kbuf state up-front so partial failure leaves the guest in a
      * fully-zeroed state rather than a stale half-initialized one. The caller
      * must treat a -1 return as "kbuf is unconfigured" and must not read
@@ -1033,6 +1066,7 @@ int guest_init_kbuf(guest_t *g, uint64_t kbuf_gpa)
         /* Up-front scrub already cleared kbuf_base / kbuf_gpa / ttbr1. */
         return -1;
     }
+
     /* From this point the kbuf is real; publish the host pointer + GPA so
      * subsequent code can look them up. ttbr1 is published last, after the
      * L0/L1/L2 tree is fully populated below.
@@ -1263,8 +1297,8 @@ static int gva_translate_perm(const guest_t *g,
     uint64_t base = g->ipa_base;
 
     /* Lock-free walk: load each level's descriptor exactly once with acquire
-     * (see pte_load_acquire) and decode that snapshot. Concurrent mutators
-     * hold the mmap lock against each other but not against this walker.
+     * (see pte_load_acquire) and decode that snapshot. Concurrent mutators hold
+     * the mmap lock against each other but not against this walker.
      */
     const uint64_t *l0 = pt_at(g, g->ttbr0 - base);
     unsigned l0_idx = (unsigned) (gva / (512ULL * BLOCK_1GIB));
@@ -1304,6 +1338,7 @@ static int gva_translate_perm(const guest_t *g,
             return -1;
 
         int perms = desc_to_perms(l3e);
+
         /* EL1-only pages (shim_data) are inaccessible to guest EL0 in the page
          * tables; the host accessors that act on a guest-supplied GVA must
          * refuse them too, otherwise a guest could pass a shim_data GVA as a
@@ -1320,6 +1355,7 @@ static int gva_translate_perm(const guest_t *g,
         if (page_ipa < base)
             return -1;
         uint64_t gpa = (page_ipa - base) + (gva & (PAGE_SIZE - 1));
+
         /* Accept GPAs inside the primary buffer or covered by an extra IPA
          * mapping (rosetta segments, kbuf, etc.). Anything else is a dangling
          * page-table entry pointing at unmapped Stage-2 IPA.
@@ -1343,6 +1379,7 @@ static int gva_translate_perm(const guest_t *g,
 
     /* L2 block descriptor: 2MiB granularity. */
     int perms = desc_to_perms(l2e);
+
     /* See the L3 page-descriptor branch above: EL1-only blocks are inaccessible
      * to host-on-behalf-of-guest accesses for the same reason. shim_data is
      * mapped as a 2MiB EL1-only block at boot.
@@ -1388,6 +1425,7 @@ static uint64_t gva_contiguous_avail(const guest_t *g,
 
     for (;;) {
         uint64_t chunk = cur.chunk;
+
         /* Clamp to the remaining bytes in whichever backing region cur.gpa
          * lives in: the primary buffer, or an extra IPA mapping. The original
          * primary-buffer clamp underflowed harmlessly for high GPAs, but the
@@ -2401,6 +2439,7 @@ static uint64_t make_block_desc(uint64_t gpa, int perms)
      */
     if (perms & MEM_PERM_EL1_ONLY) {
         desc |= PT_AP_RW_EL1;
+
         /* EL1-only data: never EL0-executable (already set above if MEM_PERM_X
          * is unset, but assert defensively).
          */
@@ -2532,6 +2571,7 @@ static bool finalize_block_perms(guest_t *g, const mem_region_t *regions, int n)
                 uint64_t apply_start = (s_start > b) ? s_start : b;
                 uint64_t apply_end =
                     (s_end < b + BLOCK_2MIB) ? s_end : b + BLOCK_2MIB;
+
                 /* Page-align to 4KiB so partially covered pages are recreated
                  * with the union of all overlapping segment permissions.
                  */
@@ -2588,6 +2628,7 @@ uint64_t guest_build_page_tables(guest_t *g, const mem_region_t *regions, int n)
         uint64_t gpa_start = ALIGN_2MIB_DOWN(regions[r].gpa_start);
         uint64_t gpa_end = ALIGN_2MIB_UP(regions[r].gpa_end);
         int perms = regions[r].perms;
+
         /* Non-identity regions (rosetta segments) supply a va_base so the
          * page-table entry is indexed by VA, but the block descriptor still
          * carries the GPA where the data physically lives. va_offset is the
@@ -2713,6 +2754,7 @@ int guest_extend_page_tables(guest_t *g,
             (unsigned long long) start, (unsigned long long) end);
         return -1;
     }
+
     /* Defensive: end is bounded by guest_size above, so the ALIGN_2MIB_UP below
      * cannot wrap on any reachable input. The explicit guard documents the
      * contract and matches the wrap guards in guest_invalidate_ptes /
@@ -2980,8 +3022,8 @@ static int split_l2_block(guest_t *g, uint64_t *l2_entry)
      * permissions. Extract the output IPA from bits [47:21] of the existing
      * descriptor (not from the caller's address). Plain stores are fine here:
      * the table is unreachable until the release-flip below publishes it, and
-     * the release orders the fills before the new L2 value for any walker
-     * that acquires it (see pte_store_release).
+     * the release orders the fills before the new L2 value for any walker that
+     * acquires it (see pte_store_release).
      */
     uint64_t block_ipa = *l2_entry & L2_BLOCK_ADDR_MASK;
     for (int i = 0; i < 512; i++)
@@ -3201,6 +3243,7 @@ int guest_update_perms(guest_t *g, uint64_t start, uint64_t end, int perms)
         for (uint64_t pa = page_start; pa < page_end; pa += PAGE_SIZE) {
             unsigned l3_idx =
                 (unsigned) (((base + pa) % BLOCK_2MIB) / PAGE_SIZE);
+
             /* Extract the existing output IPA from the L3 entry. For
              * non-identity mapped regions, pa is a VA not a GPA, so the builder
              * must use the IPA already stored in the descriptor (set by
@@ -3254,6 +3297,7 @@ int guest_install_va_pages(guest_t *g,
         return -1;
     if ((va | length | gpa) & (PAGE_SIZE - 1))
         return -1;
+
     /* Reject wrap on both the VA side and the GPA side. Without the gpa guard,
      * a caller could pass a near-UINT64_MAX gpa with a non-zero length and the
      * loop would wrap p back to a low GPA, silently installing descriptors

--- a/src/core/guest.h
+++ b/src/core/guest.h
@@ -149,6 +149,7 @@
 #define MEM_PERM_R (1 << 0)
 #define MEM_PERM_W (1 << 1)
 #define MEM_PERM_X (1 << 2)
+
 /* AP[2:1]=00: privileged-only (no EL0 read/write). Combine with MEM_PERM_R/W.
  * Used for shim_data so the guest cannot directly read or store to the identity
  * cache, urandom bitmap, ring, or attention flag. The EL1 shim still has full
@@ -276,7 +277,8 @@ typedef enum {
     TLBI_RANGE_LARGE = 3, /* FEAT_TLBIRANGE single-shot TLBI RVAE1IS for
                            * ranges that exceed TLBI_SELECTIVE_MAX_PAGES but
                            * stay within TLBI_RVAE_MAX_PAGES; encoded as
-                           * X8 = 4 on the wire. */
+                           * X8 = 4 on the wire.
+                           */
 } tlbi_kind_t;
 
 /* Cap selective per-page TLBI VAE1IS at this many 4 KiB pages. Beyond this, use
@@ -345,10 +347,12 @@ typedef struct {
     uint8_t icache_flush; /* 1 = the change introduced executable content
                            *     visible to EL0, so the shim must IC IALLU
                            *     after the TLBI sequence. 0 = data-only
-                           *     change, skip the I-cache invalidation. */
+                           *     change, skip the I-cache invalidation.
+                           */
     uint16_t pages;       /* Page count when kind == TLBI_RANGE (1..MAX) */
     uint64_t start;       /* Page-aligned VA when kind == TLBI_RANGE */
 } tlbi_request_t;
+
 /* Layout contract: 16 bytes (1+1+2+4 padding+8). Documents the padding and pins
  * the TLS slot size so future field additions surface as a build break rather
  * than silently growing the per-vCPU footprint.
@@ -675,6 +679,7 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
         return;
     if (end <= start)
         return;
+
     /* Page-align: TLBI VAE1IS operates on 4 KiB granules. ALIGN_UP can overflow
      * if end is within PAGE_SIZE-1 of UINT64_MAX; saturate to broadcast in that
      * pathological case rather than wrap to 0.
@@ -687,6 +692,7 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
     uint64_t s = start & ~mask;
     uint64_t e = (end + mask) & ~mask;
     uint64_t n = (e - s) >> 12;
+
     /* Two thresholds. (a) <= TLBI_SELECTIVE_MAX_PAGES uses the per-page VAE1IS
      * loop, which preserves the most TLB entries. (b) <= TLBI_RVAE_MAX_PAGES
      * uses a single TLBI RVAE1IS via FEAT_TLBIRANGE, which still preserves
@@ -707,12 +713,14 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
         cpu_tlbi_req.pages = (uint16_t) n;
         return;
     }
+
     /* Coalesce by union. Disjoint ranges still produce a single bounding
      * interval; if it stays within the active cap, the range TLBI still wins
      * over a full flush by preserving unrelated TLB entries.
      */
     uint64_t es = cpu_tlbi_req.start;
     uint64_t pe = (uint64_t) cpu_tlbi_req.pages * 4096ULL;
+
     /* The accumulator only ever holds page counts <= large_cap (enforced by the
      * cap check above), so es + pe never overflows on real callers, but be
      * explicit.
@@ -731,6 +739,7 @@ static inline void tlbi_request_range(uint64_t start, uint64_t end)
     }
     cpu_tlbi_req.start = us;
     cpu_tlbi_req.pages = (uint16_t) un;
+
     /* Promote kind if the coalesced range now exceeds the per-page cap. The
      * inverse direction (LARGE -> RANGE) is impossible because un >= pe / 4096
      * after coalescing.
@@ -799,7 +808,15 @@ int guest_init_from_shm(guest_t *g,
                         uint32_t ipa_bits,
                         bool retain_shared);
 
-/* Tear down VM and free guest memory. */
+/* Tear down VM and free guest memory. Must be terminal: the caller has to
+ * proceed straight to process exit afterwards. If a worker vCPU is still live
+ * past the join cap, HVF teardown cannot run safely, so guest_destroy leaks the
+ * VM and slab for process exit to reclaim -- and macOS allows only one VM per
+ * process, so a non-terminal caller would both leak and fail to bring up a
+ * second VM. All current callers (main() cleanup, the fork-child run loop)
+ * satisfy this. Remaining host-side cleanup (mounts, heap) is still safe to run
+ * after a deferred teardown: it never touches HVF or guest memory.
+ */
 void guest_destroy(guest_t *g);
 
 /* Install a Stage-2 mapping for a high IPA range that the primary buffer does
@@ -1157,6 +1174,7 @@ int guest_region_add_ex_gpa(guest_t *g,
                             uint64_t offset,
                             const char *name,
                             int backing_fd);
+
 /* Like guest_region_add_ex, but consumes owned_backing_fd on success or
  * failure.
  */

--- a/src/main.c
+++ b/src/main.c
@@ -117,6 +117,13 @@ static void cleanup_main_resources(guest_t *g,
                                    char *elf_path,
                                    char *sysroot_path)
 {
+    /* guest_destroy may defer HVF teardown to process exit when a worker vCPU
+     * is still live, but the remaining cleanup below touches only host state
+     * (mounts, cwd, heap) -- never HVF or guest memory -- so it is safe to run
+     * regardless and must run so a deferred teardown does not orphan the
+     * sysroot mount or the FUSE-materialized temp ELF, which process exit will
+     * not reclaim.
+     */
     if (guest_initialized)
         guest_destroy(g);
     rosettad_clear_binary_path();
@@ -160,10 +167,10 @@ _Static_assert((INFRA_PT_POOL_OFF & 0xFFF) == 0 &&
 
 /* Host descriptors used outside the guest FD table. Blocking I/O may hold two
  * duplicated descriptors per guest thread (for example, copy_file_range()),
- * requiring up to 2 * MAX_THREADS descriptors. Keep another 128 descriptors
- * for runtime pipes, fork IPC, debugger sockets, sysroot/FUSE plumbing, and
- * similar bounded overhead. Operations whose descriptor use grows with their
- * input set, such as ppoll(), require separate accounting.
+ * requiring up to 2 * MAX_THREADS descriptors. Keep another 128 descriptors for
+ * runtime pipes, fork IPC, debugger sockets, sysroot/FUSE plumbing, and similar
+ * bounded overhead. Operations whose descriptor use grows with their input set,
+ * such as ppoll(), require separate accounting.
  */
 #define HOST_FD_RESERVE 256
 
@@ -234,12 +241,14 @@ static int host_dc_zva_assert(void)
 int main(int argc, char **argv)
 {
     log_init();
+
     /* Resolve ELFUSE_STARTUP_TRACE before any guest syscall can fire so the
      * histogram captures the very first dynamic-linker openat.
      */
     syscall_hist_init();
 
     bool verbose = false;
+
     /* x86_64-via-Rosetta is on by default; --no-rosetta or ELFUSE_NO_ROSETTA=1
      * disables it. Architecture is auto-detected from the ELF header in
      * guest_bootstrap_prepare; the access() probe in rosetta_prepare surfaces
@@ -408,8 +417,8 @@ int main(int argc, char **argv)
     }
     proc_set_fakeroot_enabled(fakeroot);
 
-    /* Top-level processes establish the capacity; fork helpers normally
-     * inherit it, but recheck before receiving the parent's FD table. Guest
+    /* Top-level processes establish the capacity; fork helpers normally inherit
+     * it, but recheck before receiving the parent's FD table. Guest
      * RLIMIT_NOFILE state is virtualized separately and cannot lower this
      * internal host reserve.
      */
@@ -660,24 +669,25 @@ int main(int argc, char **argv)
 
     /* Tear down debugger state before joining workers: a worker parked in
      * gdb_stub_handle_stop() stays active (not deactivated) until this
-     * broadcasts resume_cond, so joining first would just time out and
-     * detach it while it is still paused. */
+     * broadcasts resume_cond, so joining first would just time out and detach
+     * it while it is still paused.
+     */
     gdb_stub_shutdown();
 
     /* Wait for worker vCPU threads to stop before tearing down guest memory.
-     * The main thread leaves the run loop as soon as it observes the
-     * exit_group flag, but sibling vCPU threads may still be mid-iteration in
-     * their own run loops (e.g. touching shim_globals). cleanup_main_resources
-     * unmaps the guest slab via guest_destroy, so a still-running worker would
-     * fault on freed guest memory and crash the host with SIGSEGV, masking the
-     * real exit code. thread_join_workers() is a no-op once the workers have
-     * already wound down (the common single-threaded case).
+     * The main thread leaves the run loop as soon as it observes the exit_group
+     * flag, but sibling vCPU threads may still be mid-iteration in their own
+     * run loops (e.g. touching shim_globals). cleanup_main_resources unmaps the
+     * guest slab via guest_destroy, so a still-running worker would fault on
+     * freed guest memory and crash the host with SIGSEGV, masking the real exit
+     * code. thread_join_workers() is a no-op once the workers have already
+     * wound down (the common single-threaded case).
      *
      * vcpu_run_loop can also return here without anyone having requested
      * exit_group or kicked the siblings out of hv_vcpu_run: the alarm timeout
      * (exit_code 124), a fatal default-disposition signal, or ELR_EL1==0 all
-     * bail out with a bare break. On those paths siblings are still spinning
-     * in the guest, so mirror guest_destroy's request-interrupt prefix before
+     * bail out with a bare break. On those paths siblings are still spinning in
+     * the guest, so mirror guest_destroy's request-interrupt prefix before
      * joining -- otherwise this call burns its full poll cap, detaches every
      * worker, and guest_destroy's own request-interrupt-join (which honors
      * join_abandoned) skips them, leaving live pthreads to fault on the
@@ -688,8 +698,9 @@ int main(int argc, char **argv)
     futex_interrupt_request();
     wakeup_pipe_signal();
     thread_interrupt_all();
-    /* Workers parked on internal condvars (fork barrier, ptrace stop/wait)
-     * see neither the pipe nor the vCPU kick; broadcast so they re-check the
+
+    /* Workers parked on internal condvars (fork barrier, ptrace stop/wait) see
+     * neither the pipe nor the vCPU kick; broadcast so they re-check the
      * exit-group flag and terminate before the join below gives up on them.
      */
     thread_wake_exit_waiters();

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -237,6 +237,7 @@ int fork_child_main(int ipc_fd,
     g.ttbr0 = hdr.ttbr0;
     g.mmap_rx_next = hdr.mmap_rx_next;
     g.mmap_rx_end = hdr.mmap_rx_end;
+
     /* Restore rosetta placement so the non-identity page-table entries that
      * came across in the memory transfer continue to resolve. ttbr1 points at
      * the L0 page the parent's PT pool emitted; that page sits inside the
@@ -274,9 +275,9 @@ int fork_child_main(int ipc_fd,
         return 1;
     }
 
-    /* Linux preserves already-open descriptors above a newly lowered soft
-     * limit across fork. Install the inherited table under the default table
-     * limit first, then restore the parent's guest-visible limit.
+    /* Linux preserves already-open descriptors above a newly lowered soft limit
+     * across fork. Install the inherited table under the default table limit
+     * first, then restore the parent's guest-visible limit.
      */
     if (sys_nofile_restore(hdr.nofile_cur, hdr.nofile_max) < 0) {
         log_error("fork-child: failed to restore RLIMIT_NOFILE");
@@ -308,8 +309,8 @@ int fork_child_main(int ipc_fd,
 
     /* Do not enter guest code until the parent has committed both the local
      * process-table slot and the shared lifecycle entry. EOF here means fork
-     * admission failed, so this helper exits without exposing a child whose
-     * PID the parent cannot later wait for.
+     * admission failed, so this helper exits without exposing a child whose PID
+     * the parent cannot later wait for.
      */
     uint8_t admission_ready = 0;
     if (fork_ipc_read_all(ipc_fd, &admission_ready, sizeof(admission_ready)) <
@@ -441,6 +442,7 @@ int fork_child_main(int ipc_fd,
     shim_globals_set_trace_enabled(&g, verbose);
     shim_globals_publish_pid(&g, hdr.child_pid, hdr.parent_pid);
     shim_globals_publish_creds(&g, hdr.uid, hdr.euid, hdr.gid, hdr.egid);
+
     /* proc_set_session above committed hdr.pgid/sid into proc-identity; mirror
      * into the shim cache so the child's getpgid(0)/getsid(0) fast paths see
      * the inherited session state from the first syscall. Publish via
@@ -448,22 +450,26 @@ int fork_child_main(int ipc_fd,
      * even though no sibling vCPU exists at this point.
      */
     proc_publish_pgsid_snapshot(&g);
+
     /* Fresh entropy for the child. Linux's vDSO getrandom epoch-bumps across
      * fork; this path re-fills the ring from arc4random_buf which seeds from
      * the host kernel's RNG, so parent and child do not share future urandom
      * output.
      */
     shim_globals_refill_urandom_ring(&g);
+
     /* Register the singleton for the child's signal.c so its attention setters
      * know which guest to update.
      */
     signal_set_shim_globals_guest(&g);
+
     /* The parent may exit after publishing this child but before bootstrap
      * reaches the guest loop. Pull any reparent transaction that arrived in
      * that window after the shim cache is live, so the fork header's original
      * PPID cannot overwrite the adopter selected by the lifecycle registry.
      */
     proc_lifecycle_sync_self(&g);
+
     /* Same for the fd-table hooks. Must precede any fd_alloc the child performs
      * (the fd-table-restore step has already run above, but those slots are
      * populated via direct memcpy of the parent's entries; subsequent
@@ -471,6 +477,7 @@ int fork_child_main(int ipc_fd,
      * in sync).
      */
     shim_globals_set_singleton(&g);
+
     /* shim_globals_init above zeroed the urandom bitmap. Walk the inherited fd
      * table and re-mark every readable FD_URANDOM slot so the shim's read fast
      * path sees the correct state from the first syscall onward.
@@ -686,6 +693,7 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         log_error("clone_thread: thread table full");
         return -LINUX_EAGAIN;
     }
+
     /* Captured now, while the slot is guaranteed still ours (thread_alloc just
      * marked it active, so no concurrent thread_alloc reuse-scan will touch it
      * until our own worker deactivates it). Passed to thread_set_host_thread
@@ -736,11 +744,10 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_EFAULT;
     }
 
-    /* Create the host pthread (joinable; the main thread joins all live
-     * workers via thread_join_workers before guest teardown, and a worker
-     * that exits on its own is joined when its table slot is reused by
-     * thread_alloc). Threads clean up their TID address via
-     * CLONE_CHILD_CLEARTID + futex wake.
+    /* Create the host pthread (joinable; the main thread joins all live workers
+     * via thread_join_workers before guest teardown, and a worker that exits on
+     * its own is joined when its table slot is reused by thread_alloc). Threads
+     * clean up their TID address via CLONE_CHILD_CLEARTID + futex wake.
      */
     pthread_t host_thread;
     pthread_attr_t attr;
@@ -755,6 +762,7 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         thread_deactivate(t);
         pthread_cond_destroy(&startup.cond);
         pthread_mutex_destroy(&startup.lock);
+
         /* Roll back any SETTID writes done before pthread_create. Same
          * rationale as the post-handshake failure path: clone(2) does not leave
          * live-looking TIDs behind for a thread that never started.
@@ -815,6 +823,22 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
     return child_tid;
 }
 
+/* Destroy this thread's own vCPU and clear the published handle, in that order,
+ * with thread_lock held by the caller. HVF vCPUs are thread-affine, so only the
+ * owning thread runs this. Destroying before clearing vcpu_valid keeps a
+ * concurrent thread_destroy_all_vcpus scan from ever observing this slot as
+ * active-and-valid-but-live: it sees either a live handle (and defers) or a
+ * fully torn-down slot. The vcpu_valid guard covers the bring-up-failure
+ * caller, where hv_vcpu_create failed before any handle was published.
+ */
+static void thread_destroy_own_vcpu_locked(thread_entry_t *t)
+{
+    if (t->vcpu_valid)
+        hv_vcpu_destroy(t->vcpu);
+    t->vcpu_valid = false;
+    t->vcpu = 0;
+}
+
 /* Worker pthread entry: creates the HVF vCPU on this thread (required by Apple
  * HVF, since the vCPU is bound to the creating thread), configures all
  * registers from parent state, then enters the run loop. On exit, performs
@@ -850,15 +874,18 @@ static void *thread_create_and_run(void *arg)
      * concurrently; they read t->vcpu under thread_lock, so an unlocked store
      * here is a data race (flagged by ThreadSanitizer). Until this store the
      * scanners observe vcpu_valid=false and skip the slot; the startup_failed
-     * path below deactivates before destroying, so a scan that does observe a
-     * valid handle only ever hands HVF a live vCPU. The separate flag is
-     * required because handle value zero is valid for the first vCPU.
+     * path below destroys the handle and clears vcpu_valid in one locked
+     * section before deactivating, so a scan either observes a live handle (and
+     * defers) or a fully torn-down slot, never an inactive-yet-undestroyed
+     * vCPU. The separate flag is required because handle value zero is valid
+     * for the first vCPU.
      */
     pthread_mutex_t *tlock = thread_get_lock();
     pthread_mutex_lock(tlock);
     t->vcpu = vcpu;
     t->vcpu_valid = true;
     t->vexit = vexit;
+
     /* A PTRACE_INTERRUPT that raced this bring-up (arrived before the handle
      * was published) recorded a pending request it could not deliver via
      * hv_vcpus_exit. Consume it under the same lock and self-kick below so the
@@ -963,18 +990,19 @@ static void *thread_create_and_run(void *arg)
     goto startup_ok;
 
 startup_failed:
-    /* HVF sysreg/GPR setup failed after vCPU creation. Drop the thread slot
-     * before tearing the vCPU down: the vCPU handle was already published under
-     * thread_lock, so a concurrent thread_interrupt_all /
-     * thread_destroy_all_vcpus / exit_group could otherwise observe it.
-     * Deactivating first removes the slot from THREAD_FOR_EACH_ACTIVE iteration
-     * so subsequent scans skip it before the handle is destroyed. Then destroy
-     * the vCPU on its owning thread (the only thread allowed to do so), free
-     * args, and finally signal the parent so it observes a fully torn-down
-     * state.
+    /* HVF sysreg/GPR setup failed after vCPU creation. The vCPU handle was
+     * already published under thread_lock, so destroy it on its owning thread
+     * (the only thread allowed to do so) and clear vcpu_valid in the same
+     * critical section, then deactivate. Destroying before clearing the flag
+     * keeps a concurrent thread_destroy_all_vcpus scan from ever observing an
+     * active-and-valid-but-live handle or an inactive-yet-undestroyed one: it
+     * either sees the live handle and defers, or sees the slot fully torn down.
+     * Finally signal the parent so it observes a fully torn-down state.
      */
+    pthread_mutex_lock(tlock);
+    thread_destroy_own_vcpu_locked(t);
+    pthread_mutex_unlock(tlock);
     thread_deactivate(t);
-    hv_vcpu_destroy(vcpu);
     free(tca);
     pthread_mutex_lock(&startup->lock);
     startup->startup_rc = -LINUX_EIO;
@@ -983,8 +1011,7 @@ startup_failed:
     pthread_mutex_unlock(&startup->lock);
     return NULL;
 
-startup_ok:;
-
+startup_ok:
     /* If a sibling armed a fork snapshot while this worker was still in
      * bring-up, thread_quiesce_siblings could not kick a not-yet-published
      * vCPU, but it still counted this slot in fork_target_count. Check the
@@ -1034,11 +1061,15 @@ startup_ok:;
 
     log_debug("thread tid=%lld exiting", (long long) t->guest_tid);
 
+    /* Destroy the vCPU on its owning thread while still holding the lock, and
+     * only then clear vcpu_valid. thread_destroy_all_vcpus scans under the same
+     * lock; keeping the handle valid until it is actually gone means a teardown
+     * scan can never observe this slot as active-with-a-live-but-invalid vCPU
+     * and tear down the VM/slab out from under an undestroyed vCPU.
+     */
     pthread_mutex_lock(tlock);
-    t->vcpu_valid = false;
-    t->vcpu = 0;
+    thread_destroy_own_vcpu_locked(t);
     pthread_mutex_unlock(tlock);
-    hv_vcpu_destroy(vcpu);
     thread_deactivate(t);
 
     /* When all CLONE_THREAD workers have exited and only the main thread
@@ -1149,6 +1180,7 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
         log_error("clone_vm: pthread_create failed: %s", strerror(err));
         free(tca);
         thread_deactivate(t);
+
         /* Roll back the SETTID writes clone_apply_tid_flags made: no child
          * thread was created, so clone(2) must not leave live-looking TIDs.
          */
@@ -1177,21 +1209,19 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
 /* Report a vm-clone worker that failed HVF bring-up as an exited child so the
  * parent's wait4 can reap it. sys_clone_vm already returned the child tid, so
  * dropping the slot with thread_deactivate (which clears active) would make
- * wait4 skip it and leave the parent unable to collect a status. Publish the
- * exit status and invalidate t->vcpu under the thread lock, so
- * thread_interrupt_all and thread_destroy_all_vcpus cannot hand the
- * torn-down vCPU to HVF, then destroy the handle outside the lock. Keep the
- * slot active for wait4. Reports SIGKILL because the child never ran a guest
- * instruction. Does not trigger exit_group: only the child failed.
+ * wait4 skip it and leave the parent unable to collect a status. Destroy the
+ * vCPU and publish the exit status in one critical section, destroy first: the
+ * slot only becomes reapable (vm_exited) once the handle is gone, so a parent
+ * wait4 that reaps and deactivates it cannot leave a teardown scan racing an
+ * undestroyed vCPU. Keep the slot active for wait4. Reports SIGKILL because the
+ * child never ran a guest instruction. Does not trigger exit_group: only the
+ * child failed. Runs on the child's own thread, so the destroy is owner-local.
  */
 static void vm_clone_report_bringup_failure(thread_entry_t *t)
 {
     pthread_mutex_t *lock = thread_get_lock();
     pthread_mutex_lock(lock);
-    hv_vcpu_t dying = t->vcpu;
-    bool dying_valid = t->vcpu_valid;
-    t->vcpu_valid = false;
-    t->vcpu = 0;
+    thread_destroy_own_vcpu_locked(t);
     t->vm_exited = true;
     t->vm_exit_status = LINUX_SIGKILL; /* WIFSIGNALED, WTERMSIG == SIGKILL */
     /* The slot stays active for wait4 rather than deactivating, so the fork
@@ -1202,8 +1232,6 @@ static void vm_clone_report_bringup_failure(thread_entry_t *t)
     thread_fork_release_counted_locked(t);
     pthread_cond_broadcast(&t->ptrace_cond);
     pthread_mutex_unlock(lock);
-    if (dying_valid)
-        hv_vcpu_destroy(dying);
 }
 
 /* Worker entry for vm-clone children. Sets up vCPU, runs guest code, then marks
@@ -1236,6 +1264,7 @@ static void *vm_clone_thread_run(void *arg)
     t->vcpu = vcpu;
     t->vcpu_valid = true;
     t->vexit = vexit;
+
     /* Deliver a PTRACE_INTERRUPT that raced bring-up; see
      * thread_create_and_run. vm-clone children are the usual ptrace targets.
      */
@@ -1317,52 +1346,47 @@ static void *vm_clone_thread_run(void *arg)
     if (wake_ctid)
         futex_wake_one(g, t->clear_child_tid);
 
-    /* Mark exit status for parent's wait4 to collect. vm_exit_status uses
-     * wait-format: (exit_code << 8) for normal exit.
+    log_debug("vm_clone tid=%lld exiting (code=%d)", (long long) t->guest_tid,
+              exit_code);
+
+    /* Destroy the vCPU and publish exit status in one critical section, destroy
+     * first. The slot only becomes reapable (vm_exited) once the handle is
+     * gone, so a parent wait4 that reaps and deactivates the slot can never
+     * leave a later teardown scan racing an undestroyed vCPU. thread_lock also
+     * serializes this against thread_destroy_all_vcpus. Destroying this vCPU
+     * ahead of thread_interrupt_all below is fine: the current vCPU already
+     * left hv_vcpu_run, and thread_interrupt_all only needs the OTHER vCPUs'
+     * handles. vm_exit_status is wait-format: (exit_code << 8) for a normal
+     * exit.
      */
     pthread_mutex_t *lock = thread_get_lock();
     pthread_mutex_lock(lock);
+    thread_destroy_own_vcpu_locked(t);
     t->vm_exited = true;
     t->vm_exit_status = wait_status;
     pthread_cond_broadcast(&t->ptrace_cond);
     pthread_mutex_unlock(lock);
 
-    log_debug("vm_clone tid=%lld exiting (code=%d)", (long long) t->guest_tid,
-              exit_code);
+    /* Slot stays active until the parent collects status with wait4;
+     * thread_ptrace_wait frees it when it reads vm_exited.
+     */
 
-    /* Check if this was the last VM-clone child BEFORE destroying the vCPU,
-     * because thread_interrupt_all needs valid vCPU handles. In real Linux,
-     * child exit delivers exit_signal (SIGCHLD) which interrupts the parent's
-     * futex_wait with -EINTR. The emulator simulates this by requesting
-     * exit_group and interrupting all vCPUs.
+    /* Last VM-clone child triggers exit_group so the main thread's futex_wait /
+     * run loop unblocks (mirrors SIGCHLD on child exit). vm_exited is already
+     * set, so this slot excludes itself from the active-clone count.
      */
     int last_clone = (thread_count_active_vm_clones() == 0);
-
     if (last_clone) {
         log_debug("last vm_clone exited, triggering exit_group");
         proc_request_exit_group(exit_code);
-        /* Interrupt all vCPUs while the current one is still valid. The main
-         * thread's vCPU may be blocked in hv_vcpu_run; this forces it out so it
-         * can check proc_exit_group_requested. The current vCPU is not in
-         * hv_vcpu_run (loop already exited) so the exit call on it is a
-         * harmless no-op.
+
+        /* thread_interrupt_all only reaches threads inside hv_vcpu_run; peers
+         * parked on fork_cond or another slot's ptrace_cond/resume_cond need
+         * the separate broadcast.
          */
         thread_interrupt_all();
-        /* thread_interrupt_all only reaches threads inside hv_vcpu_run.
-         * Peers parked on fork_cond or another slot's ptrace_cond/resume_cond
-         * see neither the vCPU kick nor this exit, so broadcast separately.
-         */
         thread_wake_exit_waiters();
     }
-
-    pthread_mutex_lock(lock);
-    t->vcpu_valid = false;
-    t->vcpu = 0;
-    pthread_mutex_unlock(lock);
-    hv_vcpu_destroy(vcpu);
-    /* Keep the slot active until the parent collects status with wait4. The
-     * slot is freed when thread_ptrace_wait reads vm_exited.
-     */
 
     return NULL;
 }
@@ -1400,6 +1424,7 @@ static int fork_snapshot_shm_via_clonefile(int src_fd)
     }
     int clone_fd = open(clone_path, O_RDWR | O_CLOEXEC);
     int saved_errno = errno;
+
     /* Best-effort cleanup: the clone fd alone keeps the inode alive, so any
      * unlink/rmdir failure here is a directory-leak nuisance, not a correctness
      * issue. Caller still gets the open fd.
@@ -1509,6 +1534,7 @@ int64_t sys_clone(hv_vcpu_t vcpu,
     child_argv[ci++] = self_path;
     if (verbose)
         child_argv[ci++] = "--verbose";
+
     /* Rosetta is on by default; only propagate the opt-out flag when the parent
      * explicitly disabled it. The child re-reads ELFUSE_NO_ROSETTA from the
      * environment too, so an env-based opt-out is preserved across fork without
@@ -1625,6 +1651,7 @@ int64_t sys_clone(hv_vcpu_t vcpu,
     mmap_fork_anon_shared_txn_t *anon_shared_txn = NULL;
     guest_region_t *regions_snapshot = NULL;
     guest_region_t preannounced_snapshot[GUEST_MAX_PREANNOUNCED];
+
     /* APFS clone fd for the CoW snapshot sent to the child. Declared up front
      * so early goto fail_snapshot exits do not read an uninitialized local.
      */
@@ -1700,6 +1727,7 @@ int64_t sys_clone(hv_vcpu_t vcpu,
                 len -= (uint64_t) nw;
             }
         }
+
         /* Attempt the APFS clone snapshot for every guest, not just Rosetta:
          * the clone gives POSIX-style isolation at O(metadata) cost and avoids
          * torn-snapshot reads in guests that snapshot their own state across
@@ -1882,6 +1910,7 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         log_error("clone: failed to release admitted child");
         goto fail_snapshot;
     }
+
     /* The process-state payload includes the SCM_RIGHTS handoff for region
      * backing fds. Keep siblings quiesced until that send completes so a
      * concurrent munmap/remap cannot close or recycle the captured fd numbers.
@@ -1938,6 +1967,7 @@ fail_snapshot:
     free(regions_snapshot);
     if (snapshot_shm_fd >= 0)
         close(snapshot_shm_fd);
+
     /* Roll back the in-place anon-shared overlay conversion while siblings are
      * still parked. A partial rollback failure (e.g., region drift past the
      * quiesce timeout) leaves the parent in a mixed state: the originating
@@ -1957,6 +1987,7 @@ fail_snapshot:
         close(vfork_notify_fds[0]);
     if (vfork_notify_fds[1] >= 0)
         close(vfork_notify_fds[1]);
+
     /* posix_spawn at the top of sys_clone always succeeds before any goto
      * fail_snapshot fires, so child_host_pid is a live process here. The IPC
      * socket just closed; the child reads EOF on fork_ipc_read_all and returns

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -132,6 +132,7 @@ void thread_register_main(hv_vcpu_t vcpu,
     t->altstack_flags = LINUX_SS_DISABLE;
     t->on_altstack = false;
     thread_ptrace_init(t);
+
     /* Release-store so a lock-free scanner that acquire-loads active == 1 sees
      * this slot's initialized fields (see thread_pending_union,
      * thread_tid_alive).
@@ -159,11 +160,13 @@ rescan:
     THREAD_FOR_EACH (t) {
         if (__atomic_load_n(&t->active, __ATOMIC_RELAXED))
             continue;
+
         /* Skip slots where a tracer is still inside pthread_cond_wait on
          * ptrace_cond. Memset+reinit while a waiter holds a reference is UB.
          */
         if (t->ptrace_conds_inited && t->ptrace_waiters > 0)
             continue;
+
         /* Reap the previous occupant's pthread before reusing the slot. Workers
          * that exit on their own are joinable but never joined
          * (thread_join_workers snapshots active entries only), so dropping the
@@ -187,6 +190,7 @@ rescan:
             pthread_cond_destroy(&t->ptrace_cond);
             pthread_cond_destroy(&t->resume_cond);
         }
+
         /* Bump generation across the memset so a caller still holding this
          * slot's pointer from before reuse (e.g. a clone parent racing its own
          * worker's startup-failure path) can detect the recycle via
@@ -204,6 +208,7 @@ rescan:
         }
         t->altstack_flags = LINUX_SS_DISABLE;
         thread_ptrace_init(t);
+
         /* Release-store last so a lock-free scanner that observes active == 1
          * also sees the zeroed tpending / guest_tid set above.
          */
@@ -313,9 +318,9 @@ void thread_deactivate(thread_entry_t *t)
 
     /* Release store: everything this thread did -- including its last guest
      * memory access -- must happen-before thread_join_workers' acquire load
-     * observing 0, or the joiner could green-light guest_destroy's unmap
-     * while stores are still in flight. The joiner polls lock-free, so the
-     * mutex held here provides no edge to it.
+     * observing 0, or the joiner could green-light guest_destroy's unmap while
+     * stores are still in flight. The joiner polls lock-free, so the mutex held
+     * here provides no edge to it.
      */
     __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
     atomic_fetch_sub(&active_thread_count, 1);
@@ -426,6 +431,7 @@ uint64_t thread_alloc_sp_el1(const guest_t *g, thread_entry_t *t)
         log_error("thread: SP_EL1 slots exhausted");
     } else {
         int slot = bit_ctz64(free_mask);
+
         /* Main thread's SP_EL1 sits at the top of the shim data block. Each
          * subsequent thread is 4KiB below.
          */
@@ -476,16 +482,18 @@ void thread_join_workers(void)
     THREAD_FOR_EACH (t) {
         if (t == current_thread || t->join_abandoned)
             continue;
+
         /* Never wait for the main thread (slot 0): its entry only deactivates
          * inside guest_destroy, which runs on the main thread AFTER its own
-         * thread_join_workers. A worker waiting here (exit_group called from
-         * a worker) would burn the full cap on it, and the resulting mutual
-         * wait (worker polling main while main polls the worker) ends in
-         * pthread_detach on both sides, leaving the loser to touch guest
-         * memory after guest_destroy unmaps it.
+         * thread_join_workers. A worker waiting here (exit_group called from a
+         * worker) would burn the full cap on it, and the resulting mutual wait
+         * (worker polling main while main polls the worker) ends in
+         * pthread_detach on both sides, leaving the loser to touch guest memory
+         * after guest_destroy unmaps it.
          */
         if (t == &thread_table[0])
             continue;
+
         /* Inactive slots are included when they still hold an unjoined handle:
          * a worker that exited on its own shortly before teardown and whose
          * slot was never reused. Its pthread has terminated (or is in final
@@ -513,10 +521,10 @@ void thread_join_workers(void)
      * re-checks every 200ms (io.c wait helper) and the futex paths every 100ms
      * (FUTEX_OS_SYNC_POLL_CAP_NS quanta), so 500ms covers the slowest bound
      * with margin. One shared deadline keeps worst-case shutdown at the cap
-     * even with many stuck workers, rather than multiplying a per-worker cap
-     * by nworkers. A worker still alive past the cap is detached and, if this
-     * pass claimed its handle, marked join_abandoned so a later pass does not
-     * touch it again. The vCPU is NOT destroyed here because HVF vCPUs are
+     * even with many stuck workers, rather than multiplying a per-worker cap by
+     * nworkers. A worker still alive past the cap is detached and, if this pass
+     * claimed its handle, marked join_abandoned so a later pass does not touch
+     * it again. The vCPU is NOT destroyed here because HVF vCPUs are
      * thread-affine, so cross-thread hv_vcpu_destroy while the owning thread
      * may still be inside hv_vcpu_run is unsafe.
      */
@@ -527,13 +535,14 @@ void thread_join_workers(void)
                 continue;
             if (!__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE))
                 continue;
+
             /* The slot may have been reused for a new logical thread while we
              * polled: thread_alloc only recycles a slot once its previous
              * occupant is inactive, so a generation bump here proves our
              * snapshotted worker already deactivated even though the slot now
-             * reads active == 1 again for the replacement thread. Stop
-             * tracking this worker's active bit for the rest of the loop
-             * rather than following the wrong thread.
+             * reads active == 1 again for the replacement thread. Stop tracking
+             * this worker's active bit for the rest of the loop rather than
+             * following the wrong thread.
              */
             if (workers[w].t->generation != workers[w].generation) {
                 workers[w].recycled = true;
@@ -549,6 +558,7 @@ void thread_join_workers(void)
     for (int w = 0; w < nworkers; w++) {
         if (!workers[w].claimed)
             continue;
+
         /* recycled short-circuits before the active re-check: once recycled,
          * that bit belongs to the replacement thread and must not influence the
          * join-vs-detach decision for our (already-terminated) handle.
@@ -565,34 +575,91 @@ void thread_join_workers(void)
     }
 }
 
-bool thread_destroy_all_vcpus(hv_vcpu_t main_vcpu, bool main_vcpu_valid)
+bool thread_destroy_all_vcpus(hv_vcpu_t main_vcpu,
+                              bool main_vcpu_valid,
+                              bool *live_workers_left)
 {
     bool main_destroyed = false;
+    bool live_workers = false;
     pthread_mutex_lock(&thread_lock);
     THREAD_FOR_EACH_ACTIVE (t) {
-        if (!t->vcpu_valid)
-            continue;
-        if (main_vcpu_valid && t->vcpu == main_vcpu)
-            main_destroyed = true;
-        hv_vcpu_destroy(t->vcpu);
-        t->vcpu_valid = false;
-        t->vcpu = 0;
-        thread_free_sp_el1_locked(t);
-        __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
-        /* Do NOT destroy condvars. Same race as thread_deactivate: a waiter
-         * woken by an earlier broadcast may still reference the condvar.
-         * Process is exiting, so the leak is harmless.
+        /* The main vCPU is the only handle owned by the thread running
+         * guest_destroy, so it is the only one this thread may destroy. The
+         * vcpu_valid term guards a not-yet-published worker whose t->vcpu still
+         * reads 0 from colliding with a main_vcpu handle of 0 (a valid value
+         * for the first vCPU).
          */
+        if (main_vcpu_valid && t->vcpu_valid && t->vcpu == main_vcpu) {
+            hv_vcpu_destroy(t->vcpu);
+            t->vcpu_valid = false;
+            t->vcpu = 0;
+            thread_free_sp_el1_locked(t);
+            __atomic_store_n(&t->active, 0, __ATOMIC_RELEASE);
+
+            /* Keep the count accurate rather than zeroing the whole table: any
+             * leaked live worker stays active and counted until process exit
+             * reclaims it.
+             */
+            atomic_fetch_sub(&active_thread_count, 1);
+            main_destroyed = true;
+
+            /* Do NOT destroy condvars. Same race as thread_deactivate: a waiter
+             * woken by an earlier broadcast may still reference the condvar.
+             * Process is exiting, so the leak is harmless.
+             */
+            continue;
+        }
+
+        /* A slot that has already published vm_exited destroyed its own vCPU on
+         * its owning thread (under thread_lock, before setting vm_exited) and
+         * that thread has terminated; a vm-clone child stays active past that
+         * only so a later wait4 can reap it. It holds no live vCPU, so it does
+         * not block teardown -- treating it as live would wrongly defer the
+         * explicit HVF teardown/unmaps for an already-dead slot.
+         *
+         * Gate on !vcpu_valid too, not vm_exited alone: this is the guard that
+         * keeps hv_vm_destroy/munmap from running under a live foreign vCPU and
+         * panicking the host, so it checks the direct fact (no live handle
+         * here) rather than trusting that vm_exited always implies the handle
+         * is gone. The two are published together under thread_lock, so this
+         * term is currently always true; keeping it fails closed (defer to
+         * process exit) if that ordering ever regresses.
+         */
+        if (t->vm_exited && !t->vcpu_valid)
+            continue;
+
+        /* Every other active non-main slot is a live worker: running a vCPU, or
+         * mid-bring-up (active, vcpu_valid not yet set) about to create and
+         * enter one on its own thread. HVF vCPUs are thread-affine, so this
+         * thread can neither destroy such a handle nor let hv_vm_destroy /
+         * munmap run while the worker is live without corrupting kernel state
+         * and panicking the host. vcpu_valid alone is not a sufficient proxy --
+         * a bring-up worker is active with vcpu_valid still false. Report it so
+         * guest_destroy defers teardown to process exit, the only safe way to
+         * stop a foreign vCPU.
+         */
+        live_workers = true;
     }
-    atomic_store(&active_thread_count, 0);
+
     pthread_mutex_unlock(&thread_lock);
+    if (live_workers_left)
+        *live_workers_left = live_workers;
     return main_destroyed;
 }
 
 void thread_interrupt_all(void)
 {
-    /* Collect active vCPUs under the lock, then call hv_vcpus_exit outside the
-     * lock to avoid holding it during a framework call.
+    /* Collect active vCPUs and kick them out of hv_vcpu_run() in one critical
+     * section. hv_vcpus_exit must run under thread_lock, not after releasing
+     * it: a worker destroys its own vCPU under the same lock on exit, so a
+     * handle collected here and used after the lock is dropped could be handed
+     * to HVF after it was freed, faulting the host on the released vCPU object.
+     * Holding the lock across the kick serializes it against destruction --
+     * every handle passed is still live, or the worker already cleared
+     * vcpu_valid and was skipped. hv_vcpus_exit only signals the target vCPUs
+     * to leave hv_vcpu_run and returns without waiting, so it does not block
+     * under the lock (the signal-preemption path already kicks under
+     * thread_lock the same way).
      */
     hv_vcpu_t vcpus[MAX_THREADS];
     int count = 0;
@@ -601,13 +668,13 @@ void thread_interrupt_all(void)
     THREAD_FOR_EACH_ACTIVE (t)
         if (t->vcpu_valid) /* skip bring-up/torn-down slots */
             vcpus[count++] = t->vcpu;
-    pthread_mutex_unlock(&thread_lock);
 
-    /* Force all active vCPUs out of hv_vcpu_run(). Each vCPU will see
-     * HV_EXIT_REASON_CANCELED and check for pending signals.
+    /* Each kicked vCPU sees HV_EXIT_REASON_CANCELED and checks pending signals
+     * / teardown.
      */
     if (count > 0)
         hv_vcpus_exit(vcpus, (uint32_t) count);
+    pthread_mutex_unlock(&thread_lock);
 }
 
 int thread_signal_deliverable(uint64_t sigbit)
@@ -663,11 +730,15 @@ void thread_quiesce_siblings(void)
     fork_quiesced_count = 0;
     fork_target_count = targets;
 
-    pthread_mutex_unlock(&thread_lock);
-
-    /* Force siblings out of hv_vcpu_run */
+    /* Force siblings out of hv_vcpu_run under the lock, before releasing it: a
+     * sibling destroys its own vCPU under thread_lock on exit, so kicking a
+     * collected handle after the lock is dropped could hand HVF a freed vCPU.
+     * The kick does not block, so holding the lock across it is safe.
+     */
     if (count > 0)
         hv_vcpus_exit(vcpus, (uint32_t) count);
+
+    pthread_mutex_unlock(&thread_lock);
 
     /* Wait until all siblings have blocked on the barrier. Use a bounded wait:
      * siblings in long-running host syscalls (poll, read, accept) may not reach
@@ -695,6 +766,7 @@ void thread_resume_siblings(void)
     fork_quiesce_active = false;
     fork_quiesced_count = 0;
     fork_target_count = 0;
+
     /* Clear any fork_counted still set on siblings that never reached the
      * barrier (blocked in a host syscall and released by the timeout) so the
      * next barrier generation starts from a clean slate.
@@ -727,10 +799,10 @@ int thread_fork_barrier_check(void)
     }
 
     /* Block until fork is complete. Bail out on exit_group: the resume
-     * broadcast comes from the forking thread, whose progress the teardown
-     * path does not control, so waiting for it would leave this park outside
-     * the bounded-wake guarantee. thread_wake_exit_waiters broadcasts
-     * fork_cond after the flag is set; the caller's run loop re-checks
+     * broadcast comes from the forking thread, whose progress the teardown path
+     * does not control, so waiting for it would leave this park outside the
+     * bounded-wake guarantee. thread_wake_exit_waiters broadcasts fork_cond
+     * after the flag is set; the caller's run loop re-checks
      * proc_exit_group_requested and exits.
      */
     while (fork_quiesce_active && !proc_exit_group_requested())
@@ -750,11 +822,11 @@ void thread_wake_exit_waiters(void)
     pthread_cond_broadcast(&fork_cond);
 
     /* Ptrace parks: tracers blocked in thread_ptrace_wait (ptrace_cond) and
-     * tracees blocked in thread_ptrace_stop (resume_cond). Scan every slot
-     * with live condvars, not just active ones: a tracer may still be parked
-     * on a slot whose thread was deactivated. ptrace_conds_inited only
-     * transitions under thread_lock with ptrace_waiters == 0, so broadcasting
-     * here never touches a destroyed condvar.
+     * tracees blocked in thread_ptrace_stop (resume_cond). Scan every slot with
+     * live condvars, not just active ones: a tracer may still be parked on a
+     * slot whose thread was deactivated. ptrace_conds_inited only transitions
+     * under thread_lock with ptrace_waiters == 0, so broadcasting here never
+     * touches a destroyed condvar.
      */
     THREAD_FOR_EACH (t) {
         if (!t->ptrace_conds_inited)
@@ -827,6 +899,7 @@ retry:
         }
         nranges++;
     }
+
     /* Pass 2: commit. Both passes iterate the table in the same order under the
      * same lock, so the active set seen here matches pass 1.
      */
@@ -1087,10 +1160,10 @@ int thread_ptrace_stop(thread_entry_t *t, int sig)
     pthread_cond_broadcast(&t->ptrace_cond);
 
     /* Block until tracer calls PTRACE_CONT. Bail out on exit_group: only the
-     * tracer signals resume_cond, and a tracer that exits (or calls
-     * exit_group itself) will never CONT this stop. thread_wake_exit_waiters
-     * broadcasts resume_cond; returning 0 sends the caller back to its run
-     * loop, which re-checks proc_exit_group_requested.
+     * tracer signals resume_cond, and a tracer that exits (or calls exit_group
+     * itself) will never CONT this stop. thread_wake_exit_waiters broadcasts
+     * resume_cond; returning 0 sends the caller back to its run loop, which
+     * re-checks proc_exit_group_requested.
      */
     while (t->ptrace_stopped && !proc_exit_group_requested())
         pthread_cond_wait(&t->resume_cond, &thread_lock);
@@ -1148,8 +1221,9 @@ int64_t thread_ptrace_wait(int64_t tracer_tid,
 
     for (;;) {
         /* exit_group teardown: the stop/exit notifications that would signal
-         * ptrace_cond stop arriving once workers are being torn down. Return 0
-         * ("no matching children") so the caller falls through and its
+         * ptrace_cond stop arriving once workers are being torn down.
+         *
+         * Return 0 ("no matching children") so the caller falls through and its
          * blocking paths re-check proc_exit_group_requested.
          */
         if (proc_exit_group_requested()) {
@@ -1179,6 +1253,7 @@ int64_t thread_ptrace_wait(int64_t tracer_tid,
                 int64_t tid = t->guest_tid;
                 if (out_status)
                     *out_status = t->vm_exit_status;
+
                 /* Destroy condvars after the last waiter returns from
                  * pthread_cond_wait().
                  */
@@ -1188,6 +1263,7 @@ int64_t thread_ptrace_wait(int64_t tracer_tid,
                 t->ptrace_cleanup_pending = true;
                 thread_ptrace_cleanup_locked(t);
                 pthread_mutex_unlock(&thread_lock);
+
                 /* Slot is now inactive; drop any unconsumed thread-directed
                  * pending bits from the global hint (same rationale as
                  * thread_deactivate). Outside thread_lock to honor sig_lock (4)

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -39,7 +39,8 @@ typedef struct thread_entry {
     hv_vcpu_t vcpu;              /* HVF vCPU handle for this thread */
     bool vcpu_valid;             /* Handle has been published and not destroyed.
                                   * hv_vcpu_t value 0 is valid, so the handle
-                                  * itself cannot be used as a sentinel. */
+                                  * itself cannot be used as a sentinel.
+                                  */
     hv_vcpu_exit_t *vexit;       /* vCPU exit info pointer */
     pthread_t host_thread;       /* macOS host thread running this vCPU */
     bool host_thread_needs_join; /* host_thread was created joinable and nobody
@@ -304,20 +305,32 @@ void thread_for_each(void (*fn)(thread_entry_t *t, void *ctx), void *ctx);
  */
 int thread_count_active_vm_clones(void);
 
-/* Join worker threads (all active threads except the caller, minus any
- * already join_abandoned by a prior pass). Collects thread handles under the
- * lock, then polls OUTSIDE the lock under one shared 500ms deadline so
- * workers can call thread_deactivate() to set active=0. Workers still alive
- * past the deadline are detached and marked join_abandoned so a later pass
- * (e.g. guest_destroy's internal join after main()'s) does not touch the same
- * handle twice.
+/* Join worker threads (all active threads except the caller, minus any already
+ * join_abandoned by a prior pass). Collects thread handles under the lock, then
+ * polls OUTSIDE the lock under one shared 500ms deadline so workers can call
+ * thread_deactivate() to set active=0. Workers still alive past the deadline
+ * are detached and marked join_abandoned so a later pass (e.g. guest_destroy's
+ * internal join after main()'s) does not touch the same handle twice.
  */
 void thread_join_workers(void);
 
-/* Destroy all active worker vCPUs. Called during guest_destroy to ensure no
- * vCPUs remain active before hv_vm_destroy().
+/* Destroy the main vCPU (owned by the calling thread) during guest_destroy. HVF
+ * vCPUs are thread-affine, so worker vCPUs are never destroyed here: an active
+ * worker slot that has not published vm_exited is one whose owning thread is
+ * still live -- running a vCPU or mid-bring-up about to enter one -- and a
+ * cross-thread hv_vcpu_destroy on such a handle, or hv_vm_destroy while it
+ * holds one, corrupts the kernel vCPU object and panics the host. Such a worker
+ * is left for process-exit reclamation and reported via live_workers_left (may
+ * be NULL) so the caller defers the rest of HVF teardown. A slot that has
+ * already published vm_exited (a vm-clone child that self-destroyed its vCPU
+ * and stays active only for wait4) holds no live vCPU and does not force the
+ * deferral.
+ *
+ * Returns whether the main vCPU was destroyed.
  */
-bool thread_destroy_all_vcpus(hv_vcpu_t main_vcpu, bool main_vcpu_valid);
+bool thread_destroy_all_vcpus(hv_vcpu_t main_vcpu,
+                              bool main_vcpu_valid,
+                              bool *live_workers_left);
 
 /* Interrupt all active vCPUs by calling hv_vcpus_exit(). Used for signal
  * preemption: when a signal is queued while a vCPU is running in a tight loop
@@ -326,14 +339,14 @@ bool thread_destroy_all_vcpus(hv_vcpu_t main_vcpu, bool main_vcpu_valid);
  */
 void thread_interrupt_all(void);
 
-/* Wake workers parked on internal condvars (fork barrier, ptrace stop/wait)
- * so exit_group teardown reaches them within a bounded time. hv_vcpus_exit
- * only interrupts threads inside hv_vcpu_run, and the wakeup pipe / futex
- * interrupt only cover guest syscall waits; a thread parked on fork_cond,
- * ptrace_cond, or resume_cond would otherwise sleep past the join cap in
- * thread_join_workers and still be live when guest memory is unmapped.
- * Callers must set the exit-group flag (proc_request_exit_group) BEFORE
- * calling this so woken waiters observe it when they re-check.
+/* Wake workers parked on internal condvars (fork barrier, ptrace stop/wait) so
+ * exit_group teardown reaches them within a bounded time. hv_vcpus_exit only
+ * interrupts threads inside hv_vcpu_run, and the wakeup pipe / futex interrupt
+ * only cover guest syscall waits; a thread parked on fork_cond, ptrace_cond, or
+ * resume_cond would otherwise sleep past the join cap in thread_join_workers
+ * and still be live when guest memory is unmapped. Callers must set the
+ * exit-group flag (proc_request_exit_group) BEFORE calling this so woken
+ * waiters observe it when they re-check.
  */
 void thread_wake_exit_waiters(void);
 
@@ -434,6 +447,7 @@ int thread_prepare_deferred_stack_unmaps_for_cleanup(thread_entry_t *t,
                                                      uint64_t *starts,
                                                      uint64_t *ends,
                                                      int max_ranges);
+
 /* Snapshot the deferred unmap entries without modifying the thread record.
  * Returns the number of entries copied (capped at max_ranges).
  */

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -68,6 +68,7 @@ static _Atomic uint64_t sysreg_write_count =
  * check and surfaces an install hint regardless.
  */
 static _Atomic bool rosetta_enabled = true;
+
 /* Runtime indicator: distinct from rosetta_enabled (user opt-in). Set when the
  * active guest_t is actually running under rosetta, so callers without direct
  * guest_t access (proc_intercept_readlink, log paths) can branch on runtime
@@ -223,6 +224,7 @@ static void proc_init_child_entry(proc_entry_t *entry,
     entry->reserved = false;
     entry->host_pid = host_pid;
     entry->guest_pid = guest_pid_val;
+
     /* Seed with the group the child inherited at fork. The caller passes the
      * exact value sent in the fork IPC header so the parent's view and the
      * child's own pgid cannot disagree even if a sibling thread changes the
@@ -404,8 +406,8 @@ out:
 int proc_reserve_child(int64_t guest_pid_val, int64_t pgid)
 {
     /* Explicit SIG_IGN/SA_NOCLDWAIT children are not guest-waitable. Reclaim
-     * any that have already terminated before consuming another table slot,
-     * so a workload that intentionally never calls wait does not retain stale
+     * any that have already terminated before consuming another table slot, so
+     * a workload that intentionally never calls wait does not retain stale
      * bookkeeping entries indefinitely.
      */
     if (signal_sigchld_autoreap())
@@ -546,10 +548,10 @@ static bool process_registry_path(char *out, size_t out_size)
 }
 
 /* The process-group registry above intentionally contains only live host
- * members. Linux lifecycle state has different retention rules: an exited
- * child must remain discoverable until a guest wait consumes it, including
- * after its original host parent exits. Keep that state in a separate binary
- * registry protected by flock so unrelated signal/group readers stay simple.
+ * members. Linux lifecycle state has different retention rules: an exited child
+ * must remain discoverable until a guest wait consumes it, including after its
+ * original host parent exits. Keep that state in a separate binary registry
+ * protected by flock so unrelated signal/group readers stay simple.
  */
 #define LIFECYCLE_MAGIC 0x454C464CU /* "ELFL" */
 #define LIFECYCLE_VERSION 5
@@ -780,8 +782,10 @@ static int lifecycle_publish_child(pid_t host_pid,
         lifecycle_entry_t *entry = lifecycle_find_guest(registry, guest_pid);
         if (entry) {
             entry->host_pid = host_pid;
+
             /* The reservation owns the parent/group fields, while an exit or
-             * reparent transaction that won this race owns terminal state. */
+             * reparent transaction that won this race owns terminal state.
+             */
             if (!entry->exited && !entry->reparent_pending) {
                 entry->ppid = ppid;
                 entry->pgid = pgid;
@@ -805,10 +809,11 @@ static void lifecycle_publish_self(void)
         lifecycle_entry_t *entry = lifecycle_upsert(&registry, proc_get_pid());
         if (entry) {
             entry->host_pid = getpid();
-            /* A parent-exit transaction writes the authoritative adopter
-             * before notifying this process. Do not let an unrelated publish
-             * from the child overwrite that value with its stale local PPID
-             * while the reparent control record is still pending.
+
+            /* A parent-exit transaction writes the authoritative adopter before
+             * notifying this process. Do not let an unrelated publish from the
+             * child overwrite that value with its stale local PPID while the
+             * reparent control record is still pending.
              */
             if (!entry->reparent_pending)
                 entry->ppid = proc_get_ppid();
@@ -932,6 +937,7 @@ static bool lifecycle_reparent_complete(int64_t guest_pid, int64_t ppid)
     lifecycle_registry_t *registry = lifecycle_load_locked(fd);
     if (registry) {
         lifecycle_entry_t *entry = lifecycle_find_guest(registry, guest_pid);
+
         /* A missing/consumed child or one that has already exited no longer
          * needs its live shim PPID cache updated.
          */
@@ -980,6 +986,7 @@ static void proc_register_adopted_local(const lifecycle_entry_t *source)
         pthread_mutex_unlock(&pid_lock);
         return;
     }
+
     /* A direct child is visible in the lifecycle registry before its local
      * admission transaction commits. The registry's host PID may already have
      * been published while the local slot is still reserved, so checking only
@@ -1035,6 +1042,7 @@ static void lifecycle_import_children(void)
         int64_t self = proc_get_pid();
         for (uint32_t i = 0; i < registry->count; i++) {
             lifecycle_entry_t *entry = &registry->entries[i];
+
             /* host_pid==0 is a pre-spawn reservation, not a live or waitable
              * child. The local reserved-slot check in
              * proc_register_adopted_local() also closes the later window after
@@ -1157,13 +1165,13 @@ typedef struct {
     bool found;
 } registry_find_ctx_t;
 
-/* Locate @target's guest pid without registry_parse_cb's per-record
- * kill(2) liveness probe: that check exists to build a filtered live-
- * membership list for group-signal delivery, but a host_pid ->guest_pid
- * lookup is only ever done for a pid the caller just observed to be alive
- * (e.g. it holds a conflicting file lock right now), so it is redundant
- * here. proc_host_to_guest_pid still verifies the match via proc_pidpath
- * to guard against the pid having been recycled.
+/* Locate @target's guest pid without registry_parse_cb's per-record kill(2)
+ * liveness probe: that check exists to build a filtered live- membership list
+ * for group-signal delivery, but a host_pid ->guest_pid lookup is only ever
+ * done for a pid the caller just observed to be alive (e.g. it holds a
+ * conflicting file lock right now), so it is redundant here.
+ * proc_host_to_guest_pid still verifies the match via proc_pidpath to guard
+ * against the pid having been recycled.
  */
 static void registry_find_by_host_cb(char *rec, void *vctx)
 {
@@ -1232,6 +1240,7 @@ static void proc_registry_publish(pid_t host_pid,
         }
     if (idx < 0) {
         if (n == REGISTRY_MAX_ENTRIES)
+
             /* No slot for a new live member: group signals (kill(-1),
              * kill(-pgid), kill(0)) reaching this pid via the registry will
              * miss it. Warn rather than drop silently.
@@ -1293,6 +1302,7 @@ void proc_registry_sync_self_pgid(guest_t *g)
     pid_t self = getpid();
     int64_t self_guest = proc_get_pid();
     for (int i = 0; i < n; i++)
+
         /* Match host pid AND guest pid: a stale same-host-pid record left by a
          * recycled pid must not overwrite this process's group.
          */
@@ -1384,6 +1394,7 @@ int proc_send_guest_signal(pid_t host_pid, int64_t target_guest_pid, int signum)
         close(fd);
         return -1;
     }
+
     /* The line is durably appended under the lock, so ring the doorbell even if
      * close() reports an error; suppressing the kill would leave the queued
      * line waiting for some later unrelated signal.
@@ -1489,9 +1500,10 @@ void proc_process_exit(int wait_status)
 
     for (uint32_t i = 0; i < nreparented; i++) {
         if (reparented[i].exited) {
-            /* The exiting process is not necessarily a child of the adopter,
-             * so its own SIGCHLD goes elsewhere. Notify the adopter explicitly
-             * for every already-terminal child that became waitable there. */
+            /* The exiting process is not necessarily a child of the adopter, so
+             * its own SIGCHLD goes elsewhere. Notify the adopter explicitly for
+             * every already-terminal child that became waitable there.
+             */
             if (adopter_host_pid > 0)
                 (void) proc_send_guest_signal(adopter_host_pid, adopter_pid,
                                               LINUX_SIGCHLD);
@@ -1561,8 +1573,8 @@ static void proc_notify_reparent(pid_t host_pid,
     /* SIGUSR2 is a standard signal, so multiple doorbells can coalesce. The
      * file record remains durable, but a process exiting immediately after one
      * successful kill must not assume the receiver already updated its shim
-     * identity cache. Retry until the child acknowledges the registry's
-     * pending transaction, with a bounded 50ms exit-path delay.
+     * identity cache. Retry until the child acknowledges the registry's pending
+     * transaction, with a bounded 50ms exit-path delay.
      */
     for (int attempt = 0; attempt < 20; attempt++) {
         if (lifecycle_reparent_complete(target_guest_pid, new_ppid))
@@ -1691,8 +1703,8 @@ int64_t proc_host_to_guest_pid(pid_t host_pid)
     if (!ctx.found)
         return -1;
 
-    /* Guard against host pid reuse: only trust the hit if the pid still
-     * runs this elfuse binary, same check as proc_get_namespace_targets.
+    /* Guard against host pid reuse: only trust the hit if the pid still runs
+     * this elfuse binary, same check as proc_get_namespace_targets.
      */
     char our_path[PROC_PIDPATHINFO_MAXSIZE];
     int our_len = proc_pidpath(getpid(), our_path, sizeof(our_path));
@@ -1793,10 +1805,11 @@ int64_t sys_ptrace(guest_t *g,
          * the tracee out of hv_vcpu_run; the tracee will then enter ptrace-stop
          * in its HV_EXIT_REASON_CANCELED handler.
          *
-         * Read the vCPU handle under thread_lock: thread_find drops the lock
-         * before returning, so touching target->vcpu afterwards would race a
-         * concurrent teardown/recycle. Snapshot the handle while locked, then
-         * call HVF outside the lock (framework calls must not run under it).
+         * Kick the tracee under thread_lock, not after releasing it: the tracee
+         * destroys its own vCPU under the same lock on exit, so snapshotting
+         * the handle and calling hv_vcpus_exit outside the lock could hand HVF
+         * a freed vCPU. Holding the lock across the kick serializes it against
+         * destruction; the kick does not block, so this is safe.
          */
         pthread_mutex_t *tlock = thread_get_lock();
         pthread_mutex_lock(tlock);
@@ -1809,22 +1822,19 @@ int64_t sys_ptrace(guest_t *g,
             pthread_mutex_unlock(tlock);
             return 0; /* Already stopped */
         }
-        hv_vcpu_t vcpu = target->vcpu;
-        bool vcpu_valid = target->vcpu_valid;
+
         /* If the tracee is still in vCPU bring-up (handle not yet published),
          * hv_vcpus_exit cannot reach it, and dropping the interrupt would lose
-         * it silently. Record it under thread_lock: the worker checks this flag
-         * at publish and self-kicks so the interrupt is delivered before it
-         * runs any guest code. This serializes against the worker's publish
-         * (also under thread_lock), so exactly one of the two paths delivers
-         * it.
+         * it silently. Record it instead: the worker checks this flag at
+         * publish and self-kicks so the interrupt is delivered before it runs
+         * any guest code. This serializes against the worker's publish (also
+         * under thread_lock), so exactly one of the two paths delivers it.
          */
-        if (!vcpu_valid)
+        if (target->vcpu_valid)
+            hv_vcpus_exit(&target->vcpu, 1);
+        else
             target->ptrace_interrupt_pending = true;
         pthread_mutex_unlock(tlock);
-
-        if (vcpu_valid)
-            hv_vcpus_exit(&vcpu, 1);
         return 0;
     }
 
@@ -2152,6 +2162,7 @@ int64_t sys_wait4(guest_t *g,
             }
             return ptrace_tid;
         }
+
         /* ptrace_tid == 0: no matching children or WNOHANG; fall through to the
          * process table for regular fork children.
          */
@@ -2229,11 +2240,12 @@ int64_t sys_wait4(guest_t *g,
                 if (ret > 0) {
                     if (WIFEXITED(status) || WIFSIGNALED(status))
                         status = lifecycle_guest_terminal_status(gpid, status);
+
                     /* Credit CPU only on a terminal report. mac_options may
-                     * carry WUNTRACED/WCONTINUED, and a stop/continue report
-                     * is a snapshot of a still-running child: crediting it
-                     * here would double- or triple-count the same child
-                     * across its stop, continue, and final exit reports.
+                     * carry WUNTRACED/WCONTINUED, and a stop/continue report is
+                     * a snapshot of a still-running child: crediting it here
+                     * would double- or triple-count the same child across its
+                     * stop, continue, and final exit reports.
                      */
                     if (WIFEXITED(status) || WIFSIGNALED(status))
                         proc_children_cpu_add(&ru);
@@ -2351,14 +2363,14 @@ int64_t sys_wait4(guest_t *g,
             if (mac_options & WNOHANG) {
                 ret = wait4(host_pid, &status, mac_options, &ru);
             } else {
-                /* A bare blocking wait4 has no re-check point: a worker
-                 * parked here past exit_group is invisible to
-                 * thread_join_workers' poll cap and touches guest memory
-                 * (status/rusage writes below) on an eventual delayed
-                 * return, well after guest_destroy may have unmapped it.
-                 * Poll with WNOHANG under a bounded retry instead, mirroring
-                 * the pid==-1 loop above; proc_mark_child_exited broadcasts
-                 * pid_cond on every host child exit.
+                /* A bare blocking wait4 has no re-check point: a worker parked
+                 * here past exit_group is invisible to thread_join_workers'
+                 * poll cap and touches guest memory (status/rusage writes
+                 * below) on an eventual delayed return, well after
+                 * guest_destroy may have unmapped it. Poll with WNOHANG under a
+                 * bounded retry instead, mirroring the pid==-1 loop above;
+                 * proc_mark_child_exited broadcasts pid_cond on every host
+                 * child exit.
                  */
                 for (;;) {
                     ret = wait4(host_pid, &status, mac_options | WNOHANG, &ru);
@@ -2552,10 +2564,11 @@ int64_t sys_waitid(guest_t *g,
                 }
                 status = lifecycle_guest_terminal_status(entry_gpid, status);
                 pthread_mutex_lock(&pid_lock);
-                /* Host wait4 necessarily consumes the host zombie. Preserve
-                 * the status/rusage in the guest process table so Linux
-                 * WNOWAIT remains repeatable and a later consuming wait can
-                 * account and remove it exactly once.
+
+                /* Host wait4 necessarily consumes the host zombie. Preserve the
+                 * status/rusage in the guest process table so Linux WNOWAIT
+                 * remains repeatable and a later consuming wait can account and
+                 * remove it exactly once.
                  */
                 if (proc_table[i].active &&
                     proc_table[i].host_pid == host_pid) {
@@ -2640,6 +2653,7 @@ int64_t sys_waitid(guest_t *g,
 
         if (mac_options & WNOHANG) {
             pthread_mutex_unlock(&pid_lock);
+
             /* Per POSIX/Linux: zero siginfo when WNOHANG returns with no
              * waitable children, so callers can distinguish via si_pid.
              */
@@ -2798,6 +2812,7 @@ int proc_preempt_init(void)
     sigemptyset(&block);
     sigaddset(&block, SIGUSR2);
     sigaddset(&block, SIGALRM);
+
     /* pthread_sigmask returns the error code directly. If the block fails, vCPU
      * threads would inherit an unblocked mask and a signal landing mid-run
      * could still produce HV_EXIT_REASON_UNKNOWN, so fail bring-up rather than
@@ -2875,6 +2890,7 @@ static void sig_drain_cb(char *rec, void *vctx)
         return;
     p = end;
     long signum = strtol(p, &end, 10);
+
     /* Reject any trailing garbage so a forged record like "<ns> <pid> 9junk"
      * from a same-user temp-dir writer cannot be accepted as a bare signal.
      */
@@ -2897,6 +2913,7 @@ static void drain_external_guest_signal(void)
     char path[PATH_MAX];
     if (!signal_transport_path(path, sizeof(path), getpid()))
         return;
+
     /* O_RDWR (not O_RDONLY) so the drain can truncate under the lock. No
      * O_CREAT: if no sender has written since the last drain, there is nothing
      * to consume.
@@ -3081,6 +3098,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                     int ret = syscall_dispatch(vcpu, g, &exit_code, verbose);
                     if (ret == 1)
                         running = false;
+
                     /* execve replaced the process image; sys_execve already
                      * installed the new X0/syscall-return state.
                      */
@@ -3230,6 +3248,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                         value = 0x00000111ff000000ULL;
                         have_vz_override = true;
                     }
+
                     /* ID_AA64MMFR1_EL1 (3,0,0,7,1): VZ returns 0. Raw hardware
                      * (e.g., 0x11212000) exposes HPDS, PAN, LO, XNX etc. that
                      * VZ does not virtualize.
@@ -3413,14 +3432,15 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                             "%s: W^X toggle FAILED "
                             "(split=%d update=%d) far=0x%llx",
                             prefix, sr, ur, (unsigned long long) far);
+
                     /* TLB flush is done by the shim (tlbi_restore_eret) for the
                      * single faulting page. Clear this thread's pending request
                      * so the next syscall epilogue does not re-flush the W^X
                      * page. cpu_tlbi_req is per-vCPU, so this only touches our
                      * own slot -- concurrent vCPUs are unaffected.
                      *
-                     * The HVC #9 shim now consumes X8 as a post-HVC marker:
-                     * 0 means W^X succeeded and the shim should run the TLBI
+                     * The HVC #9 shim now consumes X8 as a post-HVC marker: 0
+                     * means W^X succeeded and the shim should run the TLBI
                      * retry epilogue; 2 means signal_deliver_fault installed a
                      * handler frame and the shim must drop its saved frame.
                      * Clear X8 here so a guest's pre-fault X8 value cannot be
@@ -3549,6 +3569,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                         signal_set_fault_info(LINUX_ILL_ILLOPC, elr_addr, esr);
                         int sig_ret = signal_deliver_fault(
                             vcpu, g, LINUX_SIGILL, &exit_code);
+
                         /* HVC #11 consumes X8 as the post-fault TLBI opcode.
                          * signal_deliver() may leave it unchanged when no
                          * handler is materialized, or set the syscall-path
@@ -3624,6 +3645,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                      * a later legitimate retry.
                      */
                     enum { STALE_TLB_RETRY_MAX = 16 };
+
                     /* Only translation (fsc_type 0x01) and permission (0x03)
                      * faults are stale-TLB plausible. Alignment,
                      * external-abort, and access-flag classes cannot be cleared
@@ -3690,6 +3712,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                             tlbi_request_emit_to_vcpu(vcpu);
                             break;
                         }
+
                         /* Retry budget exhausted: the entry is not actually
                          * stale. Reset the slot and fall through to SIGSEGV.
                          */
@@ -3727,6 +3750,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                     signal_set_fault_info(si_code, far_addr, esr);
                     int sig_ret = signal_deliver_fault(vcpu, g, LINUX_SIGSEGV,
                                                        &exit_code);
+
                     /* HVC #11 consumes X8 as the post-fault TLBI opcode.
                      * signal_deliver() may leave it unchanged when no handler
                      * is materialized, or set the syscall-path frame-drop
@@ -3758,6 +3782,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                     uint64_t esr;
                     hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ESR_EL1, &esr);
                     uint32_t iss = (uint32_t) (esr & 0x1FFFFFF);
+
                     /* Decode ISS for system instruction:
                      *   Op0[21:20] Op2[19:17] Op1[16:14]
                      *   CRn[13:10] Rt[9:5] CRm[4:1] Dir[0]
@@ -3917,6 +3942,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                     int reason =
                         (ec == 0x30) ? GDB_STOP_BREAKPOINT : GDB_STOP_STEP;
                     uint64_t stop_pc = vcpu_get_reg(vcpu, HV_REG_PC);
+
                     /* TDE routes debug exceptions EL0->EL2, bypassing EL1.
                      * ELR_EL1 and SPSR_EL1 are NOT updated; sync them from
                      * HV_REG_PC/HV_REG_CPSR so the GDB register snapshot reads
@@ -4084,6 +4110,7 @@ int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                 int sig_ret = signal_deliver(vcpu, g, &exit_code);
                 if (sig_ret < 0)
                     running = false;
+
                 /* sig_ret >= 0: signal delivered or nothing pending, loop back
                  * and resume vCPU execution
                  */

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -752,6 +752,12 @@ run_unit_tests()
     test_rc "$runner" "test-exit-group-teardown-fork" 42 \
         "$bindir/test-exit-group-teardown" fork
 
+    printf "\nTeardown vs live/bring-up worker vCPUs\n"
+    test_rc "$runner" "test-teardown-live-vcpu-spin" 42 \
+        "$bindir/test-teardown-live-vcpu" spin
+    test_rc "$runner" "test-teardown-live-vcpu-bringup" 42 \
+        "$bindir/test-teardown-live-vcpu" bringup
+
     printf "\nSysV shared memory\n"
     test_rc "$runner" "test-sysv-shm" 0 "$bindir/test-sysv-shm"
 

--- a/tests/test-teardown-live-vcpu-host.c
+++ b/tests/test-teardown-live-vcpu-host.c
@@ -1,0 +1,155 @@
+/*
+ * Unit test: thread_destroy_all_vcpus live-worker accounting
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * guest_destroy tears down the VM and slab only when thread_destroy_all_vcpus
+ * reports the table fully drained. HVF vCPUs are thread-affine, so an active
+ * worker slot that has not published vm_exited -- whether its vCPU is published
+ * or it is still mid-bring-up (active, vcpu_valid == false, about to create and
+ * enter a vCPU on its own thread) -- must be reported live and left untouched,
+ * never destroyed from this thread. A regression that used vcpu_valid as the
+ * liveness proxy would skip a bring-up worker and let guest_destroy tear the VM
+ * down under it. A slot that already published vm_exited (a vm-clone child that
+ * self-destroyed its vCPU and stays active only for wait4) holds no live vCPU
+ * and must NOT be reported live, or teardown is wrongly deferred.
+ *
+ * This runs on the host against the real thread.c. It drives only the worker
+ * branches, so no hv_vcpu_destroy is ever called (the main-vCPU handle is
+ * passed as not-valid); no Hypervisor entitlement or live VM is needed. proc /
+ * log / signal hooks that thread.c references are stubbed since none affect the
+ * code under test.
+ *
+ * Guest-side companion: tests/test-teardown-live-vcpu.c drives the same
+ * teardown path end-to-end through a running VM.
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "runtime/thread.h"
+
+#include "debug/log.h"    /* log_impl prototype */
+#include "syscall/proc.h" /* proc_exit_group_requested prototype */
+
+/* thread.c externs not exercised by the code paths under test. */
+int proc_exit_group_requested(void)
+{
+    return 0;
+}
+
+void signal_refresh_pending_hint(void) {}
+
+void log_impl(int level, const char *file, int line, const char *fmt, ...)
+{
+    (void) level;
+    (void) file;
+    (void) line;
+    (void) fmt;
+}
+
+static int fails;
+
+#define CHECK(cond)                                                  \
+    do {                                                             \
+        if (!(cond)) {                                               \
+            printf("  FAIL %s:%d: %s\n", __func__, __LINE__, #cond); \
+            fails++;                                                 \
+        }                                                            \
+    } while (0)
+
+/* An empty table is fully drained: nothing live, nothing destroyed. */
+static void test_empty_table_drained(void)
+{
+    thread_init();
+    bool live = true;
+    bool main_destroyed = thread_destroy_all_vcpus(0, false, &live);
+    CHECK(!live);
+    CHECK(!main_destroyed);
+}
+
+/* A worker still in bring-up (active, vCPU not yet published) must be reported
+ * live and left active -- the regression this guards skipped it via
+ * !vcpu_valid, leaving live == false. A worker is never decremented from
+ * active_thread_count here (only the main slot is).
+ */
+static void test_bringup_worker_is_live(void)
+{
+    thread_init();
+    thread_entry_t *w = thread_alloc(1000, 0, 0);
+    CHECK(w != NULL);
+    if (!w)
+        return;
+    CHECK(w->active);
+    CHECK(!w->vcpu_valid);
+    int count_before = thread_active_count();
+
+    bool live = false;
+    bool main_destroyed = thread_destroy_all_vcpus(0, false, &live);
+    CHECK(live);      /* bring-up worker counted as live */
+    CHECK(w->active); /* left untouched for process-exit reclamation */
+    CHECK(!main_destroyed);
+    CHECK(thread_active_count() == count_before); /* worker not decremented */
+}
+
+/* A worker that has published its vCPU is likewise reported live and its handle
+ * is not destroyed from this (foreign) thread.
+ */
+static void test_published_worker_not_cross_destroyed(void)
+{
+    thread_init();
+    thread_entry_t *w = thread_alloc(1001, 0, 0);
+    CHECK(w != NULL);
+    if (!w)
+        return;
+    w->vcpu = 0x1234; /* a handle this thread does not own */
+    w->vcpu_valid = true;
+    int count_before = thread_active_count();
+
+    bool live = false;
+    bool main_destroyed = thread_destroy_all_vcpus(0, false, &live);
+    CHECK(live);
+    CHECK(w->active);     /* not deactivated */
+    CHECK(w->vcpu_valid); /* not cross-thread destroyed */
+    CHECK(!main_destroyed);
+    CHECK(thread_active_count() == count_before);
+}
+
+/* A vm-clone child that already exited (vCPU self-destroyed on its own thread,
+ * vm_exited published) but stays active for wait4 holds no live vCPU, so it
+ * must NOT be reported live -- otherwise guest_destroy wrongly defers the
+ * explicit HVF teardown for an already-dead slot. Guards the vm_exited
+ * exclusion.
+ */
+static void test_exited_vmclone_worker_not_live(void)
+{
+    thread_init();
+    thread_entry_t *w = thread_alloc(1002, 0, 0);
+    CHECK(w != NULL);
+    if (!w)
+        return;
+    w->vm_exited = true; /* vCPU already destroyed; vcpu_valid stays false */
+
+    bool live = true;
+    bool main_destroyed = thread_destroy_all_vcpus(0, false, &live);
+    CHECK(!live); /* exited slot is not a live worker */
+    CHECK(!main_destroyed);
+    CHECK(w->active); /* left for wait4; teardown does not touch it */
+}
+
+int main(void)
+{
+    printf(
+        "test-teardown-live-vcpu-host: thread_destroy_all_vcpus accounting\n");
+
+    test_empty_table_drained();
+    test_bringup_worker_is_live();
+    test_published_worker_not_cross_destroyed();
+    test_exited_vmclone_worker_not_live();
+
+    if (fails == 0)
+        printf("  all checks passed\n");
+    return fails > 0 ? 1 : 0;
+}

--- a/tests/test-teardown-live-vcpu.c
+++ b/tests/test-teardown-live-vcpu.c
@@ -1,0 +1,139 @@
+/*
+ * Teardown must never cross-thread-destroy a live or bring-up worker vCPU
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * HVF vCPUs are thread-affine: only the creating thread may run or destroy a
+ * vCPU. When the process tears down (main thread exit_group -> guest_destroy)
+ * while worker threads still own live vCPUs, the teardown path must not call
+ * hv_vcpu_destroy on a worker's vCPU from the main thread, nor hv_vm_destroy /
+ * munmap the guest slab while a worker vCPU is still live. Doing either frees a
+ * kernel vCPU object out from under its owning thread and faults the host
+ * kernel (near-null dereference of the freed, poisoned vCPU struct).
+ *
+ * Two windows are exercised, each ending in exit_group(42):
+ *
+ *   spin:    a batch of workers spins on sched_yield, so every worker is inside
+ *            hv_vcpu_run (a live vCPU) when the main thread calls exit_group.
+ *            Teardown scans the thread table with those vCPUs still owned by
+ *            their threads.
+ *
+ *   bringup: a burst of workers is cloned and the main thread calls exit_group
+ *            immediately, so some workers are still mid-bring-up -- the slot is
+ *            active but the vCPU handle has not been published yet -- when the
+ *            teardown scan runs. Such a worker is about to create and enter its
+ *            own vCPU, so teardown must treat it as live and defer, not skip
+ * it.
+ *
+ * A clean exit with code 42 means teardown neither destroyed a foreign vCPU nor
+ * tore the VM down under one. A crash, a host fault, or a hang (turned into a
+ * timeout failure by the driver) means the teardown race is back.
+ *
+ * Syscalls: clone(220), nanosleep(101), sched_yield(124), exit_group(94)
+ */
+
+#include <string.h>
+
+#include "raw-syscall.h"
+
+#define CLONE_THREAD_FLAGS \
+    (0x00010000 | 0x00000100 | 0x00000200 | 0x00000800 | 0x00200000)
+
+#define EXIT_CODE 42
+
+/* Stay well under elfuse's MAX_THREADS (64); every worker here runs forever, so
+ * they are all alive at teardown alongside the main thread.
+ */
+#define WORKERS 40
+#define STACK_SIZE 16384
+
+static char worker_stacks[WORKERS][STACK_SIZE] __attribute__((aligned(16)));
+
+static void msleep(long ms)
+{
+    struct {
+        long tv_sec, tv_nsec;
+    } ts = {ms / 1000, (ms % 1000) * 1000000L};
+    raw_syscall4(101, (long) &ts, 0, 0, 0); /* nanosleep */
+}
+
+/* Never returns: keeps the worker inside hv_vcpu_run (or at a run-loop
+ * preemption point) so its vCPU is live for the whole teardown window.
+ */
+static int spin_fn(void)
+{
+    for (;;)
+        raw_syscall0(124); /* sched_yield */
+    return 0;
+}
+
+/* Clone one CLONE_THREAD worker running spin_fn on the given stack.
+ *
+ * Returns the clone result (>0 tid in the parent, <0 on failure); the child
+ * never returns.
+ */
+static long spawn_spinner(int i)
+{
+    char *stack_top = worker_stacks[i] + STACK_SIZE;
+    long ret = raw_syscall5(220, CLONE_THREAD_FLAGS, (long) stack_top, 0, 0, 0);
+    if (ret == 0) {
+        spin_fn();
+        raw_syscall1(93, 0); /* exit (unreached) */
+    }
+    return ret;
+}
+
+/* spin: bring every worker fully up (running a live vCPU), then exit_group. */
+static int scenario_spin(void)
+{
+    for (int i = 0; i < WORKERS; i++) {
+        if (spawn_spinner(i) < 0)
+            break; /* out of thread slots; the rest still exercise teardown */
+    }
+
+    /* Let the workers reach the spin loop so their vCPUs are live, not still in
+     * bring-up, when teardown runs.
+     */
+    msleep(100);
+    raw_syscall1(94, EXIT_CODE); /* exit_group */
+    return 1;                    /* unreached */
+}
+
+/* bringup: clone a burst and exit_group immediately, so teardown races workers
+ * that are still creating/publishing their vCPUs.
+ */
+static int scenario_bringup(void)
+{
+    for (int i = 0; i < WORKERS; i++) {
+        if (spawn_spinner(i) < 0)
+            break;
+    }
+    raw_syscall1(94, EXIT_CODE); /* exit_group with bring-up in flight */
+    return 1;                    /* unreached */
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+
+    if (argc < 2) {
+        static const char usage[] =
+            "usage: test-teardown-live-vcpu spin|bringup\n";
+        raw_syscall3(64, 2, (long) usage, sizeof(usage) - 1); /* write */
+        return 2;
+    }
+
+    if (!strcmp(argv[1], "spin"))
+        rc = scenario_spin();
+    else if (!strcmp(argv[1], "bringup"))
+        rc = scenario_bringup();
+    else
+        rc = 2;
+
+    /* Scenarios normally never return: exit_group(42) ends the process. A
+     * return means setup failed; surface it as a visible wrong exit code.
+     */
+    raw_syscall1(94, rc);
+    return rc;
+}


### PR DESCRIPTION
HVF vCPUs are thread-affine: only the creating thread may run or destroy a vCPU. guest_destroy could call hv_vcpu_destroy on a worker's vCPU from the main thread when the worker was still live past the join cap, freeing the kernel vCPU object out from under its owning thread. The owner's next kernel-side access read the freed, zone-poisoned struct at offset 0x8 and panicked the host (data abort, translation fault, seen twice with an identical backtrace on macOS 26.5.2 / xnu-12377).

Close every teardown-vs-live-vCPU window:
- thread_destroy_all_vcpus destroys only the main vCPU (owned by the calling thread) and reports any live worker via a live_workers_left out-param instead of destroying it cross-thread. Every active non-main slot counts as live, including a worker still in bring-up (active, vcpu_valid not yet published) that is about to enter its own vCPU.
- guest_destroy defers all remaining HVF teardown (vcpu destroy, hv_vm_unmap, hv_vm_destroy, munmap of the slab) to process exit when a worker is live -- the one operation that safely stops a foreign vCPU. It is always terminal: main() and the fork-child return straight into process exit after it.
- Every worker-exit and bring-up-failure path destroys the vCPU under thread_lock and only then clears vcpu_valid / publishes vm_exited, so a teardown scan or a parent wait4 reap can never observe an active-or-reapable slot whose vCPU is still live.

Also resolves the tracked guest_destroy-vs-worker teardown data race (a TSAN-caught unmap racing a live worker): the deferral returns before any teardown write. The residual stall is confirmed to come from uninterruptible host syscalls (blocking fcntl file locks, fsync); the deferral is the correct handling.

Close #247

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes host panics from cross-thread `hv_vcpu_destroy` by ensuring teardown never destroys a foreign vCPU and defers VM teardown when any worker is live or in bring-up. Also resolves the TSAN unmap‑vs‑worker race in `guest_destroy`.

- **Bug Fixes**
  - `thread_destroy_all_vcpus` destroys only the main vCPU and reports `live_workers_left` when any non‑main slot is active (including bring‑up with `vcpu_valid=false`); slots that already published `vm_exited` are not counted live.
  - `guest_destroy` defers `hv_vm_unmap`/`hv_vm_destroy`/slab `munmap` (and any cross‑thread vCPU destroy) to process exit if a worker is live; the main vCPU handle is cleared in all cases.
  - Worker exit and bring‑up failure paths destroy their own vCPU under `thread_lock` before clearing `vcpu_valid`/publishing `vm_exited`; table‑scan interrupts (`thread_interrupt_all`, `thread_quiesce_siblings`, `PTRACE_INTERRUPT`) now call `hv_vcpus_exit` while holding the lock.
  - `cleanup_main_resources` always runs host‑only cleanup even when teardown is deferred, so mounts and temp ELF files are not orphaned.
  - Tests: added `test-teardown-live-vcpu-host` and `test-teardown-live-vcpu` (spin/bringup), wired into `make check` and `tests/test-matrix.sh`.

- **Migration**
  - `guest_destroy` is terminal. If any worker remains live, HV teardown is deferred to process exit; do not reuse the process to start another VM.

<sup>Written for commit eeec2f4e4e2dcaf95247199aadfc81c5de9c2891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

