### PR TITLE
Host SIGBUS is now caught around direct guest-memory touches

### DIFF
--- a/src/core/guest.c
+++ b/src/core/guest.c
@@ -47,6 +47,7 @@
 #include "runtime/futex.h"  /* futex_interrupt_request */
 #include "runtime/thread.h" /* thread_destroy_all_vcpus */
 #include "syscall/proc.h"   /* proc_request_exit_group */
+#include "syscall/signal.h"
 #include "syscall/wakeup-pipe.h"
 
 /* Per-vCPU pending TLBI request. Zero-initialized in every host pthread by
@@ -63,6 +64,30 @@ _Thread_local tlbi_request_t cpu_tlbi_req;
 bool g_tlbi_range_supported = false;
 
 static void guest_region_clear(guest_t *g);
+
+/* Copy across the guest slab boundary with host SIGBUS recovery armed.
+ *
+ * Returns -1 when the backing page vanished under a live MAP_SHARED overlay.
+ */
+static int guest_host_memcpy(void *dst, const void *src, size_t len)
+{
+    bool faulted;
+    HOST_SIGBUS_GUARD(faulted, memcpy(dst, src, len));
+    return faulted ? -1 : 0;
+}
+
+static const void *guest_host_memchr(const void *src,
+                                     int c,
+                                     size_t len,
+                                     bool *faulted)
+{
+    /* found is read only on the non-faulted path, so it never survives a
+     * _longjmp, which is what would leave a non-volatile local indeterminate.
+     */
+    const void *found = NULL;
+    HOST_SIGBUS_GUARD(*faulted, found = memchr(src, c, len));
+    return *faulted ? NULL : found;
+}
 
 /* Page table descriptor bits. */
 #define PT_VALID (1ULL << 0)
@@ -1632,10 +1657,13 @@ static inline int guest_copy(const guest_t *g,
         size_t chunk = len - copied;
         if (chunk > avail)
             chunk = avail;
-        if (required_perms == MEM_PERM_R)
-            memcpy((uint8_t *) dst + copied, ptr, chunk);
-        else
-            memcpy(ptr, (const uint8_t *) src + copied, chunk);
+        if (required_perms == MEM_PERM_R) {
+            if (guest_host_memcpy((uint8_t *) dst + copied, ptr, chunk) < 0)
+                return -1;
+        } else if (guest_host_memcpy(ptr, (const uint8_t *) src + copied,
+                                     chunk) < 0) {
+            return -1;
+        }
         copied += chunk;
     }
     return 0;
@@ -1651,8 +1679,7 @@ int guest_read_small(const guest_t *g, uint64_t gva, void *dst, size_t len)
     uint64_t avail = 0;
     void *src = guest_ptr_bound(g, gva, &avail, MEM_PERM_R, (uint64_t) len);
     if (src && avail >= len) {
-        memcpy(dst, src, len);
-        return 0;
+        return guest_host_memcpy(dst, src, len);
     }
 
     return guest_read(g, gva, dst, len);
@@ -1668,8 +1695,7 @@ int guest_write_small(guest_t *g, uint64_t gva, const void *src, size_t len)
     uint64_t avail = 0;
     void *dst = guest_ptr_bound(g, gva, &avail, MEM_PERM_W, (uint64_t) len);
     if (dst && avail >= len) {
-        memcpy(dst, src, len);
-        return 0;
+        return guest_host_memcpy(dst, src, len);
     }
 
     return guest_write(g, gva, src, len);
@@ -1680,6 +1706,12 @@ int guest_read_str(const guest_t *g, uint64_t gva, char *dst, size_t max)
     if (max == 0)
         return -1;
     size_t copied = 0, limit = max - 1;
+
+    /* Separated from the other ways out, because a caller that retries with a
+     * bigger buffer must not retry a fault: the same address faults again. Both
+     * still return negative, so a caller testing < 0 is unaffected.
+     */
+    bool faulted = false;
 
     while (copied < limit) {
         if (gva > UINT64_MAX - copied)
@@ -1693,18 +1725,26 @@ int guest_read_str(const guest_t *g, uint64_t gva, char *dst, size_t max)
         size_t remain = limit - copied, chunk = avail < remain ? avail : remain;
         const char *src = (const char *) ptr;
 
-        const void *nul = memchr(src, '\0', chunk);
+        const void *nul = guest_host_memchr(src, '\0', chunk, &faulted);
+        if (faulted)
+            break;
         if (nul) {
             size_t slen = (const char *) nul - src;
-            memcpy(dst + copied, src, slen + 1);
+            if (guest_host_memcpy(dst + copied, src, slen + 1) < 0) {
+                faulted = true;
+                break;
+            }
             return (int) (copied + slen);
         }
-        memcpy(dst + copied, src, chunk);
+        if (guest_host_memcpy(dst + copied, src, chunk) < 0) {
+            faulted = true;
+            break;
+        }
         copied += chunk;
     }
 
     dst[copied] = '\0';
-    return -1;
+    return faulted ? -2 : -1;
 }
 
 int guest_read_str_small(const guest_t *g, uint64_t gva, char *dst, size_t max)
@@ -1717,11 +1757,22 @@ int guest_read_str_small(const guest_t *g, uint64_t gva, char *dst, size_t max)
     const char *src =
         guest_ptr_bound(g, gva, &avail, MEM_PERM_R, (uint64_t) limit);
     if (src && avail >= limit) {
-        const char *nul = memchr(src, '\0', limit);
+        bool faulted;
+        const char *nul = guest_host_memchr(src, '\0', limit, &faulted);
         if (nul) {
             size_t slen = (size_t) (nul - src);
-            memcpy(dst, src, slen + 1);
+            if (guest_host_memcpy(dst, src, slen + 1) < 0) {
+                /* Terminate as guest_read_str does on its own failure path, so
+                 * no caller can read the partially copied bytes as a string.
+                 */
+                dst[0] = '\0';
+                return -2;
+            }
             return (int) slen;
+        }
+        if (faulted) {
+            dst[0] = '\0';
+            return -2;
         }
     }
 

--- a/src/core/guest.c
+++ b/src/core/guest.c
@@ -76,6 +76,53 @@ static int guest_host_memcpy(void *dst, const void *src, size_t len)
     return faulted ? -1 : 0;
 }
 
