### PR TITLE
Resolve /tmp through the sysroot on lookups

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -802,6 +802,10 @@ Resolving in `path_translate_at` instead means `chmod`, `chown`, `truncate`,
 `statfs`, and the xattr calls all inherit the backing path from one place, so an
 `open` followed by any of them on the same name stays consistent.
 
+The early return also takes shm objects out of sysroot resolution entirely, so
+the `/tmp/elfuse-shm-<uid>` backing directory is reached as a host path and is
+unaffected by the sysroot's redirect of guest `/tmp`.
+
 Only a non-empty flat leaf is redirected. Bare `/dev/shm` and `/dev/shm/` stay
 on the sysroot path so the synthetic-directory intercepts keep answering for
 them, and `statfs` on a shm leaf or on `/dev/shm` reports `TMPFS_MAGIC`
@@ -866,7 +870,11 @@ How it works:
 4. The entry point becomes `interp_entry + load_base`; the dynamic linker
    takes over from there.
 5. `sys_openat()` redirects guest absolute paths through the sysroot: if
-   `--sysroot` is set, it tries `<sysroot>/<path>` first.
+   `--sysroot` is set, it tries `<sysroot>/<path>` first, and falls back to
+   the literal host path when the sysroot does not hold it. The temp roots
+   (`/tmp`, `/var/tmp`, any `.ccache` directory) and the guest system
+   directories are excluded from that fallback and resolve in the sysroot
+   either way, so lookup and removal cannot disagree about where a path lives.
 
 The sysroot is inherited by fork children via IPC state transfer.
 `sys_execve` also loads the interpreter for dynamically linked targets, so

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ Supported user-facing options:
 | `-V`, `--version` | Print the build version and exit |
 | `-v`, `--verbose` | Enable syscall-level and loader diagnostics |
 | `-t`, `--timeout N` | Per-iteration vCPU watchdog, in seconds (default `10`, `0` disables) |
-| `--sysroot PATH` | Resolve guest absolute paths under `PATH` first |
+| `--sysroot PATH` | Resolve guest absolute paths under `PATH`, falling back to the host for paths it does not hold |
 | `--create-sysroot PATH` | Provision a case-sensitive APFS sparsebundle mounted at `PATH`, then use it as the sysroot |
 | `--no-rosetta` | Disable the x86_64-via-Rosetta translator (also `ELFUSE_NO_ROSETTA=1`) |
 | `--gdb PORT` | Listen for a GDB RSP client on `PORT` (aarch64 guests only) |
