### PR TITLE
Report a pty hangup once the guest slaves close

### DIFF
--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -1633,8 +1633,33 @@ static struct {
     int slave_host_fd;
     uint32_t linux_pts_num;
     bool stale_open_once;
+    /* Slaves the guest has open, and whether it ever had one. Both are needed:
+     * a count of zero means hung up only after the first open.
+     */
+    int guest_slave_count;
+    bool guest_slave_seen;
     char slave_path[PTY_SLAVE_PATH_MAX];
 } pty_keepalive_table[PTY_KEEPALIVE_MAX];
+
+/* Guest-held slave fds, so a master can report the hangup Linux gives once the
+ * last slave closes.
+ *
+ * elfuse keeps one slave open for the master's whole life (see the side-table
+ * header above), which is what stops macOS from ever hanging the master up: it
+ * only does so when *every* slave fd is gone. A guest terminal waiting for that
+ * hangup to learn its shell exited therefore waits forever, which is what
+ * happens to foot. Counting the slaves the guest itself holds lets sys_poll and
+ * sys_read answer for the pty layer instead of the host, without giving up the
+ * keepalive the tty ioctls need.
+ *
+ * The count only means anything once the guest has opened a slave at least
+ * once; before that a master with no slave is ordinary, not hung up.
+ */
+#define PTY_GUEST_SLAVE_MAX (PTY_KEEPALIVE_MAX * 4)
+static struct {
+    int slave_host_fd; /* PTY_KEEPALIVE_FREE when the slot is unused */
+    uint32_t linux_pts_num;
+} pty_guest_slave_table[PTY_GUEST_SLAVE_MAX];
 static pthread_mutex_t pty_keepalive_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_once_t pty_keepalive_once = PTHREAD_ONCE_INIT;
 
@@ -1645,6 +1670,8 @@ static void pty_keepalive_init(void)
 {
     for (int i = 0; i < PTY_KEEPALIVE_MAX; i++) {
         pty_keepalive_table[i].master_host_fd = PTY_KEEPALIVE_FREE;
+        pty_keepalive_table[i].guest_slave_count = 0;
+        pty_keepalive_table[i].guest_slave_seen = false;
         pty_keepalive_table[i].slave_host_fd = PTY_KEEPALIVE_FREE;
     }
 }
@@ -1668,6 +1695,8 @@ static int pty_keepalive_clear_slot_locked(int slot)
 {
     int slave = pty_keepalive_table[slot].slave_host_fd;
     pty_keepalive_table[slot].master_host_fd = PTY_KEEPALIVE_FREE;
+    pty_keepalive_table[slot].guest_slave_count = 0;
+    pty_keepalive_table[slot].guest_slave_seen = false;
     pty_keepalive_table[slot].slave_host_fd = PTY_KEEPALIVE_FREE;
     pty_keepalive_table[slot].linux_pts_num = 0;
     pty_keepalive_table[slot].stale_open_once = false;
@@ -1767,6 +1796,8 @@ static int pty_keepalive_register_locked(int master_host_fd,
             return PTY_REG_FULL;
     }
     pty_keepalive_table[slot].master_host_fd = master_host_fd;
+    pty_keepalive_table[slot].guest_slave_count = 0;
+    pty_keepalive_table[slot].guest_slave_seen = false;
     if (pty_keepalive_table[slot].slave_host_fd >= 0 &&
         pty_keepalive_table[slot].slave_host_fd != slave_host_fd)
         close(pty_keepalive_table[slot].slave_host_fd);
@@ -2000,6 +2031,107 @@ bool proc_pty_slave_stat(const char *path, struct stat *out)
     return true;
 }
 