+/* Copy between two already-resolved host pointers with the pad armed, returning
+ * how many bytes landed.
+ *
+ * guest_host_memcpy can only say whether the whole copy survived, so a caller
+ * reporting a partial transfer had to fall back to the count from before the
+ * copy and lose whatever the faulting copy had already moved. Stepping bounds
+ * that, but only if a step cannot itself be torn: each one is cut at the next
+ * page boundary on whichever side reaches one first, so it lies within a single
+ * page at both ends. A page is the granularity at which backing vanishes, so
+ * such a step either lands whole or faults whole, and done is exact rather than
+ * approximate. A flat stride would not do: unaligned against the real
+ * boundaries by up to a page, it could tear and lose what it had written.
+ *
+ * The unit is the guest page rather than the host's 16 KiB, so the granularity
+ * holds whichever side vanished. done is volatile because it is the one value
+ * read after the jump.
+ *
+ * Exact has one exception, and it is a race rather than a miscount: a truncate
+ * landing while a step is mid-copy can take the page after part of that step
+ * has been written, and those bytes go unreported. The error is bounded by one
+ * page and is always an under-report, which callers absorb because a short
+ * count means resume-from-here and re-copying is idempotent. si_addr cannot
+ * close it: nothing specifies the order memmove touches its range in, so the
+ * faulting address does not say how much of the step had landed.
+ */
+size_t guest_host_copy_partial(void *dst, const void *src, size_t len)
+{
+    volatile size_t done = 0;
+    bool faulted;
+    uintptr_t d = (uintptr_t) dst, s = (uintptr_t) src;
+
+    HOST_SIGBUS_GUARD(
+        faulted, while (done < len) {
+            size_t to_d =
+                GUEST_PAGE_SIZE - ((d + done) & (GUEST_PAGE_SIZE - 1));
+            size_t to_s =
+                GUEST_PAGE_SIZE - ((s + done) & (GUEST_PAGE_SIZE - 1));
+            size_t unit = to_d < to_s ? to_d : to_s;
+            if (unit > len - done)
+                unit = len - done;
+            memmove((uint8_t *) dst + done, (const uint8_t *) src + done, unit);
+            done += unit;
+        });
+    (void) faulted;
+    return done;
+}
+
 static const void *guest_host_memchr(const void *src,
                                      int c,
                                      size_t len,

--- a/src/core/guest.h
+++ b/src/core/guest.h
@@ -1063,13 +1063,24 @@ int guest_write_small(guest_t *g, uint64_t gva, const void *src, size_t len);
 
 /* Read a null-terminated string from guest memory. Copies up to max-1 bytes +
  * NUL into dst.
- * Returns string length or -1 if out of bounds / unterminated.
+ *
+ * Returns the string length, -1 if out of bounds or unterminated, or -2 when a
+ * host SIGBUS hit a vanished MAP_SHARED page. The two failures differ only for
+ * a caller deciding whether to retry: a -1 can be worth another attempt with a
+ * bigger buffer, a -2 never is. Both are negative, so a caller testing < 0 need
+ * not care.
  */
 int guest_read_str(const guest_t *g, uint64_t gva, char *dst, size_t max);
 
 /* Optimized guest string read for short, contiguous paths. Uses a direct guest
  * pointer when a full max-1-byte window is readable, otherwise falls back to
  * guest_read_str() for boundary-safe scanning.
+ *
+ * Returns the string length, -1 when the fast window did not apply and the
+ * fallback also failed, or -2 when either took a host SIGBUS on a vanished
+ * MAP_SHARED page. A caller holding a larger buffer can retry a -1 but never a
+ * -2: the same address faults again. The fallback propagates its own -2, so a
+ * path that straddles a page boundary is not retried either.
  */
 int guest_read_str_small(const guest_t *g, uint64_t gva, char *dst, size_t max);
 

--- a/src/core/guest.h
+++ b/src/core/guest.h
@@ -1084,6 +1084,15 @@ int guest_read_str(const guest_t *g, uint64_t gva, char *dst, size_t max);
  */
 int guest_read_str_small(const guest_t *g, uint64_t gva, char *dst, size_t max);
 
+/* Copy between two resolved host pointers with host SIGBUS recovery armed.
+ *
+ * Returns the number of bytes that landed, which is len when nothing faulted
+ * and less when a backing page vanished partway. Callers reporting a partial
+ * transfer use this instead of guest_host_memcpy, which can only say whether
+ * the whole copy survived.
+ */
+size_t guest_host_copy_partial(void *dst, const void *src, size_t len);
+
 /* Build L0->L1->L2 page tables from an array of memory regions. Uses 2MiB block
  * descriptors.
  *

--- a/src/debug/gdbstub.c
+++ b/src/debug/gdbstub.c
@@ -355,6 +355,14 @@ static thread_entry_t *find_thread_for_tid(int64_t tid)
     return thread_find(tid);
 }
 
+/* The one host-user-mode touch of guest memory left outside HOST_SIGBUS_GUARD.
+ *
+ * sys_icache_invalidate would fault the same way a memcpy does if the range sat
+ * in a MAP_SHARED overlay whose file had been truncated. It is left unguarded
+ * deliberately: reaching it requires --gdb, so no guest can drive it, and the
+ * ranges it flushes are code the debugger just wrote, not file-backed data. Do
+ * not treat this as precedent; anything a guest can reach belongs in the pad.
+ */
 static void gdb_invalidate_written_code(uint64_t gva, size_t len)
 {
     size_t flushed = 0;

--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -210,6 +210,62 @@ static void futex_wake_waiter_locked(futex_waiter_t **pp)
     futex_waiter_notify_group(w);
 }
 
+/* Guarded access to a guest futex word.
+ *
+ * A futex word can sit in a MAP_SHARED file mapping, which elfuse backs with a
+ * live host overlay. Once anything truncates that file the page is gone, and
+ * these atomics run from host user mode, so an unguarded access kills elfuse
+ * instead of reporting an error. Both helpers return false on that fault; every
+ * caller turns it into EFAULT the same way it handles an unresolvable uaddr.
+ *
+ * The jump lands inside these helpers, so a caller holding a bucket lock still
+ * reaches its own unlock path.
+ */
+static bool futex_word_load(const uint32_t *word, uint32_t *out)
+{
+    bool faulted;
+    HOST_SIGBUS_GUARD(faulted, *out = __atomic_load_n(word, __ATOMIC_SEQ_CST));
+    return !faulted;
+}
+
+/* swapped may be NULL where the caller retries regardless of who won the race.
+ */
+static bool futex_word_cas(uint32_t *word,
+                           uint32_t *expected,
+                           uint32_t desired,
+                           bool *swapped)
+{
+    bool faulted, won;
+    HOST_SIGBUS_GUARD(faulted, won = __atomic_compare_exchange_n(
+                                   word, expected, desired, /*weak=*/0,
+                                   __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST));
+    if (faulted)
+        return false;
+    if (swapped)
+        *swapped = won;
+    return true;
+}
+
+/* Best-effort clear of FUTEX_WAITERS on a PI word whose last waiter gave up.
+ * The caller is already returning a terminal status, so a fault here only means
+ * the bit stays set on a page nobody can reach anyway.
+ */
+static void futex_clear_waiters_bit(uint32_t *word)
+{
+    for (;;) {
+        uint32_t v;
+        bool cleared;
+        if (!futex_word_load(word, &v))
+            return;
+        if (!(v & FUTEX_WAITERS))
+            return;
+        if (!futex_word_cas(word, &v, v & ~FUTEX_WAITERS, &cleared))
+            return;
+        if (cleared)
+            return;
+    }
+}
+
 /* Public API */
 
 void futex_init(void)
@@ -465,7 +521,9 @@ static int64_t futex_os_sync_wait(guest_t *g,
     if (!host_addr)
         return -LINUX_EFAULT;
 
-    uint32_t current = __atomic_load_n(host_addr, __ATOMIC_SEQ_CST);
+    uint32_t current;
+    if (!futex_word_load(host_addr, &current))
+        return -LINUX_EFAULT;
     if (current != expected)
         return -LINUX_EAGAIN;
 
@@ -510,7 +568,9 @@ static int64_t futex_os_sync_wait(guest_t *g,
              * expected cannot miss an os_sync_wake_by_address, and any value
              * change carries the state the caller re-reads.
              */
-            uint32_t observed = __atomic_load_n(host_addr, __ATOMIC_SEQ_CST);
+            uint32_t observed;
+            if (!futex_word_load(host_addr, &observed))
+                return -LINUX_EFAULT;
             return observed == expected ? 0 : -LINUX_EAGAIN;
         }
 
@@ -632,7 +692,11 @@ static int64_t futex_wait(guest_t *g,
         return -LINUX_EFAULT;
     }
 
-    uint32_t current = __atomic_load_n(word, __ATOMIC_SEQ_CST);
+    uint32_t current;
+    if (!futex_word_load(word, &current)) {
+        pthread_mutex_unlock(&b->lock);
+        return -LINUX_EFAULT;
+    }
     if (current != expected) {
         pthread_mutex_unlock(&b->lock);
         return -LINUX_EAGAIN;
@@ -874,12 +938,13 @@ static int64_t futex_requeue(guest_t *g,
             pthread_mutex_unlock(&b_src->lock);
             return -LINUX_EFAULT;
         }
-        uint32_t current = __atomic_load_n(word, __ATOMIC_SEQ_CST);
-        if (current != expected) {
+        uint32_t current;
+        bool ok = futex_word_load(word, &current);
+        if (!ok || current != expected) {
             if (idx_src != idx_dst)
                 pthread_mutex_unlock(&b_dst->lock);
             pthread_mutex_unlock(&b_src->lock);
-            return -LINUX_EAGAIN;
+            return ok ? -LINUX_EAGAIN : -LINUX_EFAULT;
         }
     }
 
@@ -1007,8 +1072,11 @@ static int64_t futex_wake_op(guest_t *g,
      * atomic w.r.t. concurrent guest stores.
      */
     uint32_t old_val, new_val;
+    bool swapped = false, ok;
     do {
-        old_val = __atomic_load_n(word2, __ATOMIC_SEQ_CST);
+        ok = futex_word_load(word2, &old_val);
+        if (!ok)
+            break;
         switch (wake_op) {
         case 0:
             new_val = op_arg;
@@ -1029,9 +1097,15 @@ static int64_t futex_wake_op(guest_t *g,
             new_val = old_val;
             break;
         }
-    } while (!__atomic_compare_exchange_n(word2, &old_val, new_val,
-                                          /*weak=*/0, __ATOMIC_SEQ_CST,
-                                          __ATOMIC_SEQ_CST));
+        ok = futex_word_cas(word2, &old_val, new_val, &swapped);
+    } while (ok && !swapped);
+
+    if (!ok) {
+        if (idx1 != idx2)
+            pthread_mutex_unlock(&b2->lock);
+        pthread_mutex_unlock(&b1->lock);
+        return -LINUX_EFAULT;
+    }
 
     /* Wake up to val waiters at uaddr (unlink woken entries) */
     int woken1 = 0;
@@ -1164,11 +1238,11 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
         /* Fast path: try to CAS 0 -> the current TID (uncontended acquisition)
          */
         uint32_t expected = 0;
-        if (__atomic_compare_exchange_n(word, &expected, tid,
-                                        /*weak=*/0, __ATOMIC_SEQ_CST,
-                                        __ATOMIC_SEQ_CST)) {
-            return 0; /* Acquired */
-        }
+        bool acquired;
+        if (!futex_word_cas(word, &expected, tid, &acquired))
+            return -LINUX_EFAULT;
+        if (acquired)
+            return 0;
 
         /* Already own it? Deadlock (Linux returns EDEADLK) */
         if ((expected & FUTEX_TID_MASK) == tid)
@@ -1183,9 +1257,8 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
          * spin forever.
          */
         if (expected & FUTEX_OWNER_DIED) {
-            __atomic_compare_exchange_n(word, &expected, 0,
-                                        /*weak=*/0, __ATOMIC_SEQ_CST,
-                                        __ATOMIC_SEQ_CST);
+            if (!futex_word_cas(word, &expected, 0, NULL))
+                return -LINUX_EFAULT;
             continue; /* Retry acquisition */
         }
 
@@ -1203,20 +1276,25 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
          * concurrently.
          */
         for (;;) {
-            uint32_t cur = __atomic_load_n(word, __ATOMIC_SEQ_CST);
+            uint32_t cur;
+            if (!futex_word_load(word, &cur))
+                return -LINUX_EFAULT;
             if ((cur & FUTEX_TID_MASK) == 0)
                 break; /* Owner released; retry outer loop */
             if (cur & FUTEX_WAITERS)
                 break; /* Already set by another waiter */
             uint32_t desired = cur | FUTEX_WAITERS;
-            if (__atomic_compare_exchange_n(word, &cur, desired,
-                                            /*weak=*/0, __ATOMIC_SEQ_CST,
-                                            __ATOMIC_SEQ_CST))
+            bool marked;
+            if (!futex_word_cas(word, &cur, desired, &marked))
+                return -LINUX_EFAULT;
+            if (marked)
                 break; /* WAITERS bit set */
         }
 
         /* Re-check after WAITERS bit: if lock is now free, retry */
-        uint32_t cur = __atomic_load_n(word, __ATOMIC_SEQ_CST);
+        uint32_t cur;
+        if (!futex_word_load(word, &cur))
+            return -LINUX_EFAULT;
         if ((cur & FUTEX_TID_MASK) == 0)
             continue;
 
@@ -1226,7 +1304,10 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
         /* Double-check under bucket lock: owner may have released and called
          * UNLOCK_PI between the current WAITERS set and lock.
          */
-        cur = __atomic_load_n(word, __ATOMIC_SEQ_CST);
+        if (!futex_word_load(word, &cur)) {
+            pthread_mutex_unlock(&b->lock);
+            return -LINUX_EFAULT;
+        }
         if ((cur & FUTEX_TID_MASK) == 0) {
             pthread_mutex_unlock(&b->lock);
             continue;
@@ -1292,20 +1373,8 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
                     }
                     pthread_mutex_unlock(&b->lock);
                     pthread_cond_destroy(&waiter.cond);
-                    if (!has_waiters) {
-                        for (;;) {
-                            uint32_t v =
-                                __atomic_load_n(word, __ATOMIC_SEQ_CST);
-                            if (!(v & FUTEX_WAITERS))
-                                break;
-                            uint32_t nv = v & ~FUTEX_WAITERS;
-                            if (__atomic_compare_exchange_n(word, &v, nv,
-                                                            /*weak=*/0,
-                                                            __ATOMIC_SEQ_CST,
-                                                            __ATOMIC_SEQ_CST))
-                                break;
-                        }
-                    }
+                    if (!has_waiters)
+                        futex_clear_waiters_bit(word);
                     return -LINUX_ETIMEDOUT;
                 }
             } else {
@@ -1356,7 +1425,13 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
                  * below); a non-robust dead owner keeps its TID but has no
                  * OWNER_DIED, and Linux yields -ESRCH.
                  */
-                uint32_t check = __atomic_load_n(word, __ATOMIC_SEQ_CST);
+                uint32_t check;
+                if (!futex_word_load(word, &check)) {
+                    bucket_unlink_locked(b, &waiter);
+                    pthread_mutex_unlock(&b->lock);
+                    pthread_cond_destroy(&waiter.cond);
+                    return -LINUX_EFAULT;
+                }
                 if (check & FUTEX_OWNER_DIED) {
                     owner_died = true;
                     break;
@@ -1378,10 +1453,10 @@ static int64_t futex_lock_pi(guest_t *g, uint64_t uaddr, uint64_t timeout_gva)
 
         if (owner_died) {
             /* Clear the dead owner's lock word and retry acquisition */
-            uint32_t v = __atomic_load_n(word, __ATOMIC_SEQ_CST);
-            __atomic_compare_exchange_n(word, &v, 0,
-                                        /*weak=*/0, __ATOMIC_SEQ_CST,
-                                        __ATOMIC_SEQ_CST);
+            uint32_t v;
+            if (!futex_word_load(word, &v) ||
+                !futex_word_cas(word, &v, 0, NULL))
+                return -LINUX_EFAULT;
             continue;
         }
 
@@ -1409,11 +1484,11 @@ static int64_t futex_trylock_pi(guest_t *g, uint64_t uaddr)
                                   : (uint32_t) proc_get_pid();
 
     uint32_t expected = 0;
-    if (__atomic_compare_exchange_n(word, &expected, tid,
-                                    /*weak=*/0, __ATOMIC_SEQ_CST,
-                                    __ATOMIC_SEQ_CST)) {
-        return 0; /* Acquired */
-    }
+    bool acquired;
+    if (!futex_word_cas(word, &expected, tid, &acquired))
+        return -LINUX_EFAULT;
+    if (acquired)
+        return 0;
 
     return -LINUX_EAGAIN; /* Lock held, cannot acquire */
 }
@@ -1458,10 +1533,12 @@ static int64_t futex_unlock_pi(guest_t *g, uint64_t uaddr)
      * loop in case another thread is concurrently setting WAITERS.
      */
     for (;;) {
-        uint32_t v = __atomic_load_n(word, __ATOMIC_SEQ_CST);
-        if (__atomic_compare_exchange_n(word, &v, 0,
-                                        /*weak=*/0, __ATOMIC_SEQ_CST,
-                                        __ATOMIC_SEQ_CST))
+        uint32_t v;
+        bool released;
+        if (!futex_word_load(word, &v) ||
+            !futex_word_cas(word, &v, 0, &released))
+            return -LINUX_EFAULT;
+        if (released)
             break;
     }
 
@@ -1771,7 +1848,11 @@ int64_t sys_futex_waitv(guest_t *g,
             goto unlock_early;
         }
 
-        uint32_t current = __atomic_load_n(word, __ATOMIC_SEQ_CST);
+        uint32_t current;
+        if (!futex_word_load(word, &current)) {
+            result_err = -LINUX_EFAULT;
+            goto unlock_early;
+        }
         if (current != expected) {
             result_err = -LINUX_EAGAIN;
             goto unlock_early;

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -578,10 +578,20 @@ static inline int guest_read_path(guest_t *g,
                                   size_t long_sz,
                                   const char **out)
 {
-    if (guest_read_str_small(g, gva, short_buf, short_sz) >= 0) {
+    int rc = guest_read_str_small(g, gva, short_buf, short_sz);
+    if (rc >= 0) {
         *out = short_buf;
         return 0;
     }
+
+    /* -2 means a host SIGBUS on the guest page rather than running out of
+     * short_buf. Retrying the same address through the long buffer would only
+     * fault again. guest_read_str_small reports it for both its own fast path
+     * and the boundary-crossing fallback it delegates to.
+     */
+    if (rc == -2)
+        return -LINUX_EFAULT;
+
     if (guest_read_str(g, gva, long_buf, long_sz) >= 0) {
         *out = long_buf;
         return 0;

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -1991,10 +1991,21 @@ static int64_t process_vm_copy(guest_t *g,
         if (chunk == 0)
             return copied > 0 ? (int64_t) copied : -LINUX_EFAULT;
 
-        memmove(dst, src, (size_t) chunk);
-        copied += chunk;
-        lo += chunk;
-        ro += chunk;
+        /* Both ends are guest memory touched from host user mode, so either
+         * side can be a vanished MAP_SHARED overlay page. Linux reports a
+         * partial transfer here, or EFAULT when nothing moved.
+         *
+         * The copy reports its own progress rather than being wrapped in a bare
+         * guard: chunk runs to the end of the contiguous region and can be
+         * megabytes, so treating a fault as "this whole chunk moved nothing"
+         * would drop everything the copy had already written.
+         */
+        size_t moved = guest_host_copy_partial(dst, src, (size_t) chunk);
+        copied += moved;
+        lo += moved;
+        ro += moved;
+        if (moved < (size_t) chunk)
+            return copied > 0 ? (int64_t) copied : -LINUX_EFAULT;
     }
 }
 

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -348,21 +348,81 @@ static int64_t urandom_fill_iov(int guest_fd,
     return (int64_t) done;
 }
 
-static int64_t validate_iov_total(guest_t *g, uint64_t iov_gva, int iovcnt)
+static int64_t validate_iov_total(guest_t *g,
+                                  uint64_t iov_gva,
+                                  int iovcnt,
+                                  linux_iovec_t *iov)
 {
     if (!iov_count_ok(iovcnt))
         return -LINUX_EINVAL;
 
     uint64_t total = 0;
     for (int i = 0; i < iovcnt; i++) {
-        linux_iovec_t giov;
-        if (guest_read_small(g, iov_gva + (uint64_t) i * sizeof(giov), &giov,
-                             sizeof(giov)) < 0)
+        if (guest_read_small(g, iov_gva + (uint64_t) i * sizeof(*iov), &iov[i],
+                             sizeof(*iov)) < 0)
             return -LINUX_EFAULT;
-        if (!iov_total_add(total, giov.iov_len, &total))
+        if (!iov_total_add(total, iov[i].iov_len, &total))
             return -LINUX_EINVAL;
     }
     return 0;
+}
+
+/* Fill count guest bytes at gva with entropy, staged through a host buffer.
+ *
+ * urandom_fill_iov holds the per-fd cache lock while it copies, so it cannot be
+ * handed a guest pointer: see the lock rule on HOST_SIGBUS_GUARD.
+ *
+ * Returns the byte count transferred, or a negative Linux errno when nothing
+ * moved.
+ */
+static int64_t urandom_fill_guest(guest_t *g,
+                                  int guest_fd,
+                                  uint64_t gva,
+                                  uint64_t count)
+{
+    if (gva > UINT64_MAX - count)
+        return -LINUX_EFAULT;
+
+    uint8_t stage[512];
+    uint64_t done = 0, chunk;
+    while (slice_clamp(count, done, sizeof(stage), &chunk)) {
+        /* Clamp again to the contiguous writable window. Resolving the guest
+         * pointer purely to read its extent, never to dereference, keeps the
+         * short read a mapping boundary has always produced -- see
+         * tests/test-large-io-boundary.c -- instead of turning a straddling
+         * request into EFAULT.
+         */
+        uint64_t avail = 0;
+        if (!guest_ptr_bound(g, gva + done, &avail, MEM_PERM_W, chunk))
+            return done > 0 ? (int64_t) done : -LINUX_EFAULT;
+        if (avail < chunk)
+            chunk = avail;
+
+        /* Keep the chunk inside one guest page. A page is the granularity at
+         * which backing vanishes, so a chunk that cannot straddle one either
+         * lands whole or faults whole, and the count below is never short of
+         * what actually reached the guest. avail runs to the end of the region
+         * and can cross many pages, so without this the write could report less
+         * progress than it made.
+         */
+        uint64_t to_page_end =
+            GUEST_PAGE_SIZE - ((gva + done) & (GUEST_PAGE_SIZE - 1));
+        if (chunk > to_page_end)
+            chunk = to_page_end;
+        if (chunk == 0)
+            break;
+
+        struct iovec iov = {.iov_base = stage, .iov_len = (size_t) chunk};
+        int64_t got = urandom_fill_iov(guest_fd, &iov, 1);
+        if (got <= 0)
+            return done > 0 ? (int64_t) done : got;
+        if (guest_write(g, gva + done, stage, (size_t) got) < 0)
+            return done > 0 ? (int64_t) done : -LINUX_EFAULT;
+        done += (uint64_t) got;
+        if ((uint64_t) got < chunk)
+            break;
+    }
+    return (int64_t) done;
 }
 
 static int64_t urandom_read(guest_t *g,
@@ -377,15 +437,9 @@ static int64_t urandom_read(guest_t *g,
         return urandom_fill_iov(guest_fd, &empty, 1);
     }
 
-    uint64_t avail = 0;
-    void *dst = guest_ptr_bound(g, buf_gva, &avail, MEM_PERM_W, count);
-    if (!dst)
-        return -LINUX_EFAULT;
-    if (count > avail)
-        count = avail;
-
-    struct iovec iov = {.iov_base = dst, .iov_len = (size_t) count};
-    int64_t rc = urandom_fill_iov(guest_fd, &iov, 1);
+    int64_t rc = urandom_fill_guest(g, guest_fd, buf_gva, count);
+    if (rc < 0)
+        return rc;
 
     /* This slow path runs when the shim's identity-class fast path could not
      * serve the read: either the request was larger than the shim's inline
@@ -1443,15 +1497,49 @@ int64_t sys_readv(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
         int64_t err = urandom_check_readable(fd);
         if (err < 0)
             return err;
-        err = validate_iov_total(g, iov_gva, iovcnt);
-        if (err < 0)
+        if (!iov_count_ok(iovcnt))
+            return -LINUX_EINVAL;
+
+        linux_iovec_t stack_giov[SYSCALL_IOV_STACK_MAX];
+        linux_iovec_t *giov = stack_giov;
+        linux_iovec_t *heap_giov = NULL;
+        if (iovcnt > SYSCALL_IOV_STACK_MAX) {
+            heap_giov = malloc((size_t) iovcnt * sizeof(*giov));
+            if (!heap_giov)
+                return -LINUX_ENOMEM;
+            giov = heap_giov;
+        }
+        err = validate_iov_total(g, iov_gva, iovcnt, giov);
+        if (err < 0) {
+            free(heap_giov);
             return err;
-        host_iov_buf_t host_iov;
-        err = host_iov_prepare(g, iov_gva, iovcnt, MEM_PERM_W, &host_iov);
-        if (err < 0)
-            return err;
-        int64_t ret = urandom_fill_iov(fd, host_iov.iov, iovcnt);
-        host_iov_free(&host_iov);
+        }
+
+        /* Stage every entry through a host buffer for the reason spelled out on
+         * urandom_fill_guest: a resolved guest pointer would be written under
+         * the per-fd cache lock, where a vanished MAP_SHARED page kills the
+         * host instead of reporting EFAULT.
+         */
+        int64_t ret = 0;
+        for (int i = 0; i < iovcnt; i++) {
+            if (giov[i].iov_len == 0)
+                continue;
+            int64_t got =
+                urandom_fill_guest(g, fd, giov[i].iov_base, giov[i].iov_len);
+            if (got < 0) {
+                ret = ret > 0 ? ret : got;
+                break;
+            }
+            ret += got;
+
+            /* A short entry means the guest buffer ran out mid-way; POSIX
+             * requires the transfer to stop there rather than pack the tail of
+             * entry i into entry i+1.
+             */
+            if ((uint64_t) got < giov[i].iov_len)
+                break;
+        }
+        free(heap_giov);
 
         /* Mirror sys_read's slow-path refill so a readv consumer that drains
          * the shim ring leaves it ready for the next call, instead of forcing

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -16,6 +16,11 @@
  */
 
 #include <stdbool.h>
+#include <errno.h>
+#include <signal.h>
+#include <mach/arm/thread_status.h>
+#include <sys/ucontext.h>
+#include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -56,6 +61,7 @@ _Static_assert(sizeof(linux_rt_sigframe_t) + SIGFRAME_ALIGN - 1 <=
 /* Signal state (module-level, process-wide). */
 static signal_state_t sig_state;
 static _Thread_local int termination_wait_status;
+static _Thread_local host_sigbus_recovery_t host_sigbus_recovery;
 
 /* Per-thread pending fault info. When a synchronous fault (BRK, segfault, etc.)
  * needs to deliver a signal, the caller sets this before
@@ -97,6 +103,106 @@ static pthread_mutex_t sig_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 4 */
  */
 #include <stdatomic.h>
 static _Atomic uint64_t sig_pending_hint = 0;
+
+/* Disposition SIGBUS had before the recovery pad took it over. Restored, rather
+ * than assuming SIG_DFL, so an unguarded fault still reaches whatever the
+ * process had installed.
+ */
+static struct sigaction host_sigbus_prev;
+
+/* Where a recovered fault resumes. The kernel enters this on handler return, so
+ * it is never called directly and runs in ordinary thread context rather than
+ * on the handler's.
+ *
+ * The jump has to happen here rather than in the handler. Jumping straight out
+ * of a signal handler never returns through the wrapper a sanitizer installs
+ * around it, so ThreadSanitizer's per-thread signal bookkeeping is left
+ * inconsistent: measured, the first recovered SIGBUS worked and the second one
+ * deadlocked. Returning normally and letting the kernel resume here keeps that
+ * bookkeeping balanced, and has the side benefit that the thread-local read
+ * below happens outside handler context.
+ */
+static void host_sigbus_resume(void)
+{
+    host_sigbus_recovery.armed = 0;
+    _longjmp(host_sigbus_recovery.env, 1);
+}
+
+static void host_sigbus_handler(int signo, siginfo_t *info, void *ucontext)
+{
+    /* A null si_addr means the signal was sent rather than raised by an access:
+     * measured on Darwin, a hardware fault carries the faulting address and an
+     * external kill -BUS carries 0. si_code cannot make this call, since both
+     * report 1 and sys/signal.h marks BUS_ADRERR and BUS_OBJERR NOTIMP. A
+     * genuine fault at address 0 would be SIGSEGV, not SIGBUS.
+     *
+     * This is decided before the armed check, not after. A kill -BUS that lands
+     * while some thread happens to be inside a guard is not that thread's page
+     * fault, and recovering from it would swallow the signal and hand the
+     * guarded copy a spurious EFAULT.
+     */
+    bool fault = info && info->si_addr;
+
+    if (fault && host_sigbus_recovery.armed && ucontext) {
+        /* Redirect the interrupted context instead of jumping from here; see
+         * host_sigbus_resume. The faulting instruction is never re-executed
+         * because the resume address replaces it.
+         */
+        ucontext_t *uc = ucontext;
+        arm_thread_state64_set_pc_fptr(uc->uc_mcontext->__ss,
+                                       host_sigbus_resume);
+        return;
+    }
+
+    /* Sent signals are re-raised so a kill -BUS still kills on the first one.
+     * raise() is async-signal-safe; signal() is not, which is why the
+     * disposition goes back through sigaction().
+     */
+    sigaction(signo, &host_sigbus_prev, NULL);
+    if (!fault) {
+        raise(signo);
+        return;
+    }
+
+    /* A genuine fault outside any guard is a host bug. Returning re-executes
+     * the faulting instruction against the restored disposition, so the process
+     * dies on the original siginfo with si_addr and the faulting PC intact,
+     * which is the whole point of getting here.
+     *
+     * The restore is process-wide while the pad is per-thread, so for the few
+     * microseconds until this thread re-faults, a guarded fault on another
+     * thread would meet the restored disposition rather than recover. That
+     * cannot change whether the process dies, only which of the two faults the
+     * crash report names.
+     */
+}
+
+static void host_sigbus_install_once(void)
+{
+    struct sigaction sa = {0};
+    sa.sa_sigaction = host_sigbus_handler;
+    sigemptyset(&sa.sa_mask);
+
+    /* SA_NODEFER keeps SIGBUS unblocked inside the handler so the recovery pad
+     * can use the mask-free _setjmp/_longjmp pair. Without it the mask saved by
+     * sigsetjmp would be the only way back to an unblocked state, at the cost
+     * of two sigprocmask traps per guest memory copy.
+     */
+    sa.sa_flags = SA_SIGINFO | SA_NODEFER;
+    if (sigaction(SIGBUS, &sa, &host_sigbus_prev) < 0)
+        log_error("sigaction(SIGBUS) failed: %s", strerror(errno));
+}
+
+static void host_sigbus_install(void)
+{
+    static pthread_once_t once = PTHREAD_ONCE_INIT;
+    pthread_once(&once, host_sigbus_install_once);
+}
+
+host_sigbus_recovery_t *signal_host_sigbus_recovery(void)
+{
+    return &host_sigbus_recovery;
+}
 
 /* Guest ITIMER_REAL emulation. Signal emulation keeps the guest's ITIMER_REAL
  * internally rather than forwarding to the host setitimer(), because macOS
@@ -324,6 +430,7 @@ static _Atomic(guest_t *) attention_guest;
 
 void signal_init(void)
 {
+    host_sigbus_install();
     memset(&sig_state, 0, sizeof(sig_state));
 
     /* Clear the attention singleton on every init pass. Bootstrap and the

--- a/src/syscall/signal.h
+++ b/src/syscall/signal.h
@@ -17,6 +17,8 @@
 #include <Hypervisor/Hypervisor.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <setjmp.h>
+#include <signal.h>
 #include <sys/time.h>
 #include "core/guest.h"
 
@@ -250,8 +252,47 @@ typedef struct {
 
 /* API */
 
+typedef struct {
+    jmp_buf env;
+    volatile sig_atomic_t armed;
+} host_sigbus_recovery_t;
+
 /* Initialize signal state: all SIG_DFL, nothing pending/blocked. */
 void signal_init(void);
+
+/* Arm per-thread host SIGBUS recovery for direct guest memory copies. */
+host_sigbus_recovery_t *signal_host_sigbus_recovery(void);
+
+/* Run the trailing statement with host SIGBUS recovery armed for this thread,
+ * setting faulted to true when it took a fault instead of killing the host.
+ *
+ * A MAP_SHARED overlay stays live in the guest slab after anything truncates
+ * the file, so a host access to the vanished page raises SIGBUS. Only host user
+ * mode needs this; kernel copyin/copyout reports EFAULT instead. SA_NODEFER on
+ * the handler is what lets the mask-free _setjmp serve here.
+ *
+ * Rules for the statement, worst breakage first:
+ * - No return, break, goto, or longjmp out. That skips the disarm and leaves
+ *   env naming a dead frame, so the next fault jumps into freed stack.
+ * - No lock, including one inside a callee: arc4random_buf here stranded a libc
+ *   lock and hung the next fork. Keep to memcpy, memchr, atomic builtins.
+ * - No result in a non-volatile local read when faulted; _longjmp leaves those
+ *   indeterminate.
+ * - No nesting: an inner guard disarms the outer on exit.
+ */
+#define HOST_SIGBUS_GUARD(faulted, ...)                               \
+    do {                                                              \
+        host_sigbus_recovery_t *hsr_ = signal_host_sigbus_recovery(); \
+        if (_setjmp(hsr_->env) != 0) {                                \
+            signal_host_sigbus_recovery()->armed = 0;                 \
+            (faulted) = true;                                         \
+        } else {                                                      \
+            hsr_->armed = 1;                                          \
+            __VA_ARGS__;                                              \
+            hsr_->armed = 0;                                          \
+            (faulted) = false;                                        \
+        }                                                             \
+    } while (0)
 
 /* Reset signal state for exec (POSIX requirement). Handlers set to SIG_DFL
  * (except SIG_IGN stays SIG_IGN). Pending signals and signal mask are

--- a/src/syscall/sys.c
+++ b/src/syscall/sys.c
@@ -24,6 +24,8 @@
 
 #include "utils.h"
 
+#include "proved/slice.h"
+
 #include "core/shim-globals.h"
 #include "syscall/linux-wire.h"
 #include "syscall/internal.h"
@@ -207,19 +209,16 @@ int64_t sys_getrandom(guest_t *g,
     if (buf_gva > UINT64_MAX - buflen)
         return -LINUX_EFAULT;
 
-    uint64_t offset = 0;
-    while (offset < buflen) {
-        uint64_t remaining = buflen - offset, avail = 0;
-        void *dst =
-            guest_ptr_bound(g, buf_gva + offset, &avail, MEM_PERM_W, remaining);
-        if (!dst)
+    /* arc4random_buf takes a libc lock, so it cannot be handed a guest pointer:
+     * see the lock rule on HOST_SIGBUS_GUARD. Stage, then let guest_write do
+     * the copy inside the pad.
+     */
+    uint8_t stage[512];
+    uint64_t offset = 0, chunk;
+    while (slice_clamp(buflen, offset, sizeof(stage), &chunk)) {
+        arc4random_buf(stage, (size_t) chunk);
+        if (guest_write(g, buf_gva + offset, stage, (size_t) chunk) < 0)
             return -LINUX_EFAULT;
-
-        size_t chunk = (size_t) remaining;
-        if (avail < chunk)
-            chunk = (size_t) avail;
-
-        arc4random_buf(dst, chunk);
         offset += chunk;
     }
 

--- a/tests/bench-hot-guard.c
+++ b/tests/bench-hot-guard.c
@@ -4,12 +4,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Minimal bench that measures the three labels the guardrail script checks
- * against the TODO ceilings:
+ * Minimal bench that measures the four labels the guardrail script checks:
  *
  *   getpid          (raw SVC; shim identity fast path)
  *   clock_gettime   (vDSO trampoline; see -DGUARD_USE_LIBC_CG below)
  *   read-urandom1   (raw read; shim urandom ring fast path)
+ *   stat-path       (full SVC round trip through guest_read_path)
  *
  * Built twice from this single source:
  *   build/bench-hot-guard       -- static glibc. Compiled without
@@ -46,6 +46,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/auxv.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
@@ -177,10 +178,38 @@ static long bench_read_urandom1(void *ctx)
     return read(fd, &byte, 1);
 }
 
+/* The path-resolving lane. Every syscall that takes a path pays guest_read_path
+ * (guest_read_str_small, then guest_read_str), and stat pays a
+ * guest_write_small for the result struct on top, so this is the densest
+ * guest-copy caller a one-line bench can reach. The other three cases are all
+ * served by the shim or the vDSO and never touch those helpers, which is how a
+ * 45% regression in them once passed this guardrail unnoticed.
+ */
+static long bench_stat_path(void *ctx)
+{
+    struct stat *st = ctx;
+    return stat("/dev/null", st);
+}
+
 static void run_case(clock_gettime_fn cg,
                      const bench_case_t *bc,
                      unsigned long iters)
 {
+    /* Discard a warmup pass. Without it the first case in the table absorbs
+     * every one-time cost in the run: first-touch faults on the guest stack,
+     * the initial urandom ring fill, and the page tables the path resolver
+     * walks once. getpid runs first and was reading 50 ns warm against 62 to 72
+     * ns cold, a 40% swing on the lane the stat-path ratio divides by, which is
+     * enough to hide a real regression in the numerator.
+     */
+    unsigned long warmup = iters / 20;
+    if (warmup < 1000)
+        warmup = 1000;
+    if (warmup > iters)
+        warmup = iters;
+    for (unsigned long i = 0; i < warmup; i++)
+        (void) bc->fn(bc->ctx);
+
     uint64_t start = monotonic_ns(cg);
     long last = 0;
     for (unsigned long i = 0; i < iters; i++)
@@ -220,10 +249,12 @@ int main(int argc, char **argv)
     }
 
     cg_ctx_t cg_ctx = {.fn = vdso_cg};
+    struct stat stat_buf;
     const bench_case_t cases[] = {
         {"getpid", bench_getpid, NULL},
         {"clock_gettime", bench_clock_gettime, &cg_ctx},
         {"read-urandom1", bench_read_urandom1, &urandomfd},
+        {"stat-path", bench_stat_path, &stat_buf},
     };
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -109,6 +109,7 @@ test-fork-synthetic-fd
 [section] Guard page / mmap edge cases
 test-guard-page
 test-mmap-hint
+test-mmap-sigbus-efault
 
 [section] mremap tests
 test-mremap

--- a/tests/test-bench-guardrail.sh
+++ b/tests/test-bench-guardrail.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
+
 # Hot-syscall performance guardrail
 #
-# Runs bench-hot-guard (musl-static) and, when the cross-glibc toolchain
-# is available, bench-hot-guard-glibc (dynamic glibc)
-# under elfuse, then enforces explicit ns/op ceilings on the three hot
-# paths the TODO baseline tracked:
+# Runs bench-hot-guard (musl-static) and, when the cross-glibc toolchain is
+# available, bench-hot-guard-glibc (dynamic glibc) under elfuse, then enforces
+# limits on four hot paths:
 #
-#   getpid                <= 200 ns/op   (shim identity fast path)
-#   clock_gettime(libc)   <=  50 ns/op   (vDSO CNTVCT fast path)
-#   read(/dev/urandom, 1) <= 200 ns/op   (shim urandom ring fast path)
+#   getpid                <= 200 ns/op    (shim identity fast path)
+#   clock_gettime(libc)   <=  50 ns/op    (vDSO CNTVCT fast path)
+#   read(/dev/urandom, 1) <= 400 ns/op    (shim urandom ring fast path)
+#   stat("/dev/null")     <= Nx getpid    (guest_read_path, no fast path)
 #
-# The static (musl) bench is the baseline; the dynamic-glibc bench
-# verifies that glibc 2.41's vDSO probe (NT_GNU_ABI_TAG PT_NOTE) keeps
-# clock_gettime on the trampolines instead of trapping. When
-# LINUX_TOOLCHAIN is missing the glibc variant skips cleanly.
+# The first three are absolute; stat-path is a ratio. See the threshold block
+# below for why the two kinds of limit are not interchangeable.
+#
+# The static (musl) bench is the baseline; the dynamic-glibc bench verifies that
+# glibc 2.41's vDSO probe (NT_GNU_ABI_TAG PT_NOTE) keeps clock_gettime on the
+# trampolines instead of trapping. When LINUX_TOOLCHAIN is missing the glibc
+# variant skips cleanly.
 
 set -u
 
@@ -27,16 +31,43 @@ GLIBC_TOOLCHAIN="${LINUX_TOOLCHAIN:-/opt/toolchain/aarch64-linux-gnu}"
 GLIBC_SYSROOT="${GLIBC_TOOLCHAIN}/aarch64-unknown-linux-gnu/sysroot"
 ITERS="${BENCH_GUARDRAIL_ITERS:-200000}"
 
-# Thresholds in ns/op. The TODO baseline calls for 200 / 50 / 200,
-# which leaves a tight 1.5x margin for read-urandom1 (~140 ns measured
-# baseline). On shared / virtualized hosts under load the urandom
-# numbers were observed up to ~280 ns/op across 5 sequential runs on a
-# laptop with concurrent workloads, so the ceiling is widened to 400 ns
-# while still catching the real regression target: a fast-path bail
-# back to SVC would push the measurement into the ~1000+ ns range.
+# Absolute ceilings for the three shim/vDSO-served lanes. The wide headroom is
+# deliberate and matches what these lanes actually check: each is served inline
+# and regresses as a step function, not a slope. Losing the shim identity path
+# takes getpid from ~50 ns to SVC time, and losing vDSO acceptance takes
+# clock_gettime from ~5 ns to ~2000 ns. Both blow past any of these numbers, so
+# tightening them buys nothing and only risks flaking on slower CI hardware.
+# read-urandom1 keeps the widest margin of the three: on a loaded laptop it was
+# observed up to ~280 ns/op across sequential runs, while an SVC bail lands past
+# 1000 ns, so 400 separates them without chasing load noise.
 THRESH_GETPID=200
 THRESH_CLOCK_GETTIME=50
 THRESH_URANDOM=400
+
+# stat-path is checked as a ratio to getpid from the same run, not as an
+# absolute figure. It is the only lane whose cost is a slope: it scales with
+# what the guest-copy helpers charge per call, so it regresses by a percentage
+# rather than by falling off a fast path. An absolute ceiling cannot catch that
+# without being tuned to one machine. Dividing by getpid, measured on the same
+# hardware moments earlier, cancels the machine out.
+#
+# The number this exists to catch: arming the SIGBUS recovery pad with sigsetjmp
+# instead of _setjmp added two sigprocmask traps per guest copy and took stat
+# from 4.2 us to 6.1 us, a ratio of 84 to 122. It tripped no ceiling here,
+# because this lane did not exist.
+#
+# Observed 84 static and 407 dynamic, both within 3% across runs. The dynamic
+# arm is 5x the static one because sysroot redirection resolves every path
+# component. Ceilings sit ~1.25x over observed.
+#
+# The static arm is the detector. Restoring the sigsetjmp regression moves it
+# 82 -> 125, comfortably past 105, while the dynamic arm moved only 407 -> 488
+# and slipped under its ceiling on one run: sysroot resolution is so much of
+# that 13.6 us that a per-copy cost is diluted to noise. Keep the dynamic arm
+# for gross regressions, do not tighten it toward 450 chasing the small ones,
+# and do not read a dynamic pass as evidence the copy helpers are clean.
+THRESH_STAT_RATIO_STATIC=105
+THRESH_STAT_RATIO_GLIBC=500
 
 C_RED='\033[0;31m'
 C_GREEN='\033[0;32m'
@@ -62,9 +93,14 @@ fi
 failures=0
 benchmarks_run=0
 
-# extract_ns <bench-output> <label>
-# Prints the floating-point ns/op for the line whose first column is
-# exactly <label>. Returns nothing if the line is absent.
+# Set by any failure a second run would reproduce, so run_and_check skips the
+# retry. Reset per pass by run_and_check.
+deterministic=0
+
+# extract_ns <bench-output> <label> Prints the floating-point ns/op for the line
+# whose first column is exactly <label>.
+#
+# Returns nothing if the line is absent.
 extract_ns()
 {
     awk -v label="$2" '$1 == label { print $2 }' "$1"
@@ -78,6 +114,7 @@ check_threshold()
         printf "  ${C_RED}MISS${C_RESET}  %-12s %-22s no measurement reported\n" \
             "$variant" "$label" >&2
         failures=$((failures + 1))
+        deterministic=1
         return
     fi
     awk -v a="$actual" -v c="$ceiling" 'BEGIN { exit !(a <= c) }'
@@ -91,41 +128,114 @@ check_threshold()
     fi
 }
 
-run_and_check()
+check_ratio()
 {
-    local variant="$1" bench="$2"
-    shift 2
+    local variant="$1" label="$2" actual="$3" base="$4" ceiling="$5"
+    if [ -z "$actual" ] || [ -z "$base" ]; then
+        printf "  ${C_RED}MISS${C_RESET}  %-12s %-22s no measurement reported\n" \
+            "$variant" "$label" >&2
+        failures=$((failures + 1))
+        deterministic=1
+        return
+    fi
+    local ratio
+    ratio="$(awk -v a="$actual" -v b="$base" \
+        'BEGIN { if (b <= 0) print ""; else printf "%.1f", a / b }')"
+    if [ -z "$ratio" ]; then
+        printf "  ${C_RED}MISS${C_RESET}  %-12s %-22s getpid baseline was zero\n" \
+            "$variant" "$label" >&2
+        failures=$((failures + 1))
+        deterministic=1
+        return
+    fi
+    if awk -v r="$ratio" -v c="$ceiling" 'BEGIN { exit !(r <= c) }'; then
+        printf "  ${C_GREEN}OK${C_RESET}    %-12s %-22s %7.1f ns/op  (%sx getpid, ceiling %dx)\n" \
+            "$variant" "$label" "$actual" "$ratio" "$ceiling"
+    else
+        printf "  ${C_RED}FAIL${C_RESET}  %-12s %-22s %7.1f ns/op  %sx getpid > %dx\n" \
+            "$variant" "$label" "$actual" "$ratio" "$ceiling" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+run_one_pass()
+{
+    local variant="$1" bench="$2" stat_ratio="$3"
+    shift 3
     local out
     out="$(mktemp)"
-    benchmarks_run=$((benchmarks_run + 1))
     if ! "$ELFUSE" "$@" "$bench" "$ITERS" > "$out" 2>&1; then
         echo "  ${C_RED}FAIL${C_RESET}  $variant bench exited non-zero" >&2
         cat "$out" >&2
         failures=$((failures + 1))
+        deterministic=1
         rm -f "$out"
         return
     fi
 
-    check_threshold "$variant" "getpid" \
-        "$(extract_ns "$out" getpid)" "$THRESH_GETPID"
+    local getpid_ns
+    getpid_ns="$(extract_ns "$out" getpid)"
+
+    check_threshold "$variant" "getpid" "$getpid_ns" "$THRESH_GETPID"
     check_threshold "$variant" "clock_gettime" \
         "$(extract_ns "$out" clock_gettime)" "$THRESH_CLOCK_GETTIME"
     check_threshold "$variant" "read-urandom1" \
         "$(extract_ns "$out" read-urandom1)" "$THRESH_URANDOM"
+    check_ratio "$variant" "stat-path" \
+        "$(extract_ns "$out" stat-path)" "$getpid_ns" "$stat_ratio"
 
     rm -f "$out"
+}
+
+# Re-measure once before failing, and report only what survives the retry.
+#
+# Every lane here shares the machine with whatever else is running, and the
+# lanes do not degrade together: getpid is served inside the shim and never
+# leaves the process, while stat-path makes a real host filesystem call. Under
+# filesystem load the second moves and the first does not, so the ratio between
+# them climbs on a build where nothing changed. Measured: a `make clean` build
+# put stat-path at 205x against a 105x ceiling purely because Gatekeeper was
+# scanning the binaries that had just been produced, and the same binary on a
+# quiet machine came back at 87x.
+#
+# A retry separates the two cases at the cost of one extra run on the rare bad
+# pass: real slowdowns are in the code and reproduce, load spikes usually do
+# not. A gate that fails on a clean tree gets ignored, which costs more than the
+# regressions it would have caught.
+#
+# Only a measurement over its limit is retried. A bench that exited non-zero or
+# produced no number for a lane failed for a reason a second run reproduces, so
+# re-running it would burn a full pass and report the wrong cause.
+run_and_check()
+{
+    local variant="$1"
+    local before=$failures
+    benchmarks_run=$((benchmarks_run + 1))
+
+    deterministic=0
+    run_one_pass "$@"
+    if [ "$failures" -eq "$before" ] || [ "$deterministic" -eq 1 ]; then
+        return
+    fi
+
+    printf "  ${C_YELLOW}RETRY${C_RESET} %-12s first pass exceeded a limit; re-measuring\n" \
+        "$variant"
+    failures=$before
+    deterministic=0
+    run_one_pass "$@"
 }
 
 echo "=== bench-guardrail (iters=$ITERS) ==="
 
 if [ "$run_static" = 1 ]; then
     echo "[static (musl)]"
-    run_and_check static "$STATIC_BENCH"
+    run_and_check static "$STATIC_BENCH" "$THRESH_STAT_RATIO_STATIC"
 fi
 
 if [ -x "$GLIBC_BENCH" ] && [ -d "$GLIBC_SYSROOT" ]; then
     echo "[dynamic-glibc]"
-    run_and_check dyn-glibc "$GLIBC_BENCH" --sysroot "$GLIBC_SYSROOT"
+    run_and_check dyn-glibc "$GLIBC_BENCH" "$THRESH_STAT_RATIO_GLIBC" \
+        --sysroot "$GLIBC_SYSROOT"
 else
     /usr/bin/printf "  ${C_YELLOW}SKIP${C_RESET}  dyn-glibc      cross-toolchain absent: %s\n" \
         "$GLIBC_TOOLCHAIN"

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -774,6 +774,8 @@ run_unit_tests()
     test_check "$runner" "test-guard-page" "PASS" "$bindir/test-guard-page"
     test_rc "$runner" "test-mmap-hint" 0 "$bindir/test-mmap-hint"
 
+    test_rc "$runner" "test-mmap-sigbus-efault" 0 "$bindir/test-mmap-sigbus-efault"
+
     printf "\nLow-base ET_EXEC memory regression\n"
     test_rc "$runner" "test-lowbase-mem-200000" 0 "$bindir/test-lowbase-mem-200000"
     test_rc "$runner" "test-lowbase-mem-300000" 0 "$bindir/test-lowbase-mem-300000"
@@ -1347,8 +1349,8 @@ run_suite()
 # observed counts diverge. apple-unknown is the fallback row for SoC strings the
 # detector does not recognize yet.
 EXPECTED_BASELINES=(
-    "elfuse-aarch64|242|0"
-    "qemu-aarch64|224|0"
+    "elfuse-aarch64|243|0"
+    "qemu-aarch64|225|0"
     "elfuse-x86_64:apple-m1-m2|71|0"
     "elfuse-x86_64:apple-m3-plus|71|0"
     "elfuse-x86_64:apple-unknown|71|0"

--- a/tests/test-mmap-sigbus-efault.c
+++ b/tests/test-mmap-sigbus-efault.c
@@ -227,12 +227,40 @@ static void test_urandom_read(void)
     close(fd);
 }
 
+/* The host-side memmove in process_vm_readv, guest memory on both ends. */
+static void test_process_vm_readv(void)
+{
+    TEST("process_vm_readv from truncated MAP_SHARED returns EFAULT");
+
+    const size_t page = (size_t) sysconf(_SC_PAGESIZE);
+    int fd = -1;
+    char *p = map_then_truncate(page, &fd);
+    if (!p)
+        return;
+
+    char dst[64];
+    struct iovec local = {.iov_base = dst, .iov_len = sizeof(dst)};
+    struct iovec remote = {.iov_base = p, .iov_len = sizeof(dst)};
+
+    errno = 0;
+    long rc = syscall(SYS_process_vm_readv, (long) getpid(), &local, 1UL,
+                      &remote, 1UL, 0UL);
+
+    /* ENOSYS is an acceptable outcome: the point is that elfuse survives. */
+    EXPECT_TRUE(rc < 0 && (errno == EFAULT || errno == ENOSYS),
+                "process_vm_readv should fail rather than kill the host");
+
+    munmap(p, page);
+    close(fd);
+}
+
 int main(void)
 {
     test_path_copy();
     test_futex_word();
     test_getrandom_fill();
     test_urandom_read();
+    test_process_vm_readv();
     SUMMARY("test-mmap-sigbus-efault");
     return fails ? 1 : 0;
 }

--- a/tests/test-mmap-sigbus-efault.c
+++ b/tests/test-mmap-sigbus-efault.c
@@ -114,9 +114,41 @@ static void test_path_copy(void)
     close(fd);
 }
 
+/* The futex word atomics, which run from host user mode. */
+static void test_futex_word(void)
+{
+    TEST("futex on truncated MAP_SHARED returns EFAULT");
+
+    const size_t page = (size_t) sysconf(_SC_PAGESIZE);
+    int fd = -1;
+    char *p = map_then_truncate(page, &fd);
+    if (!p)
+        return;
+
+    /* FUTEX_WAIT compares before it decides anything, so the read that faults
+     * happens whatever value is passed.
+     *
+     * 0 is deliberately a value the word cannot hold: map_then_truncate leaves
+     * the poison path string at offset 0, so the word reads as "/tmp". A page
+     * that has not actually lost its backing therefore answers EAGAIN and fails
+     * the assertion below, where an expected value that matched would enqueue a
+     * waiter and hang the suite instead.
+     */
+    errno = 0;
+    long rc =
+        syscall(SYS_futex, (int *) p, FUTEX_WAIT_PRIVATE, 0, NULL, NULL, 0);
+
+    EXPECT_TRUE(rc < 0 && errno == EFAULT,
+                "FUTEX_WAIT should fail with EFAULT after truncate");
+
+    munmap(p, page);
+    close(fd);
+}
+
 int main(void)
 {
     test_path_copy();
+    test_futex_word();
     SUMMARY("test-mmap-sigbus-efault");
     return fails ? 1 : 0;
 }

--- a/tests/test-mmap-sigbus-efault.c
+++ b/tests/test-mmap-sigbus-efault.c
@@ -145,10 +145,94 @@ static void test_futex_word(void)
     close(fd);
 }
 
+/* arc4random_buf writing into the guest slab behind getrandom(2). */
+static void test_getrandom_fill(void)
+{
+    TEST("getrandom into truncated MAP_SHARED returns EFAULT");
+
+    const size_t page = (size_t) sysconf(_SC_PAGESIZE);
+    int fd = -1;
+    char *p = map_then_truncate(page, &fd);
+    if (!p)
+        return;
+
+    errno = 0;
+    long rc = syscall(SYS_getrandom, p, (size_t) 64, 0);
+
+    EXPECT_TRUE(rc < 0 && errno == EFAULT,
+                "getrandom should fail with EFAULT after truncate");
+
+    munmap(p, page);
+    close(fd);
+}
+
+/* read/readv on /dev/urandom, the sibling of the getrandom fill. Both are
+ * served by a host-side memcpy under the per-fd entropy cache lock, so both
+ * have to stage through a host buffer rather than take the recovery pad.
+ *
+ * The request is deliberately larger than the shim's inline urandom limit so
+ * the read reaches the host handler instead of being served from EL1.
+ */
+static void test_urandom_read(void)
+{
+    TEST("read(/dev/urandom) into truncated MAP_SHARED returns EFAULT");
+
+    const size_t page = (size_t) sysconf(_SC_PAGESIZE);
+    int fd = -1;
+    char *p = map_then_truncate(page, &fd);
+    if (!p)
+        return;
+
+    int u = open("/dev/urandom", O_RDONLY);
+    if (u < 0) {
+        munmap(p, page);
+        close(fd);
+        FAIL("open /dev/urandom");
+        return;
+    }
+
+    errno = 0;
+    long rc = read(u, p, 2048);
+    EXPECT_TRUE(rc < 0 && errno == EFAULT,
+                "read(/dev/urandom) should fail with EFAULT after truncate");
+
+    struct iovec iov = {.iov_base = p, .iov_len = 2048};
+    errno = 0;
+    rc = readv(u, &iov, 1);
+    EXPECT_TRUE(rc < 0 && errno == EFAULT,
+                "readv(/dev/urandom) should fail with EFAULT after truncate");
+
+    /* Two entries, because one short-circuits to the scalar read path and never
+     * reaches the multi-entry loop that resolves each iov separately. That loop
+     * is its own host kill: it dies with SIGBUS before the staging fix.
+     *
+     * The good page comes first so some bytes move before the vanished one is
+     * reached, which is what makes this a partial transfer rather than an
+     * outright failure. Both outcomes are accepted because the split depends on
+     * how far the kernel got, not on anything elfuse decides; what must not
+     * happen is a full count, which would mean the vanished page was reported
+     * as written.
+     */
+    char scratch[64];
+    struct iovec two[2] = {{.iov_base = scratch, .iov_len = sizeof(scratch)},
+                           {.iov_base = p, .iov_len = 2048}};
+    errno = 0;
+    rc = readv(u, two, 2);
+    EXPECT_TRUE(rc < 0 ? errno == EFAULT
+                       : rc >= 0 && rc < (long) (sizeof(scratch) + 2048),
+                "multi-entry readv must stop at the vanished page");
+
+    close(u);
+    munmap(p, page);
+    close(fd);
+}
+
 int main(void)
 {
     test_path_copy();
     test_futex_word();
+    test_getrandom_fill();
+    test_urandom_read();
     SUMMARY("test-mmap-sigbus-efault");
     return fails ? 1 : 0;
 }

--- a/tests/test-mmap-sigbus-efault.c
+++ b/tests/test-mmap-sigbus-efault.c
@@ -1,0 +1,122 @@
+/*
+ * MAP_SHARED host SIGBUS recovery regression test
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * elfuse backs a MAP_SHARED file mapping with a live host mmap overlay onto the
+ * guest slab. Truncating the file leaves the overlay in place with no backing
+ * page, so every host-side access from user mode raises SIGBUS and, without a
+ * recovery pad, kills elfuse itself. Each case below drives one host path that
+ * dereferences guest memory directly and expects EFAULT instead.
+ *
+ * Host syscall buffers are deliberately absent: the kernel reports EFAULT from
+ * copyin/copyout rather than signaling, so read/write/sendmsg never needed a
+ * pad.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* Map one page MAP_SHARED, then truncate the file out from under it.
+ *
+ * This only exercises the recovery pad while elfuse serves the mapping through
+ * a live host file overlay, which it installs for MAP_SHARED at a
+ * host-page-aligned slab offset and file offset. Offset 0 keeps the file side
+ * aligned and the mmap gap finder keeps the slab side aligned. Should either
+ * stop holding, the mapping falls back to snapshot pread, no host page can
+ * vanish, and every case here passes without proving anything.
+ *
+ * Returns the mapping, or NULL after reporting the failure. On success *fd_out
+ * holds the still-open file descriptor.
+ */
+static char *map_then_truncate(size_t page, int *fd_out)
+{
+    char path[] = "/tmp/elfuse-mmap-sigbus-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        FAIL("mkstemp");
+        return NULL;
+    }
+    unlink(path);
+
+    if (ftruncate(fd, (off_t) page) < 0) {
+        close(fd);
+        FAIL("initial ftruncate");
+        return NULL;
+    }
+
+    char *p = mmap(NULL, page, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (p == MAP_FAILED) {
+        close(fd);
+        FAIL("mmap");
+        return NULL;
+    }
+    memset(p, 0, page);
+    strcpy(p, "/tmp/elfuse-never-opened");
+
+    /* Truncate from a child so the mapping in this process stays live. */
+    pid_t pid = fork();
+    if (pid == 0)
+        _exit(ftruncate(fd, 0) == 0 ? 0 : 1);
+    if (pid < 0) {
+        munmap(p, page);
+        close(fd);
+        FAIL("fork");
+        return NULL;
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid || !WIFEXITED(status) ||
+        WEXITSTATUS(status) != 0) {
+        munmap(p, page);
+        close(fd);
+        FAIL("child truncate");
+        return NULL;
+    }
+
+    *fd_out = fd;
+    return p;
+}
+
+/* guest_read_str, through the path argument of open(2). */
+static void test_path_copy(void)
+{
+    TEST("path copy from truncated MAP_SHARED returns EFAULT");
+
+    const size_t page = (size_t) sysconf(_SC_PAGESIZE);
+    int fd = -1;
+    char *p = map_then_truncate(page, &fd);
+    if (!p)
+        return;
+
+    errno = 0;
+    int got = open(p, O_RDONLY);
+    if (got >= 0)
+        close(got);
+
+    EXPECT_TRUE(got < 0 && errno == EFAULT,
+                "open path copy should fail with EFAULT after truncate");
+
+    munmap(p, page);
+    close(fd);
+}
+
+int main(void)
+{
+    test_path_copy();
+    SUMMARY("test-mmap-sigbus-efault");
+    return fails ? 1 : 0;
+}

--- a/tests/test-process-vm.c
+++ b/tests/test-process-vm.c
@@ -155,6 +155,52 @@ static void test_error_paths(void)
               "zero count failed");
 }
 
+/* Overlapping ranges within one address space.
+ *
+ * sys_process_vm accepts the caller's own pid, so both iovecs can resolve into
+ * the same guest memory and a guest can make them overlap. The host-side copy
+ * has to stay defined there: copying an overlapping range forward is undefined
+ * behavior, not merely a strange result, which is why the copy helper uses
+ * memmove per step.
+ *
+ * This does not try to catch that undefined behavior by its output. Measured
+ * on this host, the forward copy it replaced produced correct leading bytes and
+ * a result that simply differed from memmove, so nothing observable separates
+ * the two reliably; the fix rests on the language rule, not on a reproducer.
+ *
+ * What the case does pin is the part that is specified: the full count comes
+ * back and nothing outside the destination is disturbed. The content of the
+ * overlap is asserted nowhere, because it is unspecified and the reference
+ * kernel matches neither memmove nor a page-wise move.
+ */
+static void test_overlapping_self_copy(void)
+{
+    static char buf[16384], original[16384];
+    const size_t head = 512, span = 8192;
+
+    for (size_t delta = 1; delta <= 64; delta *= 8) {
+        for (size_t i = 0; i < sizeof(buf); i++)
+            buf[i] = (char) (i * 7 + delta);
+        memcpy(original, buf, sizeof(buf));
+
+        char *dst = buf + head + delta;
+        struct iovec dst_iov = {.iov_base = dst, .iov_len = span};
+        struct iovec src_iov = {.iov_base = buf + head, .iov_len = span};
+
+        TEST("process_vm_readv overlapping self copy");
+        EXPECT_EQ(raw_process_vm_readv(getpid(), &dst_iov, 1, &src_iov, 1, 0),
+                  (long) span, "overlapping copy reported short");
+        /* head + delta, not head: the destination starts past the delta gap,
+         * so those bytes are before it too and a stray write there must fail.
+         */
+        EXPECT_TRUE(memcmp(buf, original, head + delta) == 0,
+                    "overlapping copy wrote before the destination");
+        EXPECT_TRUE(memcmp(dst + span, original + head + delta + span,
+                           sizeof(buf) - head - delta - span) == 0,
+                    "overlapping copy wrote past the destination");
+    }
+}
+
 int main(void)
 {
     printf("test-process-vm: process_vm_readv/writev tests\n\n");
@@ -164,6 +210,7 @@ int main(void)
     test_short_copy_on_remote_fault();
     test_short_copy_on_local_fault();
     test_error_paths();
+    test_overlapping_self_copy();
 
     SUMMARY("test-process-vm");
     return fails > 0 ? 1 : 0;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Catches host SIGBUS around direct guest-memory touches so MAP_SHARED truncations no longer kill the host. Previously a vanished page aborted the process; now syscalls return EFAULT with precise partial counts, recovered faults resume outside the handler, and sent SIGBUS is re-raised.

- Path resolution: syscalls using guest_read_path now return EFAULT when the path is on a truncated MAP_SHARED page. guest_read_str returns -2 on SIGBUS; guest_read_str_small propagates it; guest_read_path maps -2 to EFAULT and does not retry the long buffer.
- Futex: WAIT/WAITV/REQUEUE/WAKE_OP/PI lock/trylock/unlock return EFAULT when the futex word is on a vanished page. Atomics run under the guard; clearing WAITERS is best-effort.
- Entropy: getrandom stages into a host buffer, then guest_write; EFAULT on vanished pages. read/readv(/dev/urandom) stage per entry, clamp each write to the current guest page for exact partial counts, and stop on the first vanished page with EFAULT or a short count.
- process_vm_readv: copies in guest-page units via guest_host_copy_partial using memmove to stay defined on overlaps. Returns bytes moved, or EFAULT (or ENOSYS) when nothing lands; counts are exact except a possible one-page under-report if a truncate lands mid-step.
- Guard rail: installs a per-thread SIGBUS handler (SA_NODEFER) and HOST_SIGBUS_GUARD for memcpy/memchr/atomics. Only faults with si_addr are recovered; sent SIGBUS is re-raised. The handler redirects execution to a resume thunk so sanitizers stay consistent. The gdbstub icache flush remains intentionally unguarded.
- Tests/bench: add MAP_SHARED-truncation EFAULT coverage (paths, futex, entropy, process_vm overlap/partial) and a stat-path lane to the hot bench checked as a ratio to getpid, with warmup and a single retry on limit breaches; baselines updated.

<sup>Written for commit f91b895ba246466d211afaf91764ee59391d9bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

