### PR TITLE
Read the wakeup pipe fds atomically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ SRCS := \
     syscall/fs-xattr.c \
     syscall/io.c \
     syscall/poll.c \
+    syscall/wakeup-pipe.c \
     syscall/fd.c \
     syscall/asyncio.c \
     syscall/inotify.c \
@@ -217,6 +218,14 @@ $(BUILD_DIR)/probe-volume-naming: $(BUILD_DIR)/probe-volume-naming.o \
 # the test links exactly the code under test and nothing else.
 $(BUILD_DIR)/test-casefold-host: $(BUILD_DIR)/test-casefold-host.o \
 		$(BUILD_DIR)/syscall/casefold.o | $(BUILD_DIR)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(CFLAGS) -o $@ $^
+
+## Build the wakeup pipe concurrency host test (native macOS binary)
+# wakeup-pipe.o is a leaf translation unit, so the test links the code under
+# test and nothing else.
+$(BUILD_DIR)/test-wakeup-pipe-host: $(BUILD_DIR)/test-wakeup-pipe-host.o \
+		$(BUILD_DIR)/syscall/wakeup-pipe.o | $(BUILD_DIR)
 	@echo "  LD      $@"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -27,7 +27,8 @@ NATIVE_TESTS := tests/test-multi-vcpu.c tests/test-rwx.c \
                 tests/test-absock-names-host.c \
                 tests/probe-volume-naming.c \
                 tests/test-dynamic-array-host.c \
-                tests/test-string-builder-host.c
+                tests/test-string-builder-host.c \
+                tests/test-wakeup-pipe-host.c
 SPECIAL_TEST_SRCS := tests/test-lowbase-mem.c
 SPECIAL_TEST_BINS := $(BUILD_DIR)/test-lowbase-mem-200000 $(BUILD_DIR)/test-lowbase-mem-300000
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -33,6 +33,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-sysroot-absock-names test-absock-cleanup \
         test-linkat-symlink-fallback test-casefold-host \
         test-casefold-walk-host test-absock-names-host \
+        test-wakeup-pipe-host \
         test-sysroot-name-unique \
         test-sysroot-name-relative \
         test-nosysroot-literal-names test-sysroot-outside-names \
@@ -165,7 +166,7 @@ CHECK_HOST_UNIT_BINS := $(addprefix $(BUILD_DIR)/, \
         test-vcpu-run-hooks-host test-identity-override-host \
         test-teardown-live-vcpu-host test-casefold-host \
         test-casefold-walk-host test-absock-names-host \
-        test-dynamic-array-host test-string-builder-host)
+        test-dynamic-array-host test-string-builder-host test-wakeup-pipe-host)
 
 # Lanes shared by check and check-sanitizer, in execution order: the host
 # unit binaries, then the name-contract lanes cheap enough for a sanitizer
