### PR TITLE
Wait out socket backpressure when streaming fds across a clone

### DIFF
--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -8,6 +8,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -48,12 +49,20 @@ int fork_ipc_read_all(int fd, void *buf, size_t len)
  */
 #define FORK_IPC_FD_CHUNK 120
 
+/* Consecutive waits that fail to place a chunk before the sender starts
+ * sleeping between attempts, and how long it then sleeps. Only reached if a
+ * platform asserts POLLOUT with less room free than one control message needs.
+ */
+#define FORK_IPC_SEND_STALL_LIMIT 8
+#define FORK_IPC_SEND_BACKOFF_US 1000
+
 int fork_ipc_send_fds(int sock, const int *fds, int count)
 {
     if (count <= 0)
         return 0;
 
     int sent = 0;
+    int stalled = 0;
     while (sent < count) {
         int chunk = count - sent;
         if (chunk > FORK_IPC_FD_CHUNK)
@@ -88,10 +97,49 @@ int fork_ipc_send_fds(int sock, const int *fds, int count)
         memcpy(CMSG_DATA(cmsg), fds + sent, (size_t) chunk * sizeof(int));
 
         ssize_t ret = sendmsg(sock, &msg, 0);
+        int send_errno = errno;
         free(cmsg_buf);
-        if (ret < 0)
+        if (ret >= 0) {
+            sent += chunk;
+            stalled = 0;
+            continue;
+        }
+        if (send_errno != EMSGSIZE) {
+            errno = send_errno;
             return -1;
-        sent += chunk;
+        }
+
+        /* EMSGSIZE here is backpressure, not an oversized message: the chunk is
+         * fixed and small, so the only way it does not fit is that the peer has
+         * not drained yet. A control message that does not fit is refused
+         * outright rather than queued, so a blocking sendmsg reports EMSGSIZE
+         * where a data-only write would block. The receiver is the freshly
+         * cloned child, draining concurrently, so waiting for writability and
+         * retrying the same chunk converges. Waiting without a deadline matches
+         * fork_ipc_write_all, which blocks on the same socket for the same
+         * peer.
+         *
+         * POLLOUT is asserted only once SO_SNDLOWAT bytes are free (2048 on
+         * macOS, against 492 for a full chunk), so poll blocks here rather than
+         * returning writable on room too small to use. That is a platform
+         * tunable, not a guarantee, so sleep once waiting stops making
+         * progress: a smaller lowat can then only slow the transfer, never spin
+         * a core.
+         */
+        struct pollfd pfd = {.fd = sock, .events = POLLOUT};
+        int pret;
+        do {
+            pret = poll(&pfd, 1, -1);
+        } while (pret < 0 && errno == EINTR);
+        if (pret < 0)
+            return -1;
+        if (!(pfd.revents & POLLOUT) &&
+            (pfd.revents & (POLLHUP | POLLERR | POLLNVAL))) {
+            errno = EPIPE;
+            return -1;
+        }
+        if (++stalled > FORK_IPC_SEND_STALL_LIMIT)
+            usleep(FORK_IPC_SEND_BACKOFF_US);
     }
     return 0;
 }

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -1542,6 +1542,28 @@ int64_t sys_clone(hv_vcpu_t vcpu,
         log_error("clone: socketpair failed: %s", strerror(errno));
         return -LINUX_ENOMEM;
     }
+
+    /* A fork-child that dies mid-handshake makes every send on this socket
+     * raise SIGPIPE, which elfuse leaves at its default terminate disposition
+     * (only SIGUSR2 and SIGALRM are masked at bring-up), so the whole host
+     * process would die instead of the clone failing. Suppress it per-socket
+     * the way syscall/net.c does for guest sockets; the option rides on the
+     * file description, so the spawned child inherits it.
+     *
+     * Failing the clone beats continuing without it: proceeding would leave the
+     * host one dead child away from being killed by a signal it never handles,
+     * which is worse than the guest seeing a fork it can retry.
+     */
+    int nosigpipe = 1;
+    if (setsockopt(sock_fds[0], SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe,
+                   sizeof(nosigpipe)) < 0 ||
+        setsockopt(sock_fds[1], SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe,
+                   sizeof(nosigpipe)) < 0) {
+        log_error("clone: SO_NOSIGPIPE failed: %s", strerror(errno));
+        close(sock_fds[0]);
+        close(sock_fds[1]);
+        return -LINUX_ENOMEM;
+    }
     if (is_vfork && pipe(vfork_notify_fds) < 0) {
         log_error("clone: vfork notify pipe failed: %s", strerror(errno));
         close(sock_fds[0]);


### PR DESCRIPTION
fork_ipc_send_fds chunks descriptors at 120 per SCM_RIGHTS message, which bounds each control message but not how many sit unread in the socket at once. The parent streams every chunk in a tight loop while the freshly cloned child is still starting, so it outruns the receiver by a full socket buffer.

macOS refuses a control message that does not fit rather than queuing it, so a blocking sendmsg reports EMSGSIZE where a data-only write would block. At the default 8 KiB buffer that lands after about 1900 descriptors, which a guest reaches once its region list grows large enough -- dpkg passed it around the 198th package of an install:

  clone: send backing fds failed: Message too long
  clone: failed to send process state
  dpkg: unrecoverable fatal error, aborting:
   fork failed: Cannot allocate memory

Treat EMSGSIZE from a fixed-size chunk as backpressure: wait for writability and retry the same chunk. The child drains concurrently, and POLLOUT stays clear while the buffer holds control mbufs, so this blocks rather than spins. Waiting without a deadline matches fork_ipc_write_all on the same socket; a child that dies surfaces as POLLHUP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle socket backpressure when streaming file descriptors during clone and prevent host termination from SIGPIPE. Previously, a blocking sendmsg of a fixed-size SCM_RIGHTS chunk could return EMSGSIZE and abort the clone; now we treat EMSGSIZE as backpressure, wait for POLLOUT, and retry the same chunk.

- Block on POLLOUT with poll(-1), handle EINTR, and resend the same chunk; add a small backoff after repeated stalls to avoid spinning if SNDLOWAT is low.
- On POLLHUP/ERR/NVAL, fail with EPIPE instead of looping.
- Set SO_NOSIGPIPE on both ends of the clone socketpair; if setsockopt fails, close the fds and fail the clone.

<sup>Written for commit 15e4ae7a337a961bf1af23cb4ade3e2ef28702bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

