### PR TITLE
signal suspend properly in rt_sigsuspend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,11 @@ $(BUILD_DIR)/test-process-lifecycle: tests/test-process-lifecycle.c src/utils.h 
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -Isrc -o $@ $< -lpthread
 
+# test-sigsuspend parks two threads on one process-directed signal.
+$(BUILD_DIR)/test-sigsuspend: tests/test-sigsuspend.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -Itests -o $@ $< -lpthread
+
 # test-thread-churn creates >64 threads to force thread-table slot reuse.
 $(BUILD_DIR)/test-thread-churn: tests/test-thread-churn.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -983,7 +983,24 @@ static void proc_register_adopted_local(const lifecycle_entry_t *source)
     pthread_mutex_lock(&pid_lock);
     proc_entry_t *entry = proc_find_guest_entry(source->guest_pid);
     if (entry && entry->host_waitable) {
+        /* proc_process_exit() publishes the status and raises SIGCHLD while
+         * the host process is still tearing down, so wait4 reports "running"
+         * for a moment after the guest was told the child is gone -- a skew
+         * Linux never has. Copy the status across so a WNOHANG poll from the
+         * handler cannot miss it; proc_deferred_reap_poll() does the host
+         * reap later so nothing blocks here.
+         */
+        if (source->exited && !entry->exited) {
+            entry->exited = true;
+            entry->exit_status = source->exit_status;
+            entry->rusage = source->rusage;
+            entry->rusage_valid = source->rusage_valid;
+            entry->host_reap_pending = true;
+            pthread_cond_broadcast(&pid_cond);
+        }
         pthread_mutex_unlock(&pid_lock);
+        if (source->exited)
+            proc_pidfd_notify_exit(source->guest_pid);
         return;
     }
 
@@ -2137,12 +2154,43 @@ static int64_t proc_wait_autoreap_children(int pid, int options)
 
 /* sys_wait4. */
 