@@ -182,6 +183,7 @@ $(call run-host-unit,test-casefold-walk-host,case-exact path resolution unit tes
 $(call run-host-unit,test-absock-names-host,absock derived-name unit test)
 $(call run-host-unit,test-dynamic-array-host,dynamic array unit test)
 $(call run-host-unit,test-string-builder-host,string builder unit test)
+$(call run-host-unit,test-wakeup-pipe-host,wakeup pipe concurrency unit test)
 $(call run-lane,test-sysroot-name-unique,one on-disk name per guest name)
 $(call run-lane,test-sysroot-name-relative,relative and dirfd-relative names)
 $(call run-lane,test-sysroot-name-i18n,non-ASCII guest filenames)
@@ -1460,6 +1462,12 @@ test-casefold-walk-host: $(BUILD_DIR)/test-casefold-walk-host
 ## Run the absock derived-name unit test natively on the host
 test-absock-names-host: $(BUILD_DIR)/test-absock-names-host
 	$(BUILD_DIR)/test-absock-names-host
+
+# Wakeup pipe concurrency unit test. Only a -fsanitize=thread build carries a
+# race detector, so check-sanitizer is where this lane has its full weight.
+## Run the wakeup pipe concurrency unit test natively on the host
+test-wakeup-pipe-host: $(BUILD_DIR)/test-wakeup-pipe-host
+	$(BUILD_DIR)/test-wakeup-pipe-host
 
 # Volume naming probe
 ## Report how the filesystem treats filenames (regenerates docs/filenames.md tables)

--- a/src/core/guest.c
+++ b/src/core/guest.c
@@ -46,8 +46,8 @@
 #include "utils.h"
 #include "runtime/futex.h"  /* futex_interrupt_request */
 #include "runtime/thread.h" /* thread_destroy_all_vcpus */
-#include "syscall/poll.h"   /* wakeup_pipe_signal */
 #include "syscall/proc.h"   /* proc_request_exit_group */
+#include "syscall/wakeup-pipe.h"
 
 /* Per-vCPU pending TLBI request. Zero-initialized in every host pthread by
  * virtue of TLS default-zeroing, which maps to TLBI_NONE.

--- a/src/core/launch.c
+++ b/src/core/launch.c
@@ -29,8 +29,8 @@
 #include "runtime/futex.h"   /* futex_interrupt_request */
 #include "runtime/procemu.h" /* proc_pty_release_process_slaves */
 #include "runtime/thread.h"
-#include "syscall/poll.h" /* wakeup_pipe_signal */
 #include "syscall/proc.h"
+#include "syscall/wakeup-pipe.h"
 
 #include "debug/gdbstub.h"
 #include "debug/log.h"

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@
 #include "syscall/fuse.h"
 #include "syscall/path.h"
 #include "syscall/proc.h"
+#include "syscall/wakeup-pipe.h"
 
 #include "debug/log.h"
 #include "debug/syscall-hist.h"

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -42,12 +42,12 @@
 #include "syscall/chown-overlay.h"
 #include "syscall/internal.h"
 #include "syscall/mem.h"
-#include "syscall/net.h"  /* absock namespace IPC state */
-#include "syscall/poll.h" /* wakeup_pipe_signal */
+#include "syscall/net.h" /* absock namespace IPC state */
 #include "syscall/proc.h"
 #include "syscall/proc-pidfd.h"
 #include "syscall/signal.h"
 #include "syscall/sys.h"
+#include "syscall/wakeup-pipe.h"
 
 #include "debug/log.h"
 #include "debug/syscall-hist.h"

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -47,9 +47,9 @@
 #include "syscall/net.h"
 #include "syscall/net-identity.h"
 #include "syscall/net-sockopt.h"
-#include "syscall/poll.h"
 #include "syscall/proc.h"
 #include "syscall/signal.h"
+#include "syscall/wakeup-pipe.h"
 
 #define URANDOM_CACHE_SIZE 4096
 

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -33,53 +33,7 @@
 #include "syscall/proc.h" /* proc_exit_group_requested */
 #include "syscall/signal.h"
 #include "syscall/time.h" /* linux_timespec_valid */
-
-/* Global wakeup pipe: write end signals exit_group/futex_interrupt/guest
- * signals to threads blocked in host poll/select/kevent. The read end is added
- * to every blocking wait with infinite timeout.
- */
-static int wakeup_pipe_rd = -1, wakeup_pipe_wr = -1;
-
-void wakeup_pipe_init(void)
-{
-    /* Idempotent: syscall_init is reached twice on some paths (bootstrap and
-     * the fork-child's fork_ipc_recv_fd_table), and re-running the pipe(2) here
-     * would overwrite the fds and leak the first pair.
-     */
-    if (wakeup_pipe_rd >= 0)
-        return;
-
-    int pipefd[2];
-    if (pipe(pipefd) == 0) {
-        fcntl(pipefd[0], F_SETFL, O_NONBLOCK);
-        fcntl(pipefd[1], F_SETFL, O_NONBLOCK);
-        wakeup_pipe_rd = pipefd[0];
-        wakeup_pipe_wr = pipefd[1];
-    }
-}
-
-void wakeup_pipe_signal(void)
-{
-    if (wakeup_pipe_wr >= 0) {
-        uint8_t byte = 1;
-        write(wakeup_pipe_wr, &byte, 1);
-    }
-}
-
-int wakeup_pipe_read_fd(void)
-{
-    return wakeup_pipe_rd;
-}
-
-void wakeup_pipe_drain(void)
-{
-    if (wakeup_pipe_rd < 0)
-        return;
-
-    uint8_t drain;
-    while (read(wakeup_pipe_rd, &drain, 1) > 0)
-        ;
-}
+#include "syscall/wakeup-pipe.h"
 
 /* polling/select. */
 
@@ -220,8 +174,9 @@ int64_t sys_ppoll(guest_t *g,
      * they're not in hv_vcpu_run().
      */
     bool added_wakeup = false;
-    if (timeout_ms < 0 && wakeup_pipe_rd >= 0 && nfds < 256) {
-        host_fds[nfds].fd = wakeup_pipe_rd;
+    int wake_fd = wakeup_pipe_read_fd();
+    if (timeout_ms < 0 && wake_fd >= 0 && nfds < 256) {
+        host_fds[nfds].fd = wake_fd;
         host_fds[nfds].events = POLLIN;
         host_fds[nfds].revents = 0;
         added_wakeup = true;
@@ -515,11 +470,15 @@ int64_t sys_pselect6(guest_t *g,
      * requests can interrupt.
      */
     bool added_wakeup = false;
-    if (!has_timeout && wakeup_pipe_rd >= 0) {
-        if (RANGE_CHECK(wakeup_pipe_rd, 0, FD_SETSIZE)) {
-            FD_SET(wakeup_pipe_rd, &read_set);
-            if (wakeup_pipe_rd > max_host_fd)
-                max_host_fd = wakeup_pipe_rd;
+    /* One read of the pipe fd for the whole call: the FD_SET here and the
+     * FD_ISSET/FD_CLR after the wait must name the same descriptor.
+     */
+    int wake_fd = wakeup_pipe_read_fd();
+    if (!has_timeout && wake_fd >= 0) {
+        if (RANGE_CHECK(wake_fd, 0, FD_SETSIZE)) {
+            FD_SET(wake_fd, &read_set);
+            if (wake_fd > max_host_fd)
+                max_host_fd = wake_fd;
         }
         added_wakeup = true;
         read_setp = &read_set;
@@ -548,7 +507,7 @@ int64_t sys_pselect6(guest_t *g,
             break;
         }
     }
-    if (added_wakeup && !RANGE_CHECK(wakeup_pipe_rd, 0, FD_SETSIZE))
+    if (added_wakeup && !RANGE_CHECK(wake_fd, 0, FD_SETSIZE))
         use_poll_fallback = true;
 
     int ret;
@@ -587,7 +546,7 @@ pselect_retry:
                 poll_fds[i].revents = 0;
             }
             if (added_wakeup) {
-                poll_fds[req_count].fd = wakeup_pipe_rd;
+                poll_fds[req_count].fd = wake_fd;
                 poll_fds[req_count].events = POLLIN;
                 poll_fds[req_count].revents = 0;
             }
@@ -629,12 +588,11 @@ pselect_retry:
      */
     bool wakeup_fired =
         added_wakeup &&
-        (use_poll_fallback ? poll_wakeup_fired
-                           : FD_ISSET(wakeup_pipe_rd, &read_set));
+        (use_poll_fallback ? poll_wakeup_fired : FD_ISSET(wake_fd, &read_set));
     if (wakeup_fired) {
         wakeup_pipe_drain();
         if (!use_poll_fallback)
-            FD_CLR(wakeup_pipe_rd, &read_set);
+            FD_CLR(wake_fd, &read_set);
         if (ret > 0)
             ret--;
         if (ret == 0 && !has_timeout)

--- a/src/syscall/poll.h
+++ b/src/syscall/poll.h
@@ -61,13 +61,3 @@ int epoll_dup_fd(int src_fd,
                  int fixed_guest_fd,
                  bool fixed_slot,
                  int linux_flags);
-
-/* Global wakeup pipe for interrupting blocking poll/select/epoll. When
- * exit_group, futex_interrupt, or a guest signal is requested, write to
- * wakeup_pipe_wr to unblock any thread stuck in a host-side poll/select/kevent
- * with infinite timeout.
- */
-void wakeup_pipe_init(void);
-void wakeup_pipe_signal(void);
-int wakeup_pipe_read_fd(void);
-void wakeup_pipe_drain(void);

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -50,8 +50,8 @@
 #include "syscall/proc.h"
 #include "syscall/proc-pidfd.h"
 #include "syscall/proc-state.h"
-#include "syscall/poll.h"
 #include "syscall/signal.h"
+#include "syscall/wakeup-pipe.h"
 
 #include "debug/crashreport.h"
 #include "debug/gdbstub.h"

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -36,11 +36,11 @@
 
 #include "syscall/linux-wire.h"
 #include "syscall/fd.h"   /* signalfd_notify */
-#include "syscall/poll.h" /* wakeup_pipe_signal */
 #include "syscall/proc.h" /* proc_get_pid, proc_get_uid, SYSCALL_EXEC_HAPPENED */
 #include "syscall/sigframe-math.h"
 #include "syscall/signal.h"
 #include "syscall/time.h" /* linux_timespec_valid, linux_timespec_to_ns_sat */
+#include "syscall/wakeup-pipe.h"
 
 /* sigaltstack rejects a stack below LINUX_MINSIGSTKSZ, and that is the only
  * thing keeping a frame from being placed below the altstack base: the

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -59,6 +59,7 @@
 #include "syscall/net.h"
 #include "syscall/net-sockopt.h"
 #include "syscall/poll.h"
+#include "syscall/wakeup-pipe.h"
 #include "syscall/path.h"
 #include "syscall/proc.h"
 #include "syscall/proc-pidfd.h"

--- a/src/syscall/wakeup-pipe.c
+++ b/src/syscall/wakeup-pipe.c
@@ -1,0 +1,65 @@
+/*
+ * Blocking-wait wakeup pipe
+ *
+ * Copyright 2026 elfuse contributors
+ * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The self-pipe every indefinite host poll/select/kevent waits on alongside
+ * its real fds. Free of syscall-layer dependencies, so the concurrency
+ * contract in wakeup-pipe.h can be tested on its own.
+ */
+
+#include <fcntl.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "syscall/wakeup-pipe.h"
+
+/* Read by the sigwait thread and by every guest thread while wakeup_pipe_init()
+ * is still assigning them, which plain int would let the compiler tear or fold.
+ * Relaxed suffices: each fd is read on its own and publishes no other state,
+ * and pipe(2) creates the descriptors before either store.
+ */
+static _Atomic int wakeup_pipe_rd = -1, wakeup_pipe_wr = -1;
+
+void wakeup_pipe_init(void)
+{
+    /* Replacing a published pair strands every thread parked on the old fd. */
+    if (atomic_load_explicit(&wakeup_pipe_rd, memory_order_relaxed) >= 0)
+        return;
+
+    int pipefd[2];
+    if (pipe(pipefd) == 0) {
+        fcntl(pipefd[0], F_SETFL, O_NONBLOCK);
+        fcntl(pipefd[1], F_SETFL, O_NONBLOCK);
+        atomic_store_explicit(&wakeup_pipe_rd, pipefd[0], memory_order_relaxed);
+        atomic_store_explicit(&wakeup_pipe_wr, pipefd[1], memory_order_relaxed);
+    }
+}
+
+void wakeup_pipe_signal(void)
+{
+    int wr = atomic_load_explicit(&wakeup_pipe_wr, memory_order_relaxed);
+    if (wr >= 0) {
+        uint8_t byte = 1;
+        write(wr, &byte, 1);
+    }
+}
+
+int wakeup_pipe_read_fd(void)
+{
+    return atomic_load_explicit(&wakeup_pipe_rd, memory_order_relaxed);
+}
+
+void wakeup_pipe_drain(void)
+{
+    int rd = atomic_load_explicit(&wakeup_pipe_rd, memory_order_relaxed);
+    if (rd < 0)
+        return;
+
+    uint8_t drain;
+    while (read(rd, &drain, 1) > 0)
+        ;
+}

--- a/src/syscall/wakeup-pipe.h
+++ b/src/syscall/wakeup-pipe.h
@@ -1,0 +1,32 @@
+/*
+ * Blocking-wait wakeup pipe
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A process-wide self-pipe whose read end joins every host poll/select/kevent
+ * that would otherwise wait forever, so exit_group, futex_interrupt, and guest
+ * signal delivery reach a thread parked outside hv_vcpu_run(), where
+ * hv_vcpus_exit() cannot.
+ */
+
+#pragma once
+
+/* Create the pipe, once. Main thread only: the one-shot gate is an
+ * unsynchronized check-then-act, and by the time syscall_init(), the only
+ * caller, reaches it the sigwait thread is already reading the fds.
+ */
+void wakeup_pipe_init(void);
+
+/* Wake every thread parked on the read end. Safe from a signal-handling
+ * thread; a missing pipe is a no-op.
+ */
+void wakeup_pipe_signal(void);
+
+/* The read end to add to a blocking wait, or -1 when the pipe is missing.
+ * poll(2) ignores a negative fd, so callers can pass the result through.
+ */
+int wakeup_pipe_read_fd(void);
+
+/* Consume every queued byte. The pipe is nonblocking, so this cannot park. */
+void wakeup_pipe_drain(void);

--- a/tests/test-wakeup-pipe-host.c
+++ b/tests/test-wakeup-pipe-host.c
@@ -1,0 +1,85 @@
+/*
+ * Native-host unit test for the wakeup pipe's concurrency contract
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A reader thread runs wakeup_pipe_signal() and wakeup_pipe_read_fd() across
+ * the main thread's wakeup_pipe_init(), the pairing ThreadSanitizer reported
+ * on wakeup_pipe_wr under test-fork-exec. Only a -fsanitize=thread build has a
+ * race detector; elsewhere this checks init, idempotency, and drain.
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "host-test-util.h"
+
+#include "syscall/wakeup-pipe.h"
+
+/* Plain bool here would be the defect under test, blamed on the harness. */
+static atomic_bool reader_run = true;
+
+/* Pacing is what makes the race observable: an unpaced loop churns
+ * ThreadSanitizer's history until a conflicting access is evicted before its
+ * partner arrives. With the fds plain: unpaced 0 of 20 runs, paced 20 of 20.
+ */
+#define RACE_WINDOW_US 20000
+#define READER_PACE_US 200
+
+static void *reader_main(void *arg)
+{
+    (void) arg;
+    while (atomic_load_explicit(&reader_run, memory_order_relaxed)) {
+        wakeup_pipe_signal();
+        (void) wakeup_pipe_read_fd();
+        usleep(READER_PACE_US);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    host_check(wakeup_pipe_read_fd() == -1, "unset read end",
+               "the read end must be -1 before init");
+
+    pthread_t reader;
+    if (pthread_create(&reader, NULL, reader_main, NULL) != 0) {
+        fprintf(stderr, "FAIL thread: cannot start the reader thread\n");
+        return 1;
+    }
+
+    /* Bracket the one-shot store with loads already in flight: a race is
+     * reported only when an access finds a conflicting one recorded.
+     */
+    usleep(RACE_WINDOW_US);
+
+    wakeup_pipe_init();
+
+    usleep(RACE_WINDOW_US);
+
+    atomic_store_explicit(&reader_run, false, memory_order_relaxed);
+    pthread_join(reader, NULL);
+
+    int fd = wakeup_pipe_read_fd();
+    host_check(fd >= 0, "init", "init must publish a read end");
+
+    /* Regression guard: syscall_init() runs once per process. */
+    wakeup_pipe_init();
+    host_check(wakeup_pipe_read_fd() == fd, "idempotent init",
+               "a second init must keep the first read end");
+
+    wakeup_pipe_drain();
+    char byte;
+    host_check(read(fd, &byte, 1) == -1 && errno == EAGAIN, "drain",
+               "drain must leave the pipe empty and nonblocking");
+
+    wakeup_pipe_signal();
+    host_check(read(fd, &byte, 1) == 1, "signal", "signal must queue a byte");
+
+    return host_summary("test-wakeup-pipe-host");
+}


### PR DESCRIPTION
Address the race condition caught by CI

```
test-fork-exec                                [ FAIL ] (exit 134)
    ==================
    WARNING: ThreadSanitizer: data race (pid=76887)
      Read of size 4 at 0x0001004fc6c4 by thread T1:
        #0 wakeup_pipe_signal poll.c:63 (elfuse:arm64+0x100060248)
        #1 preempt_thread_main proc.c:2897 (elfuse:arm64+0x10007368c)
    
      Previous write of size 4 at 0x0001004fc6c4 by main thread:
        #0 wakeup_pipe_init poll.c:57 (elfuse:arm64+0x1000601e8)
        #1 syscall_init syscall.c:117 (elfuse:arm64+0x10002dcbc)
        #2 guest_bootstrap_prepare bootstrap.c:574 (elfuse:arm64+0x10000fce4)
        #3 guest_bootstrap_prepare bootstrap.c:369 (elfuse:arm64+0x10000ecd4)
        #4 main main.c:243 (elfuse:arm64+0x1000008c4)
    
      Location is global 'wakeup_pipe_wr' at 0x0001004fc6c4 (elfuse+0x1000c46c4)
    
      Thread T1 (tid=39753171, running) created by main thread at:
        #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x33834)
        #1 proc_preempt_init proc.c:2997 (elfuse:arm64+0x1000735c4)
        #2 main main.c:464 (elfuse:arm64+0x100001254)
    
    SUMMARY: ThreadSanitizer: data race poll.c:63 in wakeup_pipe_signal
    ==================

```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wakeup-pipe data race by making the pipe fds atomic and reading the wake fd once per wait. Old behavior: plain ints allowed torn reads between init and signal delivery and code re-read the fd in `pselect6`. New behavior: `_Atomic int` with relaxed loads/stores and a single read per `ppoll`/`pselect6`; no readiness semantics change.

- In `ppoll`/`pselect6`, load the wake fd once, reuse it across FD_SET/ISSET/CLR and the poll fallback, then drain and decrement the result when only the wakeup fired.
- Move the wakeup-pipe API to `syscall/wakeup-pipe.c/.h`; remove it from `syscall/poll.h`; update all includes to `syscall/wakeup-pipe.h`.
- Add native host concurrency test `test-wakeup-pipe-host`; build and run in host and sanitizer lanes.

<sup>Written for commit 52b7b098f1f6b306a641c79ff74c6b06eb59190c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

