### PR TITLE
Consolidations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,7 @@ Checks: >
   misc-redundant-expression,
   performance-*,
   -performance-no-int-to-ptr,
+  readability-function-size,
   readability-inconsistent-declaration-parameter-name
 
 WarningsAsErrors: ''
@@ -31,3 +32,35 @@ HeaderFilterRegex: 'src/.*\.h$'
 CheckOptions:
   - key: bugprone-unsafe-functions.ReportMoreUnsafeFunctions
     value: false
+  # A ceiling, not a target. Nothing else in the tree measures how big a
+  # function has grown, so a syscall body could and did reach four figures
+  # without any gate noticing.
+  #
+  # With the eleven NOLINT suppressions in place the check reports nothing on
+  # this tree today, and all eleven are load-bearing: clang-tidy accounts for
+  # exactly eleven NOLINT suppressions on a full run. That is not the same as
+  # 400 being a comfortable margin. Eleven further functions already exceed
+  # 250 lines by this check's own counting, which includes comments and blank
+  # lines, so the next function to cross 400 is more likely to be one of those
+  # than anything newly written. Expect this to land on existing code first.
+  #
+  # Advisory, like every other check here: WarningsAsErrors is empty and the
+  # tidy CI job says out loud that it logs rather than gates, so this reports
+  # a new oversized function, it does not stop one. Making it a real gate
+  # means naming it in WarningsAsErrors, which is a policy change and not one
+  # this threshold makes on its own.
+  #
+  # The other size axes stay off (-1) because the line count is the one that
+  # correlates with a body no reader can hold at once.
+  - key: readability-function-size.LineThreshold
+    value: 400
+  - key: readability-function-size.StatementThreshold
+    value: -1
+  - key: readability-function-size.BranchThreshold
+    value: -1
+  - key: readability-function-size.ParameterThreshold
+    value: -1
+  - key: readability-function-size.NestingThreshold
+    value: -1
+  - key: readability-function-size.VariableThreshold
+    value: -1

--- a/.claude/skills/elfuse-conventions/SKILL.md
+++ b/.claude/skills/elfuse-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elfuse-conventions
-description: elfuse conventions that are not guessable from the code - the seven-rule commit message style, ASCII-only source comments, kebab-case filenames, the type and return conventions at the ABI boundary, the untracked root working docs, and externals/ being evaluation-only. Use when drafting a commit message or PR description, adding a new file or a new type, or touching anything under externals/.
+description: elfuse conventions that are not guessable from the code - the seven-rule commit message style, ASCII-only source comments, kebab-case filenames, the type and return conventions at the ABI boundary, the untracked root working docs, and the rule that a tool checked out for evaluation never becomes a build dependency. Use when drafting a commit message or PR description, adding a new file or a new type, or wiring the build to anything a fresh clone would not have.
 ---
 
 # elfuse conventions
@@ -48,7 +48,9 @@ Filenames use kebab-case, never underscore. Symbol names use snake_case.
 ## Code
 
 The conventions below are the ones that come from this project being a Linux
-ABI reimplementation rather than an ordinary C program.
+ABI reimplementation rather than an ordinary C program. They settle what a
+declaration looks like, not whether the function should exist; for judging and
+cleaning code that already works, `elfuse-refactor` is the calibration set.
 
 Fixed-width types for anything the guest defines: guest addresses, Linux ABI
 structures, binary layouts, protocol fields, page-table entries. Host-side
@@ -85,20 +87,27 @@ module.
 New C tests are `tests/test-<feature>.c` and use the shared harness macros
 rather than rolling their own reporting.
 
-## externals/
+## Vendored tools checked out for evaluation
 
-Tools vendored under `externals/` (`ls externals/` for what is actually
-checked out locally) are for evaluation and discovery.
+A third-party tool checked out into an untracked directory to be tried out is
+for evaluation and discovery only. Nothing in the build may come to depend on
+it: no make target, no script, no CI job, and no documented workflow step. It
+is absent from a fresh clone, so anything that reaches for it breaks for the
+next person and cannot run in CI.
 
-`externals/` is gitignored, so anything that depends on it breaks on a fresh
-clone and cannot run in CI. That single fact settles every case: no make
-target, no script, no CI job, no documented workflow step may reference it.
-
-Run such a tool by hand from a scratch directory and leave any fixes to the
-tool inside its own checkout. Record the outcome in the root working docs,
+Run such a tool by hand from a scratch directory and leave any fixes to it
+inside its own checkout. Record the outcome in the root working docs,
 including when the answer was "evaluated, not integrated" - a rejected
 evaluation is worth writing down so the next person does not repeat it. If the
 output is worth keeping, land the finding in tree, not the tool.
+
+Being untracked is not itself the test, and reading it that way gets the rule
+backwards. The test fixtures are untracked too, and the build depends on them
+on purpose: a make variable points at them, `make distclean` removes them, CI
+restores them from a cache before the lanes that need them, and
+`docs/testing.md` documents the paths the suites resolve. What makes that legitimate is that a tracked script fetches them, so
+a fresh clone can reproduce the tree it needs. An evaluation checkout has no
+such script, and that is the difference.
 
 ## Commit messages
 

--- a/.claude/skills/elfuse-refactor/SKILL.md
+++ b/.claude/skills/elfuse-refactor/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: elfuse-refactor
+description: Judging and cleaning existing elfuse C code - which Refactoring and Clean Code smells carry weight in a Linux ABI reimplementation, which ones are false alarms in this tree, how to measure structure here, and what has to stay green before a change counts as behavior-preserving. Use when asked to clean up, simplify, deduplicate, shorten, or restructure code that already works, or when reviewing a diff for maintainability rather than for bugs. Also use on the symptom rather than the request - a function past a few hundred lines, a parameter list past about six, the same cleanup block repeated at many failure exits, a field list spelled out in three places, a helper that returns 0 or -1 and is read with a < 0 test, a comment asserting a number or a guarantee, or an ask like "is this over-engineered", "while you are in there", "any quick wins". Not for adding a syscall (elfuse-syscall), for naming and commit style (elfuse-conventions), or for chasing a live failure (elfuse-debug).
+---
+
+# Refactoring elfuse code
+
+Refactoring is behavior-preserving change, and in this tree the behavior that
+must be preserved is what the guest observes, not what the host code returns.
+That makes the two halves of this file: what is worth changing, and what has
+to stay green before the change counts.
+
+## What the gates actually measure
+
+Worth knowing before treating a green build as a verdict. `.clang-tidy` enables
+`bugprone-*`, `cert-*`, `clang-analyzer-*`, and `performance-*`, which answer
+"is this a bug". The one structural check is `readability-function-size`, and
+it measures line count only: nesting, statement, branch, and parameter
+thresholds are explicitly off, and the functions that predate the ceiling carry
+`NOLINTNEXTLINE`. Nothing counts a repeated block or a duplicated field list.
+`make check-format` settles layout and the generated dispatch header.
+
+Two things follow, and both have been claimed wrongly before. Read
+`.clang-tidy` rather than this paragraph for the current check set: it changes,
+and a stale summary of a gate is exactly the kind of assertion that reads as
+verified.
+
+First, none of it gates. `WarningsAsErrors` is empty and the tidy CI job says
+in its own comment that it logs rather than fails. A ceiling here reports; it
+does not stop anything.
+
+Second, `make lint` has never been clean. It emits thousands of advisory
+warnings, mostly `bugprone-multi-level-implicit-pointer-conversion`, none of
+which fail a build. "Lint is clean" is therefore not a claim this tree
+supports. The claims it does support are narrower and worth making precisely:
+no new warnings inside the code you touched, and zero `function-size`
+warnings.
+
+So structure here is a judgment call with almost no compiler behind it, and
+this file is the calibration set for the judgment.
+
+## Measure before judging
+
+Say which numbers were measured and which were eyeballed, and never quote a
+count from a document, including this one. Recompute it. The tree is
+clang-formatted, which is the only reason these one-liners are honest: a
+function definition is a signature at column 0 followed by a lone `{`, and its
+body ends at the first lone `}`.
+
+```sh
+# function lengths over 60 body lines, longest first
+awk 'FNR==1{d=0} /^\{$/{d=1;s=FNR;next}
+     d&&/^\}$/{if(FNR-s-1>60)printf "%5d  %s:%d\n",FNR-s-1,FILENAME,s;d=0}' \
+    $(git ls-files 'src/*.c') | sort -rn
+
+# statements at nesting depth 4 or deeper (4-space indent, so 20 columns in)
+grep -rn '^ \{20\}[^ *]' --include='*.c' src
+
+# file sizes
+git ls-files 'src/*.c' | xargs wc -l | sort -rn | head -20
+```
+
+The nesting grep also catches wrapped continuation lines, so it is a lead, not
+a count. Duplication has no mechanical detector here; `jscpd` and `lizard` are
+not part of this build and adding a dependency to score a cleanup is not worth
+it. Call duplication findings what they are: judgment, with the two locations
+quoted so a reader can check the call.
+
+Report a measured number with the command that produced it, and a judgment as
+a judgment. A count with no command behind it reads as a fact and rots into a
+wrong one.
+
+## Behavior-preserving is a claim the lanes settle
+
+`docs/testing.md`, section "Validation Strategy By Change Type", maps the area
+touched to the minimum command set; a pure cleanup does not earn a smaller set
+than the feature would have. `elfuse-verify` explains what a failure in each
+lane means.
+
+Three cases where "I only moved code" is wrong:
+
+- Anything under `src/proved/`. The contracts move with the arithmetic, so
+  `make verify` and `make verify-mutants` both have to pass again. A proof
+  that still discharges after a rewrite but no longer rejects the mutant is a
+  proof that got weaker while looking green.
+- Anything that writes guest registers on the return path, sets page
+  permissions, or touches the TLBI epilogue. That is guest-observable, so it
+  is not a refactor until `elfuse-guest-abi` says the observable side is
+  unchanged.
+- Extracting a helper that acquires a lock. The lock order comment at the top
+  of `src/syscall/internal.h` is the contract, and moving an acquire inside a
+  callee changes the order at every call site at once.
+
+## Smells that carry weight here
+
+- A `sys_` function that has grown to hold several unrelated Linux behaviors.
+  Length alone is not the finding: one syscall's flag matrix is allowed to be
+  long, because each branch is a documented kernel behavior and splitting it
+  scatters one contract. The finding is when the flag matrix, the path
+  resolution, the host call, and the result translation are all inline in one
+  body, because then no reader can tell which of the four a bug lives in.
+- Shotgun surgery across the translation boundary. If a new syscall needs an
+  edit in `src/syscall/translate.c`, a domain file, and two other places that
+  each re-derive the same thing, the re-derivations are the bug.
+- Dead flexibility: a parameter every caller passes the same value for, a hook
+  with one implementation, scaffolding for a feature the root working docs
+  still list as future work. Delete it; the git history keeps it.
+- A raw ABI literal in a domain file. The constant belongs in
+  `src/syscall/abi.h` with a name, and the domain file uses the name.
+- A helper that returns 0 or -1 and is only ever read with `< 0`. That is a
+  `bool` wearing an `int`, and `elfuse-conventions` says which is which.
+- A comment that asserts a number or a guarantee. Both rot silently and both
+  read as checked. A comment saying a buffer is "~100KiB" when the type it
+  sizes has since grown, or saying a check "has to be declared in the diff"
+  when `WarningsAsErrors` is empty and the CI job logs rather than gates, is
+  worse than no comment: the next reader trusts it instead of measuring. When
+  a refactor moves a comment, its claims move with it unverified, so recompute
+  the number and re-read the config the sentence describes. This is the same
+  failure `scripts/check-skill-refs.py` exists to catch in the skills, and
+  nothing catches it in `src/`.
+
+## Smells that are false alarms in this tree
+
+Each of these is a textbook finding that a generic audit reports and that is
+correct code here.
+
+- Two structures that look alike across the ABI boundary. A Linux `stat` and a
+  macOS `stat` are not duplicated knowledge; they are two knowledges that
+  happen to rhyme, and merging them puts one definition where a translation
+  belongs. `elfuse-conventions` requires packed Linux structures to live next
+  to the translation code that reads them, precisely so they can diverge.
+
+  A translation and its inverse are the opposite case, and the resemblance is
+  easy to wave off with the rule above. Which Linux bit means which macOS bit
+  is one fact, and a hand-written forward function plus a hand-written reverse
+  function state it twice, so a bit added to one silently misses the other and
+  nothing fails. State it once as a table and walk it in both directions. The
+  test is whether the two bodies encode the same correspondence or two
+  different ones.
+- Repeated switches at the translation boundary. errno, `AT_*` flags, clock
+  ids, and socket flags each get their own switch in
+  `src/syscall/translate.c`. That concentration is the design; the smell is a
+  conversion written inline somewhere else.
+- The wall of `sc_` wrappers in `src/syscall/syscall.c`. They look like
+  boilerplate begging for a loop; they are the typed unpack the generated
+  dispatch table calls. Moving one into a domain file yields a symbol nothing reaches.
+- `uint64_t gva` as primitive obsession. The fixed-width type is the signal
+  that says which side of the boundary the value came from. A wrapper type
+  removes information rather than adding it.
+- A `_Thread_local` slot that "should" be shared state. `cpu_tlbi_req` is
+  per-vCPU on purpose, and promoting it to guest-global reintroduces the
+  cross-vCPU drain race it was split to fix.
+- A test that makes no assertion. Guest fixtures like `tests/test-argc.c` only
+  print; the oracle is the shell lane that greps their output, so an
+  assertion-free `main` is the design rather than a gap. Among the tests that
+  do run in-process, `EXPECT_EQ` and friends are a convenience layer over
+  `TEST` / `PASS` / `FAIL` in `tests/test-harness.h`, so a file using only the
+  latter is fully asserted. Judge a test by whether something fails when the
+  behavior breaks, not by which macro it spells.
+- Apparently dead code. Before deleting a symbol, grep `src/syscall/dispatch.tbl`,
+  `src/core/shim.S`, and `tests/` for it. Reachability here runs through a
+  generated table, hand-written assembly, and test lanes, so the C call graph
+  alone does not decide it.
+
+## Where a textbook refactor is a bug
+
+- Vector entry stubs in `src/core/shim.S` must not clobber any GPR before
+  `svc_handler`. A shared prologue macro that uses one scratch register
+  corrupts the EL0 caller after ERET, and the tests that notice are not the
+  ones a cleanup runs.
+- The paths that hand the shim its drop-frame marker in X8 look like one
+  duplication and are not safely unified. Which paths those are has already
+  changed once, so grep for the writes rather than trusting any list,
+  including this sentence: `grep -rn 'HV_REG_X8' src/` shows who sets it and
+  to what, and `src/core/shim.S` documents what each value means. They differ
+  in whether they return through the dispatch epilogue at all, so read
+  `elfuse-guest-abi` first; a wrong unification ties the handler PC to a stale
+  syscall frame and only shows up under signals.
+- The generated dispatch header is generated. Edit `src/syscall/dispatch.tbl`
+  and rerun `make check-format`.
+
+## Leave it cleaner, in proportion
+
+Every edit is a chance to leave one thing better, and the tree reached
+four-figure functions because nobody took it. But "in proportion" is the
+load-bearing half, and in this tree it has a mechanical edge that a good
+intention does not survive.
+
+Do not run `clang-format -i` on a whole file to tidy a small change. Files
+here are format-clean but their comment wrapping predates the current
+formatter, so a whole-file pass rewraps comments nowhere near your edit and
+buries the change in churn. Format the file only when you added code to it,
+and check `git diff --numstat` before calling the work done: a file you meant
+to touch in one line reporting twenty is churn, not cleanup. The same goes for
+a scripted edit that rewrites whole files.
+
+The proportionality test is the diff, not the intent. A cleanup that lands in
+a file the task never needed to open is a separate change, and it costs the
+next reader a bisect.
+
+## Fix it now, or write it down
+
+Most findings are not for the change you are making. Fix one now only when it
+blocks the task, when it is a live risk, or when your own edit introduced it.
+Everything else gets reported, in the summary or in the root working docs, and
+that report is the deliverable rather than a consolation prize: a named,
+located finding is worth more than a drive-by fix nobody asked to review.
+
+Two cases decide themselves. A correctness bug found while cleaning is never
+folded into the cleanup, because a diff that both moves code and changes
+behavior cannot be reviewed as either. A finding whose fix would touch a
+subsystem the task never opened is a separate change, however obvious it looks
+from here.
+
+## Before a multi-step cleanup
+
+Run the lanes before touching anything, and keep the output. This tree is not
+green everywhere: `make check-format` fails on shell scripts, `make lint`
+emits thousands of advisory warnings, and neither is your doing. Without that
+baseline you will spend the session unable to tell your breakage from the
+breakage you inherited, or worse, you will report someone else's red as your
+own.
+
+Then work in batches that each end green, one smell family or one file at a
+time, and say after every batch which lanes ran. When a lane cannot run, name
+it and say what risk that leaves rather than rounding up to success. When the
+baseline is already red in the area you are about to change, stop and report
+instead of refactoring on top of it.
+
+## Sequencing
+
+One behavior-preserving step per commit, each with its own green lanes, so a
+bisect lands on a step rather than on a rewrite. A commit that both moves code
+and changes behavior cannot be reviewed as either. Subject lines follow the
+seven rules in `elfuse-conventions`, and a cleanup commit says what stops
+happening, not that things were cleaned up.
+
+## Authoritative sources
+
+This skill is a working summary. These are tracked and survive a fresh clone,
+so prefer them when the two disagree:
+
+- `.clang-tidy` - the enabled check set, which is what `make lint` decides.
+- `docs/testing.md`, section "Validation Strategy By Change Type" - the change
+  area to command mapping.
+- `src/syscall/internal.h` - the lock order comment at the top.