+/* The guest-slave table is zero-initialized, so mark every slot free the first
+ * time it is touched: fd 0 is a legitimate host descriptor and must not read as
+ * an occupied slot.
+ */
+static void pty_guest_slave_table_init_once(void)
+{
+    static bool done;
+    if (done)
+        return;
+    for (int i = 0; i < PTY_GUEST_SLAVE_MAX; i++)
+        pty_guest_slave_table[i].slave_host_fd = PTY_KEEPALIVE_FREE;
+    done = true;
+}
+
+/* Retire a recorded slave fd and credit its master. Caller holds the lock. */
+static void pty_guest_slave_release_locked(int slave_host_fd)
+{
+    for (int i = 0; i < PTY_GUEST_SLAVE_MAX; i++) {
+        if (pty_guest_slave_table[i].slave_host_fd != slave_host_fd)
+            continue;
+        uint32_t pts_num = pty_guest_slave_table[i].linux_pts_num;
+        pty_guest_slave_table[i].slave_host_fd = PTY_KEEPALIVE_FREE;
+        for (int k = 0; k < PTY_KEEPALIVE_MAX; k++) {
+            if (pty_keepalive_table[k].master_host_fd == PTY_KEEPALIVE_FREE)
+                continue;
+            if (pty_keepalive_table[k].linux_pts_num != pts_num)
+                continue;
+            if (pty_keepalive_table[k].guest_slave_count > 0)
+                pty_keepalive_table[k].guest_slave_count--;
+            break;
+        }
+        break;
+    }
+}
+
+void proc_pty_note_guest_slave(int slave_host_fd, uint32_t linux_pts_num)
+{
+    if (slave_host_fd < 0)
+        return;
+    pthread_mutex_lock(&pty_keepalive_lock);
+    pty_guest_slave_table_init_once();
+    /* Drop any entry left over for this host fd number first. The open is
+     * recorded before the guest fd is installed, so a failed fd_alloc closes
+     * the host fd without passing through the close hooks; retiring the stale
+     * slot on reuse keeps that from inflating an unrelated pty's count.
+     */
+    pty_guest_slave_release_locked(slave_host_fd);
+    for (int i = 0; i < PTY_GUEST_SLAVE_MAX; i++) {
+        if (pty_guest_slave_table[i].slave_host_fd != PTY_KEEPALIVE_FREE)
+            continue;
+        pty_guest_slave_table[i].slave_host_fd = slave_host_fd;
+        pty_guest_slave_table[i].linux_pts_num = linux_pts_num;
+        for (int k = 0; k < PTY_KEEPALIVE_MAX; k++) {
+            if (pty_keepalive_table[k].master_host_fd == PTY_KEEPALIVE_FREE)
+                continue;
+            if (pty_keepalive_table[k].linux_pts_num != linux_pts_num)
+                continue;
+            pty_keepalive_table[k].guest_slave_count++;
+            pty_keepalive_table[k].guest_slave_seen = true;
+            break;
+        }
+        break;
+    }
+    pthread_mutex_unlock(&pty_keepalive_lock);
+}
+
+void proc_pty_slave_fd_closed(int host_fd)
+{
+    if (host_fd < 0)
+        return;
+    pthread_mutex_lock(&pty_keepalive_lock);
+    pty_guest_slave_table_init_once();
+    pty_guest_slave_release_locked(host_fd);
+    pthread_mutex_unlock(&pty_keepalive_lock);
+}
+
+bool proc_pty_master_hung_up(int guest_fd)
+{
+    /* Keyed on the guest fd rather than a host one: callers reach the master
+     * through host_fd_ref, which hands out a dup, and the keepalive table is
+     * keyed by the canonical host fd that dup does not share.
+     */
+    fd_entry_t snap;
+    if (!fd_snapshot(guest_fd, &snap))
+        return false;
+    int master_host_fd = snap.host_fd;
+    if (master_host_fd < 0)
+        return false;
+    bool hung_up = false;
+    pthread_mutex_lock(&pty_keepalive_lock);
+    for (int i = 0; i < PTY_KEEPALIVE_MAX; i++) {
+        if (pty_keepalive_table[i].master_host_fd != master_host_fd)
+            continue;
+        hung_up = pty_keepalive_table[i].guest_slave_seen &&
+                  pty_keepalive_table[i].guest_slave_count == 0;
+        break;
+    }
+    pthread_mutex_unlock(&pty_keepalive_lock);
+    return hung_up;
+}
+
 static int pty_open_slave(uint32_t linux_pts_num, int linux_flags)
 {
     int oflags = translate_open_flags(linux_flags) &
@@ -2201,6 +2333,8 @@ void proc_pty_close_keepalive(int master_host_fd)
              * closes it on the first translated open attempt.
              */
             pty_keepalive_table[slot].master_host_fd = PTY_KEEPALIVE_FREE;
+            pty_keepalive_table[slot].guest_slave_count = 0;
+            pty_keepalive_table[slot].guest_slave_seen = false;
         } else {
             slave = pty_keepalive_clear_slot_locked(slot);
         }
