### PR TITLE
Keep /run inside the sysroot

### DIFF
--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -739,9 +739,15 @@ static bool is_guest_system_path(const char *path)
     if (!path || path[0] != '/')
         return false;
 
-    /* Check prefix patterns (path/...) and exact root matches (path) */
+    /* Check prefix patterns (path/...) and exact root matches (path)
+     *
+     * /run is guest-only runtime state with no host counterpart, so a fallback
+     * there can only find something unrelated. Listing it keeps an absent /run
+     * path on the sysroot spelling, where the caller's own syscall reports the
+     * ENOENT the guest is owed.
+     */
     static const char *const dirs[] = {
-        "/usr/", "/bin/",  "/sbin/", "/lib/",  "/lib64/",
+        "/usr/", "/bin/",  "/sbin/", "/lib/",  "/lib64/", "/run/",
         "/opt/", "/boot/", "/srv/",  "/root/", "/home/",
     };
     for (size_t i = 0; i < sizeof(dirs) / sizeof(dirs[0]); i++) {


### PR DESCRIPTION
is_guest_system_path() listed every guest tree with no macOS counterpart except /run, so a /run path absent from the sysroot fell out of sysroot confinement. The resolver then collapsed it to host "/", open() succeeded on the host root, and the caller got a directory fd where Linux owes ENOENT.

systemd's drop-in search walks /etc, /run and /usr/lib for the same basename, so the /run leg handed systemd-sysusers a directory and it stopped there instead of continuing to /usr/lib:

  Failed to read '/run/sysusers.d/basic.conf': Is a directory

which broke `dpkg --configure systemd` on a freshly provisioned Ubuntu 26.04 rootfs.

/run is guest-only runtime state; a host fallback there can only find something unrelated. Pin it to the sysroot spelling so the caller's own syscall reports the absence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `/run` to the guest sysroot during path resolution so absent paths return ENOENT instead of collapsing to the host root. Fixes systemd’s drop-in search and unblocks `dpkg --configure systemd` on fresh Ubuntu 26.04 rootfs.

- **Bug Fixes**
  - Add `/run/` to `is_guest_system_path()` to prevent host fallback.
  - systemd-sysusers no longer stops on `/run/sysusers.d/basic.conf` and continues to `/usr/lib`.

<sup>Written for commit fb1405cc36020f052a3750ba39e1edafe339afb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