--- a/src/main.c
+++ b/src/main.c
@@ -219,6 +219,7 @@ static int host_dc_zva_assert(void)
 #define ELFUSE_USAGE ELFUSE_USAGE_BODY(" ")
 #define ELFUSE_USAGE_WRAPPED ELFUSE_USAGE_BODY("\n              ")
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int main(int argc, char **argv)
 {
     log_init();

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -82,6 +82,7 @@ void fork_notify_vfork_exec(void)
     fork_child_vfork_notify_fd = -1;
 }
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int fork_child_main(int ipc_fd,
                     int vfork_notify_fd,
                     bool verbose,
@@ -1478,6 +1479,7 @@ static int fork_snapshot_shm_via_clonefile(int src_fd)
     return clone_fd;
 }
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_clone(hv_vcpu_t vcpu,
                   guest_t *g,
                   uint64_t flags,

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -2244,6 +2244,7 @@ static int proc_open_mounts_node(const char *path)
     return PROC_NOT_INTERCEPTED;
 }
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int proc_intercept_open(const guest_t *g,
                         const char *path,
                         int linux_flags,

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -605,6 +605,14 @@ typedef struct {
     char resolved[LINUX_PATH_MAX];
     char display_path[LINUX_PATH_MAX];
     int fd;
+
+    /* resolved holds a materialized temporary that the caller must unlink. The
+     * flag lives beside the buffer it describes because
+     * exec_resolve_guest_host_path clears it on entry and then sets it for
+     * whichever buffer it filled: a flag belonging to some other buffer would
+     * be silently retargeted, losing one temp and unlinking the wrong path.
+     */
+    bool resolved_temp;
 } exec_interp_t;
 
 /* Resolve, open, and parse the PT_INTERP interpreter (headers only) before exec
@@ -616,16 +624,12 @@ typedef struct {
  * 3.
  *
  * On failure the fd, if any, is left in interp for the caller's fail label to
- * close.
- *
- * host_temp belongs to the caller: exec_resolve_interp_host_path sets it when
- * it materializes a temporary, and the caller's cleanup consults it.
+ * close, as is interp->resolved_temp when a temporary was materialized.
  */
 static int64_t exec_preload_interp(const guest_t *g,
                                    const elf_info_t *elf_info,
                                    bool target_is_rosetta,
-                                   exec_interp_t *interp,
-                                   bool *host_temp)
+                                   exec_interp_t *interp)
 {
     if (target_is_rosetta || elf_info->interp_path[0] == '\0')
         return 0;
@@ -633,15 +637,16 @@ static int64_t exec_preload_interp(const guest_t *g,
     bool shm = false;
 
     if (exec_resolve_interp_host_path(elf_info->interp_path, interp->resolved,
-                                      sizeof(interp->resolved), host_temp,
-                                      &shm) < 0) {
+                                      sizeof(interp->resolved),
+                                      &interp->resolved_temp, &shm) < 0) {
         log_error("execve: failed to resolve interpreter: %s",
                   elf_info->interp_path);
         return -LINUX_ENOEXEC;
     }
-    str_copy_trunc(interp->display_path,
-                   *host_temp ? elf_info->interp_path : interp->resolved,
-                   sizeof(interp->display_path));
+    str_copy_trunc(
+        interp->display_path,
+        interp->resolved_temp ? elf_info->interp_path : interp->resolved,
+        sizeof(interp->display_path));
 
     log_debug("execve: pre-validating interpreter: %s", interp->resolved);
 
@@ -1119,8 +1124,7 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     }
 
     /* Pre-load the interpreter before the point of no return. */
-    err = exec_preload_interp(g, &elf_info, target_is_rosetta, &interp,
-                              &interp_host_temp);
+    err = exec_preload_interp(g, &elf_info, target_is_rosetta, &interp);
     if (err < 0)
         goto fail;
 
@@ -1173,6 +1177,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         if (interp.fd >= 0)
             close(interp.fd);
         free(temp_str);
+        if (interp.resolved_temp)
+            unlink(interp.resolved);
         exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
                             path_host_temp, interp_host_buf, interp_host_temp);
         return err;
@@ -1321,6 +1327,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         if (interp.fd >= 0) {
             close(interp.fd);
         }
+        if (interp.resolved_temp)
+            unlink(interp.resolved);
         exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
                             path_host_temp, interp_host_buf, interp_host_temp);
         return SYSCALL_EXEC_HAPPENED;
@@ -1651,6 +1659,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         close(exec_fd);
     if (interp.fd >= 0)
         close(interp.fd);
+    if (interp.resolved_temp)
+        unlink(interp.resolved);
     exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
                         path_host_temp, interp_host_buf, interp_host_temp);
 

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -507,6 +507,189 @@ static int check_exec_permission(const struct stat *st)
     return -LINUX_EACCES;
 }
 