@@ -2871,7 +3005,11 @@ int proc_intercept_open(const guest_t *g,
          * two-argument open(2) never sees a creation-mode-required combination
          * without a mode arg.
          */
-        return pty_open_slave((uint32_t) n, linux_flags);
+        {
+            int slave_fd = pty_open_slave((uint32_t) n, linux_flags);
+            proc_pty_note_guest_slave(slave_fd, (uint32_t) n);
+            return slave_fd;
+        }
     }
 
     /* /proc -> synthetic directory with PID entries for busybox ps, top, etc.

--- a/src/runtime/procemu.h
+++ b/src/runtime/procemu.h
@@ -111,6 +111,23 @@ int proc_dev_shm_resolve(const char *guest_suffix,
  */
 void proc_pty_close_keepalive(int master_host_fd);
 
+/* Record a slave fd the guest now holds, so the master knows it is not yet
+ * hung up. Both guest-facing slave opens report through this: the /dev/pts/N
+ * intercept and the TIOCGPTPEER ioctl.
+ */
+void proc_pty_note_guest_slave(int slave_host_fd, uint32_t linux_pts_num);
+
+/* Drop a guest-held pty slave fd from the per-master accounting. Called for
+ * every closing host fd and a no-op for anything that is not a tracked slave.
+ */
+void proc_pty_slave_fd_closed(int host_fd);
+
+/* True when the guest has closed every slave fd it held for this master, the
+ * state Linux reports as a hangup: poll gives POLLHUP and read gives EIO.
+ * elfuse's own keepalive slave stays open, so the host cannot answer this.
+ */
+bool proc_pty_master_hung_up(int guest_fd);
+
 /* Caller-locked variant of pty keepalive duplication. Brackets the host
  * fd_snapshot_and_dup and the keepalive mirror under one pty_keepalive_lock
  * window so a sibling close cannot run proc_pty_close_keepalive in the gap and

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -713,6 +713,12 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
      */
     proc_pty_close_keepalive(snap->host_fd);
 
+    /* Mirror for the slave side: the master reports a hangup once the guest
+     * has closed every slave it held, which only this accounting can see --
+     * elfuse's own keepalive slave stays open. No-op for other fds.
+     */
+    proc_pty_slave_fd_closed(snap->host_fd);
+
     /* Deregister any SIGIO/SIGURG readiness watch before the host fd closes.
      * Closing the fd auto-removes the knote too, but doing it explicitly avoids
      * a stale event landing on a host fd number reused by a racing open.

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -748,6 +748,12 @@ int64_t sys_close(int fd)
          * no per-type cleanup is registered.
          */
         proc_pty_close_keepalive(host_fd);