+/* Reap host children whose terminal status the guest already consumed from the
+ * lifecycle registry. Their exit was published before the host process finished
+ * tearing down, so wait4() had nothing to collect at the time; collecting it
+ * later keeps a zombie from being stranded without making any wait path block.
+ */
+static void proc_deferred_reap_poll(void)
+{
+    pthread_mutex_lock(&pid_lock);
+    for (size_t i = 0; i < proc_table_capacity; i++) {
+        if (!proc_table[i].host_reap_pending)
+            continue;
+        pid_t host_pid = proc_table[i].host_pid;
+        if (host_pid <= 0) {
+            proc_table[i].host_reap_pending = false;
+            continue;
+        }
+        pthread_mutex_unlock(&pid_lock);
+        int st;
+        pid_t r = wait4(host_pid, &st, WNOHANG, NULL);
+        pthread_mutex_lock(&pid_lock);
+        /* Only clear the flag once the zombie is gone (r > 0) or the child is
+         * no longer ours to reap (r < 0, typically ECHILD).
+         */
+        if (r != 0 && i < proc_table_capacity &&
+            proc_table[i].host_pid == host_pid)
+            proc_table[i].host_reap_pending = false;
+    }
+    pthread_mutex_unlock(&pid_lock);
+}
+
 int64_t sys_wait4(guest_t *g,
                   int pid,
                   uint64_t status_gva,
                   int options,
                   uint64_t rusage_gva)
 {
+    proc_deferred_reap_poll();
     lifecycle_import_children();
     if (signal_sigchld_autoreap())
         return proc_wait_autoreap_children(pid, options);

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -314,6 +314,11 @@ typedef struct {
     bool rusage_valid;
     bool rusage_accounted;
     bool host_waitable; /* false for a child adopted from another host parent */
+    /* Terminal status was taken from the lifecycle registry before wait4()
+     * could observe the zombie, so the host process still needs reaping. Set
+     * only for host_waitable children; see proc_deferred_reap_poll().
+     */
+    bool host_reap_pending;
     struct rusage rusage;
 } proc_entry_t;
 

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -1297,10 +1297,76 @@ int64_t signal_rt_sigprocmask(guest_t *g,
     return 0;
 }
 
+/* True when any signal in @candidates would actually reach the guest, and so
+ * should end a wait: one with a handler installed, or a SIG_DFL disposition
+ * that terminates or dumps core. SIG_IGN, and the SIG_DFL dispositions that
+ * ignore/stop/continue, are discarded by signal_deliver() without the guest
+ * ever observing them, so they must not wake a sleeper. An out-of-range bit
+ * counts as a wake so a malformed set can never pin a thread asleep forever.
+ * Caller holds sig_lock.
+ */
+static int signal_first_waking_locked(uint64_t candidates)
+{
+    uint64_t bits = candidates;
+    while (bits) {
+        int idx = bit_ctz64(bits);
+        bits &= bits - 1;
+        if (!RANGE_CHECK(idx, 0, LINUX_NSIG))
+            return idx + 1;
+        linux_sigaction_t *act = &sig_state.actions[idx];
+        if (act->sa_handler == LINUX_SIG_IGN)
+            continue;
+        if (act->sa_handler == LINUX_SIG_DFL) {
+            sig_disposition_t disp = signal_default_disposition(idx + 1);
+            if (disp == SIG_DISP_IGN || disp == SIG_DISP_CONT ||
+                disp == SIG_DISP_STOP)
+                continue;
+        }
+        return idx + 1;
+    }
+    return 0;
+}
+
+static bool signal_set_would_wake_locked(uint64_t candidates)
+{
+    return signal_first_waking_locked(candidates) != 0;
+}
+
+/* Bind a process-directed signal to this thread by moving it from the shared
+ * set into the caller's private set, siginfo included.
+ *
+ * signal_deliver() drains the shared set on whichever thread reaches it first,
+ * so a waiter that woke on a shared signal can lose it to another vCPU and
+ * return with no handler to run -- and, for sigsuspend, with its temporary mask
+ * still installed and nothing left to restore it. Claiming the signal while
+ * still holding sig_lock makes this thread's delivery the one that happens.
+ * Caller holds sig_lock.
+ */
+static void signal_claim_shared_locked(signal_pending_t *tp, int signum)
+{
+    /* Seed the descriptor before dequeuing, the same way signal_deliver() does:
+     * signal_rt_dequeue_locked() leaves it untouched when the RT queue holds no
+     * saved siginfo, so the fields it does not write must already be valid.
+     */
+    signal_rt_info_t info = signal_default_info(signum);
+    if (signum >= LINUX_SIGRTMIN) {
+        if (!signal_rt_dequeue_locked(&sig_state.shared, signum, &info))
+            return;
+    } else {
+        info = signal_standard_peek_locked(&sig_state.shared, signum);
+        sig_state.shared.std_info_valid[signum - 1] = false;
+        sig_state.shared.pending &= ~sig_bit(signum);
+    }
+    signal_enqueue_locked(tp, signum, &info);
+    refresh_pending_hint_locked();
+}
+
 /* rt_sigsuspend. */
 
 int64_t signal_rt_sigsuspend(guest_t *g, uint64_t mask_gva, uint64_t sigsetsize)
 {
+#define SIGSUSPEND_CHUNK_NS 1000000LL /* 1ms chunks */
+
     if (sigsetsize != 8)
         return -LINUX_EINVAL;
 
@@ -1311,41 +1377,101 @@ int64_t signal_rt_sigsuspend(guest_t *g, uint64_t mask_gva, uint64_t sigsetsize)
 
         pthread_mutex_lock(&sig_lock);
         uint64_t *blocked = thread_blocked_ptr();
-        uint64_t *saved_ptr = thread_saved_blocked_ptr();
-        bool *valid_ptr = thread_saved_valid_ptr();
 
         /* Save original blocked mask for restoration after signal delivery */
         uint64_t saved_blocked = *blocked;
 
         /* Temporarily set blocked mask (never block SIGKILL/SIGSTOP) */
         uint64_t unmaskable = sig_bit(LINUX_SIGKILL) | sig_bit(LINUX_SIGSTOP);
-        *blocked = mask & ~unmaskable;
+        __atomic_store_n(blocked, mask & ~unmaskable, __ATOMIC_RELEASE);
+        pthread_mutex_unlock(&sig_lock);
 
-        /* If no signal is pending with the new mask, restore immediately. In a
-         * real kernel, sigsuspend blocks until a signal arrives. Signal
-         * emulation check if any signal became deliverable with the new mask.
-         * If yes, the vCPU loop will deliver it. If no, restore the mask; the
-         * caller will loop (musl retries on -EINTR).
+        /* Suspend until a signal that will actually reach the guest becomes
+         * deliverable under the temporary mask.
+         *
+         * Returning -EINTR immediately and leaving the caller to retry looks
+         * equivalent, because the guest does loop -- but sigsuspend() carries
+         * no timeout and has nothing to interleave between retries, so that
+         * loop degenerates into a spin that pins a core. glibc waits for
+         * SIGCHLD this way, so a program doing nothing but waiting burns a
+         * whole CPU and never makes progress.
+         *
+         * Delivery itself still belongs to the vCPU loop: this only waits for
+         * the signal to become deliverable, then returns -EINTR so the handler
+         * runs on the way back out.
          */
-        if (!(self_pending_locked() & ~*blocked)) {
-            *blocked = saved_blocked;
-        }
-        /* If a signal IS pending, the mask stays temporarily modified.
-         * signal_deliver() will execute the handler, and rt_sigreturn will
-         * restore uc_sigmask. But signal delivery needs to set uc_sigmask to
-         * the ORIGINAL mask (saved_blocked), not the sigsuspend mask. Store it
-         * for signal_deliver to use.
-         */
-        else {
-            *saved_ptr = saved_blocked;
-            *valid_ptr = true;
+        bool woke = false;
+        while (!proc_exit_group_requested()) {
+            /* Drain any expired guest itimer so its SIGALRM / SIGVTALRM /
+             * SIGPROF queues into the pending set. Nothing else advances the
+             * timers while this thread is parked here, and sigsuspend() waiting
+             * on alarm() is a common enough shape that skipping this poke turns
+             * the wait into a permanent sleep.
+             */
+            signal_check_timer();
+
+            pthread_mutex_lock(&sig_lock);
+            uint64_t now_blocked =
+                __atomic_load_n(thread_blocked_ptr(), __ATOMIC_ACQUIRE);
+            signal_pending_t *tp =
+                current_thread ? &current_thread->tpending : NULL;
+            /* Private set first, matching signal_deliver()'s dequeue order: a
+             * thread-directed signal is already bound here and needs no claim.
+             */
+            int wake_sig =
+                signal_first_waking_locked(tp ? tp->pending & ~now_blocked : 0);
+            if (!wake_sig) {
+                int shared_sig = signal_first_waking_locked(
+                    sig_state.shared.pending & ~now_blocked);
+                if (shared_sig) {
+                    wake_sig = shared_sig;
+                    /* Without a thread to bind it to there is only one vCPU to
+                     * race with, so leave the signal shared.
+                     */
+                    if (tp)
+                        signal_claim_shared_locked(tp, shared_sig);
+                }
+            }
+            woke = wake_sig != 0;
+            pthread_mutex_unlock(&sig_lock);
+            if (woke)
+                break;
+
+            struct timespec req = {
+                .tv_sec = 0,
+                .tv_nsec = SIGSUSPEND_CHUNK_NS,
+            };
+            /* A host EINTR just means recheck sooner; the loop condition
+             * above is the only thing that decides when to stop.
+             */
+            nanosleep(&req, NULL);
         }
 
+        pthread_mutex_lock(&sig_lock);
+        if (woke) {
+            /* Leave the temporary mask installed so the handler runs under it,
+             * but hand signal_deliver() the pre-suspend mask to stamp into
+             * uc_sigmask, so rt_sigreturn restores what the guest had before
+             * the suspend rather than the sigsuspend mask.
+             */
+            *thread_saved_blocked_ptr() = saved_blocked;
+            *thread_saved_valid_ptr() = true;
+        } else {
+            /* Left the loop without a signal (exit_group). No handler will
+             * run, so nothing would restore the mask: put it back here.
+             * signal_pending() and thread_signal_deliverable() read this field
+             * lock-free, so store it the same way rt_sigprocmask does.
+             */
+            __atomic_store_n(thread_blocked_ptr(), saved_blocked,
+                             __ATOMIC_RELEASE);
+        }
         pthread_mutex_unlock(&sig_lock);
     }
 
     /* Always return -EINTR. */
     return -LINUX_EINTR;
+
+#undef SIGSUSPEND_CHUNK_NS
 }
 
 /* rt_sigpending. */
@@ -1493,27 +1619,7 @@ int64_t signal_rt_sigtimedwait(guest_t *g,
         pthread_mutex_lock(&sig_lock);
         uint64_t *blocked = thread_blocked_ptr();
         uint64_t candidates = self_pending_locked() & ~*blocked & ~mask;
-        bool interrupt = false;
-        uint64_t bits = candidates;
-        while (bits) {
-            int idx = bit_ctz64(bits);
-            bits &= bits - 1;
-            if (!RANGE_CHECK(idx, 0, LINUX_NSIG)) {
-                interrupt = true;
-                break;
-            }
-            linux_sigaction_t *act = &sig_state.actions[idx];
-            if (act->sa_handler == LINUX_SIG_IGN)
-                continue;
-            if (act->sa_handler == LINUX_SIG_DFL) {
-                sig_disposition_t disp = signal_default_disposition(idx + 1);
-                if (disp == SIG_DISP_IGN || disp == SIG_DISP_CONT ||
-                    disp == SIG_DISP_STOP)
-                    continue;
-            }
-            interrupt = true;
-            break;
-        }
+        bool interrupt = signal_set_would_wake_locked(candidates);
         pthread_mutex_unlock(&sig_lock);
         if (interrupt)
             return -LINUX_EINTR;
@@ -1975,7 +2081,41 @@ int signal_take_termination_wait_status(void)
     return status;
 }
 
+/* signal_deliver_one() consumed a signal the guest never observes, so the
+ * caller should look at the next one. Distinct from the documented 0/1/-1
+ * contract of deliver_signal_locked() and never escapes signal_deliver().
+ */
+#define SIGNAL_DELIVER_DISCARDED 2
+
+static int signal_deliver_one(hv_vcpu_t vcpu, guest_t *g, int *exit_code);
+
 int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
+{
+    /* Callers invoke this once per syscall epilogue, so stopping at the first
+     * signal that turns out to be discarded (SIG_IGN, or a SIG_DFL disposition
+     * of ignore/stop/continue) would let a lower-numbered ignored signal mask a
+     * higher-numbered one the guest can actually see. Waiters decide whether to
+     * wake using the same disposition filter -- see
+     * signal_pending_interruption() and signal_first_waking_locked() -- so a
+     * mismatch here strands them: rt_sigsuspend in particular returns expecting
+     * a handler to run and restore its temporary mask, and nothing else does.
+     *
+     * Keep going past discarded signals to the first one that reaches the
+     * guest. Each pass dequeues its signal, so the pending set shrinks and the
+     * loop terminates.
+     */
+    for (;;) {
+        int result = signal_deliver_one(vcpu, g, exit_code);
+        if (result != SIGNAL_DELIVER_DISCARDED)
+            return result;
+    }
+}
+
+/* Select, dequeue, and act on one pending signal. Returns
+ * SIGNAL_DELIVER_DISCARDED when the signal was consumed without the guest
+ * observing it, so the caller can move on to the next one.
+ */
+static int signal_deliver_one(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
 {
     pthread_mutex_lock(&sig_lock);
     uint64_t *blocked = thread_blocked_ptr();
@@ -2024,9 +2164,12 @@ int signal_deliver(hv_vcpu_t vcpu, guest_t *g, int *exit_code)
     refresh_pending_hint_locked();
 
     int result = deliver_signal_locked(vcpu, g, signum, rt_info, exit_code);
-    if (result < 0)
+    if (result < 0) {
         signal_record_termination(signum);
-    return result;
+        return result;
+    }
+    /* 0 means the signal was dequeued but never reached the guest. */
+    return result == 0 ? SIGNAL_DELIVER_DISCARDED : result;
 }
 
 int signal_deliver_fault(hv_vcpu_t vcpu, guest_t *g, int signum, int *exit_code)

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -89,6 +89,7 @@ test-mprotect-mt               # diff=skip
 
 [section] Signal + thread tests
 test-signal-thread
+test-sigsuspend
 test-fault-signal-mt           # diff=skip
 test-exit-group-worker
 

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -613,6 +613,7 @@ run_unit_tests()
     printf "\nSignal tests\n"
     test_check "$runner" "test-signal" "PASS|0 failed" "$bindir/test-signal"
     test_check "$runner" "test-signal-thread" "PASS|0 failed" "$bindir/test-signal-thread"
+    test_check "$runner" "test-sigsuspend" "PASS|0 failed" "$bindir/test-sigsuspend"
     test_check "$runner" "test-tgkill-directed" "0 failed" "$bindir/test-tgkill-directed"
     test_check "$runner" "test-sigill" "0 failed" "$bindir/test-sigill"
     test_check "$runner" "test-kill-broadcast" "0 failed" \

--- a/tests/test-sigsuspend.c
+++ b/tests/test-sigsuspend.c
@@ -1,0 +1,242 @@
+/*
+ * rt_sigsuspend blocking semantics
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * sigsuspend() must install the temporary mask, block until a signal that the
+ * guest can actually observe becomes deliverable, run the handler, and leave
+ * the caller's original mask behind. Returning early -- the behaviour before
+ * rt_sigsuspend learned to block -- is invisible to a caller that loops, but
+ * pins a core and lets an alarm-driven waiter report a spurious timeout.
+ *
+ * The multi-threaded case covers the shared-signal race: a process-directed
+ * signal wakes one waiter, and signal delivery drains the shared set on
+ * whichever vCPU reaches it first. A waiter that loses that race would return
+ * with no handler run and its temporary mask still installed, so this checks
+ * that exactly one thread reports the handler and that both threads come back
+ * with the mask they started with.
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+static volatile sig_atomic_t alarm_ran;
+static volatile sig_atomic_t usr1_ran;
+/* Delivery count while only the process-directed signal is in flight. The
+ * per-thread wakeups sent afterwards must not be able to satisfy the
+ * shared-signal assertion, so they are counted in a separate phase.
+ */
+static volatile sig_atomic_t usr1_shared_phase;
+static volatile sig_atomic_t usr1_shared_deliveries;
+
+static void on_alarm(int s)
+{
+    (void) s;
+    alarm_ran = 1;
+}
+
+static void on_usr1(int s)
+{
+    (void) s;
+    usr1_ran = 1;
+    if (usr1_shared_phase)
+        usr1_shared_deliveries++;
+}
+
+static double elapsed_since(const struct timespec *t0)
+{
+    struct timespec t1;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    return (t1.tv_sec - t0->tv_sec) + (t1.tv_nsec - t0->tv_nsec) / 1e9;
+}
+
+/* sigsuspend must not return before a signal arrives, must run the handler,
+ * and must restore the mask it was called with.
+ */
+static void test_blocks_until_signal(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = on_alarm;
+    sigaction(SIGALRM, &sa, NULL);
+
+    sigset_t block, orig, empty;
+    sigemptyset(&block);
+    sigaddset(&block, SIGALRM);
+    sigprocmask(SIG_BLOCK, &block, &orig);
+    sigemptyset(&empty);
+
+    alarm_ran = 0;
+    struct timespec t0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    alarm(1);
+    sigsuspend(&empty);
+    double waited = elapsed_since(&t0);
+
+    TEST("sigsuspend blocks until the signal arrives");
+    EXPECT_TRUE(waited >= 0.5, "returned before the alarm fired");
+
+    TEST("handler ran before sigsuspend returned");
+    EXPECT_TRUE(alarm_ran == 1, "handler did not run");
+
+    TEST("sigsuspend reports EINTR");
+    EXPECT_TRUE(errno == EINTR, "errno was not EINTR");
+
+    /* The temporary mask must not outlive the call: SIGALRM was blocked on
+     * entry and must still be blocked on return.
+     */
+    sigset_t after;
+    sigemptyset(&after);
+    sigprocmask(SIG_BLOCK, NULL, &after);
+    TEST("original mask restored after delivery");
+    EXPECT_TRUE(sigismember(&after, SIGALRM) == 1,
+                "temporary sigsuspend mask leaked past the call");
+
+    sigprocmask(SIG_SETMASK, &orig, NULL);
+}
+
+/* An ignored signal is discarded without reaching the guest, so it must not
+ * end the wait. The alarm is the escape hatch that keeps this bounded.
+ */
+static void test_ignored_signal_does_not_wake(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = SIG_IGN;
+    sigaction(SIGUSR2, &sa, NULL);
+    sa.sa_handler = on_alarm;
+    sigaction(SIGALRM, &sa, NULL);
+
+    sigset_t block, orig, empty;
+    sigemptyset(&block);
+    sigaddset(&block, SIGUSR2);
+    sigaddset(&block, SIGALRM);
+    sigprocmask(SIG_BLOCK, &block, &orig);
+    sigemptyset(&empty);
+
+    alarm_ran = 0;
+    raise(SIGUSR2); /* pending, but ignored: must not wake the sleeper */
+    alarm(1);
+    sigsuspend(&empty);
+
+    TEST("ignored signal does not end the wait");
+    EXPECT_TRUE(alarm_ran == 1, "woke on the ignored signal instead");
+
+    sigprocmask(SIG_SETMASK, &orig, NULL);
+}
+
+static pthread_barrier_t ready;
+static volatile sig_atomic_t mask_leaked;
+/* Incremented immediately before each worker calls sigsuspend(). The barrier
+ * only gates the threads up to that point, so waiting on this instead of a
+ * wall-clock sleep keeps the test honest on a loaded or cross-checked host.
+ */
+static volatile sig_atomic_t parked;
+
+static void *suspender(void *arg)
+{
+    (void) arg;
+    sigset_t block, empty, after;
+    sigemptyset(&block);
+    sigaddset(&block, SIGUSR1);
+    pthread_sigmask(SIG_BLOCK, &block, NULL);
+    sigemptyset(&empty);
+
+    pthread_barrier_wait(&ready);
+    parked++;
+    sigsuspend(&empty);
+
+    sigemptyset(&after);
+    pthread_sigmask(SIG_BLOCK, NULL, &after);
+    if (sigismember(&after, SIGUSR1) != 1)
+        mask_leaked = 1;
+    return NULL;
+}
+
+/* Two threads wait on one process-directed signal. Whichever thread the
+ * delivery lands on, neither may come back with the temporary mask still
+ * installed.
+ */
+static void test_shared_signal_two_waiters(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = on_usr1;
+    sigaction(SIGUSR1, &sa, NULL);
+    sa.sa_handler = on_alarm;
+    sigaction(SIGALRM, &sa, NULL);
+
+    usr1_ran = 0;
+    mask_leaked = 0;
+    parked = 0;
+    usr1_shared_phase = 0;
+    usr1_shared_deliveries = 0;
+
+    sigset_t block, orig;
+    sigemptyset(&block);
+    sigaddset(&block, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &block, &orig);
+
+    pthread_t a, b;
+    pthread_barrier_init(&ready, NULL, 3);
+    pthread_create(&a, NULL, suspender, NULL);
+    pthread_create(&b, NULL, suspender, NULL);
+    pthread_barrier_wait(&ready);
+
+    /* Wait for both workers to reach sigsuspend rather than guessing with a
+     * sleep. parked is bumped just before the call, so one short grace period
+     * after it reaches 2 covers the remaining instructions into the syscall.
+     */
+    for (int i = 0; i < 500 && parked < 2; i++)
+        usleep(1000);
+    usleep(50000);
+
+    /* Phase 1: one process-directed signal, delivered to exactly one thread. */
+    usr1_shared_phase = 1;
+    kill(getpid(), SIGUSR1);
+    for (int i = 0; i < 500 && usr1_shared_deliveries == 0; i++)
+        usleep(1000);
+    usleep(50000);
+    usr1_shared_phase = 0;
+
+    /* Phase 2: wake whichever thread lost the race so it can check its mask.
+     * These are per-thread and no longer counted against the assertion above.
+     */
+    pthread_kill(a, SIGUSR1);
+    pthread_kill(b, SIGUSR1);
+
+    pthread_join(a, NULL);
+    pthread_join(b, NULL);
+    pthread_barrier_destroy(&ready);
+
+    TEST("process-directed signal delivered exactly once");
+    EXPECT_TRUE(usr1_shared_deliveries == 1,
+                "shared signal was not delivered exactly once");
+
+    TEST("no waiter leaked its temporary mask");
+    EXPECT_TRUE(mask_leaked == 0, "a thread returned with the suspend mask");
+
+    sigprocmask(SIG_SETMASK, &orig, NULL);
+}
+
+int main(void)
+{
+    printf("test-sigsuspend: rt_sigsuspend blocking semantics\n");
+
+    test_blocks_until_signal();
+    test_ignored_signal_does_not_wake();
+    test_shared_signal_two_waiters();
+
+    SUMMARY("test-sigsuspend");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
rt_sigsuspend returned -EINTR the moment it was called and left the guest to retry. That is fine for musl, which loops, but sigsuspend carries no timeout and has nothing to interleave between retries, so the loop degenerates into a spin. glibc waits for SIGCHLD this way, so a process doing nothing but waiting pins a core and never makes progress. A GTK D-Bus service was observed spinning at 99 percent forever, never sending its reply, with the client reporting only that the recipient had disconnected.

Wait until a signal that will actually reach the guest becomes deliverable under the temporary mask, using the same chunked poll loop rt_sigtimedwait already uses. Delivery still belongs to the vCPU loop; this only decides when to stop waiting.

Poke signal_check_timer each pass. Nothing else advances guest itimers while the thread is parked here, and without it a wait on alarm sleeps forever instead of spinning, which is no better.

Restore the mask when the loop exits without a signal. No handler runs on that path so nothing else would put it back.

rt_sigtimedwait already had the "would this signal really wake anyone" test inline. Both callers now share it.

Fix #257

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `rt_sigsuspend` block until a deliverable signal instead of returning `-EINTR` immediately, preventing busy loops in glibc waits. Fixes #257 and stops idle processes from pegging a core.

- **Bug Fixes**
  - Block in 1 ms chunks until a signal that would reach the guest is deliverable; keep the temporary mask for the handler, save the original for `rt_sigreturn`, then return `-EINTR`.
  - Claim process-directed shared signals under `sig_lock` so the waking thread keeps delivery; avoids returning with no handler and a leaked suspend mask.
  - Skip discarded signals in `signal_deliver` so ignored or default-ignored signals don’t mask a real one; keeps suspend/handler behavior consistent.
  - Tick `signal_check_timer` each pass so guest itimers fire; avoids hangs when waiting on `SIGALRM`.
  - In `wait4`, copy exit status from the lifecycle registry and defer host reaping; prevents brief spins and avoids stranded zombies in `WNOHANG` polls.

- **Refactors**
  - Added `signal_first_waking_locked` and `signal_set_would_wake_locked`; reused in `rt_sigtimedwait`.
  - Added `signal_claim_shared_locked`.
  - Added `test-sigsuspend`, build rule, manifest entry, and matrix hook to validate blocking semantics and the shared-signal race.

<sup>Written for commit 9a89b104bbce8077c2349755c6cc830414eaad8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

