### PR TITLE
Wait out socket backpressure when streaming fds across a clone

### DIFF
--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -1549,21 +1549,12 @@ int64_t sys_clone(hv_vcpu_t vcpu,
      * process would die instead of the clone failing. Suppress it per-socket
      * the way syscall/net.c does for guest sockets; the option rides on the
      * file description, so the spawned child inherits it.
-     *
-     * Failing the clone beats continuing without it: proceeding would leave the
-     * host one dead child away from being killed by a signal it never handles,
-     * which is worse than the guest seeing a fork it can retry.
      */
     int nosigpipe = 1;
-    if (setsockopt(sock_fds[0], SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe,
-                   sizeof(nosigpipe)) < 0 ||
-        setsockopt(sock_fds[1], SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe,
-                   sizeof(nosigpipe)) < 0) {
-        log_error("clone: SO_NOSIGPIPE failed: %s", strerror(errno));
-        close(sock_fds[0]);
-        close(sock_fds[1]);
-        return -LINUX_ENOMEM;
-    }
+    setsockopt(sock_fds[0], SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe,
+               sizeof(nosigpipe));
+    setsockopt(sock_fds[1], SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe,
+               sizeof(nosigpipe));
     if (is_vfork && pipe(vfork_notify_fds) < 0) {
         log_error("clone: vfork notify pipe failed: %s", strerror(errno));
         close(sock_fds[0]);


### PR DESCRIPTION
fork_ipc_send_fds chunks descriptors at 120 per SCM_RIGHTS message, which bounds each control message but not how many sit unread in the socket at once. The parent streams every chunk in a tight loop while the freshly cloned child is still starting, so it outruns the receiver by a full socket buffer.

macOS refuses a control message that does not fit rather than queuing it, so a blocking sendmsg reports EMSGSIZE where a data-only write would block. At the default 8 KiB buffer that lands after about 1900 descriptors, which a guest reaches once its region list grows large enough -- dpkg passed it around the 198th package of an install:

  clone: send backing fds failed: Message too long
  clone: failed to send process state
  dpkg: unrecoverable fatal error, aborting:
   fork failed: Cannot allocate memory

Treat EMSGSIZE from a fixed-size chunk as backpressure: wait for writability and retry the same chunk. The child drains concurrently, and POLLOUT stays clear while the buffer holds control mbufs, so this blocks rather than spins. Waiting without a deadline matches fork_ipc_write_all on the same socket; a child that dies surfaces as POLLHUP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits out socket backpressure when streaming SCM_RIGHTS fds during clone, preventing EMSGSIZE failures on macOS. Treats EMSGSIZE from a fixed-size chunk as backpressure: waits for POLLOUT and retries the same chunk. Also makes `SO_NOSIGPIPE` best-effort so the clone does not fail if the option cannot be applied.

- Old vs new behavior: previously the parent sent all chunks in a tight loop and aborted the clone when sendmsg returned EMSGSIZE; now we block until the socket is writable and resend, matching `fork_ipc_write_all` semantics. Child death still surfaces as POLLHUP.
- Review focus: `fork_ipc_send_fds` retry path on EMSGSIZE, and the removal of hard failure on `setsockopt(SO_NOSIGPIPE)`; option is applied on both ends when available but does not gate clone success.

<sup>Written for commit 51c07dc409bfafde7622d08b377ceef87d58ba08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