+        /* A pty slave is an ordinary FD_REGULAR slot, so every guest close of
+         * one lands here rather than in fd_cleanup_entry. Without this the
+         * per-master slave count never falls back to zero and the master never
+         * reports its hangup.
+         */
+        proc_pty_slave_fd_closed(host_fd);
         chown_overlay_clear_closed_unlinked_fd(host_fd);
         if (close(host_fd) < 0)
             return linux_errno();

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -1072,6 +1072,22 @@ int64_t sys_read(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
     if (count > avail)
         count = avail;
 
+    /* A pty master whose guest-side slaves have all closed is hung up. Linux
+     * answers EIO there; the host would block forever instead, because
+     * elfuse's keepalive slave keeps the pty alive from its point of view.
+     *
+     * Only once nothing is left to read: a shell that printed on its way out
+     * leaves that output queued, and Linux hands it over before reporting the
+     * hangup. Deciding on the hangup first would swallow it.
+     */
+    if (proc_pty_master_hung_up(fd)) {
+        struct pollfd drain = {.fd = host_ref.fd, .events = POLLIN};
+        if (poll(&drain, 1, 0) <= 0 || !(drain.revents & POLLIN)) {
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EIO;
+        }
+    }
+
     off_t offset = lseek(host_ref.fd, 0, SEEK_CUR);
     if (offset >= 0) {
         int64_t intercepted =

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -28,6 +28,7 @@
 
 #include "syscall/abi.h"
 #include "syscall/internal.h"
+#include "runtime/procemu.h"
 #include "syscall/poll.h"
 #include "syscall/proc.h" /* proc_exit_group_requested */
 #include "syscall/signal.h"
@@ -246,6 +247,17 @@ ppoll_retry:
          * and nothing happened, loop back. If the caller had a real timeout,
          * poll emulation only called poll once with that timeout, so break.
          */
+        /* An infinite poll re-arms on a 200ms slice; break out when a master
+         * has hung up, since the host will never make that fd ready.
+         */
+        if (ret == 0) {
+            bool hup_pending = false;
+            for (uint32_t i = 0; i < nfds && !hup_pending; i++)
+                hup_pending = !need_pollnval[i] && guest_fds[i].fd >= 0 &&
+                              proc_pty_master_hung_up(guest_fds[i].fd);
+            if (hup_pending)
+                break;
+        }
     } while (ret == 0 && poll_timeout_ms < 0);
 
     /* POSIX poll() ignores entries with fd < 0 and resets revents to 0, so
@@ -257,6 +269,23 @@ ppoll_retry:
             if (need_pollnval[i])
                 host_fds[i].revents = POLLNVAL;
         ret += (int) invalid_count;
+    }
+
+    /* A pty master whose guest-side slaves have all closed is hung up, but the
+     * host still sees elfuse's keepalive slave and reports nothing. Stamp
+     * POLLHUP here so a terminal waiting for its shell to exit -- foot polls
+     * for exactly this -- is not left waiting forever.
+     */
+    if (ret >= 0) {
+        for (uint32_t i = 0; i < nfds; i++) {
+            if (need_pollnval[i] || guest_fds[i].fd < 0)
+                continue;
+            if (!proc_pty_master_hung_up(guest_fds[i].fd))
+                continue;
+            if (host_fds[i].revents == 0)
+                ret++;
+            host_fds[i].revents |= POLLHUP;
+        }
     }
 
     int saved_errno = errno;

--- a/tests/test-pty.c
+++ b/tests/test-pty.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <signal.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -73,6 +74,15 @@
 #endif
 
 int passes = 0, fails = 0;
+
+/* A master with no hangup support blocks these reads forever; the alarm turns
+ * that into a visible failure instead of a wedged run.
+ */
+static void hup_on_alarm(int sig)
+{
+    (void) sig;
+    _exit(2);
+}
 
 static int count_pts_entries(void)
 {
@@ -725,6 +735,62 @@ int main(void)
                 FAIL("TIOCGPTN/TIOCSPTLCK failed, no slave to test with");
             }
             close(pkt_master);
+        }
+    }
+
+    /* Hangup. macOS only hangs a master up once every slave fd is gone, and
+     * elfuse keeps one open for the master's whole life, so the pty layer has
+     * to report this itself. A terminal waiting for it to learn its shell
+     * exited -- foot polls for exactly this -- otherwise never closes.
+     */
+    {
+        int hup_master = open("/dev/ptmx", O_RDWR | O_NOCTTY);
+        unsigned int hup_ptyno = (unsigned int) -1;
+        int hup_unlock = 0;
+        if (hup_master < 0 || ioctl(hup_master, TIOCGPTN, &hup_ptyno) != 0 ||
+            ioctl(hup_master, TIOCSPTLCK, &hup_unlock) != 0) {
+            TEST("master reports POLLHUP once the slave closes");
+            FAIL("could not stage a master");
+            if (hup_master >= 0)
+                close(hup_master);
+        } else {
+            char hup_path[32];
+            snprintf(hup_path, sizeof(hup_path), "/dev/pts/%u", hup_ptyno);
+            int hup_slave = open(hup_path, O_RDWR | O_NOCTTY);
+            if (hup_slave < 0) {
+                TEST("master reports POLLHUP once the slave closes");
+                FAIL("open slave");
+            } else {
+                /* Queued output must survive: Linux hands over what the slave
+                 * wrote before reporting the hangup, so a shell's parting
+                 * words are not swallowed.
+                 */
+                static const char bye[] = "bye";
+                ssize_t put = write(hup_slave, bye, sizeof(bye) - 1);
+                close(hup_slave);
+
+                struct pollfd hp = {.fd = hup_master, .events = POLLIN};
+                int hr = poll(&hp, 1, 2000);
+                TEST("master reports POLLHUP once the slave closes");
+                EXPECT_TRUE(hr > 0 && (hp.revents & POLLHUP),
+                            "no POLLHUP after the last slave closed");
+
+                char hbuf[16];
+                ssize_t drained = put == (ssize_t) (sizeof(bye) - 1)
+                                      ? read(hup_master, hbuf, sizeof(hbuf))
+                                      : -1;
+                TEST("queued output survives the hangup");
+                EXPECT_TRUE(drained == (ssize_t) (sizeof(bye) - 1) &&
+                                memcmp(hbuf, bye, sizeof(bye) - 1) == 0,
+                            "pending slave output was lost");
+
+                errno = 0;
+                TEST("read reports EIO once drained");
+                EXPECT_TRUE(
+                    read(hup_master, hbuf, sizeof(hbuf)) < 0 && errno == EIO,
+                    "read did not report the hangup as EIO");
+            }
+            close(hup_master);
         }
     }
 


