### PR TITLE
Carve the project knowledge into task skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/elfuse-conventions/SKILL.md
+++ b/.claude/skills/elfuse-conventions/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: elfuse-conventions
+description: elfuse conventions that are not guessable from the code - the seven-rule commit message style, ASCII-only source comments, kebab-case filenames, the type and return conventions at the ABI boundary, the untracked root working docs, and externals/ being evaluation-only. Use when drafting a commit message or PR description, adding a new file or a new type, or touching anything under externals/.
+---
+
+# elfuse conventions
+
+Almost nothing here is enforced by a gate. `clang-format` settles formatting
+and `make check-format` settles the generated files, so those are not in this
+file; what is left is the set a reviewer would otherwise have to say out loud.
+
+The one exception is these files themselves. `scripts/check-skill-refs.py`
+fails when a skill names a file, make target, docs section, or sibling skill
+that no longer exists. It checks every skill, plus any routing document you
+name on the command line. Run it after renaming or moving anything the skills
+point at, because a pointer that no longer resolves does not read as stale, it
+reads as authoritative.
+
+## Working docs
+
+The repo root carries per-developer working docs that are deliberately
+untracked: `CLAUDE.md`, `spec.md`, and a few others alongside them. Never
+`git add`, commit, stage, gitignore, or delete any of them. They stay
+untracked but visible in `git status`. This applies to `CLAUDE.md` itself.
+
+`spec.md` holds the full coding conventions and wins where it and this file
+disagree, but it does not survive a fresh clone. That is why the load-bearing
+subset is duplicated below rather than referenced: on a clean checkout, `docs/`
+and these skills are all a contributor gets.
+
+## Style
+
+Source comments and commit messages are ASCII only, no markdown syntax: no em
+dashes, no inline backticks, no non-ASCII arrows. Use `-`, `--`, or `:`
+instead of an em dash. Write code, path, and symbol references as plain text
+(EPOLL_CTL_MOD, tests/foo.c).
+
+This rule covers `src/` comments, `tests/` comments, and commit messages.
+Markdown files are exempt and use normal GitHub Markdown: the working docs,
+`AGENTS.md`, and these skill files. Do not strip backticks out of a `.md` file
+in the name of this rule.
+
+Comments and commit messages are third-person: name the subject (the caller,
+this function) or use imperative phrasing.
+
+Filenames use kebab-case, never underscore. Symbol names use snake_case.
+
+## Code
+
+The conventions below are the ones that come from this project being a Linux
+ABI reimplementation rather than an ordinary C program.
+
+Fixed-width types for anything the guest defines: guest addresses, Linux ABI
+structures, binary layouts, protocol fields, page-table entries. Host-side
+types (`size_t`, `ssize_t`, `int`, POSIX types) for host API calls, where they
+match what the host declares. The distinction is not cosmetic; it is how a
+reader tells which side of the boundary a value came from.
+
+```c
+uint64_t gva;       /* guest virtual address */
+uint64_t ipa;       /* intermediate physical address */
+size_t len;         /* host buffer length */
+int host_fd;        /* macOS file descriptor */
+```
+
+Packed Linux ABI structures are explicit and live next to the translation code
+that uses them, not in a shared header where they can drift away from the
+conversion that gives them meaning.
+
+Never pass a guest pointer to a host syscall. Copy through the guest memory
+helpers so bounds checking and fault behavior stay in one place.
+
+`bool` is for functions whose only meaningful outcome is success or failure.
+`int` is reserved for returns that carry a number: errno-style codes, counts,
+indices, or forwarding the status of an `int`-returning primitive. A helper
+that only ever returns 0 or -1 and is read with a `< 0` test should have been
+a `bool`; a helper that forwards a page-table or syscall primitive's status
+should stay `int`.
+
+New code goes in the existing domain file, not a new one. New shared
+declarations go in the domain's `internal.h` or an existing header. A new lock
+is documented in the lock-order comment before it is used from a second
+module.
+
+New C tests are `tests/test-<feature>.c` and use the shared harness macros
+rather than rolling their own reporting.
+
+## externals/
+
+Tools vendored under `externals/` (`ls externals/` for what is actually
+checked out locally) are for evaluation and discovery.
+
+`externals/` is gitignored, so anything that depends on it breaks on a fresh
+clone and cannot run in CI. That single fact settles every case: no make
+target, no script, no CI job, no documented workflow step may reference it.
+
+Run such a tool by hand from a scratch directory and leave any fixes to the
+tool inside its own checkout. Record the outcome in the root working docs,
+including when the answer was "evaluated, not integrated" - a rejected
+evaluation is worth writing down so the next person does not repeat it. If the
+output is worth keeping, land the finding in tree, not the tool.
+
+## Commit messages
+
+The house style is Chris Beams' seven rules (https://cbea.ms/git-commit/), and
+the log follows them closely enough that a deviation reads as an outsider
+patch. `git log --no-merges --format=%s` is the calibration set if you want to
+check the claim rather than take it.
+
+1. Separate subject from body with a blank line.
+2. Keep the subject within 50 characters. 72 is the hard ceiling, not the
+   target; if you are past 50, the commit usually wants splitting.
+3. Capitalize the subject.
+4. No period at the end of the subject.
+5. Imperative mood: "Fix the race", not "Fixed" or "Fixes" or "Fixing". The
+   test is that the subject completes "If applied, this commit will ___".
+6. Wrap the body at 72 columns. Do not let the editor reflow it into one line.
+7. The body explains what and why, not how. The diff already shows how.
+
+Real subjects from this tree, for calibration:
+
+```
+Stop nl_put_attr truncating its own extent
+Prove the netlink walk loops
+Count the shared pty declarations correctly
+Give a pty's slave accounting one home
+Say what the proof matrix cache actually costs
+```
+
+Note what is absent: no Conventional Commits prefix (`fix:`, `feat:`, `chore:`),
+no area tag, no ticket number in the subject. The subject is a sentence about
+behavior. A commit that removes something says what stops happening; a commit
+that adds a proof says what is now proved.
+
+The body is where the reasoning goes, and it is expected to be substantial for
+anything non-mechanical: what the old code claimed, why that was wrong, what
+breaks if you do it the obvious other way. Some commits label body paragraphs
+(`Verified:`, `Coverage:`, `Concurrency:`) when a specific claim needs to be
+findable later. Issue references go at the end as `Fixes #187`, `Closes #156`,
+or the full URL form.
+
+The ASCII and third-person rules above apply here too: no backticks around
+symbol names, no em dashes, no non-ASCII arrows.
+
+Merge commits keep git's generated subject and are exempt.
+
+## Layout
+
+All source under `src/`, artifacts under `build/`. The build passes `-Isrc`,
+so headers are included as `core/guest.h`, `syscall/internal.h`,
+`proved/gva.h`.
+
+Reports and analyses go in `claudedocs/` (ignored via `.git/info/exclude`,
+which is local to the clone, so never `git add` it), tests in `tests/`,
+scripts in `scripts/`.
+
+Build and toolchain requirements are in `docs/testing.md`, section "Build
+Requirements". They belong to a machine, not to this convention set.

