### PR TITLE
Record why elfuse is written in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ single-binary tooling, language runtimes, test harnesses, and
 debugger-driven workflows, `elfuse` removes the disk-image and
 boot-time overhead those tools impose.
 
+## Why C
+
+`elfuse` is C11 plus a small amount of aarch64 assembly. In short:
+
+- Most of the hazard sits inside the safety boundary, not outside it. Guest
+  memory is an `mmap`-ed slab the guest rewrites from another vCPU thread, so
+  host access already runs through bounds-checked accessors (`guest_ptr`,
+  `guest_read`, `guest_write`). Rust would enforce that discipline rather
+  than leave it to convention, which is a real gain, but the checks inside
+  those accessors are the same ones to get right.
+- The defects that surface here are arithmetic and design errors, not
+  memory-safety errors. An overflow-saturated `load_max` in `src/core/elf.c`
+  wraps once the PIE load base is added in `src/syscall/exec.c`, pushing a
+  rejection past the `execve` point of no return. Rust's `+` wraps in release
+  builds too; catching it takes an explicit checked add either way.
+- What guards the memory-safety side is language-independent and already
+  gates CI: `cppcheck`, `clang-tidy`, `scan-build`, Infer, and a runtime
+  matrix under ASAN, UBSAN, and TSAN. That catches such defects after the
+  fact rather than excluding them by construction, which is the honest cost
+  of the choice.
+- The host surface is nearly all C ABI: Hypervisor.framework, Mach, pthreads,
+  macOS syscalls, `SCM_RIGHTS`, and hosting Apple Rosetta. The EL1 shim is
+  aarch64 assembly under any host language.
+
+Longer version in [docs/internals.md](docs/internals.md#language-choice).
+
 ## Requirements
 
 - macOS on Apple Silicon

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1088,6 +1088,74 @@ The split mirrors the architectural boundary: transport and encoding are
 independent of guest execution; register layout is independent of socket I/O;
 stop/resume sequencing remains tightly coupled to process and thread state.
 
+## Language Choice
+
+`elfuse` is C11 plus a small amount of aarch64 assembly. This section records
+why, against the specifics of this codebase rather than in the abstract.
+
+### Where The Safety Boundary Falls
+
+The central data structure is a slab of guest memory obtained from `mmap`,
+which the guest rewrites at will from another vCPU thread. Host access goes
+through bounds-checked accessors over that slab: `guest_ptr`, `guest_ptr_w`,
+`guest_ptr_avail`, `guest_ptr_bound`, `guest_read`, and `guest_write` (see
+[Memory Layout](#memory-layout)), each resolving a guest-controlled address
+against the recorded mappings.
+
+Rust would express the same shape as a safe wrapper over an `unsafe` core,
+and would enforce that callers stay on the safe side, which C leaves to
+convention. That enforcement is a real gain. What it does not do is validate
+the checks inside the wrapper, and those checks are where the defects below
+live: the interior of the guest slab, the page-table walk itself, and syscall
+arguments arriving as guest-controlled integers.
+
+### What Defects Surface In Practice
+
+One worked example, from the loader. `elf_load_fd` saturates `load_max` to
+`UINT64_MAX` when `p_vaddr + p_memsz` overflows (`src/core/elf.c`). For
+`ET_EXEC` the saturation does its job: the fits-in-guest check in
+`src/syscall/exec.c` sees `UINT64_MAX` and rejects the image. For `ET_DYN`
+that check first adds `PIE_LOAD_BASE`, and the sum wraps to `0x3FFFFF`, which
+passes. Nothing lands out of bounds, because `elf_map_segments_fd`
+bounds-checks every segment against `guest_size`. What moves is the
+rejection: it lands at a call site past the `execve` point of no return,
+turning a recoverable `-ENOEXEC` into a fatal exec. Guarding it takes an
+explicit checked add where `load_max` meets the load base.
+
+The class of defect is the point. That is integer arithmetic, not memory
+safety. Rust's `+` wraps silently in release builds too, so the same checked
+add is required there.
+
+`elf_map_segments_fd` also re-reads the header and program headers from the
+fd, and can disagree with the first parse: a TOCTOU on the ELF image. Its own
+bounds checks contain the damage, but no language rules the disagreement out.
+It is a property of how the loader is structured.
+
+### Verification Actually In Place
+
+No formal-methods gate exists today. What gates CI is language-independent
+tooling: `clang-format`, a banned-API and unsafe-preprocessor scan,
+`cppcheck`, and the dispatch-table consistency check on Linux; `clang-tidy`
+and `scan-build` as advisory jobs; an Infer run that fails on any finding;
+and a runtime matrix under ASAN, UBSAN, and TSAN (see [Testing And
+Confidence](#testing-and-confidence)).
+
+That catches memory-safety defects after the fact rather than excluding them
+by construction, which is the honest cost of the choice. The improvement
+worth pursuing on this surface is a proof obligation over the ELF parser
+rather than another runtime check, because a guest-triggerable abort inside a
+VMM is a denial of service, and a language that panics on bad input does not
+address that.
+
+### Host Interface Surface
+
+`hv_vcpu_run`, `hv_vcpu_set_sys_reg`, Mach (`host_statistics64` behind
+`/proc/meminfo`), pthreads, macOS syscalls, file descriptor passing over
+`SCM_RIGHTS`, and hosting the Apple Rosetta translator are all C ABI. The EL1
+shim is aarch64 assembly (`src/core/shim.S`) under any host language. A
+safe-language port would spend a significant share of its effort on binding
+layers for that surface.
+
 ## Testing And Confidence
 
 `elfuse` uses several layers of validation:


### PR DESCRIPTION
The language question comes up, and answering it in the abstract is worthless. Answer it against this codebase instead. The argument that survives review is narrower than the one usually offered. Guest memory is an mmap-ed slab the guest rewrites from another vCPU thread, but host access already runs through bounds-checked accessors, which is the safe-wrapper-over-unsafe-core pattern a memory-safe language would enforce rather than invent. The gain is real; it is enforcement of a discipline the code already follows, not coverage of the hazard. What no language validates is the checks inside those accessors, and that is where the defects live.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a "Why C" rationale to `elfuse` that explains the safety boundary, the kinds of defects we see, the verification already in CI, and the C ABI constraints that shape the host interface.

- **Documentation**
  - Added a "Why C" section to the README with a link to the detailed internals.
  - Expanded `docs/internals.md` with the language choice rationale: safe-wrapper pattern over guest memory accessors, integer-overflow pitfalls, and CI verification tools.
  - Documented the host C ABI surface and the aarch64 EL1 shim considerations.

<sup>Written for commit 83ebd6fc7f1fcbf78f09a02a08b34e0bcb6e9d39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