+/* Close the fds marked CLOEXEC, removing them from the shared table under
+ * fd_lock and cleaning up type-specific host resources after the unlock.
+ * Cleanup acquires sfd_lock or inotify_lock, which must NOT be held under
+ * fd_lock (lock ordering: fd_lock(3) < sfd_lock(5a) < inotify_lock(7)).
+ *
+ * Two passes: count first, then heap-allocate. That avoids placing a ~236 KiB
+ * VLA on the stack (FD_TABLE_SIZE * sizeof(fd_entry_t+int)).
+ *
+ * This reads nothing from the exec in progress, which is what lets it sit
+ * outside sys_execve rather than inline in its post-PNR half.
+ */
+static void exec_close_cloexec_fds(void)
+{
+    int cloexec_count = 0;
+    pthread_mutex_lock(&fd_lock);
+    for (int i = 0; i < FD_TABLE_SIZE; i++) {
+        if (fd_table[i].type != FD_CLOSED &&
+            (fd_table[i].linux_flags & LINUX_O_CLOEXEC))
+            cloexec_count++;
+    }
+
+    struct cloexec_entry {
+        int fd;
+        fd_entry_t snap;
+    };
+    struct cloexec_entry *cloexec_list = NULL;
+    if (cloexec_count > 0) {
+        cloexec_list =
+            malloc((size_t) cloexec_count * sizeof(struct cloexec_entry));
+        if (!cloexec_list) {
+            /* OOM during exec: fall back to fixed-size batches so cleanup still
+             * runs outside fd_lock.
+             *
+             * Each batch rescans from slot 0 rather than carrying a cursor
+             * across the unlocked window, and the loop ends on the first pass
+             * that finds nothing. That is deliberate: the window drops
+             * fd_lock, so a cursor that only moves forward would never
+             * re-examine a slot it had already passed. Every pass marks what
+             * it takes closed, so the candidate set shrinks and the loop
+             * terminates. The repeated scanning is bounded by the table size
+             * times the batch count and only happens once malloc has already
+             * failed, which is a trade this path can afford.
+             */
+            struct cloexec_entry batch[32];
+            for (;;) {
+                int batch_count = 0;
+                for (int scan = 0; scan < FD_TABLE_SIZE &&
+                                   batch_count < (int) (ARRAY_SIZE(batch));
+                     scan++) {
+                    if (fd_table[scan].type == FD_CLOSED ||
+                        !(fd_table[scan].linux_flags & LINUX_O_CLOEXEC))
+                        continue;
+                    batch[batch_count].fd = scan;
+                    batch[batch_count].snap = fd_table[scan];
+                    batch_count++;
+                    fd_mark_closed_unlocked(scan);
+                }
+                if (batch_count == 0)
+                    break;
+                pthread_mutex_unlock(&fd_lock);
+                for (int j = 0; j < batch_count; j++)
+                    fd_cleanup_entry(batch[j].fd, &batch[j].snap);
+                pthread_mutex_lock(&fd_lock);
+            }
+            cloexec_count = 0;
+        } else {
+            int n = 0;
+            for (int i = 0; i < FD_TABLE_SIZE; i++) {
+                if (fd_table[i].type != FD_CLOSED &&
+                    (fd_table[i].linux_flags & LINUX_O_CLOEXEC)) {
+                    cloexec_list[n].fd = i;
+                    cloexec_list[n].snap = fd_table[i];
+                    n++;
+                    fd_mark_closed_unlocked(i);
+                }
+            }
+        }
+    }
+    pthread_mutex_unlock(&fd_lock);
+
+    /* fd_cleanup_entry may close host fds, DIR*, epoll/kqueue state, or inotify
+     * state, so keep it outside fd_lock.
+     */
+    for (int j = 0; j < cloexec_count; j++)
+        fd_cleanup_entry(cloexec_list[j].fd, &cloexec_list[j].snap);
+    free(cloexec_list);
+}
+
+/* What the PT_INTERP probe produces. The values move together: the caller's
+ * failure path closes the fd, and the post-PNR mapping needs the parsed headers
+ * plus both spellings of the path, so they are one thing rather than five
+ * locals threaded down the length of sys_execve.
+ */
+typedef struct {
+    elf_info_t info;
+    char resolved[LINUX_PATH_MAX];
+    char display_path[LINUX_PATH_MAX];
+    int fd;
+} exec_interp_t;
+
+/* Resolve, open, and parse the PT_INTERP interpreter (headers only) before exec
+ * crosses the point of no return, so a bad interpreter is a recoverable ENOEXEC
+ * instead of a fatal exit. elf_map_segments_fd runs later, post-PNR.
+ *
+ * x86_64 targets do not pre-load their PT_INTERP: Rosetta is statically linked
+ * and loads the target binary, and any guest-side dynamic linker, itself via fd
+ * 3.
+ *
+ * On failure the fd, if any, is left in interp for the caller's fail label to
+ * close.
+ *
+ * host_temp belongs to the caller: exec_resolve_interp_host_path sets it when
+ * it materializes a temporary, and the caller's cleanup consults it.
+ */
+static int64_t exec_preload_interp(const guest_t *g,
+                                   const elf_info_t *elf_info,
+                                   bool target_is_rosetta,
+                                   exec_interp_t *interp,
+                                   bool *host_temp)
+{
+    if (target_is_rosetta || elf_info->interp_path[0] == '\0')
+        return 0;
+
+    bool shm = false;
+
+    if (exec_resolve_interp_host_path(elf_info->interp_path, interp->resolved,
+                                      sizeof(interp->resolved), host_temp,
+                                      &shm) < 0) {
+        log_error("execve: failed to resolve interpreter: %s",
+                  elf_info->interp_path);
+        return -LINUX_ENOEXEC;
+    }
+    str_copy_trunc(interp->display_path,
+                   *host_temp ? elf_info->interp_path : interp->resolved,
+                   sizeof(interp->display_path));
+
+    log_debug("execve: pre-validating interpreter: %s", interp->resolved);
+
+    interp->fd = exec_open_image(interp->resolved, shm);
+    if (interp->fd < 0) {
+        log_error("execve: failed to open interpreter: %s", interp->resolved);
+        return linux_errno();
+    }
+
+    struct stat interp_st;
+    if (fstat(interp->fd, &interp_st) < 0) {
+        return linux_errno();
+    }
+    chown_overlay_apply(&interp_st);
+
+    int64_t err = check_exec_permission(&interp_st);
+    if (err < 0) {
+        return err;
+    }
+
+    if (elf_load_fd(interp->fd, interp->resolved, &interp->info) < 0) {
+        log_error("execve: failed to load interpreter: %s", interp->resolved);
+        return -LINUX_ENOEXEC;
+    }
+
+    if (interp->info.e_machine != EM_AARCH64) {
+        log_error("execve: interpreter has unsupported machine type %u: %s",
+                  interp->info.e_machine, interp->resolved);
+        return -LINUX_ENOEXEC;
+    }
+
+    /* Bound the interpreter's extent here, the same way the executable's is
+     * bounded above. Without this the only thing that rejects an over-large
+     * interpreter is elf_map_segments_fd, which runs after the point of no
+     * return where the sole remaining option is exit(128). A guest able to
+     * write its own sysroot could kill elfuse on demand by patching a PT_LOAD
+     * in ld-musl; Linux returns ENOEXEC and the caller survives.
+     */
+    if (interp->info.load_max > UINT64_MAX - g->interp_base ||
+        interp->info.load_max + g->interp_base > g->guest_size) {
+        log_error("execve: interpreter extends beyond guest memory: %s",
+                  interp->resolved);
+        return -LINUX_ENOEXEC;
+    }
+    return 0;
+}
+
+/* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_execve(hv_vcpu_t vcpu,
                    guest_t *g,
                    uint64_t path_gva,
@@ -551,7 +734,9 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     size_t envp_buf_size = 0;
     size_t running_bytes = 0;
     int exec_fd = -1;
-    int interp_fd = -1;
+    exec_interp_t interp;
+    memset(&interp, 0, sizeof(interp));
+    interp.fd = -1;
 
 
     char *temp_str = malloc(131072);
@@ -933,88 +1118,11 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         goto fail;
     }
 
-    /* Pre-load interpreter (headers only) for dynamic binaries. This validates
-     * the interpreter exists and is a valid ELF before exec crosses the point
-     * of no return. elf_map_segments() happens post-PNR.
-     */
-    elf_info_t interp_info;
-    memset(&interp_info, 0, sizeof(interp_info));
-    char interp_resolved[LINUX_PATH_MAX];
-    char interp_display_path[LINUX_PATH_MAX];
-    interp_resolved[0] = '\0';
-    interp_display_path[0] = '\0';
-
-    /* x86_64 targets do not pre-load their PT_INTERP. Rosetta is statically
-     * linked and loads the target binary (and any guest-side dynamic linker)
-     * itself via fd 3, so the aarch64-only interpreter pre-load below is
-     * skipped for rosetta exec.
-     */
-    bool interp_shm = false;
-    if (!target_is_rosetta && elf_info.interp_path[0] != '\0') {
-        if (exec_resolve_interp_host_path(elf_info.interp_path, interp_resolved,
-                                          sizeof(interp_resolved),
-                                          &interp_host_temp, &interp_shm) < 0) {
-            log_error("execve: failed to resolve interpreter: %s",
-                      elf_info.interp_path);
-            err = -LINUX_ENOEXEC;
-            goto fail;
-        }
-        str_copy_trunc(
-            interp_display_path,
-            interp_host_temp ? elf_info.interp_path : interp_resolved,
-            sizeof(interp_display_path));
-
-        log_debug("execve: pre-validating interpreter: %s", interp_resolved);
-
-        interp_fd = exec_open_image(interp_resolved, interp_shm);
-        if (interp_fd < 0) {
-            log_error("execve: failed to open interpreter: %s",
-                      interp_resolved);
-            err = linux_errno();
-            goto fail;
-        }
-
-        struct stat interp_st;
-        if (fstat(interp_fd, &interp_st) < 0) {
-            err = linux_errno();
-            goto fail;
-        }
-        chown_overlay_apply(&interp_st);
-
-        err = check_exec_permission(&interp_st);
-        if (err < 0) {
-            goto fail;
-        }
-
-        if (elf_load_fd(interp_fd, interp_resolved, &interp_info) < 0) {
-            log_error("execve: failed to load interpreter: %s",
-                      interp_resolved);
-            err = -LINUX_ENOEXEC;
-            goto fail;
-        }
-
-        if (interp_info.e_machine != EM_AARCH64) {
-            log_error("execve: interpreter has unsupported machine type %u: %s",
-                      interp_info.e_machine, interp_resolved);
-            err = -LINUX_ENOEXEC;
-            goto fail;
-        }
-
-        /* Bound the interpreter's extent here, the same way the executable's is
-         * bounded above. Without this the only thing that rejects an over-large
-         * interpreter is elf_map_segments_fd, which runs after the point of no
-         * return where the sole remaining option is exit(128). A guest able to
-         * write its own sysroot could kill elfuse on demand by patching a
-         * PT_LOAD in ld-musl; Linux returns ENOEXEC and the caller survives.
-         */
-        if (interp_info.load_max > UINT64_MAX - g->interp_base ||
-            interp_info.load_max + g->interp_base > g->guest_size) {
-            log_error("execve: interpreter extends beyond guest memory: %s",
-                      interp_resolved);
-            err = -LINUX_ENOEXEC;
-            goto fail;
-        }
-    }
+    /* Pre-load the interpreter before the point of no return. */
+    err = exec_preload_interp(g, &elf_info, target_is_rosetta, &interp,
+                              &interp_host_temp);
+    if (err < 0)
+        goto fail;
 
     /* Past pre-PNR validation. Fall through to point of no return. The fail
      * label below handles all pre-PNR error paths.
@@ -1062,8 +1170,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     fail:
         if (exec_fd >= 0)
             close(exec_fd);
-        if (interp_fd >= 0)
-            close(interp_fd);
+        if (interp.fd >= 0)
+            close(interp.fd);
         free(temp_str);
         exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
                             path_host_temp, interp_host_buf, interp_host_temp);
@@ -1076,84 +1184,7 @@ int64_t sys_execve(hv_vcpu_t vcpu,
      * fatally, matching the Linux kernel's behavior (SIGKILL after exec PNR).
      */
 
-    /* Close CLOEXEC fds by first removing them from the shared table under
-     * fd_lock, then cleaning up type-specific host resources after unlock.
-     * Cleanup acquires sfd_lock or inotify_lock, which must NOT be held under
-     * fd_lock (lock ordering: fd_lock(3) < sfd_lock(5a) < inotify_lock(7)).
-     *
-     * Two passes: count first, then heap-allocate. Avoids placing a ~100KiB VLA
-     * on the stack (FD_TABLE_SIZE * sizeof(fd_entry_t+int)).
-     */
-    int cloexec_count = 0;
-    pthread_mutex_lock(&fd_lock);
-    for (int i = 0; i < FD_TABLE_SIZE; i++) {
-        if (fd_table[i].type != FD_CLOSED &&
-            (fd_table[i].linux_flags & LINUX_O_CLOEXEC))
-            cloexec_count++;
-    }
-
-    struct cloexec_entry {
-        int fd;
-        fd_entry_t snap;
-    };
-    struct cloexec_entry *cloexec_list = NULL;
-    bool fd_lock_held = true;
-    if (cloexec_count > 0) {
-        cloexec_list =
-            malloc((size_t) cloexec_count * sizeof(struct cloexec_entry));
-        if (!cloexec_list) {
-            /* OOM during exec: fall back to fixed-size batches so cleanup still
-             * runs outside fd_lock.
-             */
-            struct cloexec_entry batch[32];
-            int scan = 0;
-            while (scan < FD_TABLE_SIZE) {
-                int batch_count = 0;
-                for (; scan < FD_TABLE_SIZE &&
-                       batch_count < (int) (ARRAY_SIZE(batch));
-                     scan++) {
-                    if (fd_table[scan].type == FD_CLOSED ||
-                        !(fd_table[scan].linux_flags & LINUX_O_CLOEXEC))
-                        continue;
-                    batch[batch_count].fd = scan;
-                    batch[batch_count].snap = fd_table[scan];
-                    batch_count++;
-                    fd_table[scan].dir = NULL;
-                    fd_mark_closed_unlocked(scan);
-                }
-                pthread_mutex_unlock(&fd_lock);
-                fd_lock_held = false;
-                for (int j = 0; j < batch_count; j++)
-                    fd_cleanup_entry(batch[j].fd, &batch[j].snap);
-                if (scan < FD_TABLE_SIZE) {
-                    pthread_mutex_lock(&fd_lock);
-                    fd_lock_held = true;
-                }
-            }
-            cloexec_count = 0;
-        } else {
-            int n = 0;
-            for (int i = 0; i < FD_TABLE_SIZE; i++) {
-                if (fd_table[i].type != FD_CLOSED &&
-                    (fd_table[i].linux_flags & LINUX_O_CLOEXEC)) {
-                    cloexec_list[n].fd = i;
-                    cloexec_list[n].snap = fd_table[i];
-                    n++;
-                    fd_table[i].dir = NULL;
-                    fd_mark_closed_unlocked(i);
-                }
-            }
-        }
-    }
-    if (fd_lock_held)
-        pthread_mutex_unlock(&fd_lock);
-
-    /* fd_cleanup_entry may close host fds, DIR*, epoll/kqueue state, or inotify
-     * state, so keep it outside fd_lock.
-     */
-    for (int j = 0; j < cloexec_count; j++)
-        fd_cleanup_entry(cloexec_list[j].fd, &cloexec_list[j].snap);
-    free(cloexec_list);
+    exec_close_cloexec_fds();
 
     /* Past this point the old image is gone; later failures are fatal like a
      * kernel exec failure after its point of no return.
@@ -1287,8 +1318,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         if (exec_fd >= 0) {
             close(exec_fd);
         }
-        if (interp_fd >= 0) {
-            close(interp_fd);
+        if (interp.fd >= 0) {
+            close(interp.fd);
         }
         exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
                             path_host_temp, interp_host_buf, interp_host_temp);
@@ -1320,7 +1351,7 @@ int64_t sys_execve(hv_vcpu_t vcpu,
 
     if (elf_info.interp_path[0] != '\0') {
         interp_base = g->interp_base;
-        if (elf_map_segments_fd(&interp_info, interp_fd, interp_resolved,
+        if (elf_map_segments_fd(&interp.info, interp.fd, interp.resolved,
                                 g->host_base, g->guest_size,
                                 (elf_window_t) {0, interp_base}, infra_lo,
                                 infra_hi) < 0) {
@@ -1333,8 +1364,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         log_debug(
             "execve: interpreter at base=0x%llx, entry=0x%llx, %d segments",
             (unsigned long long) interp_base,
-            (unsigned long long) (interp_info.entry + interp_base),
-            interp_info.num_segments);
+            (unsigned long long) (interp.info.entry + interp_base),
+            interp.info.num_segments);
     }
 
     /* memcpy wrote executable bytes through D-cache; invalidate I-cache before
@@ -1347,11 +1378,11 @@ int64_t sys_execve(hv_vcpu_t vcpu,
             sys_icache_invalidate(host_addr, elf_info.segments[i].memsz);
         }
     }
-    for (int i = 0; i < interp_info.num_segments; i++) {
-        if (interp_info.segments[i].flags & PF_X) {
+    for (int i = 0; i < interp.info.num_segments; i++) {
+        if (interp.info.segments[i].flags & PF_X) {
             void *host_addr = (uint8_t *) g->host_base +
-                              interp_info.segments[i].gpa + interp_base;
-            sys_icache_invalidate(host_addr, interp_info.segments[i].memsz);
+                              interp.info.segments[i].gpa + interp_base;
+            sys_icache_invalidate(host_addr, interp.info.segments[i].memsz);
         }
     }
     sys_icache_invalidate((uint8_t *) g->host_base + g->shim_base, shim_size);
@@ -1433,14 +1464,14 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     /* Interpreter segments use the same permission translation, shifted by
      * interp_base. Same fatal-overflow rule as the executable's segments.
      */