--- a/.claude/skills/elfuse-debug/SKILL.md
+++ b/.claude/skills/elfuse-debug/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: elfuse-debug
+description: Localizing a guest that misbehaves under elfuse - crash reports, the verbose and startup-trace switches, the syscall histogram, the TLBI bisect switch, the GDB stub, and the qemu differential. Use when a guest faults, hangs, gets a wrong errno, dies only sometimes, or starts too slowly, and you do not yet know whether the fault is host-side or guest-side.
+---
+
+# Localizing an elfuse failure
+
+Every other skill in this repo tells you which rule you broke. This one tells
+you how to find out. The question that orders all of it is the same one every
+time: did the host hand the guest something wrong, or did the guest execute
+something the guest ABI does not support?
+
+Answer that before editing anything. The most expensive mistake here is
+patching a syscall whose real fault is a stale TLB entry or a return path that
+rebuilt EL0 state incorrectly, because the syscall is where the damage becomes
+visible and not where it was caused.
+
+## Read the crash report first
+
+A fatal error prints a structured report from `crash_report()`
+(`src/debug/crashreport.c`) with the register dump and the memory layout. Its
+classification is the first bisection, and it is free:
+
+| Type | What it means for you |
+|------|-----------------------|
+| `CRASH_BAD_EXCEPTION` | The guest took an exception at EL1 (HVC #2). Guest-side: permissions, a bad mapping, or a vector rule. Start at `elfuse-guest-abi`. |
+| `CRASH_UNEXPECTED_HVC` / `CRASH_UNEXPECTED_EC` | The shim and the host dispatcher disagree about the protocol. Usually a half-landed HVC change. |
+| `CRASH_HV_CHECK` | Hypervisor.framework refused a call. Host-side: a mapping or permission elfuse asked for is not one HVF allows. |
+| `CRASH_ELR_ZERO` | Register state after exec is not what the host wrote. A return-to-EL0 path problem, not a loader problem. |
+| `CRASH_TIMEOUT` | One `hv_vcpu_run()` iteration exceeded the `--timeout` watchdog. |
+
+`CRASH_TIMEOUT` is the one that gets misread. The watchdog bounds a single run
+iteration, not total runtime, so a CPU-bound guest can trip it legitimately and
+`--timeout 0` is the right answer there. A guest that is actually stuck (futex,
+wait, poll) trips it too, and raising the timeout only makes it take longer to
+say so.
+
+## By symptom
+
+Faults at or near the first guest instruction.
+Bring-up, not your syscall. `ELFUSE_STARTUP_TRACE=steps` gives per-step
+wall-time for VM bring-up so you can see which step is the last one to
+complete. The usual causes are all in `elfuse-guest-abi`: the initial stack,
+enabling the MMU from the wrong side, or sysreg bits that HVF does not
+default the way the architecture does.
+
+Dies at a specific syscall.
+`-v` / `--verbose` turns on syscall-level and loader diagnostics. If the
+syscall is new, suspect its `dispatch.tbl` entry before its implementation: a
+fourth argument that behaves as 0 or NULL on every call is the signature of a
+missing `needs_extra_regs`. See `elfuse-syscall`.
+
+Works under `-v`, fails without it.
+That is the same bug, and the verbose flag is what hides it. The dispatcher
+fetches X3-X5 when the entry asks for them or when verbose is on, so a missing
+`needs_extra_regs` reads real arguments under `-v` and deterministic zeros
+without it. Any behavioral difference between a verbose and a quiet run is
+this until proven otherwise; do not debug it as a timing problem.
+
+Wrong result, no crash.
+Do not reason about what Linux would do. Run the same binary under the
+`qemu-aarch64` lane, which boots a real kernel and is the ground truth in this
+tree. A TIMEOUT there is emulation speed and means nothing.
+
+Works almost always, fails under load or after an mmap/mprotect.
+Suspect a stale TLB before suspecting the syscall. `ELFUSE_DISABLE_TLBI_RANGE=1`
+forces the broadcast fallback (`src/core/guest.c`); if the failure disappears,
+the selective or range request the host computed was too small, and the fix is
+in the accumulator, not in the caller. The same shape of bug appears when two
+vCPUs are involved, which is why the accumulator slot is per-vCPU.
+
+A handler runs with the wrong PC, SP, or LR.
+The host rebuilt EL0 state and the shim restored a stale frame over it, or the
+reverse. See "Paths that rebuild EL0 state" in `elfuse-guest-abi`. Nothing in
+the syscall implementation can cause or fix this.
+
+Dynamic guest starts too slowly.
+`ELFUSE_STARTUP_TRACE=syscalls` records a per-syscall histogram (count, total,
+max latency) through the linker's syscall storm and freezes at the first
+successful `execve`, so the dump is the startup picture rather than steady
+state. `=all` enables it alongside the step tracer. `ELFUSE_SHIM_STATS` dumps
+the shim's counter table at exit, attributing every fast-path bail, which is
+how you tell a syscall that is slow from one that is not being served inline
+at all.
+
+Terminal or pty behavior.
+`ELFUSE_PTY_LOG=<file>` mirrors the pty layer's diagnostics to a file.
+
+## Stepping the guest
+
+```
+build/elfuse --gdb 1234 --gdb-stop-on-entry ./binary
+aarch64-linux-gnu-gdb -ex "target remote :1234" ./binary
+```
+
+All-stop, hardware breakpoints and watchpoints, full register and memory
+access. Two properties are not negotiable and will confuse you if you forget
+them: registers come from a snapshot, because HVF requires register access on
+the owning thread, and `--gdb` is rejected for x86_64 guests because the stub
+would serve the translated aarch64 view rather than the state the guest thinks
+it has.
+
+## Before calling it an elfuse bug
+
+Reproduce it under `qemu-aarch64`. A divergence from that lane is an elfuse
+bug worth reporting with the crash report attached; identical behavior in both
+means the guest is doing something the guest itself got wrong.
+
+## Authoritative sources
+
+This skill is a working summary. These are tracked and survive a fresh clone,
+so prefer them when the two disagree:
+
+- `docs/usage.md` - the full option list and the exact semantics of
+  `--timeout`, `--fakeroot`, and `ELFUSE_FAKEROOT_EXEC`.
+- `docs/internals.md`, section "GDB Stub" - the snapshot protocol and the
+  `src/debug/` split.
+- The header comments in `src/core/startup-trace.h`, `src/debug/syscall-hist.h`,
+  and `src/debug/crashreport.h` - each states its env var's accepted values and
+  what it costs when disabled.

--- a/.claude/skills/elfuse-guest-abi/SKILL.md
+++ b/.claude/skills/elfuse-guest-abi/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: elfuse-guest-abi
+description: The elfuse guest/host boundary - HVC calls, the EL1 shim, exception vectors, page tables and W^X, TLBI, the paths that rebuild EL0 state, shim_data, memory layout, fork, and Rosetta hosting. Use when a change alters what the guest observes (registers on return, page permissions, the EL0 return path) whatever directory the file is in, when adding or changing an HVC, or when debugging a guest fault, a stale-TLB bug, or a handler that returns to the wrong PC.
+---
+
+# The elfuse guest/host boundary
+
+Everything here is a rule you find out you broke by way of a guest that faults
+on its first instruction, or worse, one that runs 99% of the time.
+
+The skill is scoped by concern, not by directory. `src/syscall/mem.c`,
+`src/syscall/signal.c`, `src/runtime/forkipc.c`, and `src/runtime/thread.c` all
+carry rules from this file even though `elfuse-syscall` owns their host-side
+half. If you cannot tell which half you are in, ask whether the guest can
+observe the difference in a register, a permission, or a PC.
+
+## Exception vectors: do not clobber GPRs
+
+Vector entry stubs for `svc_handler` MUST NOT write any GPR.
+
+This is the syscall boundary, not a function call: AAPCS64 caller-saved rules
+do not apply. Linux SVC #0 restores every register except X0 on return, so
+musl and GCC keep live values in X9-X15 across the call. Writing any GPR
+before `svc_handler` has saved the frame corrupts the EL0 caller after ERET,
+and the damage surfaces later as what looks like a miscompile somewhere else
+entirely.
+
+Only `bad_exception` vectors may clobber X5, because they halt.
+
+## HVC protocol
+
+| HVC # | Purpose | Registers |
+|-------|---------|-----------|
+| #0 | Normal exit | x0 = exit code |
+| #2 | Bad exception | x0=ESR, x1=FAR, x2=ELR, x3=SPSR, x5=vector |
+| #4 | Set sysreg | x0 = reg ID, x1 = value |
+| #5 | Syscall forward | X0-X5=args, X8=nr; on return X8=TLBI kind |
+| #6 | Embedder extension | X8=call nr, X0-X7=args |
+| #7 | MRS trap | host reads reg from ESR ISS, returns in x0 |
+| #9 | W^X toggle | x0=FAR, x1=type (0=exec->RX, 1=write->RW) |
+| #10 | BRK from EL0 | SIGTRAP / ptrace-stop |
+| #11 | EL0 fault | SIGSEGV / SIGILL |
+| #12 | System instruction trap | cache maintenance logging |
+
+The register contract per HVC, including which return values each one accepts,
+is the header comment in `src/core/shim.S`. That comment is the specification;
+this table is an index into it.
+
+Changing the protocol is never a one-file change. The shim, the host
+dispatcher, the crash and debug paths that decode HVCs, and the documentation
+all encode it, and a half-landed change shows up as `CRASH_UNEXPECTED_HVC`
+rather than as a compile error.
+
+The guest cannot set sysregs via MSR (HCR_EL2.TSC=1); it must use HVC #4.
+DC ZVA is emulated by the shim (HCR_EL2.TDZ=1 traps it): zero 64 bytes at the
+cache-line-aligned address in Rt. Startup aborts if DCZID_EL0 does not report
+the block size the shim assumes.
+
+## TLBI wire encoding on HVC #5 return
+
+| X8 | Kind | Shim action |
+|----|------|-------------|
+| 0 | TLBI_NONE | skip flush |
+| 1 | TLBI_BROADCAST | TLBI VMALLE1IS + DSB ISH + ISB |
+| 2 | drop-frame | host rebuilt EL0 state; discard saved frame on ERET |
+| 3 | TLBI_RANGE | loop TLBI VAE1IS, X9=VA, X10=page count |
+| 4 | TLBI_RANGE_LARGE | single RVAE1IS, encoded operand in X9 |
+
+X11=1 is the icache-flush hint: set when a page transitions to executable, and
+the shim then issues an IC invalidate alongside whichever TLBI it picked. The
+shim restores X11 from the saved frame before ERET, so EL0 never observes it.
+
+The host accumulates the smallest sufficient request in `cpu_tlbi_req`
+(`src/core/guest.h`), which is `_Thread_local` per vCPU. Never promote it to a
+guest-global: that reintroduces the race where one vCPU's epilogue drains
+another's pending request before that vCPU ERETs.
+
+The thresholds that pick between per-page VAE1IS, a single RVAE1IS, and a full
+broadcast live next to the accumulator, and the range forms are conditional on
+`g_tlbi_range_supported`. `TLBI VAE1IS` retires any 2 MiB block containing the
+VA (ARM ARM B2.2.5.6), so `guest_split_block` callers do not need a separate
+broadcast.
+
+X8 is not a TLBI channel on every HVC, and the accepted values differ per HVC.
+Read `shim.S` before assuming a code means the same thing on the path you are
+adding.
+
+A bug that survives most runs and fails under load is usually an accumulator
+that asked for too little. `elfuse-debug` has the bisect: forcing the
+broadcast fallback tells you whether the request or the caller is wrong.
+
+## Paths that rebuild EL0 state
+
+Three paths hand the guest a register set the guest did not produce: signal
+delivery, `rt_sigreturn`, and `execve`. They share one rule and differ only in
+how they satisfy it, and picking the wrong mechanism is how a handler ends up
+running with the wrong PC, SP, or LR.
+
+The rule: if you rebuild EL0 register state, the shim must not restore the
+stale saved frame over it on ERET.
+
+There are two ways to satisfy it, and which one you need depends on whether
+your path goes through the dispatch epilogue at all:
+
+- Inside the epilogue, set X8=2. The shim reads it as the drop-frame marker
+  and discards the saved GPR frame. Signal delivery on the syscall-return path
+  works this way. It does not need the marker when EL0 was preempted rather
+  than returning from a syscall, because there is no shim frame to drop.
+- Bypass the epilogue by returning `SYSCALL_EXEC_HAPPENED`. The epilogue
+  returns early, before it writes X0 or X8. `sys_execve` works this way, and
+  the normal X0 writeback is exactly what it needs to avoid.
+- `signal_rt_sigreturn` does both, because it has restored the entire register
+  set and neither the frame restore nor the X0 writeback may happen.
+
+Do not copy an X8=2 into a new exec-like path on the strength of the name.
+Work out which of the two situations you are in first. The comment above the
+marker write in `src/syscall/signal.c` states which delivery paths consume it
+and which do not, and it is the thing to read before adding a third.
+
+The signal frame itself is a compatibility contract, not an internal layout.
+It matches the Linux arm64 `setup_rt_frame` so that a libc `__restore_rt`
+returning through `rt_sigreturn` restores state; musl and glibc both depend on
+it, so a field that is convenient for elfuse but not where Linux puts it
+breaks every guest. Its bounds math is proved (`src/proved/sigframe.h`).
+
+## Page tables and W^X
+
+HVF enforces W^X even with SCTLR.WXN=0. Data is RW, code is RX, and there is
+no third option.
+
+Tables use 2 MiB blocks. A mixed-permission range needs
+`guest_split_block()` (`src/core/guest.c`) to convert the L2 block into a
+table descriptor over 512 x 4 KiB L3 pages. `guest_update_perms()`
+orchestrates; whole-block changes stay in place. Triggered by `sys_mmap`
+MAP_FIXED landing in a differently-permissioned block, and by `sys_mprotect`
+on a sub-block range (RELRO is the common one).
+
+The rest of this area follows from one observation: HVF's defaults are not the
+architecture's defaults, and guest state set from the host before the vCPU
+runs is not the same as guest state set from inside it.
+
+- HVF returns SCTLR as 0, which is not a legal SCTLR. RES1 bits must be set
+  explicitly: OR the `SCTLR_RES1` macro (`src/hvutil.h`) with the bits you
+  want rather than open-coding a literal.
+- The MMU comes on via HVC #4 from the shim. Setting SCTLR.M=1 from the host
+  before `hv_vcpu_run()` faults on the first instruction fetch.
+- Only the owning vCPU thread touches that vCPU's HVF registers. Cross-thread
+  register access is why both ptrace and the GDB stub use a snapshot protocol.
+- Name system registers with the `HV_SYS_REG_*` constants. A raw encoding
+  compiles and then addresses a different register than the one you meant.
+
+## Memory layout
+
+`GUEST_IPA_BASE` is 0 so that ELF link addresses equal guest IPA. Everything
+else about the layout is derived, not fixed: `compute_infra_layout` computes
+`mmap_limit`, `interp_base`, and the infra fields from `guest_size`, which
+itself comes from the IPA width the host reports and may be bisected down when
+`hv_vm_map` refuses the first size. Do not hardcode a number that
+`compute_infra_layout` produces; ask the guest for it.
+
+In ascending order the space holds: a null guard at the bottom of EL0, the ELF
+load segments, brk, a guarded stack, the mmap RX region, the mmap RW region,
+the infra reserve, the dynamic linker, and, under Rosetta, the translator and
+its kbuf alias. `docs/internals.md` section "Memory Layout" has the map with
+addresses.
+
+Two rules survive any layout change:
+
+- Guard every EL0-driven mmap, mprotect, and munmap with
+  `guest_range_hits_infra` / `guest_addr_in_infra`. The infra reserve holds
+  the page-table pool, the shim code, and shim_data, and EL0 must not reach
+  any of them.
+- An L0 entry covers 512 GiB, so a larger space needs more than one, and every
+  walker (`guest_build_page_tables`, `guest_extend_page_tables`,
+  `find_l2_entry`) computes its L0 index from the actual IPA rather than
+  assuming entry zero.
+
+## shim_data integrity
+
+shim_data is `MEM_PERM_RW_EL1_ONLY` and holds a host-published cache the EL1
+shim serves inline: identity slots (pid/ppid/uid/euid/gid/egid/tid), the
+urandom-eligible fd bitmap, a urandom ring, and an attention bitmask
+(`ATTN_BIT_SIGTIMER`, `ATTN_BIT_CRED`, `ATTN_BIT_TRACE`). HVC #5 is taken only
+when attention is raised, the fd is not in the bitmap, or the ring needs a
+refill.
+
+Four things keep EL0 out of it, and a change that weakens any one of them is a
+guest-readable host cache:
+
+- `gva_translate_perm` refuses EL1-only descriptors on EL0 behalf, in both the
+  L2 block and L3 page walk.
+- `elf_map_segments` rejects PT_LOAD/PT_PHDR copies whose page-aligned write
+  extent intersects the infra reserve.
+- The shim's EL1 data-abort recover handler catches strb faults inside the
+  urandom write ranges (a racing EL0 munmap/mprotect) and returns EFAULT.
+- `/proc/self/maps` reports the span as PROT_NONE.
+
+Publishing into the cache is bracketed rather than ordered by luck:
+`shim_globals_attn_or` (`__ATOMIC_SEQ_CST`) raises the attention bit before
+the mutator's stores, so a weakly-ordered ARM64 reader cannot observe the
+publish without the bit; the clear is `__ATOMIC_RELEASE`.
+
+## Stack construction
+
+The Linux initial stack needs SP 16-byte aligned AND pointing directly at
+argc. Padding goes above the structured area (before auxv), never after
+pushing argc.
+
+`build_linux_stack` (`src/core/stack.c`) maintains `total_entries` by hand as
+a count of the pushes below it, computes where SP must land before pushing
+anything, and fails the stack build when the final SP does not match. Adding
+an auxv entry means updating both. That comparison is the gate, so there is no
+need to memorize the current arithmetic; there is a need to keep the count
+honest, because without it a miscount would silently shift argv rather than
+fail.
+
+Do not "fix" alignment with `sp &= ~15` after pushing: that opens a gap
+between SP and argc and every libc fails to find its arguments.
+
+## Fork
+
+macOS HVF allows one VM per process, so fork is `posix_spawn` of
+`elfuse --fork-child <fd>` plus IPC state transfer. Two rules that are easy to
+violate:
+
+- The parent must NOT remap `host_base`. HVF caches host VA to PA at
+  `hv_vm_map` time, so a remap silently detaches the guest's view from the
+  hypervisor's.
+- The child must restore `g->ttbr0` from the IPC header.
+
+The fast path takes an APFS `fclonefileat` snapshot and passes the fd via
+SCM_RIGHTS; the child maps it MAP_PRIVATE. The snapshot decouples parent and
+child even before the child remaps.
+
+## Rosetta hosting
+
+x86_64 guests run under Apple's Linux translator hosted inside the guest VM.
+It is a guest-ABI subsystem, not a syscall one: what it needs from the host is
+mappings and register state, and the ways it breaks are mapping-shaped.
+
+- The translator is exposed at its link address through a non-identity
+  page-table mapping rather than being loaded there, because that address is
+  out of reach of the narrower Stage-2 IPA on some hosts.
+- Its kbuf is aliased twice, once under TTBR1 and once under TTBR0, so that
+  tagged-pointer extraction resolves to the same physical pages from either
+  side. kbuf is always RW; nothing executable is installed there.
+- Fork still attempts the APFS snapshot under Rosetta, but its fallback is
+  different: a native guest can send the live `shm_fd` when the snapshot
+  fails, and Rosetta cannot, so it drops to the region-copy path. The reason
+  is the one from the fork section above, that HVF caches host VA to PA at
+  map time.
+- For dynamic x86_64 guests the host deliberately does not load segments or
+  the interpreter. The translator reads PT_INTERP itself and mmaps the loader
+  out of `--sysroot` through ordinary guest syscalls.
+- The GDB stub is rejected for x86_64 because it would serve the translated
+  aarch64 view rather than the state the guest believes it has.
+
+`docs/internals.md` section "x86_64-via-Apple-Rosetta" has the mechanism, and
+`docs/testing.md` has the per-host baselines the x86_64 lane compares against.
+
+## Authoritative sources
+
+This skill is a working summary. These are tracked and survive a fresh clone,
+so prefer them when the two disagree:
+
+- `src/core/shim.S` - the header comment is the real HVC and marker contract,
+  including the paths that do not consume X8.
+- `docs/internals.md` - sections "Hypervisor.framework Constraints", "Memory
+  Layout", "Page Table Splitting", "Dynamic Page-Table Extension And TLBI",
+  "EL1 Shim And HVC Protocol", "Fork, Clone, And execve", "Signals",
+  "x86_64-via-Apple-Rosetta".

--- a/.claude/skills/elfuse-syscall/SKILL.md
+++ b/.claude/skills/elfuse-syscall/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: elfuse-syscall
+description: Adding or changing a Linux syscall in elfuse. Covers dispatch.tbl, sc_ wrappers, the translation boundary, path and filename resolution, fd classes, lock order, and the coverage gate. Use when touching src/syscall/ or the syscall side of src/runtime/, adding a syscall number, or debugging a guest ENOSYS/EINVAL/EPERM. If the change also alters what the guest observes on return (registers, page permissions, the EL0 return path), read elfuse-guest-abi as well.
+---
+
+# Adding a syscall to elfuse
+
+`src/syscall/dispatch.tbl` is the authoritative list. Everything else follows
+from an entry there.
+
+This skill covers the host side of the boundary: taking guest arguments,
+translating them, and calling macOS. Anything that changes what the guest sees
+when it comes back is `elfuse-guest-abi`, even when the file lives under
+`src/syscall/`.
+
+## The steps
+
+1. Add one line to `src/syscall/dispatch.tbl`:
+
+   ```
+   SYS_<name> sc_<wrapper> <extra>
+   ```
+
+   `<extra>` becomes `needs_extra_regs` in `syscall_table`
+   (`src/syscall/syscall.c`). The dispatcher always fetches X0-X2 and fetches
+   X3/X4/X5 only when it is set, so the criterion is whether the wrapper
+   expression consumes x3, x4, or x5 - not the syscall's documented argument
+   count. Several three-argument entries carry 1.
+
+   The dispatcher zero-initializes x3-x5, so a wrapper that reads them with
+   `<extra>` left at 0 sees a deterministic 0, not a stale register: a syscall
+   whose 4th argument silently behaves as NULL or 0 on every call is the
+   symptom to recognize.
+
+   Section comments (`# I/O: ...`) and blank lines are preserved into the
+   generated header, so put the entry in the right block.
+
+2. `scripts/gen-syscall-dispatch.py` regenerates the header; `make
+   check-format` runs it, via its `check-syscall-dispatch` prerequisite. Never
+   hand-edit the generated file.
+
+3. Implement it in two pieces. The `sc_` wrapper and the `sys_` function are
+   not the same thing and do not live in the same file.
+
+   3a. The wrapper goes in `src/syscall/syscall.c`, as one line built by the
+   `SC_FORWARD` / `SC_LOCKED` / `SC_STUB` macros. It exists to unpack x0-x5
+   into typed arguments. `SC_LOCKED` is the variant that holds `mmap_lock`
+   across the call.
+
+   ```c
+   SC_FORWARD(sc_read,  sys_read(g, (int) x0, x1, x2))
+   SC_FORWARD(sc_dup3,  sys_dup3((int) x0, (int) x1, (int) x2))
+   ```
+
+   Every `sc_` symbol in the tree is here. The domain files contain none, so
+   defining one there gets you a dead symbol the dispatch table never reaches.
+
+   3b. The `sys_` implementation goes in the domain file whose name says so:
+   `ls src/syscall/` is the list, and read/write/ioctl in `io.c`,
+   brk/mmap/mprotect in `mem.c`, sockets in the `net*.c` family are
+   representative. New code goes in the existing domain file; shared
+   declarations go in `internal.h`, not a new header.
+
+   Two domains sit outside `src/syscall/` because they are runtime state
+   rather than syscall surface: clone and fork in `src/runtime/forkipc.c`,
+   futex in `src/runtime/futex.c`. Both carry guest-ABI rules on top of what
+   is here.
+
+4. Add a test that names the syscall, or the build fails. See the coverage
+   gate below.
+
+## The translation boundary
+
+One rule generates this whole section: nothing crosses the boundary
+unconverted. A guest number is a Linux number until a translator turns it into
+a macOS one, and every translator lives in `translate.c`. Adding a conversion
+inline in a domain file is how the next syscall gets it wrong.
+
+The axes that actually diverge, which is the part you cannot derive by
+reading either kernel's headers alone:
+
+- errno. Return `-linux_errno(errno)`. The two agree below roughly 35 and
+  diverge above it (macOS EAGAIN is 35, Linux EAGAIN is 11), so a copied
+  constant is silently right in testing and wrong in production.
+- `AT_*` flags. `translate_at_flags()` before any macOS call, with one
+  exception that is not derivable: Linux puts `AT_EACCESS` on the same bit as
+  `AT_REMOVEDIR`, so `faccessat` paths use `translate_faccessat_flags()`
+  instead. A blanket "always call `translate_at_flags()`" produces a
+  wrong-but-plausible `faccessat`.
+- open flags. aarch64-linux differs from x86_64-linux, not just from macOS, so
+  a value cribbed from x86_64 documentation is wrong.
+- clock ids. `translate_clockid()`.
+- `UTIME_NOW` / `UTIME_OMIT`.
+- socket type flags. `SOCK_NONBLOCK` and `SOCK_CLOEXEC` are ORed into the type
+  argument on Linux and must be stripped out before `socket()`.
+- sockaddr. `linux_to_mac_sockaddr` / `mac_to_linux_sockaddr`. Linux has no
+  `sa_len` byte, and the address families do not share numbering.
+
+The numeric values are in `src/syscall/abi.h` and `translate.c`. Read them
+there rather than from a copy: a stale constant in a document is worse than no
+constant, because it looks like it was checked.
+
+## Paths and filenames
+
+Every guest path goes through `path_translate_at` (`path.c`), including the
+at-family, so an absolute path handed to `fchmodat`, `utimensat`, or an xattr
+call cannot bypass the sysroot redirect. Calling a host path syscall on a raw
+guest string is the bug this prevents.
+
+Calling the right function is necessary and not sufficient. The resolver
+upholds invariants that a caller can still break by resolving twice, by
+re-deriving a path from a resolved one, or by following a link the resolver
+deliberately did not:
+
+- `..` is clamped at the guest root, and the containment check is rechecked
+  for relative paths rather than assumed from the first resolution.
+- Some paths are resolved never-follow by design. Turning one into a
+  follow-resolution to "fix" a symlink is how containment is lost.
+- The no-symlinks precheck has no component budget, on purpose.
+
+Read the "Path Resolution" sections of `docs/internals.md` before changing
+anything in `path.c` or adding a caller that resolves a path itself.
+
+Guest filenames that collide under case-insensitive APFS are kept distinct by
+the case-fold codec (`casefold.c`, `casefold-walk.c`), which has a real
+on-disk format with golden vectors: a red `test-casefold-host` means the
+format moved, not that the test is flaky. `docs/filenames.md` is the
+specification.
+
+## Guest memory access
+
+Reads and writes of guest pointers go through the `guest_read`/`guest_write`
+path, which uses `proved/gva.h`. Do not open-code a GVA-to-host-pointer
+conversion: `gva_translate_perm` is what refuses `MEM_PERM_EL1_ONLY`
+descriptors on EL0's behalf, and that refusal is the only thing stopping
+`read(fd, shim_data_gva, n)` from leaking the EL1 cache.
+
+If your bounds math is non-trivial (a parser over guest-supplied lengths, a
+packer emitting into a guest buffer), it belongs in `src/proved/` with a proof
+target. See the `elfuse-verify` skill.
+
+## FDs and locks
+
+Guest fds are not host fds. Allocate through the bitmap allocator in
+`fdtable.c`; classify with the helpers in `fd.c` and `fd.h` (socket, pidfd,
+eventfd, timerfd, signalfd). A class check that reads the raw fd number is wrong after
+a `dup`.
+
+The lock order is the comment at the top of `internal.h`. Acquire in the order
+it lists, and add a new lock to that comment before using it in a second
+module. Three constraints in it are not derivable from the ordering:
+
+- The per-epoll-instance lock is taken under `fd_lock` by the close hook, but
+  taken alone by `epoll_ctl` and `epoll_pwait`. This is the one a summary
+  usually drops, and it is the deadlock-prone one.
+- `sfd_lock` is never held together with `thread_lock`.
+- FUSE takes `fuse_lock` first, then the per-session lock.
+
+## Subsystems with rules of their own
+
+Three areas under `src/syscall/` are not ordinary domain files, and a change
+that treats them as such tends to compile and then deadlock or leak:
+
+- FUSE (`fuse.c`) runs a whole filesystem transport inside the guest. Sessions
+  are refcounted so an in-flight read pins the session against daemon exit,
+  and the wait paths have to honor SA_RESTART rather than returning EINTR
+  blindly.
+- procfs, sysfs, and device emulation (`src/runtime/procemu.c`) run as an
+  interception layer: the resolver goes first and hands it a normalized guest
+  path, and `proc_intercept_open` and friends are consulted before the host
+  filesystem is touched, returning `PROC_NOT_INTERCEPTED` to fall through. A
+  path that looks host-backed may be synthesized, so a new file-touching
+  syscall has to offer it the intercept rather than assuming a real file.
+- Abstract Unix sockets, SCM_RIGHTS, and netlink each carry their own
+  serialization format over guest-supplied lengths, which is why several of
+  them have proof targets.
+
+`docs/internals.md` has a section for each.
+
+## The coverage gate
+
+`scripts/check-syscall-coverage.py` runs inside `make check` and fails when a
+`dispatch.tbl` entry has no direct or aliased test reference. Two ways out,
+one of them correct:
+
+- Write the test (correct).
+- Add to `INDIRECT_COVERAGE` in the script with a real reason (only when
+  success-path coverage is genuinely filesystem- or host-dependent, e.g. the
+  xattr family). The script also fails on a stale allowlist entry, so a name
+  that later gains a real test must be removed from the dict.
+
+## When the change is not only host-side
+
+Read `elfuse-guest-abi` too if your change touches any of these, whatever
+directory the file is in: page permissions or mappings (`mem.c`), signal
+delivery or `rt_sigreturn` (`signal.c`), fork and clone state transfer
+(`src/runtime/forkipc.c`, `thread.c`), or anything that writes guest registers
+on the return path.
+
+## Authoritative sources
+
+This skill is a working summary. These are tracked and survive a fresh clone,
+so prefer them when the two disagree:
+
+- `src/syscall/internal.h` - the lock order comment at the top.
+- `src/syscall/dispatch.tbl` - the syscall list itself.
+- `docs/internals.md` - syscall dispatch, the lock map, path resolution, FUSE,
+  and procfs emulation in full.
+- `docs/filenames.md` - the sidecar codec and its golden vectors.
+
+## Verifying
+
+`docs/testing.md`, section "Validation Strategy By Change Type", maps the area
+you touched to the minimum command set. Use it rather than a habit; see
+`elfuse-verify` for what the lanes mean and `elfuse-debug` for localizing a
+failure in one.

--- a/.claude/skills/elfuse-verify/SKILL.md
+++ b/.claude/skills/elfuse-verify/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: elfuse-verify
+description: How elfuse validates a change - choosing the lanes for the area you touched, the test matrix, make check, and the Frama-C proof targets declared in mk/analysis.mk, including how to drive the frama-c MCP server on a stuck proof. Use when adding bounds math to src/proved/, writing or repairing ACSL contracts, running or debugging make verify / verify-mutants, touching frama-c-stubs/, adding a test lane, or deciding what to run before calling work done.
+---
+
+# Validating an elfuse change
+
+Two independent gates: the runtime tests and the proofs. A change to
+attacker-facing bounds math needs both.
+
+## Choosing what to run
+
+`docs/testing.md`, section "Validation Strategy By Change Type", is a table
+from the area you touched to the minimum command set, and it is more specific
+than any habit. Consult it first. It is where you learn that Rosetta work
+wants `make test-rosetta-all`, that ptrace and debugger work want
+`make test-gdbstub`, and that filename-codec work wants the soak lane on top
+of `make check`.
+
+The defaults below are what that table falls back to, not a substitute for it.
+
+```
+make check                       # unit tests, busybox, syscall coverage gate
+bash tests/test-matrix.sh all    # the three modes
+```
+
+## Runtime
+
+Modes and what a failure in each means:
+
+- `elfuse-aarch64` - primary. Must stay green. A failure here is a regression.
+- `qemu-aarch64` - ground truth via Alpine `aarch64-linux-musl` under
+  `qemu-system-aarch64`. It answers "what does real Linux do", which is why
+  `elfuse-debug` reaches for it on any behavioral divergence. TIMEOUTs are
+  emulation speed, not regressions.
+- `elfuse-x86_64` - the Rosetta path, with per-host-class baselines from
+  `detect_x86_64_host_class`. Skips cleanly without the translator.
+
+`tests/fetch-fixtures.sh` pulls Alpine packages, the `linux-virt` kernel, and
+Rosetta fixtures on first run. musl is Alpine's only libc, so glibc-dynamic
+lanes skip unless `GUEST_GLIBC_*` points at an external sysroot.
+
+### Writing a test lane
+
+The runner is already hardened, and every one of these exists because a test
+once passed without running anything. Do not work around them, and do not
+loosen one to get a build green.
+
+- `tests/lib/test-runner.sh::run` and `run_check` wrap every invocation in
+  `timeout $TEST_TIMEOUT` (gtimeout fallback on macOS).
+- `run_check` and `run_pipe` fail on non-zero exit before pattern evaluation.
+  A test that greps for a string in the output of a crashed binary is not a
+  test.
+- `driver.sh::evaluate_result` requires `rc == expected_rc`.
+- `ALLOW_MISSING_BINARIES` defaults to 0. A missing fixture is a failure, not
+  a skip.
+
+## Proofs
+
+`src/proved/` is header-only arithmetic carrying ACSL contracts: the bounds
+math of an attacker-facing parser or packer, split out of a `.c` and proved
+with `-wp-rte`.
+
+Every `src/proved/` header must have a matching `make verify-<name>` target,
+but the reverse does not hold. A few targets prove a `.c` file directly, each
+for a reason stated in the comment above it in `mk/analysis.mk`; the general
+one is that the loops in question could only have been described as
+test-covered had they been split into a header.
+
+`make print-verify-targets` is the current list. CI reads it to build its
+matrix, so do not hardcode the set anywhere else, including here.
+
+```
+make verify           # every proof target, parallel by default
+make verify-<name>    # one target
+make verify-mutants   # assert each proof rejects a known-broken source
+make print-verify-targets
+make check-contracts  # rebuild with -DELFUSE_CONTRACT_ASSERT, then make check
+```
+
+`make verify` re-invokes itself with `-j$(VERIFY_JOBS)` unless you brought your
+own `-j`. `VERIFY_JOBS=1` is how you ask for serial on both GNU make 4.x and
+Apple's 3.81.
+
+`verify-mutants` accepts `MUTANT_TARGET=<name>`, `MUTANT_JOBS=<n>`, and
+`MUTANT_SINCE=<rev>` for a changed-only run.
+
+### Adding to src/proved/
+
+Nothing lands there without a proof target -
+`scripts/check-proof-targets.py` (a CI job in `.github/workflows/main.yml`)
+fails otherwise. Callers include the header as `proved/<name>.h`.
+
+The routine:
+
+1. Extract the arithmetic into `src/proved/<name>.h` with ACSL contracts.
+2. Add the `VERIFY_<NAME>_SRC` / `VERIFY_<NAME>_MODEL` / `VERIFY_<NAME>_FCTS`
+   variables in `mk/analysis.mk` so the rule template instantiates
+   `verify-<name>`. `typed` is the default choice for a model; see below.
+3. `make verify-<name>` until it discharges with `-wp-rte`.
+4. `make verify-mutants MUTANT_TARGET=<name>` - a proof that cannot reject a
+   broken source proves nothing.
+
+Supporting gates, all of which run per target:
+
+- `scripts/check-acsl-coverage.py` - catches a contract assumed because its
+  function was left out of `-wp-fct`.
+- `scripts/check-char-signedness.py` (`make check-char-signedness`) - compiles
+  each proved function under `-fsigned-char` and `-funsigned-char` at -O0 and
+  requires identical code. The data model used for proving differs from arm64
+  macOS on plain-char signedness; this is what keeps that sound.
+- `scripts/check-stub-constants.py` (`make check-stub-constants`) - asserts
+  every `frama-c-stubs/` constant matches the macOS SDK. The analyzer never
+  links, so a wrong constant cannot fail a build, it silently changes what the
+  proof reasons about.
+
+### Memory models, and what no model checks
+
+Each target picks its own model via `VERIFY_<NAME>_MODEL` in `mk/analysis.mk`,
+and the comment above it says why. Pick the model the code needs, not the
+model a neighbour target uses.
+
+The general limit is worth understanding before trusting any of them: a
+non-`typed` model buys reasoning power by assuming something the proof does
+not check. `caveat`, used where `typed` cannot follow a byte-addressed buffer
+whose entry stride is attacker-chosen, assumes formal pointer parameters do
+not alias. The contracts state that with `\separated`, but the callers are not
+in `-wp-fct`, so nothing verifies they honor it, and a future caller passing
+the same address twice would invalidate the proof with no diagnostic.
+
+That call-site gap is general, and it bites hardest for `proved/gva.h`:
+`guest.c` cannot be given to Frama-C at all, so nothing verifies its call
+sites honor the `requires` clauses. `make check-contracts` narrows it from the
+runtime side by turning the expressible ones into runtime asserts, and is
+deliberately separate from `make check` because those functions sit on the
+`guest_read` / `guest_write` hot path.
+
+### The frama-c MCP server, when it is available
+
+`make verify-<name>` is a batch run: it either discharges or it does not, and
+a failure tells you little about which obligation is stuck. If the `frama-c`
+MCP server is connected, it drives the same Frama-C interactively, which turns
+contract writing into a loop instead of a guess. Start with `self_check`,
+because the optional pieces degrade independently, then reload the target's
+sources plus `FRAMAC_STUB_DIR`, run WP one function at a time, and use
+`get_wp_goals` and `context` to find which obligation is unproved rather than
+rewriting a contract on suspicion. Retrying the unproved goals distinguishes
+"not proved" from "not proved yet", so check that before rewriting a contract
+that only needed a longer timeout. `create_sandbox` is the honest way to try a
+strengthening without touching the real source.
+
+Two rules about what any of that proves:
+
+- The MCP's default WP model is not what every target uses. A goal that
+  discharges under defaults says nothing about whether `make verify-<name>`
+  passes. Always mirror the target's own `VERIFY_<NAME>_MODEL`.
+- The MCP is an accelerator, never the gate. A change lands on `make verify`
+  plus `make verify-mutants`, run from the Makefile, because that is what CI
+  runs and what a contributor without the server can reproduce. Never report a
+  proof as done on MCP evidence alone, and never add a workflow step, script,
+  or CI job that depends on the server being connected.
+
+It also answers the coverage question rather than just the green/red one:
+asking for goal counts shows how much of the property table has a verdict,
+which is how you find a target that passes because it is proving less than you
+thought.
+
+### frama-c-stubs/
+
+Declarations the analyzer needs that the compiler or macOS supplies:
+`Hypervisor/Hypervisor.h`, `gcc-atomics.h` (Frama-C does not model
+`__atomic_*_n`; without a declaration each file infers its own argument widths
+and two files conflict), and `macos-libc.h` for Darwin constants the modeled
+libc omits.
+
+It sits outside `src/` on purpose so a real compile, which resolves through
+`-Isrc`, cannot reach it. Only `FRAMAC_STUB_DIR` in `mk/analysis.mk` does.
+It is tracked in git because every proof target needs it to parse.
+
+A missing declaration fails with "Cannot resolve variable" - that is how the
+next one gets found. Only a minority of `src/`'s `.c` files parse today; the
+rest stop on macOS headers Frama-C's libc genuinely does not model
+(`sys/mount.h`, `sys/event.h`, `sys/sysctl.h`, `sys/xattr.h`, `sys/attr.h`,
+`sys/spawn.h`). That is a real modeling gap. Do not paper over it with a fake
+stub, and do not quote a parse count without recomputing it.
+
+## Other checks
+
+These are not part of `make check` and each answers a different question:
+
+```
+make lint                  # clang-tidy
+make check-format          # formatting, and regenerates the dispatch header
+make check-asan            # use-after-free, overflow, on the host side
+make check-ubsan           # undefined behavior
+make check-tsan            # data races, worth it for anything multi-vCPU
+make infer-uninit          # uninitialized reads
+```
+
+## Authoritative sources
+
+This skill is a working summary. These are tracked and survive a fresh clone,
+so prefer them when the two disagree:
+
+- `docs/testing.md`, section "Validation Strategy By Change Type" - the change
+  area to command mapping.
+- `mk/analysis.mk` - the per-target `_SRC` / `_MODEL` / `_FCTS` variables and
+  the comment above each explaining its model choice.

--- a/scripts/check-skill-refs.py
+++ b/scripts/check-skill-refs.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Fail when a skill file points at something that no longer exists.
+
+The files under .claude/skills/ are working summaries. Every one of them says
+so, and every one closes by naming the tracked file that wins when the two
+disagree. That structure only works while the pointers resolve: a reference to
+a renamed source file, a deleted make target, or a docs section that has been
+retitled does not read as stale, it reads as authoritative and sends the
+reader somewhere that does not exist.
+
+This is the failure mode a careful read does not catch. The reference that
+prompted this script named src/syscall/sidecar.c, which had been split into
+casefold.c and casefold-walk.c; the sentence around it was still true, the
+file name was not, and it survived review by a human and by two agents.
+Nothing else in the tree checks it, because the skills are documentation and
+documentation has no compiler.
+
+What is checked, per file:
+
+  1. Frontmatter: name matches the directory, description is non-empty.
+  2. Backticked path-like tokens resolve: exactly one file in the tree ends
+     with the path as written. Two files ending that way is a failure too,
+     because the reference is ambiguous and wants a longer path.
+  3. "make <target>" names a target the makefiles define, including the
+     verify-<name> targets that mk/analysis.mk instantiates from a template.
+  4. A quoted section name attached to the word "section" exists as a heading
+     in the docs file nearest it.
+  5. A cross-reference to a sibling skill names a skill that exists.
+
+Only typeset references are checked: a path in backticks, a make command in
+backticks or in a fenced block. A file named in running prose, or in the
+frontmatter description, is invisible here by design, because the alternative
+is guessing which words are meant to be paths.
+
+Three more things are deliberately not checked. Whether the prose is true: a
+pointer that resolves can still describe behavior that changed, and this
+catches only the mechanical half, which is the half that rots silently. A bare
+markdown name at the repo root, which may be a per-developer working doc that
+no clone carries; see unverifiable() for why that stays out of the script
+rather than becoming a list of somebody's private filenames.
+
+The compact "fd.c/h" shorthand for a pair of files is rejected rather than
+ignored. Nothing here can resolve it, so allowing it would leave a reference
+that looks checked and is not.
+
+The skills are per-developer files today and may be absent. A missing
+.claude/skills/ is not a failure, it is a clone that does not carry them, and
+this exits 0 with a note so the check can be wired into a build without
+becoming a dependency on untracked files.
+
+Usage:
+    check-skill-refs.py [file ...]
+    check-skill-refs.py --self-test
+
+Every file under .claude/skills/ is checked. Any extra file named on the
+command line is checked the same way, which is how a local routing document
+that points at the skills gets covered without this script having to know it
+exists. --self-test asserts this script still rejects each class of stale
+reference; see self_test() for why that is not optional.
+"""
+
+import functools
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SKILL_DIR = ROOT / ".claude" / "skills"
+
+# Directories that hold no source this tree owns. externals/ is vendored for
+# evaluation and gitignored; a reference resolving into it would be a false
+# pass on a machine that happens to have it checked out.
+PRUNE = {".git", "build", "externals", "node_modules", ".claude", ".agents"}
+
+PATH_EXTS = ("c", "h", "S", "md", "tbl", "py", "sh", "mk", "yml")
+
+# elfuse-prefixed names that are test-matrix lanes rather than skills.
+LANES = {"elfuse-aarch64", "elfuse-x86_64"}
+
+# Headers the macOS SDK or the compiler supplies. The skills name them as the
+# things Frama-C cannot model, so they must not resolve in tree. The shape is
+# narrow on purpose: exempting everything under sys/ would wave through a
+# stale sys/anything.c as well.
+SYSTEM_HEADER_RE = re.compile(r"^(?:sys|Hypervisor)/[A-Za-z0-9_-]+\.h$")
+
+# The leading dot matters: dot directories carry real references, .github for
+# the CI job that enforces the proof targets and .claude for the skills
+# themselves, and a pattern anchored on an alphanumeric first character skips
+# exactly the references that break when either one moves. The trailing group
+# drops a shell-function suffix such as test-runner.sh::run.
+PATH_RE = re.compile(
+    r"`(\.?[A-Za-z0-9_][A-Za-z0-9_./+-]*\.(?:"
+    + "|".join(PATH_EXTS)
+    + r"))(?:::[A-Za-z_][A-Za-z0-9_]*)?`"
+)
+
+# A make target is only a reference when it is typeset as one: backticked
+# inline, or a command line inside a fenced block. Plain prose says things like
+# "no make target may reference it", and treating that as a target name is how
+# a checker earns the reputation that gets it disabled.
+MAKE_RE = re.compile(r"`make ([a-z][a-z0-9-]*)")
+MAKE_FENCED_RE = re.compile(r"^make ([a-z][a-z0-9-]*)", re.M)
+FENCE_RE = re.compile(r"^```.*?^```", re.M | re.S)
+
+DOCPATH_RE = re.compile(r"docs/[a-z0-9-]+\.md")
+QUOTED_RE = re.compile(r'"([^"]+)"')
+# A run of section names: the quotes that immediately follow the keyword,
+# joined by commas or "and", stopping at the first word that is not one.
+RUN_RE = re.compile(r'^\s*"[^"]+"(?:\s*(?:,|and)\s*"[^"]+")*')
+PRE_RUN_RE = re.compile(r'"[^"]+"(?:\s*(?:,|and)\s*"[^"]+")*\s*$')
+# The "fd.c/h" shorthand for a pair of files. It is not a path, so nothing
+# below can resolve it, and a reader reaches for it because the working docs
+# use it freely. Rejecting it is cheaper than teaching every pattern here to
+# expand it, and it keeps the blind spot from being reintroduced silently.
+SHORTHAND_RE = re.compile(r"`([A-Za-z0-9_-]+\.[chS](?:/[chS])+)`")
+SKILLREF_RE = re.compile(r"\b(elfuse-[a-z0-9-]+)\b")
+HEADING_RE = re.compile(r"^#+\s+(.*?)\s*$", re.M)
+
+
+def system_header(token):
+    """True for a system header the tree is not supposed to contain."""
+    return bool(SYSTEM_HEADER_RE.match(token))
+
+
+def unverifiable(token):
+    """True for a reference this script cannot honestly resolve.
+
+    A bare markdown name at the repo root may be a per-developer working doc.
+    Those are private by design: they are excluded locally rather than
+    gitignored, so a clone has no record that they were ever meant to exist,
+    and their absence proves nothing either way. Listing the current ones here
+    would put one developer's private filenames into a script everybody reads,
+    and would be wrong again the day someone keeps a different set.
+
+    Everything else stays checked, including the include-style paths the build
+    resolves through -Isrc, which resolve() handles by matching a trailing
+    path segment rather than a whole path.
+    """
+    return "/" not in token and token.endswith(".md")
+
+
+def section_refs(sentence):
+    """(docs path, section names) pairs a sentence claims.
+
+    Only quotes tied to the word "section" or "sections" count. A sentence can
+    name a docs file and quote something else entirely, and treating that
+    quote as a section name produces a failure the author cannot act on. Both
+    orders occur in practice: 'docs/x.md, section "A"' and 'the "A" section of
+    docs/x.md', and one keyword can introduce a list of several. The run stops
+    at the first item that is not another quoted name.
+
+    Each run is attributed to the docs file nearest the keyword that
+    introduced it. Checking against every docs file the sentence happens to
+    name would pass a heading that belongs to the other one, which is a real
+    shape here: a sentence can cite internals.md for a mechanism and
+    testing.md for its baselines.
+    """
+    docs = [(m.start(), m.group(0)) for m in DOCPATH_RE.finditer(sentence)]
+    if not docs:
+        return []
+
+    refs = []
+    for m in re.finditer(r"\bsections?\b", sentence):
+        names = []
+        before = sentence[: m.start()].rstrip()
+        prerun = PRE_RUN_RE.search(before)
+        if prerun:
+            names.extend(QUOTED_RE.findall(prerun.group(0)))
+        run = RUN_RE.match(sentence[m.end() :])
+        if run:
+            names.extend(QUOTED_RE.findall(run.group(0)))
+        if names:
+            nearest = min(docs, key=lambda d: abs(d[0] - m.start()))[1]
+            refs.append((nearest, names))
+    return refs
+
+
+def tree_paths():
+    """Every in-tree file, as a repo-relative path string."""
+    paths = []
+    for path in ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(ROOT)
+        if PRUNE & set(rel.parts):
+            continue
+        paths.append(rel.as_posix())
+    return paths
+
+
+def resolve(token, paths):
+    """Files a reference could name, matched on a trailing path segment.
+
+    The skills cite files three ways: a repo path, an include-style path the
+    build resolves through -Isrc such as core/guest.h, and a bare name. A
+    suffix match covers all three and, unlike a basename match, still rejects
+    a path that names the wrong directory: src/wrong/guest.c ends no tracked
+    path, while a bare guest.c ends exactly one.
+    """
+    return [p for p in paths if p == token or p.endswith("/" + token)]
+
+
+def make_targets():
+    """Static rule names from the makefiles, plus the generated proof targets.
+
+    mk/analysis.mk instantiates verify-<name> from a template, so those names
+    exist only after make expands it. print-verify-targets is the list make
+    itself reports, which is what CI consumes.
+    """
+    names = set()
+    for mk in [ROOT / "Makefile"] + sorted((ROOT / "mk").glob("*.mk")):
+        for line in mk.read_text(errors="replace").splitlines():
+            if line.startswith("\t"):
+                continue
+            if line.startswith(".PHONY:"):
+                names.update(line.split(":", 1)[1].split())
+                continue
+            m = re.match(r"^([A-Za-z0-9._%-]+(?:\s+[A-Za-z0-9._%-]+)*)\s*:(?!=)", line)
+            if m:
+                names.update(m.group(1).split())
+    try:
+        out = subprocess.run(
+            ["make", "print-verify-targets"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        names.update(out.stdout.split())
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return names
+
+
+@functools.lru_cache(maxsize=None)
+def headings_of(doc):
+    """Heading text of a docs file, backticks stripped, or None if absent.
+
+    Cached because a docs file is cited from several sentences and several
+    skills, and re-reading internals.md per citation is the only part of this
+    script that would notice.
+    """
+    path = ROOT / doc
+    if not path.exists():
+        return None
+    body = path.read_text(errors="replace")
+    return frozenset(h.replace("`", "") for h in HEADING_RE.findall(body))
+
+
+def check_frontmatter(path, raw):
+    """A skill's declared name has to match the directory that carries it.
+
+    Claude Code loads a skill by directory; a drifted name means the file is
+    silently not the skill it says it is, which no reader would notice.
+    """
+    if path.name != "SKILL.md":
+        return []
+
+    head = raw.split("---")[1] if raw.startswith("---") else ""
+    name = re.search(r"^name:\s*(\S+)", head, re.M)
+    desc = re.search(r"^description:\s*(\S.*)", head, re.M)
+
+    messages = []
+    if not name or name.group(1) != path.parent.name:
+        messages.append("frontmatter name does not match its directory")
+    if not desc:
+        messages.append("frontmatter has no description")
+    return messages
+
+
+def check_paths(text, paths):
+    """Every backticked path names exactly one file in the tree."""
+    messages = []
+    for token in sorted(set(SHORTHAND_RE.findall(text))):
+        names = token.split("/")
+        stem = names[0].rsplit(".", 1)[0]
+        spelled = " and ".join(f"`{stem}.{ext}`" for ext in [names[0][-1]] + names[1:])
+        messages.append(f"writes {token}, which nothing resolves; write {spelled}")
+
+    for token in sorted(set(PATH_RE.findall(text))):
+        if unverifiable(token) or (ROOT / token).exists():
+            continue
+        # A reference has to identify one file. Accepting "something in the
+        # tree ends this way" would pass a deleted src/a/foo.c because an
+        # unrelated src/b/foo.c survived, which is the exact failure this
+        # script exists to catch. Two matches is not a pass either: the
+        # reference is ambiguous and wants a longer path.
+        matches = resolve(token, paths)
+        if len(matches) == 1:
+            continue
+        # Consulted after resolution so a stub the tree really does carry,
+        # like the Hypervisor header under frama-c-stubs/, is verified rather
+        # than waved through by the exemption.
+        if system_header(token):
+            continue
+        if len(matches) > 1:
+            where = ", ".join(sorted(matches)[:3])
+            messages.append(
+                f"{token} is ambiguous, {len(matches)} files carry that "
+                f"name ({where}); write the path"
+            )
+            continue
+        messages.append(f"references {token}, which does not exist")
+    return messages
+
+
+def check_targets(text, raw, targets):
+    """Every typeset make command names a rule the makefiles define."""
+    named = set(MAKE_RE.findall(text))
+    for block in FENCE_RE.findall(raw):
+        named.update(MAKE_FENCED_RE.findall(block))
+
+    messages = []
+    for target in sorted(named):
+        # "make verify-<name>" is a form, not a target: the capture stops at
+        # the angle bracket and leaves a trailing hyphen no real rule has.
+        if target.endswith("-"):
+            continue
+        if target not in targets:
+            messages.append(f"names 'make {target}', which no makefile defines")
+    return messages
+
+
+def check_sections(text):
+    """Every quoted section name is a heading in the docs file it cites.
+
+    The match is exact once the heading's backticks are stripped: accepting a
+    prefix would pass "Validation Strategy" for a section actually titled
+    "Validation Strategy By Change Type", which is the kind of near-miss that
+    sends a reader to the wrong table.
+    """
+    messages = []
+    for sentence in text.split(". "):
+        for doc, names in section_refs(sentence):
+            known = headings_of(doc)
+            if known is None:
+                continue
+            for name in names:
+                if name not in known:
+                    messages.append(f'no section "{name}" in {doc}')
+    return messages
+
+
+def check_skill_refs(text, skills):
+    """Every sibling skill named in prose exists as a skill directory."""
+    messages = []
+    for ref in sorted(set(SKILLREF_RE.findall(text))):
+        if ref in LANES or ref in skills:
+            continue
+        messages.append(f"refers to skill {ref}, which does not exist")
+    return messages
+
+
+def check_file(path, paths, targets, skills, errors):
+    """Run every pass over one file, prefixing each finding with its path."""
+    raw = path.read_text(errors="replace")
+    # An explicitly named file may sit outside the repo, where relative_to
+    # raises rather than returning something printable.
+    try:
+        rel = path.relative_to(ROOT)
+    except ValueError:
+        rel = path
+
+    # Prose wrapped at 79 columns splits references across lines: `make\n
+    # check-format` and a section name broken mid-title are the same reference
+    # a reader sees, so every pass below runs on the text with runs of
+    # whitespace collapsed. Checking the raw text instead silently skips any
+    # reference unlucky enough to land on a line boundary, which is most of
+    # them in a file this shape. Frontmatter stays raw because its regexes are
+    # line-anchored, and the fenced-block scan needs real line starts.
+    text = re.sub(r"\s+", " ", raw)
+
+    messages = (
+        check_frontmatter(path, raw)
+        + check_paths(text, paths)
+        + check_targets(text, raw, targets)
+        + check_sections(text)
+        + check_skill_refs(text, skills)
+    )
+    errors.extend(f"{rel}: {message}" for message in messages)
+
+
+# Each case is (what it exercises, body, substring of the expected error or
+# None when the body must produce no error at all).
+SELF_TEST_CASES = [
+    ("wrong directory", "See `src/wrong/guest.c` for it.", "does not exist"),
+    ("ambiguous bare name", "See `fuse.h` for it.", "is ambiguous"),
+    ("dead make target", "Run `make\ncheck-fmt` first.", "check-fmt"),
+    ("non-header under sys/", "Frama-C lacks `sys/bogus.c`.", "does not exist"),
+    (
+        "section near-miss",
+        '`docs/testing.md`, section "Validation Strategy" is the table.',
+        "no section",
+    ),
+    (
+        "stale first pre-keyword section",
+        'the "Not A Real Heading" and "Build Requirements" sections of '
+        "`docs/testing.md` are useful.",
+        "no section",
+    ),
+    (
+        "section attributed to the wrong doc",
+        '`docs/internals.md` has it and `docs/testing.md`, section '
+        '"Memory Layout", does not.',
+        "no section",
+    ),
+    ("unknown sibling skill", "See the `elfuse-nope` skill.", "refers to skill"),
+    ("unresolvable shorthand", "Helpers in `fd.c/h` classify it.", "write `fd.c` and `fd.h`"),
+    ("valid repo path", "See `src/core/guest.c`.", None),
+    ("valid include-style path", "Include it as `core/guest.h`.", None),
+    ("valid system header", "Frama-C cannot model `sys/mount.h`.", None),
+    ("valid line-wrapped target", "Run `make\ncheck-format` first.", None),
+    ("make in prose is not a target", "No make target may reference it.", None),
+    ("target placeholder", "Run `make verify-<name>` for one.", None),
+    ("private root markdown", "`CLAUDE.md` is untracked.", None),
+    (
+        "unrelated quote after a real section",
+        '`docs/testing.md`, section "Validation Strategy By Change Type", is '
+        'a "wild guess" table.',
+        None,
+    ),
+    (
+        "two docs, section attributed correctly",
+        '`docs/internals.md` section "Memory Layout" has the map, and '
+        "`docs/testing.md` has the baselines.",
+        None,
+    ),
+]
+
+FRONTMATTER = "---\nname: {name}\ndescription: fixture\n---\n\n"
+
+
+def self_test():
+    """Assert this script still rejects each class of stale reference.
+
+    Every case here is a bug this script shipped with at some point. Two of
+    them are the reason it exists in this form: a reference broken across a
+    line boundary was invisible to every pass, and a section name that was a
+    prefix of a real heading passed as a match. Both were found by mutating a
+    file by hand, which is not a thing the next person will think to do.
+
+    The negative cases matter as much as the positive ones. A checker that
+    starts flagging valid prose gets switched off, and then it protects
+    nothing at all.
+    """
+    paths, targets, skills = tree_paths(), make_targets(), {"elfuse-syscall"}
+    failures = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        skill_dir = pathlib.Path(tmp) / "elfuse-syscall"
+        skill_dir.mkdir()
+        fixture = skill_dir / "SKILL.md"
+
+        for label, body, expect in SELF_TEST_CASES:
+            fixture.write_text(FRONTMATTER.format(name="elfuse-syscall") + body + "\n")
+            errors = []
+            check_file(fixture, paths, targets, skills, errors)
+            found = " | ".join(e.split(": ", 1)[-1] for e in errors)
+            if expect is None and errors:
+                failures.append(f"{label}: expected no error, got: {found}")
+            elif expect is not None and expect not in found:
+                failures.append(f"{label}: expected {expect!r}, got: {found or 'none'}")
+
+        # Frontmatter drift needs its own directory: the name is checked
+        # against the directory the file sits in.
+        other = pathlib.Path(tmp) / "elfuse-other"
+        other.mkdir()
+        drift = other / "SKILL.md"
+        drift.write_text(FRONTMATTER.format(name="elfuse-syscall") + "Body.\n")
+        errors = []
+        check_file(drift, paths, targets, skills, errors)
+        if not any("frontmatter name" in e for e in errors):
+            failures.append("frontmatter drift: expected a name mismatch, got none")
+
+    total = len(SELF_TEST_CASES) + 1
+    if failures:
+        print(f"  {len(failures)} of {total} self-test case(s) failed:", file=sys.stderr)
+        for f in failures:
+            print(f"    {f}", file=sys.stderr)
+        return 1
+    print(f"  self-test: {total} cases, all pass")
+    return 0
+
+
+def main():
+    if "--self-test" in sys.argv[1:]:
+        print("  SKILL   self-test", flush=True)
+        return self_test()
+
+    print("  SKILL   .claude/skills/", flush=True)
+
+    skills, files = set(), []
+    if SKILL_DIR.is_dir():
+        skills = {d.name for d in SKILL_DIR.iterdir() if (d / "SKILL.md").is_file()}
+        files = sorted(SKILL_DIR.glob("*/SKILL.md"))
+
+    # A routing file that points at the skills gets checked the same way, but
+    # only when its owner names it. Whether one exists, and what it is called,
+    # is local to a working copy and not this script's business. A named file
+    # is checked even in a clone with no skills directory, because that is
+    # where its references are most likely to have gone stale.
+    for extra in sys.argv[1:]:
+        path = pathlib.Path(extra)
+        if not path.is_absolute():
+            path = ROOT / extra
+        if not path.is_file():
+            print(f"  {extra}: not a file", file=sys.stderr)
+            return 1
+        files.insert(0, path)
+
+    if not files:
+        print("  no .claude/skills/ in this clone; nothing to check")
+        return 0
+
+    paths, targets, errors = tree_paths(), make_targets(), []
+    for path in files:
+        check_file(path, paths, targets, skills, errors)
+
+    # A file may name the same missing thing twice; report each once.
+    errors = list(dict.fromkeys(errors))
+    if errors:
+        print(f"  {len(errors)} stale reference(s):", file=sys.stderr)
+        for e in errors:
+            print(f"    {e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"  {len(files)} file(s), every path, target, section, and "
+        "cross-reference resolves"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # driver.sh - Data-driven test driver for elfuse
 #
 # Copyright 2026 elfuse contributors
@@ -15,8 +16,8 @@
 #   -l           List available tests without running them
 #   -v           Verbose: show test stdout/stderr on failure
 #   -T           TAP output format
-# If test-name arguments are given, only those tests run.
-# The test list is read from tests/manifest.txt.
+# If test-name arguments are given, only those tests run. The test list is read
+# from tests/manifest.txt.
 
 set -uo pipefail
 
@@ -28,13 +29,13 @@ SECTION=""
 LIST_ONLY=0
 VERBOSE=0
 TAP=0
-# Three values: 0 (strict, default), 1 (skip missing), auto (legacy).
-# In strict mode any missing test binary is a FAIL. The legacy "auto"
-# value flips to skip when TESTDIR is not the canonical build/ or
-# build/bin tree, which used to silently turn a partial out-of-tree
-# fixture set into a wall of green skips. Callers that genuinely want
-# permissive-skip-mode behavior should set ALLOW_MISSING_BINARIES=1
-# explicitly.
+
+# Three values: 0 (strict, default), 1 (skip missing), auto (legacy). In strict
+# mode any missing test binary is a FAIL. The legacy "auto" value flips to skip
+# when TESTDIR is not the canonical build/ or build/bin tree, which used to
+# silently turn a partial out-of-tree fixture set into a wall of green skips.
+# Callers that genuinely want permissive-skip-mode behavior should set
+# ALLOW_MISSING_BINARIES=1 explicitly.
 ALLOW_MISSING_BINARIES="${ALLOW_MISSING_BINARIES:-0}"
 
 usage()
@@ -109,9 +110,9 @@ esac
 
 # Canonicalize before the auto-policy comparison so that equivalent paths
 # (./build, symlinked build dir, trailing-slash) still resolve to the
-# default-strict branch instead of silently flipping into allow-missing
-# mode. If the dir does not exist yet, fall back to the raw string; the
-# per-test "not built" check still fires later.
+# default-strict branch instead of silently flipping into allow-missing mode. If
+# the dir does not exist yet, fall back to the raw string; the per-test "not
+# built" check still fires later.
 canonicalize()
 {
     if [ -d "$1" ]; then
@@ -205,8 +206,9 @@ if [ $# -gt 0 ]; then
         exit 1
     fi
 else
-    # -f (name) and -s (section) are independent constraints; when both are
-    # set a test must match both. Neither set selects everything.
+
+    # -f (name) and -s (section) are independent constraints; when both are set
+    # a test must match both. Neither set selects everything.
     for i in "${!test_names[@]}"; do
         if [ -n "$FILTER" ] && ! printf "%s\n" "${test_names[$i]}" | grep -Eq "$FILTER"; then
             continue
@@ -249,10 +251,11 @@ evaluate_result()
     if [ "$rc" -eq 124 ]; then
         return 1
     fi
+
     # When the manifest declares expected_rc=N, only that exact rc passes.
-    # Without this guard, a test that mistakenly exits 0 instead of its
-    # declared non-zero code (e.g. test-complex with expected_rc=42)
-    # would be reported PASS because rc=0 short-circuited the OR clause.
+    # Without this guard, a test that mistakenly exits 0 instead of its declared
+    # non-zero code (e.g. test-complex with expected_rc=42) would be reported
+    # PASS because rc=0 short-circuited the OR clause.
     if [ -n "$expected" ]; then
         if [ "$rc" -ne "$expected" ]; then
             return 1
@@ -315,10 +318,10 @@ for i in "${filtered_idx[@]}"; do
         binary="$TESTDIR_ABS/$binary"
     fi
 
-    # bash 3.2 + set -u rejects "${argv[@]}" after 'unset argv[0]' has
-    # left the array empty ("unbound variable"). The offset form
-    # "${argv[@]:1}" is well-defined to produce zero elements when the
-    # array has only one slot, so it works in every supported bash.
+    # bash 3.2 + set -u rejects "${argv[@]}" after 'unset argv[0]' has left the
+    # array empty ("unbound variable"). The offset form "${argv[@]:1}" is
+    # well-defined to produce zero elements when the array has only one slot, so
+    # it works in every supported bash.
     args=()
     for arg in "${argv[@]:1}"; do
         arg="${arg//\$TESTDIR/$TESTDIR_ABS}"
@@ -359,17 +362,17 @@ for i in "${filtered_idx[@]}"; do
     fi
 
     output=""
+
     # ${args[@]+...} guards the array expansion so a test with no extra
-    # arguments (args=()) does not trip bash 3.2's set -u rejection of
-    # an empty "${array[@]}".
-    # Host-limit annotations live in the manifest. Keep this execution path
-    # generic so adding another constrained test does not require a
-    # name-qualified branch here.
+    # arguments (args=()) does not trip bash 3.2's set -u rejection of an empty
+    # "${array[@]}". Host-limit annotations live in the manifest. Keep this
+    # execution path generic so adding another constrained test does not require
+    # a name-qualified branch here.
     if host_nofile=$(elfuse_test_host_nofile "$TEST_LIST" "$name"); then
         if [ -n "$host_nofile" ]; then
-            if output=$(ulimit -n "$host_nofile" && \
-                timeout "$TIMEOUT" "$ELFUSE" "$binary" \
-                ${args[@]+"${args[@]}"} 2>&1); then
+            if output=$(ulimit -n "$host_nofile" \
+                && timeout "$TIMEOUT" "$ELFUSE" "$binary" \
+                    ${args[@]+"${args[@]}"} 2>&1); then
                 rc=0
             else
                 rc=$?


### PR DESCRIPTION
Skills carry it now, split by concern rather than by directory, because a directory split does not survive contact: src/syscall/mem.c is syscall surface on one side and guest ABI on the other, and so are signal.c, forkipc.c, and thread.c. Each skill states the axis it sits on and sends anything the guest can observe in a register, a permission, or a PC to the guest-ABI skill, whatever directory the file lives in.

elfuse-debug is new rather than carved out. The other four each end at the rule you broke, and none of them said how to find out which rule that was, which is the second most common task in this tree after adding a syscall.

.agents/skills is a symlink to .claude/skills so Codex and Cursor read the same copy Claude Code and Amp do.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carves project knowledge into task-focused skills and adds a checker for stale references. No runtime behavior changes; `tests/driver.sh` only reflows comments and preserves logic.

Adds `elfuse-guest-abi`, `elfuse-syscall`, `elfuse-verify`, `elfuse-conventions`, and `elfuse-debug` under `.claude/skills/`, scoped by concern so guest-observable rules live in `elfuse-guest-abi` regardless of file location. Introduces `scripts/check-skill-refs.py` to fail when backticked paths, Make targets, docs sections, or sibling-skill names drift; it accepts extra routing files and includes a self-test. Symlinks `.agents/skills` to `.claude/skills` so editors and agents use the same copy.

**Review notes**
- Run `scripts/check-skill-refs.py` locally (optionally `--self-test`) and skim each skill’s “Authoritative sources”; verify headings resolve.
- Confirm `tests/driver.sh` semantics are unchanged (strict rc matching, `ALLOW_MISSING_BINARIES=0` by default, per-test timeout handling).

**Rollout**
- After renaming files, Make targets, or docs sections, run `scripts/check-skill-refs.py` and fix failures; add it to CI.
- Use `.agents/skills` for tooling; no build changes required.
- Start syscall work from `elfuse-syscall`; changes that affect guest-visible state must also follow `elfuse-guest-abi`.

<sup>Written for commit e2f4aadc4d95b0f73c4441d8546548b6cdf0d679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