### PR DESCRIPTION
Report a pty hangup once the guest slaves close

macOS hangs a master up only when every slave fd is gone, and elfuse
keeps one open for the master's whole life so tty ioctls keep working
(see the side-table header in procemu.c). A guest terminal waiting on
that hangup to learn its shell exited therefore waits forever. foot
does exactly this and never closes its window on exit; VTE escapes it
only by watching the child pid instead. waitpid reaps the child, poll
on the master returns revents=0, and the following read blocks.

Count the slave fds the guest itself holds per master, so poll can
answer POLLHUP and read EIO for the pty layer without giving up the
keepalive. The count means anything only after the first slave open,
since a master with no slave yet is ordinary rather than hung up, and
it resets whenever a keepalive slot is registered or cleared so a
reused slot cannot inherit the previous occupant's state.

The decrement runs in the relaxed close fast path as well as in
fd_cleanup_entry: a pty slave is an ordinary FD_REGULAR slot, so
every guest close of one takes that path and the count would never
fall back to zero otherwise.

read reports the hangup only once nothing is left to read. A shell
that printed on its way out leaves that output queued, and Linux
hands it over before reporting EIO; deciding on the hangup first
would swallow it. The zero-length read keeps returning 0 ahead of
that check, as on Linux.

Known gaps, all failing closed to today's behaviour: a dup'd slave fd
is not counted, nor are slave fds a fork child receives over
SCM_RIGHTS, and a slave opened through TIOCGPTPEER never registers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track guest-held pty slave FDs per master and emulate Linux hangup semantics so masters report hangup when the guest closes all slave FDs. `ppoll` now yields `POLLHUP` and `read` returns `EIO`, fixing terminals like foot that waited forever after the shell exited.

- **Bug Fixes**
  - Track guest-held slave FDs per master; increment on `/dev/pts/N` opens, decrement on close in both `fd_cleanup_entry` and `sys_close`, and reset on keepalive slot changes; hangup only considered after the first slave open.
  - In `ppoll`, stamp `POLLHUP` and break infinite polls when a master is hung up.
  - In `read`, deliver any queued input first, then return `EIO` for hung-up masters.
  - Limitations: `dup`, `SCM_RIGHTS`, and `TIOCGPTPEER` slave opens are not counted.

<sup>Written for commit 839521ac56ecfb31970a092dd589b85700ff04b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