-    for (int i = 0; i < interp_info.num_segments; i++) {
+    for (int i = 0; i < interp.info.num_segments; i++) {
         if (nregions >= MAX_REGIONS)
             goto too_many_regions;
         regions[nregions++] = (mem_region_t) {
-            .gpa_start = interp_info.segments[i].gpa + interp_base,
-            .gpa_end = interp_info.segments[i].gpa +
-                       interp_info.segments[i].memsz + interp_base,
-            .perms = elf_pf_to_prot(interp_info.segments[i].flags)};
+            .gpa_start = interp.info.segments[i].gpa + interp_base,
+            .gpa_end = interp.info.segments[i].gpa +
+                       interp.info.segments[i].memsz + interp_base,
+            .perms = elf_pf_to_prot(interp.info.segments[i].flags)};
     }
 
     /* brk region (RW). Pre-mapped up to MMAP_RX_BASE. */
@@ -1504,17 +1535,17 @@ int64_t sys_execve(hv_vcpu_t vcpu,
                          LINUX_MAP_PRIVATE, elf_info.segments[i].offset, path);
     }
 
-    /* interp_resolved was computed before guest_reset so no filesystem lookup
+    /* interp.resolved was computed before guest_reset so no filesystem lookup
      * is needed after the point of no return.
      */
-    if (interp_info.num_segments > 0) {
-        for (int i = 0; i < interp_info.num_segments; i++) {
-            guest_region_add(g, interp_info.segments[i].gpa + interp_base,
-                             interp_info.segments[i].gpa +
-                                 interp_info.segments[i].memsz + interp_base,
-                             elf_pf_to_prot(interp_info.segments[i].flags),
-                             LINUX_MAP_PRIVATE, interp_info.segments[i].offset,
-                             interp_display_path);
+    if (interp.info.num_segments > 0) {
+        for (int i = 0; i < interp.info.num_segments; i++) {
+            guest_region_add(g, interp.info.segments[i].gpa + interp_base,
+                             interp.info.segments[i].gpa +
+                                 interp.info.segments[i].memsz + interp_base,
+                             elf_pf_to_prot(interp.info.segments[i].flags),
+                             LINUX_MAP_PRIVATE, interp.info.segments[i].offset,
+                             interp.display_path);
         }
     }
 
@@ -1567,7 +1598,7 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         }
         g->start_stack = sp;
 
-        entry_point = (interp_base != 0) ? (interp_info.entry + interp_base)
+        entry_point = (interp_base != 0) ? (interp.info.entry + interp_base)
                                          : (elf_info.entry + elf_load_base);
 
         /* Publish the guest-visible path so /proc/self/exe remains stable
@@ -1618,8 +1649,8 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     free(temp_str);
     if (exec_fd >= 0)
         close(exec_fd);
-    if (interp_fd >= 0)
-        close(interp_fd);
+    if (interp.fd >= 0)
+        close(interp.fd);
     exec_cleanup_inputs(argv, envp, argv_buf, envp_buf, path_host_buf,
                         path_host_temp, interp_host_buf, interp_host_temp);
 

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -546,6 +546,77 @@ static int64_t rosetta_vz_ioctl(guest_t *g, uint64_t request, uint64_t arg)
 
 /* termios flag translation helpers. */
 
+/* Which Linux bit means which macOS bit is one fact per flag word, and both
+ * directions need it. Stating it once as a table and walking that table forward
+ * or backward is what keeps the pair consistent: the two directions used to be
+ * written out separately, so a bit added to one could silently miss the other,
+ * and nothing would have failed.
+ *
+ * A bit with no counterpart is simply absent from the table, which drops it in
+ * both directions. Where that asymmetry is deliberate the wrapper says so.
+ */
+typedef struct {
+    uint32_t linux_bit;
+    tcflag_t mac_bit;
+} termios_flag_pair_t;
+
+static tcflag_t termios_flags_to_mac(uint32_t lf,
+                                     const termios_flag_pair_t *map,
+                                     size_t count)
+{
+    tcflag_t mf = 0;
+    for (size_t i = 0; i < count; i++) {
+        if (lf & map[i].linux_bit)
+            mf |= map[i].mac_bit;
+    }
+    return mf;
+}
+
+static uint32_t termios_flags_to_linux(tcflag_t mf,
+                                       const termios_flag_pair_t *map,
+                                       size_t count)
+{
+    uint32_t lf = 0;
+    for (size_t i = 0; i < count; i++) {
+        if (mf & map[i].mac_bit)
+            lf |= map[i].linux_bit;
+    }
+    return lf;
+}
+
+/* CSIZE is a multi-bit field rather than independent bits, and its Linux CS5
+ * encoding is zero, so it cannot ride the bit tables above: a zero mask never
+ * matches. Same idea, matched on the field value.
+ */
+typedef struct {
+    uint32_t linux_value;
+    tcflag_t mac_value;
+} termios_field_pair_t;
+
+static tcflag_t termios_field_to_mac(uint32_t lf,
+                                     uint32_t linux_mask,
+                                     const termios_field_pair_t *map,
+                                     size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        if ((lf & linux_mask) == map[i].linux_value)
+            return map[i].mac_value;
+    }
+    return 0;
+}
+
+static uint32_t termios_field_to_linux(tcflag_t mf,
+                                       tcflag_t mac_mask,
+                                       const termios_field_pair_t *map,
+                                       size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        if ((mf & mac_mask) == map[i].mac_value)
+            return map[i].linux_value;
+    }
+    return 0;
+}
+
 /* Linux aarch64 c_iflag bits (from asm-generic/termbits-common.h). Low 9 bits
  * (IGNBRK..ICRNL) match macOS exactly. Bits from 0x200 onward differ: Linux
  * IUCLC=0x200 has no macOS equivalent; Linux IXON=0x400/IXOFF=0x1000 vs macOS
@@ -557,40 +628,27 @@ static int64_t rosetta_vz_ioctl(guest_t *g, uint64_t request, uint64_t arg)
 #define LINUX_IMAXBEL 0x2000 /* same value on both */
 #define LINUX_IUTF8 0x4000   /* same value on both */
 
+/* IUCLC (Linux 0x200) has no macOS equivalent and is absent on purpose. */
+static const termios_flag_pair_t iflag_map[] = {
+    {0x800, IXANY}, /* same value on both */
+    {LINUX_IXON, IXON},       {LINUX_IXOFF, IXOFF},
+    {LINUX_IMAXBEL, IMAXBEL}, {LINUX_IUTF8, IUTF8},
+};
+
 /* Translate Linux c_iflag to macOS c_iflag. */
 static tcflag_t linux_iflag_to_mac(uint32_t lf)
 {
-    tcflag_t mf = lf & LINUX_IFLAG_LOW_MASK; /* IGNBRK..ICRNL identical */
-    /* IXANY=0x800 is the same on both; pass through */
-    if (lf & 0x800)
-        mf |= IXANY;
-    if (lf & LINUX_IXON)
-        mf |= IXON; /* Linux 0x400 -> macOS 0x200 */
-    if (lf & LINUX_IXOFF)
-        mf |= IXOFF; /* Linux 0x1000 -> macOS 0x400 */
-    if (lf & LINUX_IMAXBEL)
-        mf |= IMAXBEL;
-    if (lf & LINUX_IUTF8)
-        mf |= IUTF8;
-    /* IUCLC (Linux 0x200) has no macOS equivalent; drop it */
-    return mf;
+    /* IGNBRK..ICRNL are identical, so the low bits pass through untranslated.
+     */
+    return (lf & LINUX_IFLAG_LOW_MASK) |
+           termios_flags_to_mac(lf, iflag_map, ARRAY_SIZE(iflag_map));
 }
 
 /* Translate macOS c_iflag to Linux c_iflag. */
 static uint32_t mac_iflag_to_linux(tcflag_t mf)
 {
-    uint32_t lf = mf & LINUX_IFLAG_LOW_MASK; /* IGNBRK..ICRNL identical */
-    if (mf & IXANY)
-        lf |= 0x800;
-    if (mf & IXON)
-        lf |= LINUX_IXON;
-    if (mf & IXOFF)
-        lf |= LINUX_IXOFF;
-    if (mf & IMAXBEL)
-        lf |= LINUX_IMAXBEL;
-    if (mf & IUTF8)
-        lf |= LINUX_IUTF8;
-    return lf;
+    return (uint32_t) (mf & LINUX_IFLAG_LOW_MASK) |
+           termios_flags_to_linux(mf, iflag_map, ARRAY_SIZE(iflag_map));
 }
 
 /* Linux aarch64 c_oflag bits (asm-generic/termbits-common.h + termbits.h). Only
@@ -609,48 +667,25 @@ static uint32_t mac_iflag_to_linux(tcflag_t mf)
 #define LINUX_OFDEL 0x080  /* macOS OFDEL=0x020000 */
 /* Linux NLDLY/CRDLY/TABDLY/BSDLY/VTDLY/FFDLY have no macOS equivalents */
 