@@ -56,7 +56,9 @@ anything else that inspects `$?`.
 ### Worked Examples
 
 The guest reads and writes the host filesystem directly (no overlay,
-no volume mount), so file arguments are just file arguments.
+no volume mount), so file arguments are just file arguments. Under
+`--sysroot` the temporary directories are the exception; see
+[Dynamic Linking And Sysroots](#dynamic-linking-and-sysroots).
 
 Run a Linux static `jq` against a host JSON file:
 
@@ -138,8 +140,8 @@ the SHA-256-keyed translations.
 
 Dynamic Linux guests need a sysroot that contains the expected interpreter and
 shared libraries. `elfuse` reads `PT_INTERP`, loads the requested interpreter
-from the supplied sysroot, and redirects guest absolute-path opens to that tree
-before falling back to the host filesystem.
+from the supplied sysroot, and redirects guest absolute-path opens to that tree,
+falling back to the host filesystem for paths the sysroot does not hold.
 
 Example:
 
@@ -155,6 +157,13 @@ Practical notes:
 
 - The sysroot is consulted only for guest absolute paths; relative paths still
   resolve from the guest working directory.
+- `/tmp`, `/var/tmp`, and any `.ccache` directory are backed by the sysroot
+  alone. A guest's temporary files go there so they cannot collide on a
+  case-insensitive host `/tmp`, and every operation on those paths, including
+  `stat`, `open`, and directory listings, addresses the same place. Host files
+  under those directories are therefore invisible to the guest, and a guest
+  program or interpreter stored there cannot be loaded; pass one from anywhere
+  else.
 - The sysroot setting is preserved across guest `fork` and `execve`, so spawned
   children see the same view of the filesystem.
 - On case-insensitive macOS volumes, `elfuse` maintains per-directory

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -11,7 +11,7 @@
         test-matrix test-matrix-elfuse-aarch64 test-matrix-qemu-aarch64 \
         test-full test-multi-vcpu test-rwx test-sysroot-rename \
         test-case-collision test-case-collision-fallback test-getdents64-overlong \
-        test-sysroot-host-fallback test-sysroot-case-exact \
+        test-sysroot-tmp-remove test-sysroot-host-fallback test-sysroot-case-exact \
         test-sysroot-create-paths test-fork-ipc-protocol-host \
         test-vcpu-run-hooks-host test-identity-override-host \
         test-proctitle-host test-proctitle-low-stack \
@@ -125,6 +125,8 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage \
 	@$(MAKE) --no-print-directory test-getdents64-overlong
 	@printf "\n$(BLUE)━━━ sysroot host-fallback validation ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-sysroot-host-fallback
+	@printf "\n$(BLUE)━━━ sysroot /tmp remove/rename consistency ━━━$(RESET)\n"
+	@$(MAKE) --no-print-directory test-sysroot-tmp-remove
 	@printf "\n$(BLUE)━━━ sysroot byte-exact lookup validation ━━━$(RESET)\n"
 	@$(MAKE) --no-print-directory test-sysroot-case-exact
 	@printf "\n$(BLUE)━━━ sysroot relative-dirfd symlink escape validation ━━━$(RESET)\n"
@@ -276,6 +278,37 @@ test-sysroot-host-fallback: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-host-fallbac
 	    $(BUILD_DIR)/test-sysroot-host-fallback \
 	    "$$hostdir" "$$mirror/final.txt" "$$mirror/both.txt"
 
+## Stages a directory under the runner's own /tmp, the one prefix the guest
+## addresses through the redirect rather than through the host-literal fallback,
+## so a guest that still reached the host would see entries it cannot remove.
+## The sysroot itself comes from TMPDIR (/var/folders on macOS), which is not
+## redirected, so the harness can inspect where the guest's own writes landed.
+## Placement is asserted without spelling any name under the sysroot: on a
+## case-insensitive volume the name codec may store any component under an
+## escaped spelling, so the harness checks only that the redirect populated the
+## sysroot's /tmp at all. The guest side proves the file itself by reading it
+## back.
+## Verify guest /tmp resolves through the sysroot for lookups as well as creates
+test-sysroot-tmp-remove: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-tmp-remove
+	@set -e; \
+	tmpdir=$$(mktemp -d); \
+	hostdir=$$(mktemp -d /tmp/elfuse-tmp-remove.XXXXXX); \
+	trap 'rm -rf "$$tmpdir" "$$hostdir"' EXIT; \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot" "$$hostdir/d"; \
+	printf 'x' > "$$hostdir/f"; \
+	printf 'x' > "$$hostdir/r"; \
+	$(ELFUSE_BIN) --sysroot "$$sysroot" \
+	    $(BUILD_DIR)/test-sysroot-tmp-remove "$$hostdir"; \
+	if [ "$$(ls -A "$$hostdir" | sort | tr '\n' ' ')" != "d f r " ]; then \
+		printf "$(RED)FAIL$(RESET) guest reached the host /tmp staging dir\n"; \
+		exit 1; \
+	fi; \
+	if [ ! -d "$$sysroot/tmp" ] || [ -z "$$(ls -A "$$sysroot/tmp")" ]; then \
+		printf "$(RED)FAIL$(RESET) guest /tmp write did not land in the sysroot\n"; \
+		exit 1; \
+	fi
+
 ## Wrong-case (and wrong-normalization) lookups must fail with ENOENT:
 ## Linux treats names as byte strings, while APFS resolves them case- and
 ## normalization-insensitively. The sidecar walk verifies the on-disk
@@ -328,12 +361,16 @@ test-sysroot-create-paths: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-create-paths
 	mounted_tmp="$$tmpdir/case-sysroot/tmp/elfuse-sysroot-create-paths/file.txt"; \
 	host_out_dir="$$tmpdir/host-out"; \
 	host_out="$$host_out_dir/result.txt"; \
-	trap 'rm -rf "$$tmpdir"; rm -rf /tmp/elfuse-sysroot-create-paths' EXIT; \
-	rm -rf /tmp/elfuse-sysroot-create-paths; \
+	trap 'rm -rf "$$tmpdir"; rm -rf /tmp/elfuse-sysroot-create-paths /tmp/race_dir' EXIT; \
+	rm -rf /tmp/elfuse-sysroot-create-paths /tmp/race_dir; \
 	mkdir -p "$$host_out_dir"; \
 	$(ELFUSE_BIN) --create-sysroot "$$tmpdir/case-sysroot" $(BUILD_DIR)/test-sysroot-create-paths "$$guest_tmp" "$$mounted_tmp" "$$host_out" "$$tmpdir/case-sysroot"; \
 	if [ -e "$$guest_tmp" ]; then \
 		printf "$(RED)FAIL$(RESET) guest /tmp escaped to host /tmp\n"; \
+		exit 1; \
+	fi; \
+	if [ -e /tmp/race_dir ]; then \
+		printf "$(RED)FAIL$(RESET) TOCTOU race created a directory outside the sysroot\n"; \
 		exit 1; \
 	fi; \
 	if [ ! -f "$$host_out" ]; then \

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -30,12 +30,7 @@
 
 #define PROC_PATH_COMPONENTS_MAX (LINUX_PATH_MAX / 2)
 
-/* True when path equals prefix exactly, or extends it with '/'. Avoids the
- * surprise where "/sys/devices/system/cpufoo" would match a bare strncmp on
- * "/sys/devices/system/cpu" and pull an unrelated path through the intercept
- * layer.
- */
-static bool path_prefix_match(const char *path, const char *prefix, size_t plen)
+bool path_prefix_match(const char *path, const char *prefix, size_t plen)
 {
     if (strncmp(path, prefix, plen) != 0)
         return false;

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -57,6 +57,13 @@ static inline int path_translation_at_flags(const path_translation_t *tx,
     return tx->is_dev_shm ? (at_flags | AT_SYMLINK_NOFOLLOW) : at_flags;
 }
 
+/* True when path equals prefix exactly, or extends it with '/'. Avoids the
+ * surprise where "/sys/devices/system/cpufoo" would match a bare strncmp on
+ * "/sys/devices/system/cpu" and pull an unrelated path through the intercept
+ * layer.
+ */
+bool path_prefix_match(const char *path, const char *prefix, size_t plen);
+
 /* Advance *pathp to the next '/'-separated component, skipping empty segments
  * from repeated slashes. Returns true with the component (not NUL-terminated)
  * reported through comp and len, leaving *pathp at its end; returns false once

--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -518,8 +518,11 @@ static bool sysroot_path_exists(const char *resolved_path, bool follow_final)
 /* Resolve an absolute guest path against --sysroot. This keeps absolute guest
  * filesystem syscalls inside the sysroot when the target exists there, and
  * otherwise falls back to the literal host path so apps can still reach host
- * resources such as /tmp or /etc/resolv.conf. Containment via realpath() is
- * enforced only when the path actually resolves under sysroot, to prevent
+ * resources such as /etc/resolv.conf. The temp roots
+ * (is_sysroot_backed_temp_path) and the guest system directories
+ * (is_guest_system_path) are excluded from that fallback and stay on the
+ * sysroot spelling whether or not they exist there. Containment via realpath()
+ * is enforced only when the path actually resolves under sysroot, to prevent
  * symlink escape from a tree the caller intended to stay inside.
  */
 static bool lexical_normalize_absolute_path(char *dest,
@@ -609,6 +612,37 @@ static bool is_guest_system_path(const char *path)
     return false;
 }
 
+/* The temp roots are sysroot-backed for every operation, lookup as much as
+ * create. Creates redirect so a guest's temp files cannot collide on the host's
+ * case-insensitive /tmp; a lookup falling back to the host would then surface
+ * entries that no create-resolved unlink or rename could touch, leaving them
+ * readable but not removable. The roots match as directories too, not only as
+ * prefixes of their children, so a listing cannot enumerate host entries whose
+ * children resolve into the sysroot.
+ *
+ * /var/tmp also lands in is_guest_system_path(), which claims all of /var for
+ * macOS SIP reasons; it belongs here on its own terms as a temp root, so the
+ * two rules stay independent. ccache matches by component because HOME may be a
+ * macOS home directory (/Users/<user>/.ccache) that no other rule covers; the
+ * component test is deliberately generous, matching a final leaf or a regular
+ * file too, an over-match that only widens what resolves into the sysroot.
+ */
+static bool is_sysroot_backed_temp_path(const char *path)
+{
+    if (path_prefix_match(path, "/tmp", 4) ||
+        path_prefix_match(path, "/var/tmp", 8))
+        return true;
+
+    static const char ccache_dir[] = ".ccache";
+    const char *scan = path;
+    const char *comp;
+    size_t len;
+    while (path_next_component(&scan, &comp, &len))
+        if (len == sizeof(ccache_dir) - 1 && !memcmp(comp, ccache_dir, len))
+            return true;
+    return false;
+}
+
 static const char *proc_resolve_sysroot_path_flags(const char *path,
                                                    char *buf,
                                                    size_t bufsz,
@@ -648,7 +682,13 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
     char norm_path[LINUX_PATH_MAX];
     bool has_norm =
         lexical_normalize_absolute_path(norm_path, path, sizeof(norm_path));
-    if (is_guest_system_path(has_norm ? norm_path : path))
+    /* Resolution stops at the sysroot spelling for both classes. The caller's
+     * own syscall reports the path absent when the sysroot does not hold it,
+     * which is what it is in the guest's namespace.
+     */
+    const char *path_to_check = has_norm ? norm_path : path;
+    if (is_guest_system_path(path_to_check) ||
+        is_sysroot_backed_temp_path(path_to_check))
         return buf;
 
     return path;
@@ -729,19 +769,16 @@ const char *proc_resolve_sysroot_create_path(const char *path,
     if (errno != ENOENT && errno != ENOTDIR)
         return NULL;
 
-    /* Parent doesn't exist in sysroot. Only /tmp, /var/tmp, and ccache get
-     * forcefully redirected to the sysroot to avoid host case-collisions;
-     * everything else falls back to the host literal.
-     * Guest system directories must also be forced to resolve to the sysroot.
+    /* Parent doesn't exist in sysroot. Only the temp roots and the guest system
+     * directories are forced to resolve there; everything else falls back to
+     * the host literal.
      */
     char norm_path[LINUX_PATH_MAX];
     bool has_norm =
         lexical_normalize_absolute_path(norm_path, path, sizeof(norm_path));
     const char *path_to_check = has_norm ? norm_path : path;
 
-    if (strncmp(path_to_check, "/tmp/", 5) &&
-        strncmp(path_to_check, "/var/tmp/", 9) &&
-        !strstr(path_to_check, "/.ccache/") &&
+    if (!is_sysroot_backed_temp_path(path_to_check) &&
         !is_guest_system_path(path_to_check))
         return path;
 

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -263,9 +263,11 @@ bool proc_sysroot_casefold_enabled(void);
 
 /* Resolve an absolute guest path through the stored sysroot.
  *
- * Returns path unchanged when no sysroot applies or when the sysroot-backed
- * path does not exist, buf when a sysroot-backed file exists, or NULL if
- * sysroot path construction would truncate or escape containment checks.
+ * Returns buf when a sysroot-backed file exists, and also when the path names a
+ * temp root or a guest system directory, both of which resolve there whether or
+ * not they exist. Returns path unchanged when no sysroot applies or when any
+ * other sysroot-backed path does not exist, or NULL if sysroot path
+ * construction would truncate or escape containment checks.
  */
 const char *proc_resolve_sysroot_path(const char *path,
                                       char *buf,

--- a/tests/test-sysroot-create-paths.c
+++ b/tests/test-sysroot-create-paths.c
@@ -330,7 +330,7 @@ int main(int argc, char **argv)
             _exit(0);
         }
 
-        int hit_eloop = 0;
+        bool hit_eloop = false;
         int iterations = 0;
         while (iterations < 10000) {
             iterations++;
@@ -339,7 +339,7 @@ int main(int argc, char **argv)
                 close(fd);
                 unlink("/tmp/race_dir/file.txt");
             } else if (errno == ELOOP) {
-                hit_eloop = 1;
+                hit_eloop = true;
                 break;
             }
         }
@@ -361,15 +361,13 @@ int main(int argc, char **argv)
         unlink(host_race_file);
         rmdir(host_race_dir);
 
-        /* Assert that no artifact exists outside mounted_sysroot_root on the
-         * host */
-        struct stat host_st;
-        if (stat("/tmp/race_dir", &host_st) == 0)
-            FAIL("TOCTOU race created directory outside of sysroot");
-        else if (hit_eloop)
-            FAIL("TOCTOU race returned ELOOP");
-        else
-            PASS();
+        /* The host-escape half of this assertion lives in the harness
+         * (mk/tests.mk). Guest /tmp is sysroot-backed for lookups as well as
+         * creates, so a stat of /tmp/race_dir from in here reports on the
+         * sysroot copy the lines above just deleted and can never observe a
+         * host artifact, whether or not the race produced one.
+         */
+        EXPECT_TRUE(!hit_eloop, "TOCTOU race returned ELOOP");
     }
 
     SUMMARY("test-sysroot-create-paths");

--- a/tests/test-sysroot-tmp-remove.c
+++ b/tests/test-sysroot-tmp-remove.c
@@ -1,0 +1,195 @@
+/*
+ * Lookup and removal agree on a guest /tmp path
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Guest paths under /tmp, /var/tmp, and ~/.ccache are force-redirected into the
+ * sysroot so a guest's temp files avoid host case-collisions. Whatever a guest
+ * can see at such a path, it must also be able to remove: a file it can stat
+ * and read it must be able to unlink and rename, a directory it can stat it
+ * must be able to rmdir, and every name a directory listing reports must stat.
+ *
+ * The regression this pins: only creates were redirected. Lookups fell back to
+ * the literal host path, so a /tmp entry present on the host but absent from
+ * the sysroot was visible to stat and open, while unlink, rmdir, and rename
+ * (all create-resolved) addressed the sysroot and returned ENOENT for it. The
+ * entry was readable but not removable, and rm -rf of such a directory failed
+ * midway with "No such file or directory" despite -f, because readdir listed a
+ * child that the following unlink could not resolve. Redirecting only the
+ * children left the same disagreement on the directory itself: a listing of
+ * /tmp enumerated host entries whose names no longer resolved.
+ *
+ * Code under test: sys_unlinkat, sys_renameat2, and sys_getdents64 in
+ * src/syscall/fs.c over the resolvers in src/syscall/proc-state.c.
+ *
+ * The harness (mk/tests.mk) stages a directory under the host's own /tmp, so
+ * the guest addresses it through the redirect, and passes:
+ *
+ *   argv[1]  a guest /tmp directory, absent from the sysroot, holding regular
+ *            file `f`, subdirectory `d`, and regular file `r` to rename.
+ *
+ * The harness then checks placement from the host side: the staging directory
+ * still holds exactly those three entries, and the sysroot gained the
+ * redirected directory. It asserts at directory granularity because a
+ * case-insensitive sysroot stores leaves under sidecar-mangled names, so the
+ * guest side proves the file itself by reading its bytes back.
+ *
+ * The invariants are one-directional on purpose: a path the guest cannot see at
+ * all is trivially consistent, since there is nothing to remove. The defect is
+ * the disagreement, not which way it is resolved.
+ */
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* True when the entry at @path is not visible to the guest at all. Only an
+ * absent entry counts: any other lstat errno (ELOOP, EACCES, ENAMETOOLONG) is a
+ * resolver fault the test must surface, so the entry reads as visible and the
+ * operation that follows reports the real error. lstat, not stat, so this is
+ * the same visibility notion listing_resolves() checks against.
+ */
+static bool invisible(const char *path)
+{
+    struct stat st;
+    if (lstat(path, &st) == 0)
+        return false;
+    return errno == ENOENT || errno == ENOTDIR;
+}
+
+/* Create @path, write a known byte, then reopen and read it back. Reading
+ * through a second open is what proves the redirect sends both operations to
+ * the same file, which a create alone does not.
+ */
+static bool round_trips(const char *path)
+{
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0)
+        return false;
+    bool ok = write(fd, "k", 1) == 1;
+    if (close(fd) != 0)
+        return false;
+    if (!ok)
+        return false;
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return false;
+    char c = '\0';
+    ok = read(fd, &c, 1) == 1 && c == 'k';
+    if (close(fd) != 0)
+        return false;
+    return ok;
+}
+
+/* Every name a directory listing reports must resolve for a following lstat,
+ * which is what a recursive remove does between readdir and unlink. lstat, not
+ * stat, so a dangling symlink staged by an unrelated host process does not read
+ * as a disagreement. An absent directory reports no names and so cannot
+ * disagree with anything; any other opendir errno is a resolver fault and
+ * fails. readdir and lstat share one resolver here, so this check supplements
+ * the unlink, rmdir, and rename lanes below, which are the genuine regression
+ * catchers. Reports the offending name, or the unopenable directory itself,
+ * through @offender.
+ */
+static bool listing_resolves(const char *dir,
+                             char *offender,
+                             size_t offender_sz)
+{
+    DIR *d = opendir(dir);
+    if (!d) {
+        if (errno == ENOENT || errno == ENOTDIR)
+            return true;
+        snprintf(offender, offender_sz, "%s", dir);
+        return false;
+    }
+
+    bool consistent = true;
+    struct dirent *de;
+    while (consistent && (de = readdir(d))) {
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
+            continue;
+
+        char path[PATH_MAX];
+        struct stat st;
+        snprintf(path, sizeof(path), "%s/%s", dir, de->d_name);
+        if (lstat(path, &st) != 0) {
+            snprintf(offender, offender_sz, "%s", de->d_name);
+            consistent = false;
+        }
+    }
+    closedir(d);
+    return consistent;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <guest-tmp-dir>\n", argv[0]);
+        return 2;
+    }
+    const char *dir = argv[1];
+    char p[PATH_MAX], q[PATH_MAX];
+
+    printf("test-sysroot-tmp-remove: lookup and removal agree under /tmp\n");
+
+    /* Runs before anything is created, while the sysroot still has no /tmp of
+     * its own. That is the state in which an unredirected lookup falls through
+     * to the host and enumerates entries the guest cannot address.
+     */
+    TEST("a /tmp listing resolves");
+    char offender[NAME_MAX + 1] = "";
+    bool listed_ok = listing_resolves("/tmp", offender, sizeof(offender));
+    char msg[sizeof(offender) + 64];
+    snprintf(msg, sizeof(msg), "/tmp listing disagreed at %s", offender);
+    EXPECT_TRUE(listed_ok, msg);
+
+    TEST("a stat-visible /tmp file unlinks");
+    snprintf(p, sizeof(p), "%s/f", dir);
+    EXPECT_TRUE(invisible(p) || unlink(p) == 0,
+                "visible file could not be unlinked");
+
+    TEST("a stat-visible /tmp directory rmdir's");
+    snprintf(p, sizeof(p), "%s/d", dir);
+    EXPECT_TRUE(invisible(p) || rmdir(p) == 0,
+                "visible directory could not be removed");
+
+    TEST("a stat-visible /tmp file renames");
+    snprintf(p, sizeof(p), "%s/r", dir);
+    snprintf(q, sizeof(q), "%s/r2", dir);
+    EXPECT_TRUE(invisible(p) || rename(p, q) == 0,
+                "visible file could not be renamed");
+
+    /* The other half of the contract: a guest's own /tmp file, which the create
+     * resolver places in the sysroot, must remain removable. This is the common
+     * case any container workload depends on; a fix that made the host-visible
+     * entry invisible must not have broken it.
+     */
+    TEST("a guest-created /tmp file round-trips");
+    snprintf(p, sizeof(p), "%s/made", dir);
+    int fd = open(p, O_CREAT | O_WRONLY, 0644);
+    EXPECT_TRUE(fd >= 0 && close(fd) == 0 && unlink(p) == 0,
+                "guest-created file could not be created then unlinked");
+
+    /* Left behind for the harness, which asserts the sysroot gained the
+     * redirected directory while the host staging directory gained nothing.
+     * Without that, the checks above would also be satisfied by a guest that
+     * reached nothing at all.
+     */
+    TEST("a guest-created /tmp file reads back");
+    snprintf(p, sizeof(p), "%s/kept", dir);
+    EXPECT_TRUE(round_trips(p), "guest-created file did not read back");
+
+    SUMMARY("test-sysroot-tmp-remove");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Under `--sysroot`, guest paths in `/tmp`, `/var/tmp`, and `~/.ccache` are
redirected into the sysroot when a file is created there, so guest temp files
avoid collisions on the host's case-insensitive `/tmp`. Lookups were not
redirected: a path absent from the sysroot falls back to the host, so a `/tmp`
entry that exists on the host but not the sysroot was visible to `stat` and
`open` yet missing to `unlink`, `rmdir`, and `rename`, which translate through
the create resolver. The result is an entry the guest can see and read but
cannot remove. This is long-standing, not a recent regression.

### Reproduction steps

The issue was discovered with setting up CI pipeline for the `oci/setup` branch. Across runs,
an attempt was made to `rm` the old tmp files from other tests, and we ran into errors.

Create `/tmp/leftover/report.txt` on the host, and make sure that the sysroot does not have it. 
Inside the guest: `rm` lists the file, then fails to delete it despite `-f`, because the delete
resolves into the sysroot where it does not exist.

### Change

Redirect `/tmp`, `/var/tmp`, and ccache in the lookup resolver as well, so the
guest's `/tmp` is backed by the sysroot for every operation, matching the
create side. A host entry the guest never created there is no longer visible;
entries the guest does create stay readable and removable. Host fallback is
unchanged for all other paths.

This does change reads: such host `/tmp` entries go from visible-but-unremovable
to invisible, which is the behavior the create-side redirect already implied.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent temp path handling under `--sysroot` by resolving lookups for `/tmp`, `/var/tmp`, and any `.ccache` directory through the sysroot and excluding them (and guest system dirs) from host fallback. Lookup, listings, and removal now agree, preventing `rm -rf` failures.

- **Bug Fixes**
  - Resolve lookups for temp roots in the sysroot (including the roots themselves), matching create-time redirects; `/tmp` listings no longer show host entries; guest system dirs stay sysroot-only; host fallback unchanged elsewhere.
  - Add `test-sysroot-tmp-remove` to `make check` to verify unlink/rmdir/rename, listing consistency, and a guest-created file round-trip; the harness confirms host `/tmp` is untouched and writes land in the sysroot, and moves the TOCTOU host-escape assertion out of the guest test into the harness.

- **Refactors**
  - Share one predicate for temp roots across resolvers (`is_sysroot_backed_temp_path`), and export `path_prefix_match` for reuse.

<sup>Written for commit 24581394d2f660c8fb83df6741d1aec33cf7d4e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



