### PR TITLE
Follow absolute sysroot links to host paths

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -530,6 +530,7 @@ test-sysroot-symlink-target: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-symlink-tar
 	@set -e; \
 	tmpdir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmpdir"' EXIT; \
+	ln -s "$$HOME" "$$tmpdir/host-home-link"; \
 	had_target=0; [ -e "/symlink-target" ] && had_target=1; \
 	$(ELFUSE_BIN) --sysroot "$$tmpdir" \
 	    $(BUILD_DIR)/test-sysroot-symlink-target; \

--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -783,7 +783,8 @@ static casefold_verdict_t resolve_through_links(const char *sr,
                                                 size_t bufsz,
                                                 casefold_walk_t *walk,
                                                 char *guest_out,
-                                                size_t guest_outsz)
+                                                size_t guest_outsz,
+                                                bool *followed_relative_out)
 {
     char splice[LINUX_PATH_MAX];
     char norm[LINUX_PATH_MAX];
@@ -832,6 +833,8 @@ static casefold_verdict_t resolve_through_links(const char *sr,
         if (path_splice_link_target(cur, walk->link_guest_offset, target, rest,
                                     splice, sizeof(splice)) < 0)
             return CASEFOLD_ERROR;
+        if (followed_relative_out && target[0] != '/')
+            *followed_relative_out = true;
         /* A target may carry '..' that climbs above the guest root, which
          * the walk would append literally and follow out of the sysroot. Clamp
          * it exactly as an entry path is clamped; an interior '..' stays for
@@ -882,12 +885,13 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
     bool present;
     bool folded = false;
     bool followed_link = false;
+    bool followed_relative_link = false;
     char followed[LINUX_PATH_MAX];
     if (casefold_active()) {
         casefold_walk_t walk;
-        casefold_verdict_t verdict =
-            resolve_through_links(sr, lookup, follow_final, buf, bufsz, &walk,
-                                  followed, sizeof(followed));
+        casefold_verdict_t verdict = resolve_through_links(
+            sr, lookup, follow_final, buf, bufsz, &walk, followed,
+            sizeof(followed), &followed_relative_link);
 
         if (verdict == CASEFOLD_ERROR)
             return NULL;
@@ -985,29 +989,19 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
         is_sysroot_backed_temp_path(path_to_check))
         return buf;
 
-    /* A path reached by following a symlink never falls through to the host.
-     * An absolute target typed by the guest is one thing: the guest asked for
-     * it, and the host fallback is the documented answer. A target recorded
-     * inside the sysroot is another: honoring it would let anything that can
-     * write a symlink there hand the guest a file from outside the tree, which
-     * is the escape tests/test-sysroot-symlink-escape.c exists to prevent.
-     * Resolution stops at the sysroot spelling, so the caller's own syscall
-     * reports the path as missing, which is what it is in the guest's
-     * namespace.
+    /* A path reached by following a symlink has already been rebased to the
+     * target's guest spelling. For non-forced paths, keep the same host
+     * fallback rule as a path the guest typed directly: if the target exists
+     * on the host, hand that resolved target to the caller; otherwise leave
+     * the syscall on the sysroot spelling so dangling links report normally.
      */
     if (followed_link) {
-        /* The sysroot does not have it. If the host does, the link was a way
-         * to reach a file outside the tree, and refusing is the whole point;
-         * report ELOOP, which is what resolution stopping at a link means and
-         * what callers of this resolver already propagate. If the host has
-         * nothing either the link simply dangles, and buf lets the caller's own
-         * syscall say so.
-         *
-         * The collapsed spelling is what the host is asked about: a target
-         * reaching out of the tree keeps the '..' components that carried it
-         * there, and those name nothing from the host's root.
-         */
-        if (sysroot_path_exists(path_to_check, follow_final)) {
+        if (!followed_relative_link &&
+            sysroot_path_exists(path_to_check, follow_final))
+            return path_to_check;
+
+        if (followed_relative_link &&
+            sysroot_path_exists(path_to_check, follow_final)) {
             errno = ELOOP;
             return NULL;
         }
@@ -1063,6 +1057,7 @@ const char *proc_resolve_sysroot_create_path(const char *path,
      * wrong-case one folds onto a directory the create would then land in.
      */
     bool followed_link = false;
+    bool followed_relative_link = false;
     char followed[LINUX_PATH_MAX];
     if (casefold_active()) {
         casefold_walk_t walk;
@@ -1073,7 +1068,8 @@ const char *proc_resolve_sysroot_create_path(const char *path,
          * inside the directory the link names.
          */
         if (resolve_through_links(sr, lookup, false, buf, bufsz, &walk,
-                                  followed, sizeof(followed)) == CASEFOLD_ERROR)
+                                  followed, sizeof(followed),
+                                  &followed_relative_link) == CASEFOLD_ERROR)
             return NULL;
         followed_link = rebase_after_link(&lookup, followed);
         if (str_copy_trunc(parent, buf, sizeof(parent)) >= sizeof(parent)) {

--- a/tests/test-sysroot-symlink-escape.c
+++ b/tests/test-sysroot-symlink-escape.c
@@ -8,19 +8,16 @@
  * containment check on absolute guest paths, since it has no dirfd context to
  * rebuild a host location from a relative one. That left openat(dirfd, name)
  * to the host kernel's own resolution, unconfined to dirfd's subtree: a
- * symlink reachable through a sysroot-contained dirfd -- with a relative
- * target holding enough ".." components, or with an absolute target -- could
- * walk straight out of the sysroot with no check at all, even though the
- * exact same escape through an absolute guest path was already rejected with
- * ELOOP. path_translate_at() now reconstructs the absolute guest path from
- * the dirfd's guest base path and re-validates it through the same
- * containment-checked resolver the absolute-path surface uses.
+ * symlink reachable through a sysroot-contained dirfd with a relative target
+ * holding enough ".." components could walk straight out of the sysroot with
+ * no check at all. path_translate_at() now reconstructs the absolute guest
+ * path from the dirfd's guest base path and re-validates it through the same
+ * resolver the absolute-path surface uses.
  *
  * The Makefile target stages an absolute-target symlink and a relative-target
- * (deep "..") symlink under $sysroot/d1, both pointing at a secret file
- * outside the sysroot, plus a normal in-sysroot file. This guest program only
- * exercises the relative-dirfd surface (openat(dirfd, name, ...)); the
- * absolute-path surface is already covered by test-sysroot-nofollow.
+ * (deep "..") symlink under $sysroot/d1, both pointing at a host file outside
+ * the sysroot, plus a normal in-sysroot file. The absolute target is a host
+ * bridge and should follow; the relative climb-out is still blocked.
  */
 
 #include <errno.h>
@@ -54,16 +51,14 @@ int main(void)
         }
     }
 
-    TEST("absolute-target symlink escape via dirfd is blocked");
+    TEST("absolute-target symlink bridge via dirfd is followed");
     {
         int fd = openat(dirfd, "abs-link", O_RDONLY);
-        if (fd < 0 && errno == ELOOP)
+        if (fd >= 0) {
+            close(fd);
             PASS();
-        else {
-            if (fd >= 0)
-                close(fd);
-            FAIL("openat(dirfd, abs-link) did not fail with ELOOP");
-        }
+        } else
+            FAIL("openat(dirfd, abs-link) failed");
     }
 
     TEST("relative \"..\" symlink escape via dirfd is blocked");
@@ -86,13 +81,11 @@ int main(void)
             FAIL("chdir /d1 failed");
         } else {
             int fd = open("abs-link", O_RDONLY);
-            if (fd < 0 && errno == ELOOP)
+            if (fd >= 0) {
+                close(fd);
                 PASS();
-            else {
-                if (fd >= 0)
-                    close(fd);
-                FAIL("open(AT_FDCWD, abs-link) did not fail with ELOOP");
-            }
+            } else
+                FAIL("open(AT_FDCWD, abs-link) failed");
         }
     }
 

--- a/tests/test-sysroot-symlink-target.c
+++ b/tests/test-sysroot-symlink-target.c
@@ -121,6 +121,10 @@ int main(void)
     TEST("  and reads through to it");
     EXPECT_TRUE(reads("abs-escaped", "escaped") == 0, "content");
 
+    TEST("a staged host symlink is followed");
+    EXPECT_TRUE(stat("/host-home-link", &st) == 0 && S_ISDIR(st.st_mode),
+                "stat follows host link");
+
     /* readlink reports the disk. A relative target is stored verbatim, so
      * the guest's own bytes come back; an absolute one was rewritten at
      * symlink() time to the sysroot-relative spelling (see the header), and


### PR DESCRIPTION
Allow sysroot-staged symlinks with absolute targets to resolve through the normal host fallback path, while keeping relative symlink climb-outs blocked.

This fixes host bridge links such as Downloads -> /Users/Downloads returning ELOOP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow absolute-target symlinks inside the sysroot to resolve to host paths via the normal fallback, including when opened via dirfd or cwd. Relative symlink climb-outs remain blocked, fixing host bridges like `Downloads -> /Users/...` that previously returned ELOOP.

- **Bug Fixes**
  - Follow absolute sysroot symlinks to existing host paths (no ELOOP), including dirfd/cwd.
  - Keep relative-target escapes blocked (ELOOP) by tracking whether the followed link is relative.
  - Update tests to cover dirfd and cwd; add `/host-home-link` in `test-sysroot-symlink-target`.

<sup>Written for commit 853841263e6dcadcb2c1b576423f2345737ce2bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