+/* OLCUC (Linux 0x002) and the delay fields NLDLY, CRDLY, TABDLY, BSDLY, VTDLY,
+ * and FFDLY have no macOS equivalents and are absent on purpose.
+ */
+static const termios_flag_pair_t oflag_map[] = {
+    {LINUX_OPOST, OPOST}, {LINUX_ONLCR, ONLCR},   {LINUX_OCRNL, OCRNL},
+    {LINUX_ONOCR, ONOCR}, {LINUX_ONLRET, ONLRET}, {LINUX_OFILL, OFILL},
+    {LINUX_OFDEL, OFDEL},
+};
+
 /* Translate Linux c_oflag to macOS c_oflag. */
 static tcflag_t linux_oflag_to_mac(uint32_t lf)
 {
-    tcflag_t mf = 0;
-    if (lf & LINUX_OPOST)
-        mf |= OPOST;
-    /* LINUX_OLCUC (0x002) has no macOS equivalent; drop it */
-    if (lf & LINUX_ONLCR)
-        mf |= ONLCR;
-    if (lf & LINUX_OCRNL)
-        mf |= OCRNL;
-    if (lf & LINUX_ONOCR)
-        mf |= ONOCR;
-    if (lf & LINUX_ONLRET)
-        mf |= ONLRET;
-    if (lf & LINUX_OFILL)
-        mf |= OFILL;
-    if (lf & LINUX_OFDEL)
-        mf |= OFDEL;
-    /* NLDLY, CRDLY, TABDLY, BSDLY, VTDLY, FFDLY: no macOS equivalents */
-    return mf;
+    return termios_flags_to_mac(lf, oflag_map, ARRAY_SIZE(oflag_map));
 }
 
 /* Translate macOS c_oflag to Linux c_oflag. */
 static uint32_t mac_oflag_to_linux(tcflag_t mf)
 {
-    uint32_t lf = 0;
-    if (mf & OPOST)
-        lf |= LINUX_OPOST;
-    if (mf & ONLCR)
-        lf |= LINUX_ONLCR;
-    if (mf & OCRNL)
-        lf |= LINUX_OCRNL;
-    if (mf & ONOCR)
-        lf |= LINUX_ONOCR;
-    if (mf & ONLRET)
-        lf |= LINUX_ONLRET;
-    if (mf & OFILL)
-        lf |= LINUX_OFILL;
-    if (mf & OFDEL)
-        lf |= LINUX_OFDEL;
-    return lf;
+    return termios_flags_to_linux(mf, oflag_map, ARRAY_SIZE(oflag_map));
 }
 
 /* Linux aarch64 c_cflag bits (asm-generic/termbits.h). All standard flags
@@ -703,79 +738,37 @@ static speed_t linux_cbaud_to_speed(uint32_t cbaud)
     return 0;
 }
 
+/* CSIZE: Linux CS5=0x00, CS6=0x10, CS7=0x20, CS8=0x30
+ *        macOS CS5=0x00, CS6=0x100, CS7=0x200, CS8=0x300
+ */
+static const termios_field_pair_t csize_map[] = {
+    {LINUX_CS5, CS5},
+    {LINUX_CS6, CS6},
+    {LINUX_CS7, CS7},
+    {LINUX_CS8, CS8},
+};
+
+/* CBAUD and CBAUDEX are absent on purpose: the baud rate travels in the
+ * c_ispeed and c_ospeed fields, not in c_cflag.
+ */
+static const termios_flag_pair_t cflag_map[] = {
+    {LINUX_CSTOPB, CSTOPB}, {LINUX_CREAD, CREAD}, {LINUX_PARENB, PARENB},
+    {LINUX_PARODD, PARODD}, {LINUX_HUPCL, HUPCL}, {LINUX_CLOCAL, CLOCAL},
+};
+
 /* Translate Linux c_cflag to macOS c_cflag. */
 static tcflag_t linux_cflag_to_mac(uint32_t lf)
 {
-    tcflag_t mf = 0;
-
-    /* CSIZE: Linux CS5=0x00, CS6=0x10, CS7=0x20, CS8=0x30
-     *        macOS CS5=0x00, CS6=0x100, CS7=0x200, CS8=0x300
-     */
-    switch (lf & LINUX_CSIZE) {
-    case LINUX_CS5:
-        mf |= CS5;
-        break;
-    case LINUX_CS6:
-        mf |= CS6;
-        break;
-    case LINUX_CS7:
-        mf |= CS7;
-        break;
-    case LINUX_CS8:
-        mf |= CS8;
-        break;
-    default:
-        break;
-    }
-    if (lf & LINUX_CSTOPB)
-        mf |= CSTOPB;
-    if (lf & LINUX_CREAD)
-        mf |= CREAD;
-    if (lf & LINUX_PARENB)
-        mf |= PARENB;
-    if (lf & LINUX_PARODD)
-        mf |= PARODD;
-    if (lf & LINUX_HUPCL)
-        mf |= HUPCL;
-    if (lf & LINUX_CLOCAL)
-        mf |= CLOCAL;
-    /* CBAUD/CBAUDEX: drop (baud rate comes from c_ispeed/c_ospeed fields) */
-    return mf;
+    return termios_field_to_mac(lf, LINUX_CSIZE, csize_map,
+                                ARRAY_SIZE(csize_map)) |
+           termios_flags_to_mac(lf, cflag_map, ARRAY_SIZE(cflag_map));
 }
 
 /* Translate macOS c_cflag to Linux c_cflag. */
 static uint32_t mac_cflag_to_linux(tcflag_t mf)
 {
-    uint32_t lf = 0;
-    switch (mf & CSIZE) {
-    case CS5:
-        lf |= LINUX_CS5;
-        break;
-    case CS6:
-        lf |= LINUX_CS6;
-        break;
-    case CS7:
-        lf |= LINUX_CS7;
-        break;
-    case CS8:
-        lf |= LINUX_CS8;
-        break;
-    default:
-        break;
-    }
-    if (mf & CSTOPB)
-        lf |= LINUX_CSTOPB;
-    if (mf & CREAD)
-        lf |= LINUX_CREAD;
-    if (mf & PARENB)
-        lf |= LINUX_PARENB;
-    if (mf & PARODD)
-        lf |= LINUX_PARODD;
-    if (mf & HUPCL)
-        lf |= LINUX_HUPCL;
-    if (mf & CLOCAL)
-        lf |= LINUX_CLOCAL;
-    return lf;
+    return termios_field_to_linux(mf, CSIZE, csize_map, ARRAY_SIZE(csize_map)) |
+           termios_flags_to_linux(mf, cflag_map, ARRAY_SIZE(cflag_map));
 }
 
 /* Linux aarch64 c_lflag bits (asm-generic/termbits.h). Virtually every flag has
@@ -799,79 +792,26 @@ static uint32_t mac_cflag_to_linux(tcflag_t mf)
 #define LINUX_IEXTEN 0x08000
 #define LINUX_EXTPROC 0x10000
 
-/* Translate Linux c_lflag to macOS c_lflag. */
+/* Translate Linux c_lflag to macOS c_lflag. XCASE (Linux 0x004) has no macOS
+ * equivalent and is absent on purpose.
+ */
+static const termios_flag_pair_t lflag_map[] = {
+    {LINUX_ISIG, ISIG},       {LINUX_ICANON, ICANON}, {LINUX_ECHO, ECHO},
+    {LINUX_ECHOE, ECHOE},     {LINUX_ECHOK, ECHOK},   {LINUX_ECHONL, ECHONL},
+    {LINUX_NOFLSH, NOFLSH},   {LINUX_TOSTOP, TOSTOP}, {LINUX_ECHOCTL, ECHOCTL},
+    {LINUX_ECHOPRT, ECHOPRT}, {LINUX_ECHOKE, ECHOKE}, {LINUX_FLUSHO, FLUSHO},
+    {LINUX_PENDIN, PENDIN},   {LINUX_IEXTEN, IEXTEN}, {LINUX_EXTPROC, EXTPROC},
+};
+
 static tcflag_t linux_lflag_to_mac(uint32_t lf)
 {
-    tcflag_t mf = 0;
-    if (lf & LINUX_ISIG)
-        mf |= ISIG;
-    if (lf & LINUX_ICANON)
-        mf |= ICANON;
-    /* LINUX_XCASE (0x004) has no macOS equivalent; drop it */
-    if (lf & LINUX_ECHO)
-        mf |= ECHO;
-    if (lf & LINUX_ECHOE)
-        mf |= ECHOE;
-    if (lf & LINUX_ECHOK)
-        mf |= ECHOK;
-    if (lf & LINUX_ECHONL)
-        mf |= ECHONL;
-    if (lf & LINUX_NOFLSH)
-        mf |= NOFLSH;
-    if (lf & LINUX_TOSTOP)
-        mf |= TOSTOP;
-    if (lf & LINUX_ECHOCTL)
-        mf |= ECHOCTL;
-    if (lf & LINUX_ECHOPRT)
-        mf |= ECHOPRT;
-    if (lf & LINUX_ECHOKE)
-        mf |= ECHOKE;
-    if (lf & LINUX_FLUSHO)
-        mf |= FLUSHO;
-    if (lf & LINUX_PENDIN)
-        mf |= PENDIN;
-    if (lf & LINUX_IEXTEN)
-        mf |= IEXTEN;
-    if (lf & LINUX_EXTPROC)
-        mf |= EXTPROC;
-    return mf;
+    return termios_flags_to_mac(lf, lflag_map, ARRAY_SIZE(lflag_map));
 }
 
 /* Translate macOS c_lflag to Linux c_lflag. */
 static uint32_t mac_lflag_to_linux(tcflag_t mf)
 {
-    uint32_t lf = 0;
-    if (mf & ISIG)
-        lf |= LINUX_ISIG;
-    if (mf & ICANON)
-        lf |= LINUX_ICANON;
-    if (mf & ECHO)
-        lf |= LINUX_ECHO;
-    if (mf & ECHOE)
-        lf |= LINUX_ECHOE;
-    if (mf & ECHOK)
-        lf |= LINUX_ECHOK;
-    if (mf & ECHONL)
-        lf |= LINUX_ECHONL;
-    if (mf & NOFLSH)
-        lf |= LINUX_NOFLSH;
-    if (mf & TOSTOP)
-        lf |= LINUX_TOSTOP;
-    if (mf & ECHOCTL)
-        lf |= LINUX_ECHOCTL;
-    if (mf & ECHOPRT)
-        lf |= LINUX_ECHOPRT;
-    if (mf & ECHOKE)
-        lf |= LINUX_ECHOKE;
-    if (mf & FLUSHO)
-        lf |= LINUX_FLUSHO;
-    if (mf & PENDIN)
-        lf |= LINUX_PENDIN;
-    if (mf & IEXTEN)
-        lf |= LINUX_IEXTEN;
-    if (mf & EXTPROC)
-        lf |= LINUX_EXTPROC;
-    return lf;
+    return termios_flags_to_linux(mf, lflag_map, ARRAY_SIZE(lflag_map));
 }
 
 /* read/write and positional variants. */
@@ -2073,6 +2013,7 @@ int64_t sys_process_vm_writev(guest_t *g,
 
 /* terminal I/O. */
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
 {
     /* FIOCLEX/FIONCLEX are the ioctl form of fcntl(F_SETFD): they set/clear the

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -888,6 +888,7 @@ static bool high_va_replaceable_gpa_base(guest_t *g,
     return true;
 }
 
+/* NOLINTNEXTLINE(readability-function-size) */
 static int64_t sys_mmap_high_va(guest_t *g,
                                 uint64_t addr,
                                 uint64_t length,
@@ -1705,6 +1706,57 @@ static void dispose_region_snapshots(region_snapshot_t **snaps_ptr, int *n_ptr)
     }
     if (n_ptr)
         *n_ptr = 0;
+}
+
+/* Everything a relocating mremap owns while it is in flight: the tracker, the
+ * before-images it may have to restore, the private copy of the region array,
+ * and the two reserved removal descriptors.
+ *
+ * It exists because the relocating path has eighteen exits and each of them
+ * used to hand-release its own subset in its own order. Releasing a subset is
+ * the failure mode worth designing out: every one of these primitives is
+ * already idempotent and clears what it releases, so one call that releases all
+ * of them is correct at every exit, and a nineteenth exit cannot leak by
+ * forgetting one.
+ */
+typedef struct {
+    mremap_track_t track;
+    region_snapshot_t *source_snaps;
+    region_snapshot_t *dest_snaps;
+    int source_nsnaps;
+    int dest_nsnaps;
+    region_array_txn_t txn;
+    int source_remove_fd;
+    int dest_remove_fd;
+} mremap_move_t;
+
+static void mremap_move_init(mremap_move_t *move)
+{
+    memset(move, 0, sizeof(*move));
+    move->track.backing_fd = -1;
+    move->track.tail_backing_fd = -1;
+    move->source_remove_fd = -1;
+    move->dest_remove_fd = -1;
+}
+
+/* Release whatever the move still owns, in any state.
+ *
+ * Rolling the region array back is deliberately not here. Before the array
+ * transaction is committed a failing exit has to roll it back, and after the
+ * commit it must not, so that choice stays at the exit that knows which side of
+ * the commit it is on. This only finishes the transaction, which is safe either
+ * way.
+ */
+static void mremap_move_dispose(mremap_move_t *move)
+{
+    dispose_region_snapshots(&move->dest_snaps, &move->dest_nsnaps);
+    dispose_region_snapshots(&move->source_snaps, &move->source_nsnaps);
+    finish_region_array_txn(&move->txn);
+    mremap_track_dispose(&move->track);
+    close_keep_errno(move->source_remove_fd);
+    move->source_remove_fd = -1;
+    close_keep_errno(move->dest_remove_fd);
+    move->dest_remove_fd = -1;
 }
 
 static int capture_region_snapshots(guest_t *g,
@@ -2603,6 +2655,7 @@ int64_t sys_brk(guest_t *g, uint64_t addr)
     return (int64_t) guest_ipa(g, g->brk_current);
 }
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_mmap(guest_t *g,
                  uint64_t addr,
                  uint64_t length,
@@ -3418,6 +3471,7 @@ int64_t sys_mmap(guest_t *g,
 
 /* sys_mremap. */
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_mremap(guest_t *g,
                    uint64_t old_addr,
                    uint64_t old_size,
@@ -3575,34 +3629,34 @@ int64_t sys_mremap(guest_t *g,
          * metadata. The overlap check above prevents this case, but capturing
          * first is still the safe ordering.
          */
-        mremap_track_t track;
-        if (!mremap_track_init(&track, src_reg, old_off, source_inherited_size,
-                               new_size, source_vma_id))
+        mremap_move_t move;
+        mremap_move_init(&move);
+        if (!mremap_track_init(&move.track, src_reg, old_off,
+                               source_inherited_size, new_size,
+                               source_vma_id)) {
+            mremap_move_dispose(&move);
             return finish_mremap(&source, -LINUX_ENOMEM);
+        }
         bool source_overlay = mremap_source_has_overlay(&source);
         bool source_backing_ro = src_reg->backing_ro;
-        int added_regions = mremap_track_splits(&track, new_size) ? 2 : 1;
+        int added_regions = mremap_track_splits(&move.track, new_size) ? 2 : 1;
         if (!region_has_capacity_after_removes(g, removed, 2, added_regions)) {
-            mremap_track_dispose(&track);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
         /* Heap-allocated to avoid blowing the ~512 KiB default macOS thread
          * stack: each region_snapshot_t array is GUEST_MAX_REGIONS *
          * sizeof(region_snapshot_t), so two of them on the stack would be close
-         * to a megabyte. Freed via dispose_region_snapshots on every exit path
-         * below.
+         * to a megabyte. Released by mremap_move_dispose on every exit path
+         * below, including the successful one.
          */
-        region_snapshot_t *source_snaps = NULL;
-        region_snapshot_t *dest_snaps = NULL;
-        int source_nsnaps = 0, dest_nsnaps = 0;
 
-        source_snaps = malloc(GUEST_MAX_REGIONS * sizeof(*source_snaps));
-        dest_snaps = malloc(GUEST_MAX_REGIONS * sizeof(*dest_snaps));
-        if (!source_snaps || !dest_snaps) {
-            free(source_snaps);
-            free(dest_snaps);
-            mremap_track_dispose(&track);
+        move.source_snaps =
+            malloc(GUEST_MAX_REGIONS * sizeof(*move.source_snaps));
+        move.dest_snaps = malloc(GUEST_MAX_REGIONS * sizeof(*move.dest_snaps));
+        if (!move.source_snaps || !move.dest_snaps) {
+            mremap_move_dispose(&move);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
@@ -3611,44 +3665,35 @@ int64_t sys_mremap(guest_t *g,
          * successful source capture if destination capture or the preflight
          * shared-file flush fails afterward.
          */
-        region_array_txn_t capture_txn;
-        int capture_txn_err = begin_region_array_txn(g, &capture_txn);
+        int capture_txn_err = begin_region_array_txn(g, &move.txn);
         if (capture_txn_err < 0) {
-            free(source_snaps);
-            free(dest_snaps);
-            mremap_track_dispose(&track);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, capture_txn_err);
         }
 
-        source_nsnaps = capture_region_snapshots(
-            g, old_off, old_off + old_size, source_snaps, GUEST_MAX_REGIONS);
-        if (source_nsnaps < 0) {
-            rollback_region_array_txn(g, &capture_txn);
-            finish_region_array_txn(&capture_txn);
-            free(source_snaps);
-            free(dest_snaps);
-            mremap_track_dispose(&track);
-            return finish_mremap(&source, source_nsnaps);
+        move.source_nsnaps =
+            capture_region_snapshots(g, old_off, old_off + old_size,
+                                     move.source_snaps, GUEST_MAX_REGIONS);
+        if (move.source_nsnaps < 0) {
+            int snapshot_err = move.source_nsnaps;
+            rollback_region_array_txn(g, &move.txn);
+            mremap_move_dispose(&move);
+            return finish_mremap(&source, snapshot_err);
         }
-        int rebind_err =
-            rebind_mremap_source_backings(&source, source_snaps, source_nsnaps);
+        int rebind_err = rebind_mremap_source_backings(
+            &source, move.source_snaps, move.source_nsnaps);
         if (rebind_err < 0) {
-            rollback_region_array_txn(g, &capture_txn);
-            finish_region_array_txn(&capture_txn);
-            dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            free(dest_snaps);
-            mremap_track_dispose(&track);
+            rollback_region_array_txn(g, &move.txn);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, rebind_err);
         }
-        dest_nsnaps = capture_region_snapshots(g, new_off, new_off + new_size,
-                                               dest_snaps, GUEST_MAX_REGIONS);
-        if (dest_nsnaps < 0) {
-            rollback_region_array_txn(g, &capture_txn);
-            finish_region_array_txn(&capture_txn);
-            dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            free(dest_snaps);
-            mremap_track_dispose(&track);
-            return finish_mremap(&source, dest_nsnaps);
+        move.dest_nsnaps = capture_region_snapshots(
+            g, new_off, new_off + new_size, move.dest_snaps, GUEST_MAX_REGIONS);
+        if (move.dest_nsnaps < 0) {
+            int snapshot_err = move.dest_nsnaps;
+            rollback_region_array_txn(g, &move.txn);
+            mremap_move_dispose(&move);
+            return finish_mremap(&source, snapshot_err);
         }
 
         /* Reserve the backing descriptors needed by both removals before any
@@ -3657,52 +3702,30 @@ int64_t sys_mremap(guest_t *g,
          * final metadata shape while the outer transaction can still roll it
          * back if either reservation fails.
          */
-        int source_remove_fd = -1;
-        int dest_remove_fd = -1;
         if (guest_region_remove_prepare(g, old_off, old_off + old_size,
-                                        &source_remove_fd) < 0 ||
+                                        &move.source_remove_fd) < 0 ||
             guest_region_remove_prepare(g, new_off, new_off + new_size,
-                                        &dest_remove_fd) < 0) {
-            if (source_remove_fd >= 0)
-                close(source_remove_fd);
-            if (dest_remove_fd >= 0)
-                close(dest_remove_fd);
-            rollback_region_array_txn(g, &capture_txn);
-            finish_region_array_txn(&capture_txn);
-            dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-            dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            mremap_track_dispose(&track);
+                                        &move.dest_remove_fd) < 0) {
+            rollback_region_array_txn(g, &move.txn);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
         int64_t flush_err = flush_mremap_source_shared(g, &source);
         if (flush_err < 0) {
-            rollback_region_array_txn(g, &capture_txn);
-            finish_region_array_txn(&capture_txn);
-            dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-            dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            mremap_track_dispose(&track);
-            if (source_remove_fd >= 0)
-                close(source_remove_fd);
-            if (dest_remove_fd >= 0)
-                close(dest_remove_fd);
+            rollback_region_array_txn(g, &move.txn);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, flush_err);
         }
-        finish_region_array_txn(&capture_txn);
+        finish_region_array_txn(&move.txn);
 
         if (source_overlay) {
             int cleanup_err =
                 cleanup_overlays_in_range(g, old_off, old_off + old_size);
             if (cleanup_err < 0) {
-                (void) restore_snapshot_overlays_in_place(g, source_snaps,
-                                                          source_nsnaps);
-                dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-                dispose_region_snapshots(&source_snaps, &source_nsnaps);
-                mremap_track_dispose(&track);
-                if (source_remove_fd >= 0)
-                    close(source_remove_fd);
-                if (dest_remove_fd >= 0)
-                    close(dest_remove_fd);
+                (void) restore_snapshot_overlays_in_place(g, move.source_snaps,
+                                                          move.source_nsnaps);
+                mremap_move_dispose(&move);
                 return finish_mremap(&source, cleanup_err);
             }
         }
@@ -3711,51 +3734,27 @@ int64_t sys_mremap(guest_t *g,
             cleanup_overlays_in_range(g, new_off, new_off + new_size);
         if (cleanup_err < 0) {
             int restore_err = restore_snapshot_overlays_in_place(
-                g, source_snaps, source_nsnaps);
+                g, move.source_snaps, move.source_nsnaps);
             if (restore_err < 0) {
-                dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-                dispose_region_snapshots(&source_snaps, &source_nsnaps);
-                mremap_track_dispose(&track);
-                if (source_remove_fd >= 0)
-                    close(source_remove_fd);
-                if (dest_remove_fd >= 0)
-                    close(dest_remove_fd);
+                mremap_move_dispose(&move);
                 return finish_mremap(&source, restore_err);
             }
-            (void) restore_snapshot_overlays_in_place(g, dest_snaps,
-                                                      dest_nsnaps);
-            dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-            dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            mremap_track_dispose(&track);
-            if (source_remove_fd >= 0)
-                close(source_remove_fd);
-            if (dest_remove_fd >= 0)
-                close(dest_remove_fd);
+            (void) restore_snapshot_overlays_in_place(g, move.dest_snaps,
+                                                      move.dest_nsnaps);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, cleanup_err);
         }
 
-        if (mremap_extend_range(g, new_off, new_size, track.prot) < 0) {
+        if (mremap_extend_range(g, new_off, new_size, move.track.prot) < 0) {
             int restore_err = restore_snapshot_overlays_in_place(
-                g, source_snaps, source_nsnaps);
+                g, move.source_snaps, move.source_nsnaps);
             if (restore_err < 0) {
-                dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-                dispose_region_snapshots(&source_snaps, &source_nsnaps);
-                mremap_track_dispose(&track);
-                if (source_remove_fd >= 0)
-                    close(source_remove_fd);
-                if (dest_remove_fd >= 0)
-                    close(dest_remove_fd);
+                mremap_move_dispose(&move);
                 return finish_mremap(&source, restore_err);
             }
-            (void) restore_snapshot_overlays_in_place(g, dest_snaps,
-                                                      dest_nsnaps);
-            dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-            dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            mremap_track_dispose(&track);
-            if (source_remove_fd >= 0)
-                close(source_remove_fd);
-            if (dest_remove_fd >= 0)
-                close(dest_remove_fd);
+            (void) restore_snapshot_overlays_in_place(g, move.dest_snaps,
+                                                      move.dest_nsnaps);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
@@ -3763,8 +3762,8 @@ int64_t sys_mremap(guest_t *g,
          * preparation is complete.
          */
         guest_region_remove_reserved(g, new_off, new_off + new_size,
-                                     dest_remove_fd);
-        dest_remove_fd = -1;
+                                     move.dest_remove_fd);
+        move.dest_remove_fd = -1;
 
         /* Copy each logical source segment according to its own backing state.
          * The destination receives a private snapshot at mremap time (no
@@ -3772,7 +3771,7 @@ int64_t sys_mremap(guest_t *g,
          * subsequent writes consistent.
          */
         uint64_t copy_len = old_size < new_size ? old_size : new_size;
-        if (track.prot == LINUX_PROT_NONE) {
+        if (move.track.prot == LINUX_PROT_NONE) {
             memset((uint8_t *) g->host_base + new_off, 0, new_size);
         } else {
             if (source_overlay)
@@ -3781,11 +3780,11 @@ int64_t sys_mremap(guest_t *g,
                 copy_mremap_source(g, new_off, old_off, copy_len, &source);
             if (copy_err < 0) {
                 int restore_err = restore_snapshot_overlays_in_place(
-                    g, source_snaps, source_nsnaps);
+                    g, move.source_snaps, move.source_nsnaps);
                 if (restore_err < 0)
                     copy_err = restore_err;
-                restore_err =
-                    restore_region_snapshots(g, dest_snaps, dest_nsnaps);
+                restore_err = restore_region_snapshots(g, move.dest_snaps,
+                                                       move.dest_nsnaps);
 
                 /* Re-establish the destination's page-table state to match the
                  * regions we just restored. mremap_extend_range above had
@@ -3795,16 +3794,15 @@ int64_t sys_mremap(guest_t *g,
                  * restore) says nothing is mapped.
                  */
                 int pt_err = restore_snapshot_page_tables(
-                    g, new_off, new_off + new_size, dest_snaps, dest_nsnaps);
+                    g, new_off, new_off + new_size, move.dest_snaps,
+                    move.dest_nsnaps);
                 if (pt_err < 0 && restore_err >= 0)
                     restore_err = pt_err;
-                mremap_track_dispose(&track);
-                if (source_remove_fd >= 0)
-                    close(source_remove_fd);
-                dispose_region_snapshots(&source_snaps, &source_nsnaps);
-                dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
-                if (restore_err < 0)
+                if (restore_err < 0) {
+                    mremap_move_dispose(&move);
                     return finish_mremap(&source, restore_err);
+                }
+                mremap_move_dispose(&move);
                 return finish_mremap(&source, copy_err);
             }
         }
@@ -3818,8 +3816,8 @@ int64_t sys_mremap(guest_t *g,
             memset(host_ptr_for_gpa(g, src_gpa_base + (old_off - src_start)), 0,
                    old_size);
             guest_region_remove_reserved(g, old_off, old_off + old_size,
-                                         source_remove_fd);
-            source_remove_fd = -1;
+                                         move.source_remove_fd);
+            move.source_remove_fd = -1;
             guest_invalidate_ptes(g, old_off, old_off + old_size);
             if (old_off < g->mmap_rw_gap_hint)
                 g->mmap_rw_gap_hint = old_off;
@@ -3827,16 +3825,16 @@ int64_t sys_mremap(guest_t *g,
                 g->mmap_rx_gap_hint = old_off;
         }
 
-        if (add_mremap_region(g, new_off, old_size, new_size, &track) < 0) {
-            (void) restore_region_snapshots(g, dest_snaps, dest_nsnaps);
-            dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
+        if (add_mremap_region(g, new_off, old_size, new_size, &move.track) <
+            0) {
+            (void) restore_region_snapshots(g, move.dest_snaps,
+                                            move.dest_nsnaps);
+            mremap_move_dispose(&move);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
         if (source_backing_ro)
             mark_region_backing_ro(g, new_off, new_off + new_size);
-        dispose_region_snapshots(&source_snaps, &source_nsnaps);
-        dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
+        mremap_move_dispose(&move);
         return finish_mremap(&source, (int64_t) guest_ipa(g, new_off));
     }
 
@@ -3890,7 +3888,6 @@ int64_t sys_mremap(guest_t *g,
                     mremap_track_dispose(&track);
                     return finish_mremap(&source, -LINUX_ENOMEM);
                 }
-
                 if (mremap_extend_range(g, grow_off, grow_len, track.prot) <
                     0) {
                     mremap_track_dispose(&track);

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -402,22 +402,105 @@ invalid:
     return -LINUX_EFAULT;
 }
 
+/* The source VMA metadata mremap carries into the new mapping, plus the
+ * duplicated backing descriptors the move owns until a region accepts them. A
+ * range split at the inherited/private boundary becomes two regions and so
+ * needs a second descriptor.
+ *
+ * The three mremap paths (grow in place, move, fixed move) each built this by
+ * hand and each repeated the same two-descriptor release on every failure exit.
+ * Keeping the descriptors here is what lets mremap_track_dispose be the single
+ * place that releases them, so a new failure exit cannot leak one by forgetting
+ * half of the pair.
+ */
+typedef struct {
+    int prot;
+    int flags;
+    uint64_t offset;
+    uint64_t inherited_size;
+    uint64_t vma_id;
+    int backing_fd;
+    int tail_backing_fd;
+    char name[sizeof(((guest_region_t *) 0)->name)];
+} mremap_track_t;
+
+/* Release whatever descriptors the tracker still owns. Idempotent, so a failure
+ * exit may call it after ownership has already moved to a region.
+ */
+static void mremap_track_dispose(mremap_track_t *track)
+{
+    close_keep_errno(track->backing_fd);
+    close_keep_errno(track->tail_backing_fd);
+    track->backing_fd = -1;
+    track->tail_backing_fd = -1;
+}
+
+/* Whether the range splits at the inherited/private boundary, which is what
+ * makes it two regions holding two descriptors rather than one of each.
+ */
+static bool mremap_track_splits(const mremap_track_t *track, uint64_t new_size)
+{
+    return track->inherited_size > 0 && track->inherited_size < new_size;
+}
+
+/* Snapshot src_reg and duplicate the descriptors the new mapping will own.
+ * Returns false with every descriptor already released, so the caller only has
+ * to report ENOMEM.
+ *
+ * inherited_size is normalized here rather than at the point of use: the
+ * source's inherited prefix only accumulates across regions that carry
+ * inherited_at_fork, so a zero prefix and a not-inherited source are the same
+ * fact and the tracker records it once.
+ */
+static bool mremap_track_init(mremap_track_t *track,
+                              const guest_region_t *src_reg,
+                              uint64_t old_off,
+                              uint64_t inherited_size,
+                              uint64_t new_size,
+                              uint64_t vma_id)
+{
+    memset(track, 0, sizeof(*track));
+    track->prot = src_reg->prot;
+    track->flags = src_reg->flags;
+    track->offset = src_reg->offset + (old_off - src_reg->start);
+    track->inherited_size = src_reg->inherited_at_fork ? inherited_size : 0;
+    track->vma_id = vma_id;
+    track->tail_backing_fd = -1;
+    track->backing_fd = dup_region_backing_fd(src_reg);
+    if (src_reg->backing_fd >= 0 && track->backing_fd < 0)
+        return false;
+    str_copy_trunc(track->name, src_reg->name, sizeof(track->name));
+
+    if (mremap_track_splits(track, new_size) && track->backing_fd >= 0) {
+        track->tail_backing_fd = dup(track->backing_fd);
+        if (track->tail_backing_fd < 0) {
+            mremap_track_dispose(track);
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Takes ownership of both tracker descriptors on entry, so every exit below,
+ * including the failures, has already accounted for them.
+ */
 static int add_mremap_region(guest_t *g,
                              uint64_t start,
                              uint64_t old_size,
                              uint64_t new_size,
-                             int prot,
-                             int flags,
-                             uint64_t offset,
-                             const char *name,
-                             int backing_fd,
-                             bool inherited_at_fork,
-                             uint64_t inherited_size,
-                             int tail_backing_fd,
-                             uint64_t vma_id)
+                             mremap_track_t *track)
 {
-    if (!inherited_at_fork)
-        inherited_size = 0;
+    int prot = track->prot;
+    int flags = track->flags;
+    uint64_t offset = track->offset;
+    uint64_t vma_id = track->vma_id;
+    uint64_t inherited_size = track->inherited_size;
+    const char *name = track->name[0] ? track->name : NULL;
+    int backing_fd = track->backing_fd;
+    int tail_backing_fd = track->tail_backing_fd;
+    track->backing_fd = -1;
+    track->tail_backing_fd = -1;
+
     if (inherited_size > old_size)
         inherited_size = old_size;
     if (inherited_size > new_size)
@@ -3492,39 +3575,17 @@ int64_t sys_mremap(guest_t *g,
          * metadata. The overlap check above prevents this case, but capturing
          * first is still the safe ordering.
          */
-        const guest_region_t *old_reg = src_reg;
-        int prot =
-            old_reg ? old_reg->prot : (LINUX_PROT_READ | LINUX_PROT_WRITE);
-        int track_flags = old_reg ? old_reg->flags
-                                  : (LINUX_MAP_PRIVATE | LINUX_MAP_ANONYMOUS);
-        uint64_t track_offset =
-            old_reg ? old_reg->offset + (old_off - old_reg->start) : 0;
-        int track_backing_fd = dup_region_backing_fd(old_reg);
-        if (old_reg && old_reg->backing_fd >= 0 && track_backing_fd < 0)
+        mremap_track_t track;
+        if (!mremap_track_init(&track, src_reg, old_off, source_inherited_size,
+                               new_size, source_vma_id))
             return finish_mremap(&source, -LINUX_ENOMEM);
-        int tail_backing_fd = -1;
-        if (source_inherited_size > 0 && source_inherited_size < new_size &&
-            track_backing_fd >= 0) {
-            tail_backing_fd = dup(track_backing_fd);
-            if (tail_backing_fd < 0) {
-                close(track_backing_fd);
-                return finish_mremap(&source, -LINUX_ENOMEM);
-            }
-        }
         bool source_overlay = mremap_source_has_overlay(&source);
-        bool source_backing_ro = old_reg && old_reg->backing_ro;
-        bool source_inherited_at_fork = old_reg && old_reg->inherited_at_fork;
-        int added_regions =
-            source_inherited_size > 0 && source_inherited_size < new_size ? 2
-                                                                          : 1;
+        bool source_backing_ro = src_reg->backing_ro;
+        int added_regions = mremap_track_splits(&track, new_size) ? 2 : 1;
         if (!region_has_capacity_after_removes(g, removed, 2, added_regions)) {
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
-        char track_name[sizeof(old_reg->name)] = {0};
 
         /* Heap-allocated to avoid blowing the ~512 KiB default macOS thread
          * stack: each region_snapshot_t array is GUEST_MAX_REGIONS *
@@ -3535,18 +3596,13 @@ int64_t sys_mremap(guest_t *g,
         region_snapshot_t *source_snaps = NULL;
         region_snapshot_t *dest_snaps = NULL;
         int source_nsnaps = 0, dest_nsnaps = 0;
-        if (old_reg)
-            str_copy_trunc(track_name, old_reg->name, sizeof(track_name));
 
         source_snaps = malloc(GUEST_MAX_REGIONS * sizeof(*source_snaps));
         dest_snaps = malloc(GUEST_MAX_REGIONS * sizeof(*dest_snaps));
         if (!source_snaps || !dest_snaps) {
             free(source_snaps);
             free(dest_snaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
@@ -3560,10 +3616,7 @@ int64_t sys_mremap(guest_t *g,
         if (capture_txn_err < 0) {
             free(source_snaps);
             free(dest_snaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, capture_txn_err);
         }
 
@@ -3574,10 +3627,7 @@ int64_t sys_mremap(guest_t *g,
             finish_region_array_txn(&capture_txn);
             free(source_snaps);
             free(dest_snaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, source_nsnaps);
         }
         int rebind_err =
@@ -3587,10 +3637,7 @@ int64_t sys_mremap(guest_t *g,
             finish_region_array_txn(&capture_txn);
             dispose_region_snapshots(&source_snaps, &source_nsnaps);
             free(dest_snaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, rebind_err);
         }
         dest_nsnaps = capture_region_snapshots(g, new_off, new_off + new_size,
@@ -3600,10 +3647,7 @@ int64_t sys_mremap(guest_t *g,
             finish_region_array_txn(&capture_txn);
             dispose_region_snapshots(&source_snaps, &source_nsnaps);
             free(dest_snaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, dest_nsnaps);
         }
 
@@ -3627,10 +3671,7 @@ int64_t sys_mremap(guest_t *g,
             finish_region_array_txn(&capture_txn);
             dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
             dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
@@ -3640,10 +3681,7 @@ int64_t sys_mremap(guest_t *g,
             finish_region_array_txn(&capture_txn);
             dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
             dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             if (source_remove_fd >= 0)
                 close(source_remove_fd);
             if (dest_remove_fd >= 0)
@@ -3660,10 +3698,7 @@ int64_t sys_mremap(guest_t *g,
                                                           source_nsnaps);
                 dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
                 dispose_region_snapshots(&source_snaps, &source_nsnaps);
-                if (track_backing_fd >= 0)
-                    close(track_backing_fd);
-                if (tail_backing_fd >= 0)
-                    close(tail_backing_fd);
+                mremap_track_dispose(&track);
                 if (source_remove_fd >= 0)
                     close(source_remove_fd);
                 if (dest_remove_fd >= 0)
@@ -3680,10 +3715,7 @@ int64_t sys_mremap(guest_t *g,
             if (restore_err < 0) {
                 dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
                 dispose_region_snapshots(&source_snaps, &source_nsnaps);
-                if (track_backing_fd >= 0)
-                    close(track_backing_fd);
-                if (tail_backing_fd >= 0)
-                    close(tail_backing_fd);
+                mremap_track_dispose(&track);
                 if (source_remove_fd >= 0)
                     close(source_remove_fd);
                 if (dest_remove_fd >= 0)
@@ -3694,10 +3726,7 @@ int64_t sys_mremap(guest_t *g,
                                                       dest_nsnaps);
             dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
             dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             if (source_remove_fd >= 0)
                 close(source_remove_fd);
             if (dest_remove_fd >= 0)
@@ -3705,16 +3734,13 @@ int64_t sys_mremap(guest_t *g,
             return finish_mremap(&source, cleanup_err);
         }
 
-        if (mremap_extend_range(g, new_off, new_size, prot) < 0) {
+        if (mremap_extend_range(g, new_off, new_size, track.prot) < 0) {
             int restore_err = restore_snapshot_overlays_in_place(
                 g, source_snaps, source_nsnaps);
             if (restore_err < 0) {
                 dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
                 dispose_region_snapshots(&source_snaps, &source_nsnaps);
-                if (track_backing_fd >= 0)
-                    close(track_backing_fd);
-                if (tail_backing_fd >= 0)
-                    close(tail_backing_fd);
+                mremap_track_dispose(&track);
                 if (source_remove_fd >= 0)
                     close(source_remove_fd);
                 if (dest_remove_fd >= 0)
@@ -3725,10 +3751,7 @@ int64_t sys_mremap(guest_t *g,
                                                       dest_nsnaps);
             dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
             dispose_region_snapshots(&source_snaps, &source_nsnaps);
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             if (source_remove_fd >= 0)
                 close(source_remove_fd);
             if (dest_remove_fd >= 0)
@@ -3749,7 +3772,7 @@ int64_t sys_mremap(guest_t *g,
          * subsequent writes consistent.
          */
         uint64_t copy_len = old_size < new_size ? old_size : new_size;
-        if (prot == LINUX_PROT_NONE) {
+        if (track.prot == LINUX_PROT_NONE) {
             memset((uint8_t *) g->host_base + new_off, 0, new_size);
         } else {
             if (source_overlay)
@@ -3775,10 +3798,7 @@ int64_t sys_mremap(guest_t *g,
                     g, new_off, new_off + new_size, dest_snaps, dest_nsnaps);
                 if (pt_err < 0 && restore_err >= 0)
                     restore_err = pt_err;
-                if (track_backing_fd >= 0)
-                    close(track_backing_fd);
-                if (tail_backing_fd >= 0)
-                    close(tail_backing_fd);
+                mremap_track_dispose(&track);
                 if (source_remove_fd >= 0)
                     close(source_remove_fd);
                 dispose_region_snapshots(&source_snaps, &source_nsnaps);
@@ -3807,11 +3827,7 @@ int64_t sys_mremap(guest_t *g,
                 g->mmap_rx_gap_hint = old_off;
         }
 
-        if (add_mremap_region(g, new_off, old_size, new_size, prot, track_flags,
-                              track_offset, track_name[0] ? track_name : NULL,
-                              track_backing_fd, source_inherited_at_fork,
-                              source_inherited_size, tail_backing_fd,
-                              source_vma_id) < 0) {
+        if (add_mremap_region(g, new_off, old_size, new_size, &track) < 0) {
             (void) restore_region_snapshots(g, dest_snaps, dest_nsnaps);
             dispose_region_snapshots(&source_snaps, &source_nsnaps);
             dispose_region_snapshots(&dest_snaps, &dest_nsnaps);
@@ -3855,64 +3871,29 @@ int64_t sys_mremap(guest_t *g,
             if (can_grow) {
                 remove_range_t removed = {old_off, old_off + old_size};
                 /* Extend in place */
-                const guest_region_t *old_reg = src_reg;
-                int prot = old_reg ? old_reg->prot
-                                   : (LINUX_PROT_READ | LINUX_PROT_WRITE);
-                int track_flags =
-                    old_reg ? old_reg->flags
-                            : (LINUX_MAP_PRIVATE | LINUX_MAP_ANONYMOUS);
-                uint64_t track_offset =
-                    old_reg ? old_reg->offset + (old_off - old_reg->start) : 0;
-                int track_backing_fd = dup_region_backing_fd(old_reg);
-                int tail_backing_fd = -1;
-                if (source_inherited_size > 0 &&
-                    source_inherited_size < new_size && track_backing_fd >= 0) {
-                    tail_backing_fd = dup(track_backing_fd);
-                    if (tail_backing_fd < 0) {
-                        close(track_backing_fd);
-                        return finish_mremap(&source, -LINUX_ENOMEM);
-                    }
-                }
-                bool old_backing_ro = old_reg && old_reg->backing_ro;
-                bool old_inherited_at_fork =
-                    old_reg && old_reg->inherited_at_fork;
-                int added_regions = source_inherited_size > 0 &&
-                                            source_inherited_size < new_size
-                                        ? 2
-                                        : 1;
+                mremap_track_t track;
+                if (!mremap_track_init(&track, src_reg, old_off,
+                                       source_inherited_size, new_size,
+                                       source_vma_id))
+                    return finish_mremap(&source, -LINUX_ENOMEM);
+                bool old_backing_ro = src_reg->backing_ro;
+                int added_regions =
+                    mremap_track_splits(&track, new_size) ? 2 : 1;
                 if (!region_has_capacity_after_removes(g, &removed, 1,
                                                        added_regions)) {
-                    if (track_backing_fd >= 0)
-                        close(track_backing_fd);
-                    if (tail_backing_fd >= 0)
-                        close(tail_backing_fd);
-                    return finish_mremap(&source, -LINUX_ENOMEM);
-                }
-                if (old_reg && old_reg->backing_fd >= 0 &&
-                    track_backing_fd < 0) {
-                    if (tail_backing_fd >= 0)
-                        close(tail_backing_fd);
+                    mremap_track_dispose(&track);
                     return finish_mremap(&source, -LINUX_ENOMEM);
                 }
                 int source_remove_fd = -1;
                 if (guest_region_remove_prepare(g, old_off, old_off + old_size,
                                                 &source_remove_fd) < 0) {
-                    if (track_backing_fd >= 0)
-                        close(track_backing_fd);
-                    if (tail_backing_fd >= 0)
-                        close(tail_backing_fd);
+                    mremap_track_dispose(&track);
                     return finish_mremap(&source, -LINUX_ENOMEM);
                 }
-                char track_name[sizeof(old_reg->name)] = {0};
-                if (old_reg)
-                    str_copy_trunc(track_name, old_reg->name,
-                                   sizeof(track_name));
 
-                if (mremap_extend_range(g, grow_off, grow_len, prot) < 0) {
-                    if (track_backing_fd >= 0)
-                        close(track_backing_fd);
-                    if (tail_backing_fd >= 0)
-                        close(tail_backing_fd);
+                if (mremap_extend_range(g, grow_off, grow_len, track.prot) <
+                    0) {
+                    mremap_track_dispose(&track);
                     if (source_remove_fd >= 0)
                         close(source_remove_fd);
                     return finish_mremap(&source, -LINUX_ENOMEM);
@@ -3923,12 +3904,8 @@ int64_t sys_mremap(guest_t *g,
                 /* Update region tracking: remove old, add extended */
                 guest_region_remove_reserved(g, old_off, old_off + old_size,
                                              source_remove_fd);
-                if (add_mremap_region(g, old_off, old_size, new_size, prot,
-                                      track_flags, track_offset,
-                                      track_name[0] ? track_name : NULL,
-                                      track_backing_fd, old_inherited_at_fork,
-                                      source_inherited_size, tail_backing_fd,
-                                      source_vma_id) < 0)
+                if (add_mremap_region(g, old_off, old_size, new_size, &track) <
+                    0)
                     return finish_mremap(&source, -LINUX_ENOMEM);
                 mark_mremap_source_overlay_metadata(g, &source);
                 if (old_backing_ro)
@@ -3953,32 +3930,13 @@ int64_t sys_mremap(guest_t *g,
             return finish_mremap(&source, -LINUX_ENOMEM);
 
         /* Allocate a new region and move */
-        const guest_region_t *old_reg = src_reg;
-        int prot =
-            old_reg ? old_reg->prot : (LINUX_PROT_READ | LINUX_PROT_WRITE);
-        int track_flags = old_reg ? old_reg->flags
-                                  : (LINUX_MAP_PRIVATE | LINUX_MAP_ANONYMOUS);
-        uint64_t track_offset =
-            old_reg ? old_reg->offset + (old_off - old_reg->start) : 0;
-        int track_backing_fd = dup_region_backing_fd(old_reg);
-        if (old_reg && old_reg->backing_fd >= 0 && track_backing_fd < 0)
+        mremap_track_t track;
+        if (!mremap_track_init(&track, src_reg, old_off, source_inherited_size,
+                               new_size, source_vma_id))
             return finish_mremap(&source, -LINUX_ENOMEM);
-        int tail_backing_fd = -1;
-        if (source_inherited_size > 0 && source_inherited_size < new_size &&
-            track_backing_fd >= 0) {
-            tail_backing_fd = dup(track_backing_fd);
-            if (tail_backing_fd < 0) {
-                close(track_backing_fd);
-                return finish_mremap(&source, -LINUX_ENOMEM);
-            }
-        }
         bool source_overlay = mremap_source_has_overlay(&source);
-        bool source_backing_ro = old_reg && old_reg->backing_ro;
-        bool source_inherited_at_fork = old_reg && old_reg->inherited_at_fork;
-        char track_name[sizeof(old_reg->name)] = {0};
-        if (old_reg)
-            str_copy_trunc(track_name, old_reg->name, sizeof(track_name));
-        int needs_exec = (prot & LINUX_PROT_EXEC) != 0;
+        bool source_backing_ro = src_reg->backing_ro;
+        int needs_exec = (track.prot & LINUX_PROT_EXEC) != 0;
 
         uint64_t new_off;
 
@@ -3987,7 +3945,7 @@ int64_t sys_mremap(guest_t *g,
          * not narrow segment-table growth. Stay at host-page alignment.
          */
         size_t mremap_align = host_page_size_cached();
-        if (needs_exec && !(prot & LINUX_PROT_WRITE))
+        if (needs_exec && !(track.prot & LINUX_PROT_WRITE))
             new_off = find_free_gap(g, new_size, MMAP_RX_BASE, g->mmap_limit,
                                     mremap_align);
         else
@@ -3995,41 +3953,27 @@ int64_t sys_mremap(guest_t *g,
                                     mremap_align);
 
         if (new_off == UINT64_MAX) {
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
         remove_range_t removed = {old_off, old_off + old_size};
-        int added_regions =
-            source_inherited_size > 0 && source_inherited_size < new_size ? 2
-                                                                          : 1;
+        int added_regions = mremap_track_splits(&track, new_size) ? 2 : 1;
         if (!region_has_capacity_after_removes(g, &removed, 1, added_regions)) {
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
         int64_t flush_err = flush_mremap_source_shared(g, &source);
         if (flush_err < 0) {
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, flush_err);
         }
 
         int source_remove_fd = -1;
         if (guest_region_remove_prepare(g, old_off, old_off + old_size,
                                         &source_remove_fd) < 0) {
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             return finish_mremap(&source, -LINUX_ENOMEM);
         }
 
@@ -4039,10 +3983,7 @@ int64_t sys_mremap(guest_t *g,
             if (cleanup_err < 0) {
                 int restore_err =
                     restore_mremap_source_overlays_in_place(g, &source);
-                if (track_backing_fd >= 0)
-                    close(track_backing_fd);
-                if (tail_backing_fd >= 0)
-                    close(tail_backing_fd);
+                mremap_track_dispose(&track);
                 if (source_remove_fd >= 0)
                     close(source_remove_fd);
                 if (restore_err < 0)
@@ -4051,24 +3992,18 @@ int64_t sys_mremap(guest_t *g,
             }
         }
 
-        if (mremap_extend_range(g, new_off, new_size, prot) < 0) {
+        if (mremap_extend_range(g, new_off, new_size, track.prot) < 0) {
             if (source_overlay) {
                 int restore_err =
                     restore_mremap_source_overlays_in_place(g, &source);
                 if (restore_err < 0) {
-                    if (track_backing_fd >= 0)
-                        close(track_backing_fd);
-                    if (tail_backing_fd >= 0)
-                        close(tail_backing_fd);
+                    mremap_track_dispose(&track);
                     if (source_remove_fd >= 0)
                         close(source_remove_fd);
                     return finish_mremap(&source, restore_err);
                 }
             }
-            if (track_backing_fd >= 0)
-                close(track_backing_fd);
-            if (tail_backing_fd >= 0)
-                close(tail_backing_fd);
+            mremap_track_dispose(&track);
             if (source_remove_fd >= 0)
                 close(source_remove_fd);
             return finish_mremap(&source, -LINUX_ENOMEM);
@@ -4078,7 +4013,7 @@ int64_t sys_mremap(guest_t *g,
          * zero the extension. The new range is a fresh gap and receives no live
          * overlay.
          */
-        if (prot == LINUX_PROT_NONE) {
+        if (track.prot == LINUX_PROT_NONE) {
             memset((uint8_t *) g->host_base + new_off, 0, new_size);
         } else {
             if (source_overlay)
@@ -4094,10 +4029,7 @@ int64_t sys_mremap(guest_t *g,
                  */
                 (void) restore_mremap_source_overlays_in_place(g, &source);
                 guest_invalidate_ptes(g, new_off, new_off + new_size);
-                if (track_backing_fd >= 0)
-                    close(track_backing_fd);
-                if (tail_backing_fd >= 0)
-                    close(tail_backing_fd);
+                mremap_track_dispose(&track);
                 if (source_remove_fd >= 0)
                     close(source_remove_fd);
                 return finish_mremap(&source, copy_err);
@@ -4120,11 +4052,7 @@ int64_t sys_mremap(guest_t *g,
             g->mmap_rx_gap_hint = old_off;
 
         /* Track new region */
-        if (add_mremap_region(g, new_off, old_size, new_size, prot, track_flags,
-                              track_offset, track_name[0] ? track_name : NULL,
-                              track_backing_fd, source_inherited_at_fork,
-                              source_inherited_size, tail_backing_fd,
-                              source_vma_id) < 0)
+        if (add_mremap_region(g, new_off, old_size, new_size, &track) < 0)
             return finish_mremap(&source, -LINUX_ENOMEM);
         if (source_backing_ro)
             mark_region_backing_ro(g, new_off, new_off + new_size);

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -411,6 +411,7 @@ int64_t sys_sendmsg(guest_t *g, int fd, uint64_t msg_gva, int linux_flags)
     return ret;
 }
 
+/* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
 {
     if (fd_get_type(fd) == FD_NETLINK)

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -3574,6 +3574,7 @@ static bool vcpu_handle_bad_exception(guest_t *g,
  * Both modes check proc_exit_group_requested so the main thread also reacts to
  * exit_group called by a worker.
  */
+/* NOLINTNEXTLINE(readability-function-size) */
 int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,
                              hv_vcpu_exit_t *vexit,
                              guest_t *g,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Consolidates exec, termios, and mremap behind shared helpers, adds a logged function-size ceiling, and clarifies how we judge structure. Behavior change: PT_INTERP now records the guest path in maps (was a temp path) and cleans up its own temp; other paths are unchanged.

- Lint: `.clang-tidy` enables `readability-function-size` at 400 lines and stays advisory; adds `/* NOLINTNEXTLINE(readability-function-size) */` to existing oversized functions.
- Exec: extracts `exec_close_cloexec_fds` (two-pass; OOM fallback rescans from slot 0 after dropping `fd_lock`) and `exec_preload_interp`; introduces `exec_interp_t` so the interpreter buffer/flag move together; bounds interpreter extent pre-PNR; x86_64 via Rosetta skips preloading.
- Termios: replaces hand-written conversions with table-driven helpers in both directions; `CSIZE` uses a value table. Intentional omissions: IUCLC, OLCUC, delay fields, CBAUD, XCASE.
- Mremap: introduces `mremap_track_t` and `mremap_move_t`; `add_mremap_region` now takes the tracker so one owner disposes snapshots, reserved remove fds, and duplicated backings; rollback/commit points unchanged; behavior unchanged with lower leak risk.
- Docs: adds `elfuse-refactor` skill on maintainable structure and change sequencing; updates `elfuse-conventions` to scope evaluation-only tools (not build deps) vs tracked-fetch test fixtures; names `make distclean` as the target that removes fixtures.

<sup>Written for commit 8bfd76641c2e103b4da5e2ad04513df474ac42d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

