### PR TITLE
Restart syscalls interrupted only by an execve handoff to the thread-group leader

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -226,6 +226,10 @@ jobs:
           make -j4 $rules
 
       - name: Upload prover log
+        # The proof result is the step above; this only carries the log that
+        # explains a failure. The artifact service timing out has failed a lane
+        # whose proofs all passed, so a transport error here is not a verdict.
+        continue-on-error: true
         if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -284,6 +288,10 @@ jobs:
           done
 
       - name: Upload prover log
+        # The proof result is the step above; this only carries the log that
+        # explains a failure. The artifact service timing out has failed a lane
+        # whose proofs all passed, so a transport error here is not a verdict.
+        continue-on-error: true
         if: always()
         uses: actions/upload-artifact@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,11 @@ $(BUILD_DIR)/test-threaded-exec: tests/test-threaded-exec.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
 
+# test-exec-handoff parks the leader while a worker hands it a failing execve.
+$(BUILD_DIR)/test-exec-handoff: tests/test-exec-handoff.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
+
 # test-cntvct-thread verifies cloned vCPUs inherit EL0 timer access.
 $(BUILD_DIR)/test-cntvct-thread: tests/test-cntvct-thread.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -18,6 +18,78 @@ $(BUILD_DIR):
 # Automatic header dependency generation (-MMD -MP)
 DEPFLAGS = -MMD -MP -MF $(BUILD_DIR)/$(subst /,_,$*).d
 
+# Build flavor guard.
+#
+# Objects compiled with -fsanitize=... cannot be linked into a binary built
+# without it, and the failure surfaces as a wall of undefined
+# ___asan_version_mismatch symbols that names neither cause nor cure. The
+# sanitizer targets clean before they build, but nothing cleans after them, so
+# the next ordinary "make elfuse" walks into it. Record the flavor and wipe the
+# tree when it changes: the rebuild was unavoidable either way, since every
+# object is instrumented differently, so this costs nothing beyond making the
+# reason legible.
+#
+# Evaluated while the makefile is read rather than as a target, because the
+# sanitizer lanes reach $(ELFUSE_BIN) through their own prerequisites and never
+# run a phony guard hung off the elfuse target. Getting that wrong is worse than
+# no guard: the stamp stays stale, the link succeeds, and an instrumented binary
+# is handed back to a caller who asked for a plain one.
+BUILD_FLAVOR := $(strip $(CFLAGS))
+BUILD_FLAVOR_STAMP := $(BUILD_DIR)/.build-flavor
+
+# Goals that build nothing, so nothing needs the tree in a known flavor. A
+# goal-less invocation is one of them: .DEFAULT_GOAL is help, while
+# MAKECMDGOALS stays empty, so filtering the skip list out of the goals and
+# testing what remains covers both that and a mixed "make help elfuse".
+BUILD_FLAVOR_GOALS := $(filter-out clean distclean help,$(MAKECMDGOALS))
+
+ifneq ($(BUILD_FLAVOR_GOALS),)
+BUILD_FLAVOR_PREV := $(shell cat $(BUILD_FLAVOR_STAMP) 2>/dev/null)
+
+# What matters is whether objects exist that this build cannot use, so the two
+# ways that happens are separated. A stamp that disagrees is one. No stamp at
+# all beside objects is the other, since a tree written before this guard
+# existed records nothing and its objects carry unknown flags. An empty tree
+# with no stamp is neither, and treating it as a mismatch is what deleted
+# scan-build's report directory on every fresh checkout.
+BUILD_FLAVOR_OBJS := $(wildcard $(BUILD_DIR)/*.o $(BUILD_DIR)/*/*.o)
+
+ifneq ($(BUILD_FLAVOR_OBJS),)
+ifeq ($(BUILD_FLAVOR_PREV),)
+$(info   FLAVOR  build/ holds objects with no record of their CFLAGS, so they)
+$(info           are being removed)
+BUILD_FLAVOR_STALE := 1
+else ifneq ($(BUILD_FLAVOR),$(BUILD_FLAVOR_PREV))
+$(info   FLAVOR  build/ holds objects compiled with different CFLAGS, so they)
+$(info           are being removed. Was: [$(BUILD_FLAVOR_PREV)])
+$(info           Now: [$(BUILD_FLAVOR)])
+BUILD_FLAVOR_STALE := 1
+endif
+endif
+
+ifdef BUILD_FLAVOR_STALE
+# Only the objects and their dependency files, not the directory. Other tools
+# put their own output under build/ and are entitled to keep it: scan-build
+# creates its report directory and then invokes make, so removing the tree here
+# deletes the directory it is writing into and the analyzer dies on the next
+# translation unit.
+#
+# What survived is the question, not how find reported it. Both of find's
+# answers are to a different one: -delete descends into that same report
+# directory, so an unreadable entry there exits non-zero with every removal
+# having succeeded, and a removal that failed silently is invisible to stderr.
+# Stopping is the point. Carrying on writes a stamp claiming a flavor the
+# leftover objects do not have.
+BUILD_FLAVOR_RM := $(shell find $(BUILD_DIR) \( -name '*.o' -o -name '*.d' \) -delete 2>/dev/null; \
+    find $(BUILD_DIR) \( -name '*.o' -o -name '*.d' \) 2>/dev/null | head -3)
+ifneq ($(BUILD_FLAVOR_RM),)
+$(error FLAVOR: stale objects under $(BUILD_DIR) survived removal: $(BUILD_FLAVOR_RM))
+endif
+endif
+
+$(shell mkdir -p $(BUILD_DIR) && printf '%s' '$(BUILD_FLAVOR)' > $(BUILD_FLAVOR_STAMP))
+endif
+
 # Pattern rules -- source to object.
 # GENERATED_HEADERS are order-only prerequisites so clean builds have the
 # build-generated includes available before compilation. .d files track the

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -7,7 +7,7 @@
 # src/elfuse-limits.h.
 ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-nofile)
 
-.PHONY: test-hello test-all check check-syscall-coverage check-skill-refs test-gdbstub test-coreutils test-busybox \
+.PHONY: test-hello test-all check check-syscall-coverage check-eintr-contract check-skill-refs test-gdbstub test-coreutils test-busybox \
         test-static-bins \
         test-dynamic test-dynamic-coreutils test-glibc-dynamic \
         test-glibc-coreutils test-perf \
@@ -67,6 +67,10 @@ test-mremap-tail-emfile: $(ELFUSE_BIN) $(BUILD_DIR)/test-mremap-tail-emfile
 ## Verify dispatch.tbl coverage of the kernel-supported syscall set
 check-syscall-coverage:
 	@python3 scripts/check-syscall-coverage.py
+
+## Verify every path that can report EINTR states whether it may be restarted
+check-eintr-contract:
+	@python3 scripts/check-eintr-contract.py
 
 ## Verify every path, target, and section the skills name still resolves
 check-skill-refs:
@@ -206,7 +210,7 @@ check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) $(CHECK_HOST_UNIT_BINS)
 	$(CHECK_SHARED_LANES)
 
 ## Run the unit test suite plus busybox applet validation
-check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-skill-refs test-config \
+check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-eintr-contract check-skill-refs test-config \
 		$(CHECK_HOST_UNIT_BINS)
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
 	$(CHECK_SHARED_LANES)

--- a/scripts/check-eintr-contract.py
+++ b/scripts/check-eintr-contract.py
@@ -1,0 +1,276 @@
+"""Fail when a syscall path can hand the guest EINTR without saying whether the
+dispatcher may restart it.
+
+The dispatcher restarts an interrupted SVC when the only thing that broke the
+wait was an execve handed to the thread group leader (see syscall_restart_arm
+in src/syscall/proc.h). Restarting re-executes the syscall with the guest's
+original arguments, which is right for a wait that consumed nothing and wrong
+for one that did: a relative timeout starts again from zero, and a request
+already on the wire is sent twice. Both failure modes were shipped and then
+found by review rather than by a test, twice, which is why this is a gate
+rather than a convention.
+
+Nothing in C makes that decision visible. A new interruptible wait is
+restartable by default simply because the epilogue arms on any EINTR, so the
+author of the next one has to know a rule that is not written down anywhere the
+compiler can see. This script writes it down: every function that can hand the
+guest EINTR is classified here, and the classification is checked against the
+source rather than trusted.
+
+Three classifications:
+
+  forbids     The function calls syscall_restart_forbid(). Verified against the
+              body, so the claim cannot go stale while the call is deleted.
+  restartable Re-executing the syscall is harmless: the wait reports EINTR
+              before transferring anything, consuming a deadline, or leaving
+              host state behind. Needs a reason.
+  not-a-wait  The EINTR does not come from a blocking wait at all (a teardown
+              refusal, or handoff bookkeeping). Needs a reason.
+
+Adding an interruptible wait therefore fails the build until its restart
+behaviour is stated. Deleting one fails it too, so the inventory cannot rot
+into a list of functions that no longer exist.
+
+The unit is the function that decides, not the syscall that returns. A handler
+forwarding a wait helper's result carries no EINTR expression of its own and is
+not listed; the helper it called is, because that is where the wait happens and
+where the decision belongs. Moving the annotation to syscall entry points would
+name hundreds of forwarders and put the classification a long way from the code
+it describes.
+
+What this does not do is check every branch. It asks whether a function makes
+a restart decision, not whether each of its EINTR exits makes the right one, so
+a function with several exits that loses the call on one of them still passes.
+Catching that needs the reasoning a reviewer does; this only guarantees that
+the reasoning happened once and is written down.
+"""
+
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+
+# Sites that hand EINTR to the guest, keyed by "path::function".
+#
+# Keyed by function rather than by line so ordinary edits above a site do not
+# churn this table. The value is (classification, reason).
+INVENTORY = {
+    # Waits that consumed a guest-supplied deadline, or sent something.
+    "syscall/time.c::interruptible_sleep_ns": (
+        "forbids",
+        "Relative sleeps have spent part of the interval; TIMER_ABSTIME "
+        "re-derives the same instant and stays restartable.",
+    ),
+    "syscall/poll.c::sys_ppoll": (
+        "forbids",
+        "A finite poll has spent part of the guest's timeout.",
+    ),
+    "syscall/poll.c::sys_pselect6": (
+        "forbids",
+        "A finite select has spent part of the guest's timeout.",
+    ),
+    "syscall/poll.c::sys_epoll_pwait": (
+        "forbids",
+        "A finite epoll wait has spent part of the guest's timeout, and ready "
+        "events outrank leader work because kqueue consumes the edge.",
+    ),
+    "runtime/futex.c::futex_os_sync_wait": (
+        "forbids",
+        "The address-wait path plain FUTEX_WAIT takes; its deadline is " "relative.",
+    ),
+    "runtime/futex.c::futex_wait": (
+        "forbids",
+        "Relative FUTEX_WAIT has spent part of its timeout; FUTEX_WAIT_BITSET "
+        "is absolute and stays restartable.",
+    ),
+    "syscall/signal.c::signal_rt_sigtimedwait": (
+        "forbids",
+        "The timeout is spent in 1 ms chunks before this reports EINTR.",
+    ),
+    "syscall/fuse.c::fuse_request_locked": (
+        "forbids",
+        "FUSE_INTERRUPT is on the wire and the request is detached, so a "
+        "restart would re-issue the operation under a fresh unique.",
+    ),
+    # Waits that report EINTR before doing anything the guest can observe.
+    "syscall/io.c::io_retry_backoff": (
+        "restartable",
+        "Polled retry helper; reports before the operation it guards runs.",
+    ),
+    "syscall/io.c::io_wait_fd_or_interrupted": (
+        "restartable",
+        "Reports readiness or EINTR before any transfer; the caller has not "
+        "touched the fd yet.",
+    ),
+    "syscall/fs.c::open_nonblocking_writer": (
+        "restartable",
+        "FIFO open retry; nothing is opened until it succeeds.",
+    ),
+    "syscall/inotify.c::inotify_read": (
+        "restartable",
+        "Reached only when kevent returned no event, so nothing is consumed.",
+    ),
+    "syscall/fuse.c::fuse_dev_read": (
+        "restartable",
+        "The queue is empty by the loop condition; no request is dequeued.",
+    ),
+    "syscall/proc.c::sys_wait4": (
+        "restartable",
+        "Every reapable outcome returns earlier; no child is removed and no "
+        "status or rusage is written.",
+    ),
+    "syscall/proc.c::sys_waitid": (
+        "restartable",
+        "Same shape as sys_wait4: the reap and WNOHANG answers precede this.",
+    ),
+    "runtime/futex.c::futex_lock_pi": (
+        "restartable",
+        "The deadline is absolute and futex_unlock_pi zeroes the word rather "
+        "than transferring ownership, so a restart re-CASes.",
+    ),
+    "runtime/futex.c::sys_futex_waitv": (
+        "restartable",
+        "The deadline is converted to an absolute instant at entry, so a "
+        "restart re-derives the same one.",
+    ),
+    # Not blocking waits.
+    "syscall/signal.c::signal_rt_sigsuspend": (
+        "not-a-wait",
+        "Returns the EINTR sigsuspend is defined to return; the mask is "
+        "restored on the way out.",
+    ),
+    "syscall/exec.c::exec_handoff_to_leader": (
+        "not-a-wait",
+        "Handoff bookkeeping: the requester is being reaped, or the slot never "
+        "reported back.",
+    ),
+    "syscall/mem.c::hvf_apply_file_overlay": (
+        "not-a-wait",
+        "Refuses the overlay because an execve is reaping this thread.",
+    ),
+    "syscall/mem.c::hvf_remove_file_overlay": (
+        "not-a-wait",
+        "Refuses the unmap window because an execve is reaping this thread.",
+    ),
+    "syscall/mem.c::sys_mmap_high_va": (
+        "not-a-wait",
+        "Refuses the overlay because an execve is reaping this thread.",
+    ),
+    "runtime/forkipc.c::sys_clone": (
+        "not-a-wait",
+        "Refuses the fork because an execve is reaping this thread.",
+    ),
+    "syscall/syscall.c::syscall_dispatch": (
+        "not-a-wait",
+        "Tests a handler's EINTR result to decide the restart; produces none "
+        "of its own.",
+    ),
+}
+
+# Anything on these lines is the mechanism itself, not a site that reports to a
+# guest.
+SELF = {"syscall/syscall.c::syscall_restart_forbid"}
+
+EINTR_RE = re.compile(r"(return\s+-LINUX_EINTR|=\s*-LINUX_EINTR|errno\s*=\s*EINTR)\b")
+FUNC_START_RE = re.compile(r"^(\w[\w \t\*]*?)\b(\w+)\s*\([^;]*$")
+
+
+def functions(path):
+    """Yield (name, first_line, last_line) for each top-level function."""
+    lines = path.read_text(errors="ignore").split("\n")
+    name = None
+    pending = None
+    depth = 0
+    start = None
+    for i, line in enumerate(lines, 1):
+        if start is None:
+            m = FUNC_START_RE.match(line)
+            if m and not line.lstrip().startswith(
+                ("if", "for", "while", "switch", "return", "#", "}")
+            ):
+                pending = m.group(2)
+            if line.startswith("{") and pending:
+                name, start, depth = pending, i, 1
+                continue
+            if line.rstrip().endswith("{") and pending and not line.startswith(" "):
+                name, start, depth = pending, i, line.count("{") - line.count("}")
+                continue
+        else:
+            depth += line.count("{") - line.count("}")
+            if depth <= 0:
+                yield name, start, i
+                name, start, pending = None, None, None
+
+
+def scan():
+    """Return {key: has_forbid} for every function that can report EINTR."""
+    found = {}
+    for path in sorted(SRC.rglob("*.c")):
+        rel = path.relative_to(SRC).as_posix()
+        text = path.read_text(errors="ignore").split("\n")
+        for name, first, last in functions(path):
+            body = "\n".join(text[first - 1 : last])
+            if not EINTR_RE.search(body):
+                continue
+            key = f"{rel}::{name}"
+            found[key] = "syscall_restart_forbid()" in body
+    return found
+
+
+def main():
+    found = scan()
+    for key in SELF:
+        found.pop(key, None)
+
+    problems = []
+
+    for key, has_forbid in sorted(found.items()):
+        entry = INVENTORY.get(key)
+        if entry is None:
+            problems.append(
+                f"unclassified: {key} can report EINTR to the guest.\n"
+                f"    Decide whether the dispatcher may restart it and add it to\n"
+                f"    INVENTORY in {pathlib.Path(__file__).name}. A wait that has\n"
+                f"    consumed a relative timeout, transferred data, or sent a\n"
+                f"    request must call syscall_restart_forbid() and be recorded\n"
+                f"    as 'forbids'."
+            )
+            continue
+        kind, reason = entry
+        if kind == "forbids" and not has_forbid:
+            problems.append(
+                f"stale claim: {key} is recorded as 'forbids' but its body has\n"
+                f"    no syscall_restart_forbid() call."
+            )
+        if kind != "forbids" and has_forbid:
+            problems.append(
+                f"stale claim: {key} calls syscall_restart_forbid() but is\n"
+                f"    recorded as '{kind}'."
+            )
+        if not reason.strip():
+            problems.append(f"missing reason: {key}")
+
+    for key in sorted(set(INVENTORY) - set(found)):
+        problems.append(
+            f"stale entry: {key} is in INVENTORY but no longer reports EINTR.\n"
+            f"    Remove it."
+        )
+
+    if problems:
+        print("EINTR restart contract check failed:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}\n", file=sys.stderr)
+        return 1
+
+    forbids = sum(1 for k in INVENTORY if INVENTORY[k][0] == "forbids")
+    print(
+        f"  {len(found)} function(s) can report EINTR; all classified "
+        f"({forbids} forbid the SVC restart)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/runtime/futex.c
+++ b/src/runtime/futex.c
@@ -585,8 +585,15 @@ static int64_t futex_os_sync_wait(guest_t *g,
             efault_retries = 0;
         }
 
-        if (thread_stop_requested() || futex_interrupt_consume())
+        if (thread_stop_requested() || futex_interrupt_consume()) {
+            /* This path's deadline is relative (futex_make_deadline above is
+             * called with is_absolute = 0), so part of it is already spent and
+             * a restart would re-derive it from the guest's original value.
+             */
+            if (has_timeout)
+                syscall_restart_forbid();
             return -LINUX_EINTR;
+        }
 
         /* Drain any expired guest itimer so its SIGALRM / SIGVTALRM / SIGPROF
          * queues into sig_state.pending; without this poke, a guest with all
@@ -601,8 +608,11 @@ static int64_t futex_os_sync_wait(guest_t *g,
          * hint cannot produce a stale-true edge after rt_sigprocmask masked the
          * queued signal.
          */
-        if (signal_pending())
+        if (signal_pending()) {
+            if (has_timeout)
+                syscall_restart_forbid();
             return -LINUX_EINTR;
+        }
 
         /* For has_timeout: futex_remaining_ns returns 0 next iteration once the
          * user deadline elapses, so the loop exits with -ETIMEDOUT.
@@ -842,6 +852,15 @@ static int64_t futex_wait(guest_t *g,
 
     if (__atomic_load_n(&waiter.woken, __ATOMIC_ACQUIRE))
         return 0;
+
+    /* Plain FUTEX_WAIT counts its timeout from the call, so part of it is spent
+     * by the time any of the exits above reports EINTR, and an SVC restart
+     * would re-derive the deadline from the guest's original relative value.
+     * FUTEX_WAIT_BITSET is absolute and re-derives the same instant, so it
+     * stays restartable. See syscall_restart_forbid.
+     */
+    if (ret == -LINUX_EINTR && has_timeout && !is_absolute)
+        syscall_restart_forbid();
     return ret;
 }
 

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -1086,6 +1086,18 @@ bool thread_current_is_leader(void)
     return current_thread == &thread_table[0];
 }
 
+/* Milliseconds on CLOCK_MONOTONIC since @since. Only the de_thread wait needs
+ * it, which measures how long its siblings took rather than when they left.
+ */
+static int64_t thread_elapsed_ms(const struct timespec *since)
+{
+    struct timespec now;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return (int64_t) (now.tv_sec - since->tv_sec) * 1000 +
+           (now.tv_nsec - since->tv_nsec) / 1000000;
+}
+
 int thread_exec_de_thread(void)
 {
     if (!current_thread || thread_count_joinable_siblings() == 0)
@@ -1132,10 +1144,34 @@ int thread_exec_de_thread(void)
      * poll() after another one drained sits out its own 200 ms recheck no
      * matter how many bytes the wake wrote. Re-poke while they wind down, which
      * costs a threaded execve milliseconds instead of a poll quantum per parked
-     * sibling (measured: 38 s to 2.5 s over 200 threaded execs). The join below
-     * still bounds the wait if a sibling never arrives.
+     * sibling (measured: 38 s to 2.5 s over 200 threaded execs).
+     *
+     * How long to wait for is measured in departures, not in iterations. A
+     * fixed count has to be chosen against the slowest re-check quantum a
+     * parked sibling owes (200 ms, in the io wait) multiplied by how far behind
+     * schedule the host is running, and that multiplier is not a property this
+     * code can know: CI runs four sanitizer lanes on one machine, where a
+     * count wide enough is dead time on every threaded execve elsewhere.
+     * Waiting while siblings are still leaving separates a slow host from
+     * siblings nothing wakes, which is what the stall interval and the ceiling
+     * below are for.
+     *
+     * Both are wall-clock, because the sleep is a floor: an oversubscribed host
+     * stretches each iteration well past its 1 ms, so a bound counted in
+     * iterations would run for minutes and blow the caller's timeout instead of
+     * reaching the diagnosed exit.
      */
-    for (int i = 0; i < 200 && thread_count_joinable_siblings() > 0; i++) {
+    enum {
+        DE_THREAD_STALL_MS = 1000,   /* no departures before giving up */
+        DE_THREAD_CEILING_MS = 10000 /* total, however well it is going */
+    };
+    struct timespec started;
+    clock_gettime(CLOCK_MONOTONIC, &started);
+
+    int remaining = thread_count_joinable_siblings();
+    int64_t elapsed_ms = 0, progress_ms = 0;
+
+    while (remaining > 0) {
         /* The whole wake set, not just the pipe: a sibling in a tight compute
          * loop is reachable only by hv_vcpus_exit, and one kick that lands
          * between two hv_vcpu_run calls is lost. Re-issuing costs nothing here
@@ -1143,12 +1179,30 @@ int thread_exec_de_thread(void)
          */
         thread_wake_all_blocked();
         usleep(1000);
+
+        int now = thread_count_joinable_siblings();
+        elapsed_ms = thread_elapsed_ms(&started);
+        if (now < remaining) {
+            remaining = now;
+            progress_ms = elapsed_ms;
+        }
+        if (elapsed_ms >= DE_THREAD_CEILING_MS ||
+            elapsed_ms - progress_ms >= DE_THREAD_STALL_MS)
+            break;
     }
 
     /* Name who is still here before the bounded join runs, so a teardown that
      * ends fatally says which thread held it up rather than only how many did.
+     * The timings go with it: a report that spent its whole budget with
+     * siblings leaving throughout is a slow host, and one whose last departure
+     * is the start of the wait is a sibling no wake reaches, which are
+     * different bugs.
      */
-    if (thread_count_joinable_siblings() > 0) {
+    if (remaining > 0) {
+        log_warn(
+            "execve: %d sibling(s) still in the guest after %lld ms, last "
+            "departure at %lld ms",
+            remaining, (long long) elapsed_ms, (long long) progress_ms);
         pthread_mutex_lock(&thread_lock);
         THREAD_FOR_EACH_ACTIVE (t) {
             if (thread_is_joinable_sibling(t))

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -226,6 +226,7 @@ rescan:
         memset(t, 0, sizeof(*t));
         t->generation = next_generation;
         t->sp_el1_slot = -1; /* No SP_EL1 yet; thread_alloc_sp_el1 fills this */
+        t->in_syscall = -1;  /* Not in one; syscall_dispatch fills this */
         t->guest_tid = tid;
         if (stack_start < stack_end) {
             t->stack_map_start = stack_start;
@@ -1044,6 +1045,12 @@ static int thread_stop_requested_for_leader_work(void)
     return thread_leader_work_pending() && thread_current_is_leader();
 }
 
+void thread_note_syscall(int nr)
+{
+    if (current_thread)
+        __atomic_store_n(&current_thread->in_syscall, nr, __ATOMIC_RELAXED);
+}
+
 int thread_stop_requested(void)
 {
     return thread_exec_stop_requested() || proc_exit_group_requested() ||
@@ -1205,9 +1212,19 @@ int thread_exec_de_thread(void)
             remaining, (long long) elapsed_ms, (long long) progress_ms);
         pthread_mutex_lock(&thread_lock);
         THREAD_FOR_EACH_ACTIVE (t) {
-            if (thread_is_joinable_sibling(t))
-                log_warn("execve: tid=%lld has not left the guest yet",
-                         (long long) t->guest_tid);
+            if (!thread_is_joinable_sibling(t))
+                continue;
+            int32_t nr = __atomic_load_n(&t->in_syscall, __ATOMIC_RELAXED);
+            if (nr < 0)
+                log_warn(
+                    "execve: tid=%lld has not left the guest yet, "
+                    "running guest code",
+                    (long long) t->guest_tid);
+            else
+                log_warn(
+                    "execve: tid=%lld has not left the guest yet, "
+                    "in syscall %d",
+                    (long long) t->guest_tid, nr);
         }
         pthread_mutex_unlock(&thread_lock);
     }

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -480,7 +480,16 @@ void thread_for_each(void (*fn)(thread_entry_t *t, void *ctx), void *ctx)
     pthread_mutex_unlock(&thread_lock);
 }
 
-void thread_join_workers(void)
+/* exec_mode is de_thread's contract rather than teardown's: the process
+ * continues afterwards, so a straggler must not be detached (the handle stays
+ * claimable for the real teardown) and a vm-clone slot must not be waited on at
+ * all. execve leaves a CLONE_VM child on the old mm and de_thread excludes it
+ * from the survivor count, but an exited-but-unreaped one keeps active == 1 for
+ * wait4, so the poll below would spend the whole cap on a thread that already
+ * left. The other legitimate budget consumer, a sibling parked in the fork
+ * barrier, is drained before the teardown is armed; see thread_exec_de_thread.
+ */
+static void thread_join_workers_mode(bool exec_mode)
 {
     /* Snapshot worker threads under the lock. The code needs the host_thread
      * handle and a way to check the active flag without re-locking. Storing the
@@ -517,6 +526,9 @@ void thread_join_workers(void)
          * after guest_destroy unmaps it.
          */
         if (t == &thread_table[0])
+            continue;
+
+        if (exec_mode && t->is_vm_clone)
             continue;
 
         /* Inactive slots are included when they still hold an unjoined handle:
@@ -591,6 +603,27 @@ void thread_join_workers(void)
         if (workers[w].recycled ||
             !__atomic_load_n(&workers[w].t->active, __ATOMIC_ACQUIRE)) {
             pthread_join(workers[w].thr, NULL);
+        } else if (exec_mode) {
+            /* Hand the claim back instead of detaching. The caller answers a
+             * straggler with a diagnosed exit, and until it does the handle
+             * belongs to a process that is still running: detaching it here
+             * would let a later teardown pass, or thread_alloc recycling the
+             * slot, reason about a pthread nobody may touch any more.
+             *
+             * A generation bump seen only now (the poll loop broke before the
+             * recycle) means the slot belongs to a different logical thread and
+             * the claim would be handed to the wrong handle. thread_alloc only
+             * recycles an inactive slot, so the previous occupant has already
+             * exited and this join returns at once.
+             */
+            pthread_mutex_lock(&thread_lock);
+            bool same_thread =
+                workers[w].t->generation == workers[w].generation;
+            if (same_thread)
+                workers[w].t->host_thread_needs_join = true;
+            pthread_mutex_unlock(&thread_lock);
+            if (!same_thread)
+                pthread_join(workers[w].thr, NULL);
         } else {
             pthread_detach(workers[w].thr);
             pthread_mutex_lock(&thread_lock);
@@ -598,6 +631,11 @@ void thread_join_workers(void)
             pthread_mutex_unlock(&thread_lock);
         }
     }
+}
+
+void thread_join_workers(void)
+{
+    thread_join_workers_mode(false);
 }
 
 bool thread_destroy_all_vcpus(hv_vcpu_t main_vcpu,
@@ -881,19 +919,31 @@ int thread_fork_barrier_check(void)
     return 1;
 }
 
-void thread_wake_all_blocked(void)
+void thread_wake_leader_for_work(void)
 {
-    /* hv_vcpus_exit only reaches threads inside hv_vcpu_run, so the futex
-     * interrupt covers futex waiters, the wakeup pipe covers poll/epoll/read
-     * parks, and thread_wake_exit_waiters covers the internal condvars (fork
-     * barrier, ptrace stop/wait). Every teardown caller needs all four; what
-     * differs between them is only why they are tearing down.
+    /* hv_vcpus_exit only reaches threads inside hv_vcpu_run, so the wakeup pipe
+     * covers poll/epoll/read parks and thread_wake_exit_waiters covers the
+     * internal condvars (fork barrier, ptrace stop/wait). Each is answered by
+     * the woken thread re-checking its own predicate, so aiming them at the
+     * whole table to reach one thread costs nothing.
+     *
+     * Leaving futex_interrupt_request out (the header says why) loses nothing:
+     * the futex waits re-check thread_stop_requested on a 100 ms quantum, and
+     * that is what sends the leader to run the execve.
      */
-    futex_interrupt_request();
     wakeup_pipe_signal();
     thread_interrupt_all();
     thread_wake_exit_waiters();
     exec_handoff_wake_waiters();
+}
+
+void thread_wake_all_blocked(void)
+{
+    /* Teardown: every thread really is leaving, so the futex interrupt on top
+     * of the wakes above is an EINTR each of them has to see.
+     */
+    futex_interrupt_request();
+    thread_wake_leader_for_work();
 }
 
 void thread_wake_exit_waiters(void)
@@ -983,11 +1033,8 @@ int thread_exec_stop_requested(void)
            !current_thread->is_vm_clone;
 }
 
-int thread_stop_requested(void)
+static int thread_stop_requested_for_leader_work(void)
 {
-    if (thread_exec_stop_requested() || proc_exit_group_requested())
-        return 1;
-
     /* A non-leader execve is handed to the leader, which can only pick it up
      * from its run loop. Break it out of whatever it is parked in so the
      * handoff does not wait on an unrelated blocking syscall. Every other
@@ -995,6 +1042,18 @@ int thread_stop_requested(void)
      * a third thread has no part in it.
      */
     return thread_leader_work_pending() && thread_current_is_leader();
+}
+
+int thread_stop_requested(void)
+{
+    return thread_exec_stop_requested() || proc_exit_group_requested() ||
+           thread_stop_requested_for_leader_work();
+}
+
+int thread_stop_is_leader_work_only(void)
+{
+    return thread_stop_requested_for_leader_work() &&
+           !proc_exit_group_requested() && !thread_exec_stop_requested();
 }
 
 /* Whether an execve teardown will reap this slot: not the caller, not the main
@@ -1099,12 +1158,12 @@ int thread_exec_de_thread(void)
         pthread_mutex_unlock(&thread_lock);
     }
 
-    thread_join_workers();
+    thread_join_workers_mode(true);
 
-    /* thread_join_workers is bounded, so a sibling parked in a host call that
-     * never re-checked can outlive the cap and be detached. One such call is
-     * still reachable from guest code: the read side of a blocking FIFO open,
-     * which macOS gives nothing to poll on (see open_nonblocking_writer in
+    /* The join is bounded, so a sibling parked in a host call that never
+     * re-checked can outlive the cap and be detached. One such call is still
+     * reachable from guest code: the read side of a blocking FIFO open, which
+     * macOS gives nothing to poll on (see open_nonblocking_writer in
      * syscall/fs.c). semop, fcntl F_SETLKW and flock used to belong on this
      * list and no longer do; each polls a non-blocking form now.
      *

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -349,6 +349,14 @@ void thread_interrupt_all(void);
  */
 void thread_wake_all_blocked(void);
 
+/* The same wakes minus the futex interrupt, for work only the leader has to
+ * notice (an execve handed to it). The interrupt flag is process-wide and
+ * one-shot, so a teardown-strength wake used for a handoff hands an unexplained
+ * EINTR to whichever thread consumes it. Callers must publish the reason the
+ * leader's thread_stop_requested turns true BEFORE calling this.
+ */
+void thread_wake_leader_for_work(void);
+
 /* Wake workers parked on internal condvars (fork barrier, ptrace stop/wait) so
  * exit_group teardown reaches them within a bounded time. hv_vcpus_exit only
  * interrupts threads inside hv_vcpu_run, and the wakeup pipe / futex interrupt
@@ -424,6 +432,14 @@ bool thread_leader_work_pending(void);
  * cap expired.
  */
 int thread_stop_requested(void);
+
+/* True when the only thing thread_stop_requested is reporting is an execve
+ * handed to this leader: nothing is tearing this thread down. The wait it broke
+ * has nothing to report to the guest, since Linux returns no EINTR without a
+ * signal, so the syscall epilogue restarts the SVC instead and the handoff runs
+ * from the run loop in between.
+ */
+int thread_stop_is_leader_work_only(void);
 
 /* True when the caller is the thread group leader (the main host thread, the
  * one whose run loop returning tears the process down). de_thread cannot

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -103,6 +103,13 @@ typedef struct thread_entry {
     uint64_t altstack_size; /* Alternate signal stack size */
     bool on_altstack;       /* True if currently delivering on altstack */
 
+    /* The Linux syscall this thread is inside, or -1 between calls. Written
+     * around the handler call in syscall_dispatch and read only by the execve
+     * teardown, which otherwise reports a sibling that would not leave by tid
+     * alone and leaves the wait it is parked in to be guessed.
+     */
+    int32_t in_syscall;
+
     /* Robust futex list head (GVA). When non-zero, thread exit walks the list
      * and sets FUTEX_OWNER_DIED on each lock word.
      */
@@ -432,6 +439,13 @@ bool thread_leader_work_pending(void);
  * cap expired.
  */
 int thread_stop_requested(void);
+
+/* Record the syscall this thread is entering, or -1 on the way out. Relaxed:
+ * the only reader is a diagnostic on a path that is already failing, and
+ * ordering it against every syscall would cost the whole guest to sharpen one
+ * log line.
+ */
+void thread_note_syscall(int nr);
 
 /* True when the only thing thread_stop_requested is reporting is an execve
  * handed to this leader: nothing is tearing this thread down. The wait it broke

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -748,10 +748,12 @@ void exec_handoff_wake_waiters(void)
     pthread_mutex_unlock(&exec_handoff_lock);
 }
 
-/* Block until the slot reaches want. Returns false when thread_stop_requested
- * broke the wait instead, which for the requester means the exec it asked for
- * already succeeded and de_thread is reaping it. Caller holds the lock; the
- * bounded quantum is a safety net under the wake in thread_wake_all_blocked.
+/* Block until the slot reaches want.
+ *
+ * Returns false when thread_stop_requested broke the wait instead, which for
+ * the requester means the exec it asked for already succeeded and de_thread is
+ * reaping it. Caller holds the lock; the bounded quantum is a safety net under
+ * the wake in thread_wake_leader_for_work.
  */
 static bool exec_handoff_wait_for(exec_handoff_state_t want)
 {
@@ -762,13 +764,13 @@ static bool exec_handoff_wait_for(exec_handoff_state_t want)
 
         /* Re-poke while the request is still unclaimed. The leader is woken
          * once at publish, and a kick that lands between two hv_vcpu_run calls
-         * is lost; without this the requester waits forever and the leader
-         * runs on none the wiser. The wake set broadcasts this same condvar,
-         * so the lock has to come off around it.
+         * is lost; without this the requester waits forever and the leader runs
+         * on none the wiser. The wake set broadcasts this same condvar, so the
+         * lock has to come off around it.
          */
         if (exec_handoff.state == HANDOFF_PUBLISHED) {
             pthread_mutex_unlock(&exec_handoff_lock);
-            thread_wake_all_blocked();
+            thread_wake_leader_for_work();
             pthread_mutex_lock(&exec_handoff_lock);
         }
     }
@@ -787,6 +789,23 @@ static int64_t exec_handoff_to_leader(uint64_t path_gva,
                                       uint64_t envp_gva,
                                       const char *host_path)
 {
+    /* Release mmap_lock, which this thread's sc_execve wrapper holds, before
+     * touching the slot at all.
+     *
+     * Waiting for the slot under it deadlocks the second of two concurrent
+     * requesters against the leader: the leader takes the first request,
+     * releases exec_handoff_lock, and blocks acquiring mmap_lock to run it,
+     * while this thread holds mmap_lock waiting for a slot only that leader can
+     * free. Neither side is torn down, so no stop check breaks the cycle.
+     *
+     * Safe to drop this early because the handoff is the first thing sys_execve
+     * does for a non-leader, so nothing has yet read what mmap_lock protects,
+     * and the guest addresses published below are dereferenced by the leader
+     * under its own mmap_lock rather than here. Re-taken on every return path
+     * so the wrapper's unlock stays balanced.
+     */
+    pthread_mutex_unlock(&mmap_lock);
+
     pthread_mutex_lock(&exec_handoff_lock);
 
     /* Wait for the slot. A concurrent handoff either fails (freeing the slot)
@@ -794,6 +813,7 @@ static int64_t exec_handoff_to_leader(uint64_t path_gva,
      */
     if (!exec_handoff_wait_for(HANDOFF_EMPTY)) {
         pthread_mutex_unlock(&exec_handoff_lock);
+        pthread_mutex_lock(&mmap_lock);
         return -LINUX_EINTR;
     }
 
@@ -801,6 +821,7 @@ static int64_t exec_handoff_to_leader(uint64_t path_gva,
     exec_handoff.path_gva = path_gva;
     exec_handoff.argv_gva = argv_gva;
     exec_handoff.envp_gva = envp_gva;
+
     /* An empty string is the "no host_path" marker, so the flag the buffer
      * would otherwise need stays derivable from the buffer itself.
      */
@@ -811,24 +832,17 @@ static int64_t exec_handoff_to_leader(uint64_t path_gva,
         exec_handoff_set_state(HANDOFF_EMPTY);
         pthread_cond_broadcast(&exec_handoff_cond);
         pthread_mutex_unlock(&exec_handoff_lock);
+        pthread_mutex_lock(&mmap_lock);
         return -LINUX_ENAMETOOLONG;
     }
     exec_handoff.blocked_mask = current_thread ? current_thread->blocked : 0;
     pthread_mutex_unlock(&exec_handoff_lock);
 
-    /* Release mmap_lock, which this thread's sc_execve wrapper holds, for the
-     * whole wait: the leader needs it to run the exec, and the teardown that
-     * reaps this thread needs it free. Re-taken before returning so the
-     * wrapper's unlock stays balanced, and by then the leader has released it
-     * around its own teardown.
-     */
-    pthread_mutex_unlock(&mmap_lock);
-
     /* The leader may be parked in a blocking syscall. thread_stop_requested is
      * true for it while a request is pending, so its wait returns EINTR and its
      * run loop reaches the service point.
      */
-    thread_wake_all_blocked();
+    thread_wake_leader_for_work();
 
     pthread_mutex_lock(&exec_handoff_lock);
     bool reported = exec_handoff_wait_for(HANDOFF_DONE);
@@ -917,6 +931,16 @@ int64_t exec_run_handoff(hv_vcpu_t vcpu, guest_t *g, bool verbose)
 
     pthread_mutex_lock(&exec_handoff_lock);
     if (rc == SYSCALL_EXEC_HAPPENED) {
+        /* Drop any SVC restart this leader had armed before it picked the
+         * handoff up. The image it belonged to is gone, and leaving it armed
+         * lets the new image's first syscall match the recorded ELR by
+         * coincidence (most plausibly on a self-re-exec at the same load base)
+         * and read as a restart, which is what makes sys_connect swallow a
+         * genuine EISCONN. The cancel sees the mismatch and only clears the
+         * record.
+         */
+        syscall_restart_cancel(vcpu);
+
         /* The requester is being reaped by de_thread and will never read this.
          * Free the slot so the new image can execve again.
          */
@@ -1399,15 +1423,13 @@ int64_t sys_execve(hv_vcpu_t vcpu,
      * already have destroyed. It also has to precede the CLOEXEC sweep and
      * guest_reset: a sibling parked in read() on a fd about to close, or still
      * executing the old image's code, winds down against the memory and fd
-     * table its guest still expects.
-     */
-    /* Both callers hold mmap_lock (order 1) across the whole syscall, and the
-     * teardown must not run under it: a sibling blocked in
-     * pthread_mutex_lock(&mmap_lock) inside sc_brk, sc_mmap, sc_munmap,
-     * sc_mprotect, or its own deferred stack unmap is reachable by none of the
-     * teardown wakes, so it can never reach a stop check and the join below
-     * would always time out. Measured before this release: four siblings
-     * looping on mmap/munmap took the fatal path every time.
+     * table its guest still expects. Both callers hold mmap_lock (order 1)
+     * across the whole syscall, and the teardown must not run under it: a
+     * sibling blocked in pthread_mutex_lock(&mmap_lock) inside sc_brk, sc_mmap,
+     * sc_munmap, sc_mprotect, or its own deferred stack unmap is reachable by
+     * none of the teardown wakes, so it can never reach a stop check and the
+     * join below would always time out. Measured before this release: four
+     * siblings looping on mmap/munmap took the fatal path every time.
      *
      * Dropping it here is safe because nothing in the teardown touches guest
      * memory or the region table, and re-acquiring cannot contend: by the time

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -996,6 +996,13 @@ static int fuse_request_locked(fuse_session_t *session,
                     req->interrupt_sent = true;
                 }
                 req->detached = true;
+
+                /* FUSE_INTERRUPT is on the wire and the request is detached, so
+                 * an SVC restart would re-issue the whole operation under a
+                 * fresh unique: a duplicate write or unlink rather than a
+                 * resumed wait.
+                 */
+                syscall_restart_forbid();
                 return -LINUX_EINTR;
             }
         }

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -14,6 +14,14 @@
  *   epoll inst   (syscall/poll.c):    per-epoll-instance regs[]; taken under
  *                                     fd_lock by the close hook, taken alone
  *                                     (no fd_lock held) by epoll_ctl/pwait
+ *   exec_handoff (syscall/exec.c):    the one execve handoff slot; nested under
+ *                                     mmap_lock only by exec_handoff_reset, and
+ *                                     holds sig_lock beneath it through
+ *                                     signal_restore_blocked. A requester drops
+ *                                     mmap_lock before taking it: waiting for
+ *                                     the slot under mmap_lock deadlocks
+ *                                     against the leader, which needs that lock
+ *                                     to run the request that frees the slot
  *   sig_lock     (syscall/signal.c):  signal handlers/pending/blocked
  *   thread_lock  (runtime/thread.c):  thread table
  *   sfd_lock     (syscall/fd.c):      special fd (never held with thread_lock)

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -250,10 +250,36 @@ int64_t io_wait_fd_or_interrupted(int host_fd, short events)
          */
         signal_check_timer_real();
 
+        /* Teardown leaves before polling: this thread is going away and has
+         * nobody to report readiness to. An execve handed to this leader is
+         * different, because the thread keeps running and the dispatcher
+         * restarts the SVC, so leaving without looking throws away a wait whose
+         * fd may already be ready and pays for a whole syscall re-entry to
+         * discover it. Look first, with a zero timeout so the run loop still
+         * reaches the handoff promptly, and leave only if there is nothing.
+         *
+         * Correctness does not depend on this: the restart re-polls either way,
+         * and a connect loop under a sibling exec loop completes 4000/4000 with
+         * or without it. Progress does. Measured over four runs of that loop,
+         * median 1.8 s here against 2.9 s when the wait leaves before polling.
+         */
+        bool leader_only = thread_stop_is_leader_work_only();
+        if (!leader_only && thread_stop_requested())
+            return -LINUX_EINTR;
+
         /* Ignored/default-ignore signals do not interrupt; restartable handlers
          * still need to run promptly through the syscall epilogue.
+         *
+         * The futex interrupt is left alone on the leader-work path, which the
+         * single ||-chain this replaced did by short-circuiting. It is a
+         * process-wide one-shot standing in for SIGCHLD when the last
+         * clone-thread exits, and consuming it here would hand its EINTR to a
+         * restart that swallows it, so no thread would ever observe the edge.
+         * Left set, it is still there for the next interruptible wait in any
+         * thread, which is the ordering this wants: a ready fd is reported
+         * first and the one-shot keeps until something waits again.
          */
-        if (thread_stop_requested() || futex_interrupt_consume() ||
+        if ((!leader_only && futex_interrupt_consume()) ||
             signal_pending_interruption(NULL))
             return -LINUX_EINTR;
 
@@ -262,7 +288,7 @@ int64_t io_wait_fd_or_interrupted(int host_fd, short events)
          * drain the byte meant to wake this one. The 200 ms recheck guarantees
          * every waiter re-evaluates its own interrupt conditions.
          */
-        int ret = poll(fds, 2, 200);
+        int ret = poll(fds, 2, leader_only ? 0 : 200);
         if (ret < 0)
             return linux_errno();
 
@@ -270,6 +296,9 @@ int64_t io_wait_fd_or_interrupted(int host_fd, short events)
             wakeup_pipe_drain();
         if (fds[0].revents)
             return 0;
+
+        if (leader_only)
+            return -LINUX_EINTR;
     }
 }
 

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -126,7 +126,24 @@ static int64_t connect_nonblock_wait(int host_fd,
 {
     if (connect(host_fd, sa, len) == 0)
         return 0;
-    if (errno != EINPROGRESS && errno != EINTR)
+
+    /* EALREADY is this same connect still in flight. Linux never reports it to
+     * a blocking caller: __inet_stream_connect sets it, then falls through to
+     * wait out TCP_SYN_SENT and returns 0. Waiting below does the same.
+     *
+     * EISCONN is that connect having landed, and it is only swallowed for a
+     * restarted SVC. A guest that calls connect twice on a socket whose first
+     * connect returned is asking a different question and Linux answers EISCONN
+     * (sock->state is SS_CONNECTED by then). After a restart the guest never
+     * saw the first attempt return at all, so Linux would be in SS_CONNECTING
+     * and would answer 0; reporting EISCONN there would leak elfuse's own retry
+     * into a syscall the guest issued once. Measured with a connect loop under
+     * a sibling exec loop: 4000/4000 succeed on Linux, and without this gate
+     * about 60% came back EISCONN.
+     */
+    bool resuming = syscall_is_restarted();
+    if (errno != EINPROGRESS && errno != EINTR && errno != EALREADY &&
+        !(resuming && errno == EISCONN))
         return linux_errno();
 
     int64_t waited = io_wait_fd_or_interrupted(host_fd, POLLOUT);

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -255,6 +255,9 @@ ppoll_retry:
         /* Check for process/thread interrupts after waking. */
         if (thread_stop_requested() || futex_interrupt_consume() ||
             signal_pending_interruption(NULL)) {
+            /* Finite wait: part of the guest's timeout is already spent. */
+            if (deadline_ms >= 0)
+                syscall_restart_forbid();
             ret = -1;
             errno = EINTR;
             break;
@@ -641,6 +644,9 @@ pselect_retry:
 
         if (thread_stop_requested() || futex_interrupt_consume() ||
             signal_pending_interruption(NULL)) {
+            /* Finite wait: part of the guest's timeout is already spent. */
+            if (has_timeout)
+                syscall_restart_forbid();
             ret = -1;
             errno = EINTR;
             break;
@@ -1474,13 +1480,22 @@ int64_t sys_epoll_pwait(guest_t *g,
          * undelivered, and it spun at 100% CPU without ever drawing a window.
          *
          * exit_group still wins outright: the process is going away and there
-         * is nothing to deliver events to.
+         * is nothing to deliver events to. An execve handed to this leader does
+         * not: the thread keeps running, and dropping what kqueue already
+         * dequeued would be worse here than for a signal, because EV_CLEAR and
+         * EV_ONESHOT registrations consume the edge and nothing re-reports it.
+         * The handoff runs at the top of the run loop whether this returns
+         * events or EINTR, so letting the events win costs it nothing.
          */
-        bool interrupted = thread_stop_requested();
+        bool interrupted = thread_stop_requested() &&
+                           !(nready > 0 && thread_stop_is_leader_work_only());
         if (!interrupted && nready <= 0)
             interrupted =
                 futex_interrupt_consume() || signal_pending_interruption(NULL);
         if (interrupted) {
+            /* Finite wait: part of the guest's timeout is already spent. */
+            if (has_timeout)
+                syscall_restart_forbid();
             nready = -1;
             errno = EINTR;
             break;

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -2832,6 +2832,19 @@ int64_t sys_waitid(guest_t *g,
             return waitid_zero_siginfo(g, infop_gva);
         }
 
+        /* Same teardown check sys_wait4 makes, and for the same reason: a
+         * thread parked here answers neither an exit_group nor the execve
+         * de_thread otherwise, so it outlives the bounded join and pushes
+         * sys_execve onto its post-PNR exit. A leader parked here also never
+         * reaches the run loop to service an execve handed to it. Placed after
+         * the reap and WNOHANG answers above so a completed wait is still
+         * reported in preference to the interrupt.
+         */
+        if (thread_stop_requested()) {
+            pthread_mutex_unlock(&pid_lock);
+            return -LINUX_EINTR;
+        }
+
         /* Blocking: wait on condvar (100ms timeout as safety net) */
         struct timespec ts;
         timespec_deadline_in_ms(&ts, 100);

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -117,8 +117,10 @@ bool proc_fakeroot_enabled(void);
  * path resolved the way the guest resolves paths: under --sysroot the sysroot
  * spelling and the host spelling of one file both name that file, because the
  * match is on file identity rather than on the string (see
- * proc_fakeroot_exec_path). Returns false without arming anything for NULL, an
- * empty string, a relative path, or one that does not fit.
+ * proc_fakeroot_exec_path).
+ *
+ * Returns false without arming anything for NULL, an empty string, a relative
+ * path, or one that does not fit.
  *
  * Startup only. The stored path is read without a lock by every vCPU thread
  * that reaches execve, so this must be called before any of them exists;
@@ -309,9 +311,11 @@ bool proc_sysroot_casefold_enabled(void);
  *
  * Returns buf when a sysroot-backed file exists, and also when the path names a
  * temp root or a guest system directory, both of which resolve there whether or
- * not they exist. Returns path unchanged when no sysroot applies or when any
- * other sysroot-backed path does not exist, or NULL if sysroot path
- * construction would truncate or escape containment checks.
+ * not they exist.
+ *
+ * Returns path unchanged when no sysroot applies or when any other
+ * sysroot-backed path does not exist, or NULL if sysroot path construction
+ * would truncate or escape containment checks.
  */
 const char *proc_resolve_sysroot_path(const char *path,
                                       char *buf,
@@ -345,6 +349,47 @@ const char *proc_resolve_sysroot_create_path(const char *path,
  */
 #define SYSCALL_EXEC_HAPPENED (-0x10000)
 
+/* SVC restart across an execve handed to the group leader.
+ *
+ * The leader is woken out of a blocking wait so its run loop can pick the
+ * execve up, and the wait reports EINTR that no signal explains. The dispatch
+ * epilogue arms a restart instead of reporting it: X0 keeps the argument the
+ * guest passed and ELR_EL1 steps back over the SVC, so the ERET re-executes the
+ * syscall once the handoff has been serviced.
+ *
+ * A signal delivered before the guest resumes cancels it. Two reasons, and
+ * either alone would be enough. The EINTR becomes one Linux can produce, since
+ * a signal really did arrive. And the frame the handler returns through carries
+ * the live X8, which by then is the TLBI wire value the shim epilogue wrote
+ * rather than the syscall number the shim would have restored from its own
+ * saved frame. That is harmless while the saved PC is past the SVC, but a
+ * rewound PC would make rt_sigreturn re-execute the SVC as the wrong call.
+ *
+ * Cancel is a no-op unless ELR_EL1 still holds the value the arm wrote, so a
+ * later delivery on an unrelated path cannot disturb a guest that has moved on.
+ */
+void syscall_restart_arm(hv_vcpu_t vcpu,
+                         uint64_t elr_after_svc,
+                         int64_t result);
+void syscall_restart_cancel(hv_vcpu_t vcpu);
+
+/* Refuse an SVC restart for the syscall now running. Called by a wait that has
+ * already consumed part of a deadline the guest supplied: re-running the
+ * original arguments would restart that timeout from zero, and a guest whose
+ * siblings hand off execve faster than the timeout would never see it expire.
+ * Reporting EINTR there is what Linux does when it cannot resume from a
+ * remainder, and libc retries with the remainder it was handed.
+ */
+void syscall_restart_forbid(void);
+
+/* True while the handler running is the re-execution of a restarted SVC rather
+ * than a call the guest made. A syscall that left host state behind before it
+ * was interrupted needs this to resume that state instead of reporting it: the
+ * guest never saw the first attempt, so nothing about it may reach the guest.
+ * sys_connect is the one such caller; see connect_nonblock_wait.
+ */
+bool syscall_is_restarted(void);
+
 /* Process table (for fork/clone children). */
 
 typedef struct {
@@ -369,8 +414,10 @@ typedef struct {
 } proc_entry_t;
 
 /* Reserve bookkeeping before creating a helper process. A successful
- * reservation guarantees proc_register_child() can make the child visible
- * after fork IPC completes. Returns 0 or a negative Linux errno.
+ * reservation guarantees proc_register_child() can make the child visible after
+ * fork IPC completes.
+ *
+ * Returns 0 or a negative Linux errno.
  */
 int proc_reserve_child(int64_t guest_pid, int64_t pgid);
 
@@ -386,9 +433,9 @@ void proc_cancel_child(int64_t guest_pid);
 /* Mark a child as exited by host PID (for CLONE_VFORK wait). */
 void proc_mark_child_exited(pid_t host_pid, int status);
 
-/* Accumulate a reaped guest child's rusage into the cutime/cstime counters
- * that times(2) reports. Call at every host reap of a proc_table child; never
- * for emulator helper subprocesses.
+/* Accumulate a reaped guest child's rusage into the cutime/cstime counters that
+ * times(2) reports. Call at every host reap of a proc_table child; never for
+ * emulator helper subprocesses.
  */
 void proc_children_cpu_add(const struct rusage *ru);
 
@@ -397,8 +444,9 @@ void proc_children_cpu_us(uint64_t *utime_us, uint64_t *stime_us);
 
 /* Write a macOS struct rusage to guest memory as linux_rusage_t. The field
  * layout matches on LP64; ru_maxrss is converted from macOS bytes to Linux
- * kilobytes. Returns the guest_write_small result (0 on success, negative on
- * fault).
+ * kilobytes.
+ *
+ * Returns the guest_write_small result (0 on success, negative on fault).
  */
 int write_rusage_to_guest(guest_t *g, uint64_t gva, const struct rusage *ru);
 
@@ -449,8 +497,8 @@ void proc_autoreap_exited_children(void);
 /* Pull authoritative PPID state into a newly bootstrapped fork child. */
 void proc_lifecycle_sync_self(guest_t *g);
 
-/* Notify the guest parent that this process reached a terminal state. Called
- * by fork-child teardown before the host process exits.
+/* Notify the guest parent that this process reached a terminal state. Called by
+ * fork-child teardown before the host process exits.
  */
 void proc_process_exit(int wait_status);
 
@@ -470,9 +518,10 @@ pid_t proc_guest_to_host_pid(int64_t gpid);
 
 /* Look up a host PID in the child process table, falling back to the
  * cross-process registry so the rest of the fork family (grandchildren,
- * siblings' descendants) resolves too. Returns the guest PID if @host_pid is
- * a live member of this guest's fork family, or -1 otherwise (e.g. the lock
- * holder is an unrelated host process).
+ * siblings' descendants) resolves too.
+ *
+ * Returns the guest PID if @host_pid is a live member of this guest's fork
+ * family, or -1 otherwise (e.g. the lock holder is an unrelated host process).
  */
 int64_t proc_host_to_guest_pid(pid_t host_pid);
 
@@ -553,22 +602,20 @@ void proc_request_hvc6_yield(void);
  * (before each hv_vcpu_run() entry or re-entry).
  *
  * Stop semantics:
- * Return nonzero to stop the loop. A nonzero tick return is propagated
- * and returned as the run loop's exit code.
+ * Return nonzero to stop the loop. A nonzero tick return is propagated and
+ * returned as the run loop's exit code.
  *
- * Cooperative-only timing:
- * The tick is only checked at host boundaries, not during guest execution.
- * A guest spinning entirely in EL0 without VM-exiting will never trigger
- * the tick, meaning a tick-initiated hook cannot interrupt a runaway guest.
- * To force interruption of a runaway guest, use hv_vcpus_exit().
+ * Cooperative-only timing: The tick is only checked at host boundaries, not
+ * during guest execution. A guest spinning entirely in EL0 without VM-exiting
+ * will never trigger the tick, meaning a tick-initiated hook cannot interrupt a
+ * runaway guest. To force interruption of a runaway guest, use hv_vcpus_exit().
  *
- * Concurrency and lifetime:
- * When a single vcpu_run_hooks_t and its opaque data are shared across
- * multiple vCPUs, the tick function will be invoked concurrently from
- * multiple host threads and must be thread-safe. The run loop does not keep
- * a copy of the hooks structure and dereferences it every iteration; the
- * caller must ensure the hooks structure and opaque lifetime extend until
- * all run loops return.
+ * Concurrency and lifetime: When a single vcpu_run_hooks_t and its opaque data
+ * are shared across multiple vCPUs, the tick function will be invoked
+ * concurrently from multiple host threads and must be thread-safe. The run loop
+ * does not keep a copy of the hooks structure and dereferences it every
+ * iteration; the caller must ensure the hooks structure and opaque lifetime
+ * extend until all run loops return.
  */
 typedef int (*vcpu_run_loop_tick_fn)(guest_t *g, void *opaque);
 

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -1768,9 +1768,15 @@ int64_t signal_rt_sigtimedwait(guest_t *g,
         if (has_timeout && remaining_ns <= 0)
             return -LINUX_EAGAIN;
 
-        /* Exit if the process, or just this thread, is tearing down. */
-        if (thread_stop_requested())
+        /* Exit if the process, or just this thread, is tearing down. The chunks
+         * already consumed above came out of the guest's timeout, so a restart
+         * of the original request would grant it the full span again.
+         */
+        if (thread_stop_requested()) {
+            if (has_timeout)
+                syscall_restart_forbid();
             return -LINUX_EINTR;
+        }
 
         /* If a non-waited, guest-visible signal is pending, return -EINTR.
          * Mirror signal_pending_interruption()'s disposition filter: SIG_IGN
@@ -1784,8 +1790,11 @@ int64_t signal_rt_sigtimedwait(guest_t *g,
         uint64_t candidates = self_pending_locked() & ~*blocked & ~mask;
         bool interrupt = signal_set_would_wake_locked(candidates);
         pthread_mutex_unlock(&sig_lock);
-        if (interrupt)
+        if (interrupt) {
+            if (has_timeout)
+                syscall_restart_forbid();
             return -LINUX_EINTR;
+        }
 
         /* Sleep one chunk, then recheck. */
         int64_t sleep_ns =
@@ -1993,6 +2002,17 @@ static int deliver_signal_locked(hv_vcpu_t vcpu,
     }
 
     /* Deliver to user handler: build rt_sigframe on guest stack */
+
+    /* Past every disposition that discards the signal, so this is the point a
+     * handler frame is committed to. An armed SVC restart has to come off here,
+     * before the state below is snapshotted: the frame would otherwise capture
+     * the rewound PC together with the live X8, which is the shim's TLBI wire
+     * value rather than the syscall number, and rt_sigreturn would re-execute
+     * the SVC as whatever syscall that value names. Undoing the rewind also
+     * gives the guest back the EINTR it was going to get, which this signal now
+     * explains. See syscall_restart_arm in syscall/proc.h.
+     */
+    syscall_restart_cancel(vcpu);
 
     /* 1. Save current vCPU state.
      *

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -2485,8 +2485,16 @@ int signal_rt_sigreturn(hv_vcpu_t vcpu, guest_t *g)
      */
     pthread_mutex_lock(&sig_lock);
     uint64_t *blocked = thread_blocked_ptr();
-    *blocked = frame.uc.uc_sigmask;
-    *blocked &= ~(sig_bit(LINUX_SIGKILL) | sig_bit(LINUX_SIGSTOP));
+
+    /* Published in one release store, not built up in place. sig_lock only
+     * serializes the writers; thread_signal_deliverable reads this field
+     * lock-free from the run loop, so a plain two-step update is a data race
+     * that ThreadSanitizer reports and that can expose the intermediate value.
+     * signal_restore_blocked publishes the same field the same way.
+     */
+    uint64_t restored_mask = frame.uc.uc_sigmask &
+                             ~(sig_bit(LINUX_SIGKILL) | sig_bit(LINUX_SIGSTOP));
+    __atomic_store_n(blocked, restored_mask, __ATOMIC_RELEASE);
     if (current_thread) {
         uint64_t restored_sp = frame.uc.uc_mcontext.sp;
         if (current_thread->altstack_sp &&

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -2461,9 +2461,77 @@ static void escape_log_string(char *dest, const char *src, size_t dest_sz)
     dest[d] = '\0';
 }
 
+/* Per-vCPU, like cpu_tlbi_req and for the same reason: only the owning thread
+ * touches its own vCPU registers, so this needs no lock and cannot be torn by
+ * another vCPU's epilogue. See syscall_restart_arm in syscall/proc.h.
+ */
+static _Thread_local struct {
+    bool armed;
+    bool restarted;       /* this invocation is the re-executed SVC */
+    bool forbidden;       /* a wait consumed part of a guest deadline */
+    uint64_t elr_rewound; /* what the arm wrote, so cancel can recognize it */
+    uint64_t elr_after_svc;
+    int64_t result;
+} cpu_restart_req;
+
+void syscall_restart_forbid(void)
+{
+    cpu_restart_req.forbidden = true;
+}
+
+bool syscall_is_restarted(void)
+{
+    return cpu_restart_req.restarted;
+}
+
+void syscall_restart_arm(hv_vcpu_t vcpu, uint64_t elr_after_svc, int64_t result)
+{
+    cpu_restart_req.armed = true;
+    cpu_restart_req.elr_after_svc = elr_after_svc;
+    cpu_restart_req.elr_rewound = elr_after_svc - 4;
+    cpu_restart_req.result = result;
+    hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, cpu_restart_req.elr_rewound);
+}
+
+void syscall_restart_cancel(hv_vcpu_t vcpu)
+{
+    if (!cpu_restart_req.armed)
+        return;
+    cpu_restart_req.armed = false;
+
+    /* Only undo a rewind the guest has not already left. Anything else moved
+     * ELR_EL1 on (a handoff that succeeded and reloaded the image, a fault
+     * path), and putting the old value back would resume the wrong place.
+     */
+    uint64_t elr = 0;
+    hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, &elr);
+    if (elr != cpu_restart_req.elr_rewound)
+        return;
+
+    hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_ELR_EL1,
+                        cpu_restart_req.elr_after_svc);
+    hv_vcpu_set_reg(vcpu, HV_REG_X0, (uint64_t) cpu_restart_req.result);
+}
+
 int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
 {
     uint64_t x0, x1, x2, x3, x4, x5, x8;
+
+    /* A restart that survived to here was taken, and ELR_EL1 proves it: on SVC
+     * entry it is the address after the instruction, which matches only if this
+     * is the same SVC the arm rewound to. Anything that moved on in between --
+     * a cancel, or a handed-off execve that succeeded and reloaded the image --
+     * fails the compare and reads as a fresh call. Read only when armed, so the
+     * common path pays nothing for it.
+     */
+    cpu_restart_req.forbidden = false;
+    cpu_restart_req.restarted = false;
+    if (cpu_restart_req.armed) {
+        uint64_t entry_elr = 0;
+        cpu_restart_req.armed = false;
+        hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, &entry_elr);
+        cpu_restart_req.restarted = entry_elr == cpu_restart_req.elr_after_svc;
+    }
 
     hv_vcpu_get_reg(vcpu, HV_REG_X8, &x8);
     x0 = 0;
@@ -2736,8 +2804,29 @@ fast_done:
                 }
             }
         }
+
+        /* Arm rather than report; syscall_restart_arm in syscall/proc.h holds
+         * the contract, and syscall_restart_forbid the waits that opt out.
+         *
+         * No signal test here, deliberately. A queued signal may still be
+         * discarded at delivery (SIG_IGN, default-ignore), so refusing on one
+         * would hand back the very EINTR this removes. Only a delivery that
+         * commits to a handler frame cancels.
+         */
+        bool restart_armed = false;
+        if (result == -LINUX_EINTR && !cpu_restart_req.forbidden &&
+            thread_stop_is_leader_work_only()) {
+            uint64_t elr = 0;
+            hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_ELR_EL1, &elr);
+            if (elr >= 4) {
+                syscall_restart_arm(vcpu, elr, result);
+                restart_armed = true;
+            }
+        }
+
         /* Write result back to X0 */
-        hv_vcpu_set_reg(vcpu, HV_REG_X0, (uint64_t) result);
+        if (!restart_armed)
+            hv_vcpu_set_reg(vcpu, HV_REG_X0, (uint64_t) result);
 
         /* Signal the shim to flush TLB if this vCPU modified page tables.
          * Protocol after HVC #5 lives in tlbi_request_emit_to_vcpu (see

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -2556,6 +2556,17 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
     int nr = (int) x8;
     const syscall_entry_t *entry = NULL;
 
+    /* Where this thread is, for the execve teardown to report when a sibling
+     * will not leave. It covers the inline fast paths too, not just the table
+     * handlers: the read/write one performs the transfer itself, and a ready
+     * poll reserves nothing, so a concurrent reader of the same pipe or socket
+     * can take the data and leave the call parked in the host with no wake able
+     * to reach it. That is the shape of the failure this reports on, so
+     * excluding the path would answer "running guest code" for the case that
+     * most needs naming.
+     */
+    thread_note_syscall(nr);
+
     /* Per-syscall histogram for the dynamic-linker bring-up storm. Zero when
      * disabled so the bottom-of-dispatch record path is a single branch.
      */
@@ -2761,6 +2772,7 @@ slow_path:
                     syscall_hist_record(nr, hist_end_ns - hist_start_ns);
                 syscall_hist_freeze("frozen at first execve");
             }
+            thread_note_syscall(-1);
             return SYSCALL_EXEC_HAPPENED;
         }
     } else {
@@ -2777,6 +2789,8 @@ slow_path:
 
 
 fast_done:
+    thread_note_syscall(-1);
+
     if (!should_exit) {
         /* Verbose: log syscall return value and file paths */
         if (verbose) {

--- a/src/syscall/time.c
+++ b/src/syscall/time.c
@@ -115,8 +115,20 @@ static int64_t interruptible_sleep_ns(guest_t *g,
                                       uint64_t rem_gva,
                                       bool write_rem)
 {
+    int64_t requested_ns = remaining_ns;
+
     while (remaining_ns > 0) {
         if (thread_stop_requested() || signal_pending()) {
+            /* Only once part of a relative interval is spent, because the
+             * restart re-runs the original request rather than the remainder.
+             * This check also runs before the first chunk, where nothing is
+             * spent and a restart costs the guest nothing, so forbidding there
+             * would manufacture the EINTR no signal explains. An absolute
+             * deadline (write_rem false, TIMER_ABSTIME) re-derives the same
+             * instant and stays restartable throughout.
+             */
+            if (write_rem && remaining_ns != requested_ns)
+                syscall_restart_forbid();
             if (write_rem &&
                 write_remaining_sleep(g, rem_gva, remaining_ns) < 0)
                 return -LINUX_EFAULT;
@@ -133,6 +145,8 @@ static int64_t interruptible_sleep_ns(guest_t *g,
             if (slept_ns < 0)
                 slept_ns = 0;
             remaining_ns -= slept_ns;
+            if (write_rem && remaining_ns != requested_ns)
+                syscall_restart_forbid();
             if (write_rem &&
                 write_remaining_sleep(g, rem_gva, remaining_ns) < 0)
                 return -LINUX_EFAULT;

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -98,6 +98,7 @@ TEST_LIST="$SCRIPT_DIR/manifest.txt"
 # shellcheck source=tests/test-config.sh
 source "$SCRIPT_DIR/test-config.sh"
 source "$SCRIPT_DIR/lib/hang-sample.sh"
+source "$SCRIPT_DIR/lib/bash-compat.sh" # test_host_is_busy
 
 # Capture a stack sample from a test about to hit the watchdog. A hang that only
 # reproduces under suite load is otherwise reported as a bare "timeout after Ns"
@@ -401,6 +402,29 @@ for i in "${filtered_idx[@]}"; do
         hang_sample_finish 1
     else
         hang_sample_finish 0
+    fi
+
+    # A watchdog firing on a loaded machine reports the neighbours, not the
+    # code. Re-run once, and only when the host really is busy, so an idle
+    # machine still reports the timeout at once and pays nothing for this. Every
+    # genuine hang the suite has caught reproduced on every attempt, so a second
+    # timeout still fails. The sample from the first attempt is kept: it is the
+    # one taken while the suite was in the state that produced it.
+    if [ "$rc" -eq 124 ] && test_host_is_busy; then
+        report_case skip "$name" " (timeout under host load; re-running)"
+        hang_sample_arm "$binary" "$TIMEOUT" \
+            "$TESTDIR_ABS/test-timeouts/$(basename "$binary")-hang.txt"
+        if output=$(timeout "$TIMEOUT" "$ELFUSE" "$binary" \
+            ${args[@]+"${args[@]}"} 2>&1); then
+            rc=0
+        else
+            rc=$?
+        fi
+        if [ "$rc" -eq 124 ]; then
+            hang_sample_finish 1
+        else
+            hang_sample_finish 0
+        fi
     fi
 
     if evaluate_result "$rc" "$expected" "$stdout_pat" "$output"; then

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -276,6 +276,41 @@ evaluate_result()
     return 0
 }
 
+# Run one test binary and record the outcome in rc and output.
+#
+# One function for the first attempt and the host-load retry both. Not
+# tidiness: the two drifted the moment they were written apart, and the retry
+# went in without the descriptor limit the first attempt applies, so a
+# constrained test was re-run as a different test.
+#
+# ulimit runs in the subshell that produces output, and a failure to raise it
+# exits that subshell with 125 rather than chaining into timeout. A && chain
+# reports ulimit's own status, which the caller cannot tell from the binary's,
+# and the binary never ran at all.
+run_test_binary()
+{
+    local binary="$1" nofile="$2" sample="$3"
+    shift 3
+
+    hang_sample_arm "$binary" "$TIMEOUT" "$sample"
+    if [ -n "$nofile" ]; then
+        output=$(
+            ulimit -n "$nofile" 2> /dev/null || exit 125
+            exec timeout "$TIMEOUT" "$ELFUSE" "$binary" "$@" 2>&1
+        )
+        rc=$?
+    else
+        output=$(timeout "$TIMEOUT" "$ELFUSE" "$binary" "$@" 2>&1)
+        rc=$?
+    fi
+
+    if [ "$rc" -eq 124 ]; then
+        hang_sample_finish 1
+    else
+        hang_sample_finish 0
+    fi
+}
+
 report_case()
 {
     local state="$1"
@@ -286,6 +321,12 @@ report_case()
         ok) printf "%-45s [ ${GREEN}OK${RESET} ]%s\n" "$name" "$detail" ;;
         fail) printf "%-45s [ ${RED}FAIL${RESET} ]%s\n" "$name" "$detail" ;;
         skip) printf "%-45s [ ${YELLOW}SKIP${RESET} ]%s\n" "$name" "$detail" ;;
+        # No bracketed verdict, because the test has not been decided yet and
+        # every other state here is one the summary counts. The blanks are as
+        # wide as the FAIL and SKIP tags, which is the closest a single width
+        # gets: the verdicts do not share a column either (OK is 7 wide, FAIL
+        # and SKIP 9).
+        info) printf "%-45s %-8s%s\n" "$name" "" "$detail" ;;
     esac
 }
 
@@ -375,56 +416,33 @@ for i in "${filtered_idx[@]}"; do
     # "${array[@]}". Host-limit annotations live in the manifest. Keep this
     # execution path generic so adding another constrained test does not require
     # a name-qualified branch here.
-    hang_sample_arm "$binary" "$TIMEOUT" \
-        "$TESTDIR_ABS/test-timeouts/$(basename "$binary")-hang.txt"
-
     if host_nofile=$(elfuse_test_host_nofile "$TEST_LIST" "$name"); then
-        if [ -n "$host_nofile" ]; then
-            if output=$(ulimit -n "$host_nofile" \
-                && timeout "$TIMEOUT" "$ELFUSE" "$binary" \
-                    ${args[@]+"${args[@]}"} 2>&1); then
-                rc=0
-            else
-                rc=$?
-            fi
-        elif output=$(timeout "$TIMEOUT" "$ELFUSE" "$binary" \
-            ${args[@]+"${args[@]}"} 2>&1); then
-            rc=0
-        else
-            rc=$?
-        fi
+        run_test_binary "$binary" "$host_nofile" \
+            "$TESTDIR_ABS/test-timeouts/$(basename "$binary")-hang.txt" \
+            ${args[@]+"${args[@]}"}
     else
         output="invalid host_nofile test annotation"
         rc=125
-    fi
-
-    if [ "$rc" -eq 124 ]; then
-        hang_sample_finish 1
-    else
-        hang_sample_finish 0
     fi
 
     # A watchdog firing on a loaded machine reports the neighbours, not the
     # code. Re-run once, and only when the host really is busy, so an idle
     # machine still reports the timeout at once and pays nothing for this. Every
     # genuine hang the suite has caught reproduced on every attempt, so a second
-    # timeout still fails. The sample from the first attempt is kept: it is the
-    # one taken while the suite was in the state that produced it.
+    # timeout still fails.
+    #
+    # Its sample goes to a separate file. The first attempt's is the one taken
+    # while the suite was in the state that produced the timeout, so it is the
+    # one worth keeping.
     if [ "$rc" -eq 124 ] && test_host_is_busy; then
-        report_case skip "$name" " (timeout under host load; re-running)"
-        hang_sample_arm "$binary" "$TIMEOUT" \
-            "$TESTDIR_ABS/test-timeouts/$(basename "$binary")-hang.txt"
-        if output=$(timeout "$TIMEOUT" "$ELFUSE" "$binary" \
-            ${args[@]+"${args[@]}"} 2>&1); then
-            rc=0
+        if [ "$TAP" -eq 1 ]; then
+            echo "# $name timed out under host load; re-running"
         else
-            rc=$?
+            report_case info "$name" "timed out under host load; re-running"
         fi
-        if [ "$rc" -eq 124 ]; then
-            hang_sample_finish 1
-        else
-            hang_sample_finish 0
-        fi
+        run_test_binary "$binary" "$host_nofile" \
+            "$TESTDIR_ABS/test-timeouts/$(basename "$binary")-hang-retry.txt" \
+            ${args[@]+"${args[@]}"}
     fi
 
     if evaluate_result "$rc" "$expected" "$stdout_pat" "$output"; then

--- a/tests/lib/bash-compat.sh
+++ b/tests/lib/bash-compat.sh
@@ -1,20 +1,18 @@
-# bash-compat.sh -- Shared bash 3.2+ compatibility helpers for the elfuse
-# test harness.
+# bash-compat.sh -- Shared bash 3.2+ compatibility helpers for the elfuse test
+# harness.
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
-#
 # shellcheck shell=bash
-#
-# macOS still ships bash 3.2.57 as /bin/bash (frozen since 2007 over the
-# GPLv3 move). The Makefile invokes scripts via `bash tests/foo.sh`, so
-# stock macOS picks up /bin/bash regardless of the env-bash shebang. This
-# helper consolidates the small set of cross-version shims the suite
-# needs so each script does not have to re-derive them.
+# macOS still ships bash 3.2.57 as /bin/bash (frozen since 2007 over the GPLv3
+# move). The Makefile invokes scripts via `bash tests/foo.sh`, so stock macOS
+# picks up /bin/bash regardless of the env-bash shebang. This helper
+# consolidates the small set of cross-version shims the suite needs so each
+# script does not have to re-derive them.
 #
 # Source it as the first action after `set -uo pipefail`:
 #
-#     # shellcheck source=tests/lib/bash-compat.sh
+# # shellcheck source=tests/lib/bash-compat.sh
 #     . "$(dirname "${BASH_SOURCE[0]}")/lib/bash-compat.sh"
 #
 # Provides:
@@ -33,8 +31,8 @@
 #   - Do not use ${var^^} / ${var,,} case-conversion; pipe through tr.
 #   - Do not use 'mapfile' / 'readarray'; use a 'while read' loop.
 
-# Minimum bash version that the elfuse harness supports. Stays at 3.2 so
-# the stock macOS /bin/bash works without Homebrew.
+# Minimum bash version that the elfuse harness supports. Stays at 3.2 so the
+# stock macOS /bin/bash works without Homebrew.
 : "${BASH_COMPAT_MIN_MAJOR:=3}"
 : "${BASH_COMPAT_MIN_MINOR:=2}"
 
@@ -60,8 +58,8 @@ bash_compat_require()
 
 bash_compat_require
 
-# Pick the best available microsecond clock source. The chosen
-# implementation is bound to 'epoch_us' so callers stay version-agnostic.
+# Pick the best available microsecond clock source. The chosen implementation is
+# bound to 'epoch_us' so callers stay version-agnostic.
 #
 # Ordered for lowest per-call cost first:
 #   1. $EPOCHREALTIME (bash 5.0+) -- builtin, no fork.
@@ -113,3 +111,20 @@ else
     fi
     unset _bash_compat_ns_probe
 fi
+
+# True when this machine is too loaded for a wall-clock measurement to mean
+# anything. Shared so the throughput guardrail and the per-test watchdog agree
+# on what "busy" is rather than drifting apart.
+#
+# The threshold is deliberately generous: below it, a timing failure is the code
+# and gets reported; above it, the number is measuring the neighbours. Observed
+# on this project with an unrelated prover run in the background, correct code
+# ran 2 to 3 times slower and tripped several bounds at once.
+test_host_is_busy()
+{
+    local load ncpu
+    load=$(sysctl -n vm.loadavg 2> /dev/null | awk '{print $2}')
+    ncpu=$(sysctl -n hw.ncpu 2> /dev/null)
+    [ -n "$load" ] && [ -n "$ncpu" ] || return 1
+    awk -v l="$load" -v n="$ncpu" 'BEGIN { exit !(l > n * 0.6) }'
+}

--- a/tests/lib/test-runner.sh
+++ b/tests/lib/test-runner.sh
@@ -97,6 +97,12 @@ test_report()
         fail) printf "%s [ ${RED}FAIL${RESET} ]%s\n" "$name" "$detail" ;;
         skip) printf "%s [ ${YELLOW}SKIP${RESET} ]%s\n" "$name" "$detail" ;;
         xfail) printf "%s [ ${YELLOW}XFAIL${RESET} ]%s\n" "$name" "$detail" ;;
+        # No bracketed verdict, because the test has not been decided yet and
+        # every other state here is one the summary counts. The blanks are as
+        # wide as the FAIL and SKIP tags, which is the closest a single width
+        # gets: the verdicts do not share a column either (OK is 7 wide, FAIL
+        # and SKIP 9, XFAIL 10).
+        info) printf "%s %-8s%s\n" "$name" "" "$detail" ;;
     esac
 }
 
@@ -173,11 +179,15 @@ run()
     # the host is actually busy, so an idle machine still reports a timeout
     # immediately and pays nothing. Every genuine hang this has caught (an
     # execve deadlock, a restarted timeout that never expired) reproduced on
-    # every attempt, so a second one still fails.
+    # every attempt, so a second one still fails. The retry samples to its own
+    # file so the first attempt's stack, taken in the state that produced the
+    # timeout, survives.
     if [ "$harness_timed_out" -eq 1 ] && test_host_is_busy; then
-        test_report skip "$tool" " (timeout under host load; re-running)"
+        # Informational, not a verdict: the test has not been decided yet, so
+        # this must not advance the skip counter the summary reports.
+        test_report info "$tool" " (timeout under host load; re-running)"
         hang_sample_arm "$tool" "$TEST_TIMEOUT" \
-            "${BUILD_DIR:-build}/test-timeouts/$(basename "$tool")-hang.txt"
+            "${BUILD_DIR:-build}/test-timeouts/$(basename "$tool")-hang-retry.txt"
         start_us=$(epoch_us)
         if output=$(timeout "$TEST_TIMEOUT" ${TEST_RUNNER[@]+"${TEST_RUNNER[@]}"} \
             "$(test_tool_path "$tool")" "$@" 2>&1); then

--- a/tests/lib/test-runner.sh
+++ b/tests/lib/test-runner.sh
@@ -167,6 +167,33 @@ run()
     fi
     hang_sample_finish "$harness_timed_out"
 
+    # A watchdog firing on a loaded machine says as much about the neighbours as
+    # about the code, and this suite has spent real time chasing timeouts that
+    # reproduced 0 times out of 60 on an idle host. Retry once, and only when
+    # the host is actually busy, so an idle machine still reports a timeout
+    # immediately and pays nothing. Every genuine hang this has caught (an
+    # execve deadlock, a restarted timeout that never expired) reproduced on
+    # every attempt, so a second one still fails.
+    if [ "$harness_timed_out" -eq 1 ] && test_host_is_busy; then
+        test_report skip "$tool" " (timeout under host load; re-running)"
+        hang_sample_arm "$tool" "$TEST_TIMEOUT" \
+            "${BUILD_DIR:-build}/test-timeouts/$(basename "$tool")-hang.txt"
+        start_us=$(epoch_us)
+        if output=$(timeout "$TEST_TIMEOUT" ${TEST_RUNNER[@]+"${TEST_RUNNER[@]}"} \
+            "$(test_tool_path "$tool")" "$@" 2>&1); then
+            rc=0
+        else
+            rc=$?
+        fi
+        end_us=$(epoch_us)
+        elapsed_us=$((end_us - start_us))
+        harness_timed_out=0
+        if [ "$rc" -eq 124 ] && [ "$elapsed_us" -ge "$limit_us" ]; then
+            harness_timed_out=1
+        fi
+        hang_sample_finish "$harness_timed_out"
+    fi
+
     if [ "$harness_timed_out" -eq 1 ]; then
         test_report fail "$tool" " (timeout after ${TEST_TIMEOUT}s)"
         test_excerpt "$output"

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -86,6 +86,7 @@ test-pthread
 test-thread-churn
 test-threaded-exec
 test-threaded-exec worker
+test-exec-handoff
 test-simd-clone                # diff=skip
 
 [section] Stress tests

--- a/tests/test-bench-guardrail.sh
+++ b/tests/test-bench-guardrail.sh
@@ -91,6 +91,7 @@ if [ ! -x "$STATIC_BENCH" ]; then
 fi
 
 failures=0
+unmeasured=0
 benchmarks_run=0
 
 # Set by any failure a second run would reproduce, so run_and_check skips the
@@ -245,6 +246,7 @@ run_and_check()
             "$variant" "$(sysctl -n vm.loadavg 2> /dev/null | awk '{print $2}')" \
             "$(sysctl -n hw.ncpu 2> /dev/null)"
         failures=$before
+        unmeasured=$((unmeasured + 1))
     fi
 }
 
@@ -273,6 +275,22 @@ fi
 if [ "$failures" -ne 0 ]; then
     echo
     echo "guardrail FAILED ($failures threshold violation(s))" >&2
+    exit 1
+fi
+
+# A variant whose thresholds were exceeded twice and then dropped for host load
+# was not measured, so this run is no evidence that the ceilings hold. It exits
+# non-zero for the same reason it would on a real violation: make check is the
+# CI gate, and a run that never exercised the ceilings must not report the same
+# status as one that did.
+#
+# What the load check buys is the diagnosis, not the exit code. The bare
+# threshold number this replaces said nothing about why, and cost more than one
+# investigation before anyone thought to look at the host.
+if [ "$unmeasured" -ne 0 ]; then
+    echo
+    echo "guardrail UNMEASURED ($unmeasured variant(s), host busy)" >&2
+    echo "  the ceilings were not exercised; re-run on an idle host" >&2
     exit 1
 fi
 echo

--- a/tests/test-bench-guardrail.sh
+++ b/tests/test-bench-guardrail.sh
@@ -60,12 +60,12 @@ THRESH_URANDOM=400
 # arm is 5x the static one because sysroot redirection resolves every path
 # component. Ceilings sit ~1.25x over observed.
 #
-# The static arm is the detector. Restoring the sigsetjmp regression moves it
-# 82 -> 125, comfortably past 105, while the dynamic arm moved only 407 -> 488
-# and slipped under its ceiling on one run: sysroot resolution is so much of
-# that 13.6 us that a per-copy cost is diluted to noise. Keep the dynamic arm
-# for gross regressions, do not tighten it toward 450 chasing the small ones,
-# and do not read a dynamic pass as evidence the copy helpers are clean.
+# The static arm is the detector. Restoring the sigsetjmp regression moves it 82
+# -> 125, comfortably past 105, while the dynamic arm moved only 407 -> 488 and
+# slipped under its ceiling on one run: sysroot resolution is so much of that
+# 13.6 us that a per-copy cost is diluted to noise. Keep the dynamic arm for
+# gross regressions, do not tighten it toward 450 chasing the small ones, and do
+# not read a dynamic pass as evidence the copy helpers are clean.
 THRESH_STAT_RATIO_STATIC=105
 THRESH_STAT_RATIO_GLIBC=500
 
@@ -104,6 +104,21 @@ deterministic=0
 extract_ns()
 {
     awk -v label="$2" '$1 == label { print $2 }' "$1"
+}
+
+# A throughput ceiling is a claim about this machine when it is free to answer.
+# On a loaded host the number measures the load, not the code: every lane that
+# does host work inflates together while the shim-served ones barely move, so
+# the getpid-relative ratios stop cancelling and the absolute ceilings blow out.
+# Observed here at 2 to 3 times the idle figures with a prover run in the
+# background, on code that was not the cause. Consulted only after a retry has
+# also failed, so a real regression on an idle machine still fails twice and is
+# reported.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/bash-compat.sh"
+
+host_is_busy()
+{
+    test_host_is_busy
 }
 
 # check_threshold <variant> <label> <ns/op> <ceiling-ns>
@@ -223,6 +238,14 @@ run_and_check()
     failures=$before
     deterministic=0
     run_one_pass "$@"
+
+    if [ "$failures" -ne "$before" ] && [ "$deterministic" -eq 0 ] \
+        && host_is_busy; then
+        printf "  ${C_YELLOW}SKIP${C_RESET}  %-12s host load %s over %s cpus; throughput not measurable\n" \
+            "$variant" "$(sysctl -n vm.loadavg 2> /dev/null | awk '{print $2}')" \
+            "$(sysctl -n hw.ncpu 2> /dev/null)"
+        failures=$before
+    fi
 }
 
 echo "=== bench-guardrail (iters=$ITERS) ==="

--- a/tests/test-clone3.c
+++ b/tests/test-clone3.c
@@ -474,8 +474,22 @@ static void test_vfork_exec_unblocks_parent(void)
           "clock_gettime(end) failed");
     long elapsed_ms = (long) (end.tv_sec - start.tv_sec) * 1000L +
                       (long) (end.tv_nsec - start.tv_nsec) / 1000000L;
-    CHECK(elapsed_ms < 500,
-          "vfork parent resumed after %ld ms (expected < 500 ms)", elapsed_ms);
+
+    /* The property is that CLONE_VFORK released the parent at the child's
+     * execve rather than at its exit. Ask that directly rather than through a
+     * stopwatch: the child sleeps a second after exec, so a parent that really
+     * was released early finds it still running. The wall-clock form said the
+     * same thing less reliably and cost more than it caught, failing at 642 ms
+     * and 1137 ms against a 500 ms limit on runs where the behaviour was right
+     * and the host was merely busy. The elapsed time is still reported, since
+     * it is what a reader wants when this does fail.
+     */
+    int probe_status = 0;
+    pid_t probe = waitpid((pid_t) ret, &probe_status, WNOHANG);
+    CHECK(probe == 0,
+          "vfork parent resumed only after the child exited "
+          "(waitpid(WNOHANG) returned %d after %ld ms)",
+          (int) probe, elapsed_ms);
 
     int status = 0;
     pid_t waited = waitpid((pid_t) ret, &status, 0);

--- a/tests/test-exec-handoff.c
+++ b/tests/test-exec-handoff.c
@@ -1,0 +1,619 @@
+/*
+ * execve handed from a worker thread to the group leader
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * elfuse cannot destroy the main host thread, so an execve issued from a
+ * sibling is published to the leader and run on its vCPU. Getting the leader
+ * out of whatever it is parked in is part of that handoff, and this holds the
+ * two things the guest must not be able to see happen to it.
+ *
+ * 1. The leader's own blocking syscall is not collateral. Linux returns EINTR
+ *    only when a signal was delivered, and none is here, so a read() parked
+ *    across a failing handoff has to come back with its data, not -EINTR.
+ * 2. A fork in flight on a third thread does not turn the exec fatal. The
+ *    forker's siblings sit in a barrier that only the forker releases, and a
+ *    teardown armed underneath it would wait on threads that cannot answer.
+ *    The forker's SIGCHLDs double as cover for the other half of case 1: a
+ *    signal that is merely queued and then discarded must not suppress the
+ *    restart, or the bare EINTR comes straight back.
+ * 3. A signal delivered on top of a handoff leaves the guest with a result it
+ *    can read. The restart is armed before the signal is known, so delivery
+ *    has to take it back off; a half-undone restart would return the syscall's
+ *    own first argument in place of a result.
+ * 4. Two threads calling execve at once both finish. There is one handoff
+ *    slot, and a requester that waits for it while holding mmap_lock deadlocks
+ *    against the leader, which needs that lock to run the request that frees
+ *    the slot.
+ * 5. A wait the guest gave a timeout still expires. The restart re-runs the
+ *    original arguments, so a relative timeout would start again from zero and
+ *    a guest whose siblings hand off execve faster than the timeout would never
+ *    see it fire.
+ * 6. A connect issued once stays a connect issued once. It is the one syscall
+ *    here that leaves host state behind before it waits, so a restart re-issues
+ *    it against a socket that has moved on, and the errno that comes back
+ *    (EALREADY, or EISCONN once the handshake lands) is one Linux does not give
+ *    a caller that connected once. Measured before the fix: about 60% of a
+ *    connect loop under exec pressure reported EISCONN, against 4000/4000
+ *    clean on a real kernel.
+ *
+ * Every case execs a path that does not exist, so the handoff fails before its
+ * point of no return and the leader stays in the original image to be checked.
+ *
+ * Syscalls exercised: execve(221), clone(220), read(63), write(64), pipe2(59),
+ *                     wait4(260), rt_sigaction(134), tgkill(131),
+ *                     nanosleep(101), futex(98), rt_sigtimedwait(137),
+ *                     socket(198), connect(203), accept4(242)
+ */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <linux/futex.h>
+#include <sys/socket.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+extern char **environ;
+
+static int pipe_rd = -1, pipe_wr = -1;
+static atomic_int leader_parked;
+
+/* Read one byte, retrying the interruption that is not this file's subject. A
+ * sibling thread exiting arms a process-wide one-shot that makes the next
+ * blocking wait anywhere in the guest report EINTR, which elfuse does on
+ * purpose to mirror SIGCHLD on thread exit. Only case 1 treats an EINTR as the
+ * failure, and it reads directly rather than through this.
+ *
+ * Returns the read result with EINTR filtered out.
+ */
+static ssize_t read_byte_retrying(int fd, char *out)
+{
+    ssize_t n;
+
+    do {
+        n = read(fd, out, 1);
+    } while (n < 0 && errno == EINTR);
+
+    return n;
+}
+
+/* Workers report here rather than into the harness counter: fails is a plain
+ * int the main thread owns, and two threads incrementing it is a data race that
+ * can drop the very failure this test exists to report. Folded in after the
+ * join.
+ */
+static atomic_int worker_fails;
+static atomic_int handler_ran;
+static pthread_t leader_tid;
+
+static void usr1_handler(int sig)
+{
+    (void) sig;
+    atomic_fetch_add(&handler_ran, 1);
+}
+
+/* Same handoff as doomed_exec_worker, with a signal aimed at the leader so the
+ * two land together: the epilogue arms a restart for the handoff, then the
+ * delivery cancels it. Signal first, so it is queued before the leader leaves
+ * its wait.
+ */
+static void *signal_and_exec_worker(void *arg)
+{
+    (void) arg;
+
+    while (!atomic_load(&leader_parked))
+        sched_yield();
+    usleep(50000);
+
+    pthread_kill(leader_tid, SIGUSR1);
+
+    char *argv[] = {(char *) "/nonexistent/elfuse-exec-handoff", NULL};
+    execve(argv[0], argv, environ);
+    if (errno != ENOENT) {
+        atomic_fetch_add(&worker_fails, 1);
+        printf("\nworker execve errno %d, want ENOENT\n", errno);
+    }
+
+    char c = 'x';
+    if (write(pipe_wr, &c, 1) != 1) {
+        atomic_fetch_add(&worker_fails, 1);
+        printf("\nwrite to wake the leader failed\n");
+    }
+
+    return NULL;
+}
+
+/* The leader's read must end in one of the two states Linux can produce: the
+ * byte, or EINTR with the handler having run. A cancel that restored ELR_EL1
+ * without X0 would resume past the SVC carrying the read's own first argument,
+ * so any other non-negative return is the failure this looks for.
+ */
+static void expect_signal_cancels_cleanly(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = usr1_handler;
+    if (sigaction(SIGUSR1, &sa, NULL) != 0) {
+        FAIL("sigaction(SIGUSR1) failed");
+        return;
+    }
+
+    leader_tid = pthread_self();
+    atomic_store(&worker_fails, 0);
+    atomic_store(&handler_ran, 0);
+
+    int bad = 0, saw_eintr = 0, eintr_without_handler = 0;
+    for (int i = 0; i < 30; i++) {
+        /* Cleared per round: a handler that ran in an earlier one would
+         * otherwise answer for a round whose EINTR had no delivery.
+         */
+        atomic_store(&handler_ran, 0);
+        pthread_t t;
+        atomic_store(&leader_parked, 0);
+        if (pthread_create(&t, NULL, signal_and_exec_worker, NULL) != 0) {
+            FAIL("pthread_create(signal_and_exec) failed");
+            return;
+        }
+
+        char c = 0;
+        bool round_eintr = false;
+        atomic_store(&leader_parked, 1);
+        ssize_t n = read(pipe_rd, &c, 1);
+        if (n < 0 && errno == EINTR) {
+            saw_eintr++;
+            round_eintr = true;
+
+            /* The worker still wrote its byte; take it so the pipe stays
+             * balanced for the next iteration.
+             */
+            ssize_t n2 = read_byte_retrying(pipe_rd, &c);
+            if (n2 != 1 || c != 'x') {
+                bad++;
+                printf("\ndrain read returned %zd (c=%d), want the byte\n", n2,
+                       (int) c);
+            }
+        } else if (n != 1 || c != 'x') {
+            bad++;
+            printf("\nleader read returned %zd (c=%d), want 1 or EINTR\n", n,
+                   (int) c);
+        }
+        pthread_join(t, NULL);
+
+        /* Read after the round rather than at the EINTR: the guest runs the
+         * handler on the way out of the syscall, so the count is still zero at
+         * the moment the interrupted read returns.
+         */
+        if (round_eintr && atomic_load(&handler_ran) == 0)
+            eintr_without_handler++;
+    }
+
+    signal(SIGUSR1, SIG_DFL);
+
+    if (saw_eintr > 0 && eintr_without_handler > 0) {
+        bad++;
+        printf("\nread reported EINTR but no SIGUSR1 handler ran\n");
+    }
+
+    EXPECT_EQ(bad + atomic_load(&worker_fails), 0,
+              "signal on top of a handoff left an unreadable result");
+}
+
+static void *doomed_exec_worker(void *arg)
+{
+    (void) arg;
+
+    /* The leader publishes the flag just before it blocks, so give the read
+     * itself time to reach the host call. Landing early only weakens the test:
+     * the leader would not be parked and there would be nothing to interrupt.
+     */
+    while (!atomic_load(&leader_parked))
+        sched_yield();
+    usleep(50000);
+
+    /* Fails before the point of no return (the path cannot be resolved), so the
+     * leader that runs it survives and returns to this image.
+     */
+    char *argv[] = {(char *) "/nonexistent/elfuse-exec-handoff", NULL};
+    execve(argv[0], argv, environ);
+    if (errno != ENOENT) {
+        atomic_fetch_add(&worker_fails, 1);
+        printf("\nworker execve errno %d, want ENOENT\n", errno);
+    }
+
+    /* Release the leader whether or not the handoff behaved, so a failure
+     * reports rather than hanging the suite.
+     */
+    char c = 'x';
+    if (write(pipe_wr, &c, 1) != 1) {
+        atomic_fetch_add(&worker_fails, 1);
+        printf("\nwrite to wake the leader failed\n");
+    }
+
+    return NULL;
+}
+
+/* The leader parks here with no EINTR retry: a retry is what would hide the
+ * bug. The read must return the byte the worker writes after its execve fails.
+ */
+static void expect_uninterrupted_read(void)
+{
+    char c = 0;
+    atomic_store(&leader_parked, 1);
+    ssize_t n = read(pipe_rd, &c, 1);
+
+    if (n == 1 && c == 'x')
+        PASS();
+    else if (n < 0 && errno == EINTR)
+        FAIL("leader read returned EINTR across a sibling execve");
+    else
+        FAIL("leader read returned neither the byte nor EINTR");
+}
+
+static void *forking_worker(void *arg)
+{
+    atomic_int *stop = arg;
+
+    while (!atomic_load(stop)) {
+        pid_t pid = fork();
+        if (pid == 0)
+            _exit(0);
+        if (pid < 0 && errno == EINTR)
+            continue;
+        if (pid < 0) {
+            atomic_fetch_add(&worker_fails, 1);
+            printf("\nfork failed: %s\n", strerror(errno));
+            return NULL;
+        }
+        while (waitpid(pid, NULL, 0) < 0 && errno == EINTR)
+            ;
+    }
+
+    return NULL;
+}
+
+/* A fork snapshot parks every other thread in the fork barrier, which only the
+ * forker releases. An exec teardown armed under an open window would wait on
+ * threads that cannot answer it and take the post-PNR fatal. Run the two
+ * against each other and require the process to still be here afterwards.
+ */
+static void expect_fork_and_exec_coexist(void)
+{
+    atomic_int stop = 0;
+    pthread_t forker, execer;
+
+    atomic_store(&worker_fails, 0);
+    if (pthread_create(&forker, NULL, forking_worker, &stop) != 0) {
+        FAIL("pthread_create(forker) failed");
+        return;
+    }
+
+    int leader_fails = 0;
+    for (int i = 0; i < 20; i++) {
+        atomic_store(&leader_parked, 0);
+        if (pthread_create(&execer, NULL, doomed_exec_worker, NULL) != 0) {
+            FAIL("pthread_create(execer) failed");
+            atomic_store(&stop, 1);
+            pthread_join(forker, NULL);
+            return;
+        }
+
+        char c = 0;
+        atomic_store(&leader_parked, 1);
+        ssize_t got = read_byte_retrying(pipe_rd, &c);
+        if (got != 1) {
+            leader_fails++;
+            printf("\nleader read failed during the fork race\n");
+        }
+        pthread_join(execer, NULL);
+    }
+
+    atomic_store(&stop, 1);
+    pthread_join(forker, NULL);
+
+    EXPECT_EQ(leader_fails + atomic_load(&worker_fails), 0,
+              "fork and execve on different threads diverged");
+}
+
+/* Keeps handing the leader an execve that fails, until told to stop. Unlike
+ * doomed_exec_worker this does not synchronize with the leader: the point is
+ * sustained handoff pressure across many connects, not one placed interruption.
+ */
+static void *exec_pressure_worker(void *arg)
+{
+    atomic_int *stop = arg;
+    char *argv[] = {(char *) "/nonexistent/elfuse-exec-handoff", NULL};
+
+    while (!atomic_load(stop))
+        execve(argv[0], argv, environ);
+
+    return NULL;
+}
+
+static int accept_listener = -1;
+static atomic_int accept_stop;
+
+static void *accept_worker(void *arg)
+{
+    (void) arg;
+
+    while (!atomic_load(&accept_stop)) {
+        int c = accept(accept_listener, NULL, NULL);
+        if (c >= 0) {
+            close(c);
+            continue;
+        }
+
+        /* Retried like any real server would. A sibling thread exiting arms a
+         * one-shot interrupt that the next blocking wait anywhere in the guest
+         * reports as EINTR, so treating it as fatal would leave the listener
+         * unattended, fill its backlog, and stall the connects this case is
+         * measuring rather than the handoff it is about.
+         */
+        if (errno == EINTR)
+            continue;
+        return NULL;
+    }
+
+    return NULL;
+}
+
+/* Closing a listener does not reliably return a thread already blocked inside
+ * accept(), on Linux or on macOS, so hand it one last connection instead and
+ * let it observe the stop flag. Called with the pressure worker already joined,
+ * so this connect runs without a handoff racing it.
+ */
+static void stop_accepter(int listener,
+                          const struct sockaddr_in *addr,
+                          pthread_t accepter)
+{
+    atomic_store(&accept_stop, 1);
+
+    int waker = socket(AF_INET, SOCK_STREAM, 0);
+    if (waker >= 0) {
+        connect(waker, (const struct sockaddr *) addr, sizeof(*addr));
+        close(waker);
+    }
+    pthread_join(accepter, NULL);
+    close(listener);
+}
+
+/* Two requesters against the one handoff slot. The second has to wait for the
+ * first to be serviced, and the leader has to be able to service it: with both
+ * of them queued the lock the leader needs must not be one a waiting requester
+ * is holding. Both threads must return from every execve they issue.
+ */
+static void *concurrent_exec_worker(void *arg)
+{
+    int *rounds = arg;
+    char *argv[] = {(char *) "/nonexistent/elfuse-exec-handoff", NULL};
+
+    for (int i = 0; i < 25; i++) {
+        execve(argv[0], argv, environ);
+        if (errno != ENOENT) {
+            atomic_fetch_add(&worker_fails, 1);
+            printf("\nconcurrent execve errno %d, want ENOENT\n", errno);
+            return NULL;
+        }
+        (*rounds)++;
+    }
+
+    return NULL;
+}
+
+static void expect_concurrent_execves_finish(void)
+{
+    pthread_t a, b;
+    int rounds_a = 0, rounds_b = 0;
+
+    atomic_store(&worker_fails, 0);
+    if (pthread_create(&a, NULL, concurrent_exec_worker, &rounds_a) != 0 ||
+        pthread_create(&b, NULL, concurrent_exec_worker, &rounds_b) != 0) {
+        FAIL("pthread_create(concurrent execve) failed");
+        return;
+    }
+    pthread_join(a, NULL);
+    pthread_join(b, NULL);
+
+    /* Asserted separately rather than summed: a worker that failed on its last
+     * round would contribute its failure back into a total of 50 and pass.
+     */
+    bool ok =
+        rounds_a == 25 && rounds_b == 25 && atomic_load(&worker_fails) == 0;
+    if (!ok)
+        printf("\nrounds a=%d b=%d, failures=%d, want 25/25/0\n", rounds_a,
+               rounds_b, atomic_load(&worker_fails));
+    EXPECT_TRUE(ok, "concurrent execves did not both complete");
+}
+
+static double elapsed_ms(struct timespec *t0, struct timespec *t1)
+{
+    clock_gettime(CLOCK_MONOTONIC, t1);
+    return (t1->tv_sec - t0->tv_sec) * 1000.0 +
+           (t1->tv_nsec - t0->tv_nsec) / 1e6;
+}
+
+/* A timeout the guest supplied has to expire even while handoffs keep arriving.
+ * Restarting the SVC re-runs the original relative timeout, so without an
+ * opt-out the wait below never returns and the elapsed time runs away.
+ */
+static void expect_timeout_still_expires(void)
+{
+    atomic_int stop = 0;
+    pthread_t pressure;
+
+    atomic_store(&worker_fails, 0);
+    if (pthread_create(&pressure, NULL, exec_pressure_worker, &stop) != 0) {
+        FAIL("pthread_create(exec pressure) failed");
+        return;
+    }
+
+    /* Retried on EINTR the way every libc sleep wrapper does, so what this
+     * measures is whether the guest can finish the interval at all, not whether
+     * any single call returns it.
+     */
+    struct timespec t0, t1, req = {0, 400 * 1000 * 1000}, rem;
+    int interruptions = 0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    while (nanosleep(&req, &rem) != 0 && errno == EINTR) {
+        req = rem;
+        interruptions++;
+    }
+    double sleep_ms = elapsed_ms(&t0, &t1);
+
+    /* The other two relative-timeout waits reach the same hazard through
+     * different code: a plain FUTEX_WAIT, which elfuse serves on an
+     * address-wait fast path rather than the bucket path FUTEX_WAIT_BITSET
+     * uses, and sigtimedwait, which spends its timeout in a chunk loop of its
+     * own. Neither is retried here, because one bounded return is the whole
+     * question.
+     */
+    int word = 0;
+    struct timespec rel = {1, 0};
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    syscall(SYS_futex, &word, FUTEX_WAIT, 0, &rel, NULL, 0);
+    double futex_ms = elapsed_ms(&t0, &t1);
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR2);
+    rel.tv_sec = 1;
+    rel.tv_nsec = 0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    sigtimedwait(&set, NULL, &rel);
+    double sigwait_ms = elapsed_ms(&t0, &t1);
+
+    atomic_store(&stop, 1);
+    pthread_join(pressure, NULL);
+
+    /* The interruption count is reported, not asserted. On elfuse a handoff
+     * breaks the sleep and it is non-zero; on a real kernel there is no handoff
+     * to break it and zero is the right answer, which is why the timings rather
+     * than the count are what both have to satisfy. Linux measures 403 ms, 1002
+     * ms and 1000 ms here, all of them expiring on schedule.
+     */
+    bool ok = sleep_ms >= 400 && sleep_ms <= 3000 && futex_ms <= 3000 &&
+              sigwait_ms <= 3000;
+    if (!ok)
+        printf(
+            "\nsleep %.0fms (%d interruptions), futex %.0fms, "
+            "sigtimedwait %.0fms\n",
+            sleep_ms, interruptions, futex_ms, sigwait_ms);
+    EXPECT_TRUE(ok, "a guest timeout did not expire on schedule");
+}
+
+/* A blocking connect that the guest issued once must report what Linux reports:
+ * success. EINTR is the bug this file exists for; EALREADY and EISCONN are the
+ * host's answer to elfuse re-issuing the call, which the guest never asked for
+ * and must never see.
+ */
+static void expect_connect_survives_handoff(void)
+{
+    int listener = socket(AF_INET, SOCK_STREAM, 0);
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    socklen_t addrlen = sizeof(addr);
+
+    if (listener < 0 ||
+        bind(listener, (struct sockaddr *) &addr, sizeof(addr)) < 0 ||
+        listen(listener, 64) < 0 ||
+        getsockname(listener, (struct sockaddr *) &addr, &addrlen) < 0) {
+        FAIL("listener setup failed");
+        if (listener >= 0)
+            close(listener);
+        return;
+    }
+
+    atomic_int stop = 0;
+    pthread_t pressure, accepter;
+    accept_listener = listener;
+    atomic_store(&accept_stop, 0);
+    if (pthread_create(&accepter, NULL, accept_worker, NULL) != 0) {
+        FAIL("pthread_create(accepter) failed");
+        close(listener);
+        return;
+    }
+    if (pthread_create(&pressure, NULL, exec_pressure_worker, &stop) != 0) {
+        FAIL("pthread_create(exec pressure) failed");
+        stop_accepter(listener, &addr, accepter);
+        return;
+    }
+
+    int bad = 0, bad_errno = 0;
+    for (int i = 0; i < 400; i++) {
+        int s = socket(AF_INET, SOCK_STREAM, 0);
+        if (s < 0)
+            continue;
+        if (connect(s, (struct sockaddr *) &addr, sizeof(addr)) != 0) {
+            if (!bad)
+                bad_errno = errno;
+            bad++;
+        }
+        close(s);
+    }
+
+    atomic_store(&stop, 1);
+    pthread_join(pressure, NULL);
+    stop_accepter(listener, &addr, accepter);
+
+    if (bad)
+        printf("\n%d of 400 connects failed, first errno=%d\n", bad, bad_errno);
+    EXPECT_EQ(bad, 0, "connect reported the host's retry state to the guest");
+}
+
+int main(void)
+{
+    int fds[2];
+    if (pipe2(fds, 0) != 0) {
+        FAIL("pipe2 failed");
+        return 1;
+    }
+    pipe_rd = fds[0];
+    pipe_wr = fds[1];
+
+    printf("test-exec-handoff: execve handed from a worker to the leader\n");
+
+    pthread_t t;
+    TEST("leader read across a failed handoff");
+    if (pthread_create(&t, NULL, doomed_exec_worker, NULL) != 0) {
+        FAIL("pthread_create failed");
+        return 1;
+    }
+    expect_uninterrupted_read();
+    pthread_join(t, NULL);
+    fails += atomic_exchange(&worker_fails, 0);
+
+    TEST("fork and handoff on separate threads");
+    expect_fork_and_exec_coexist();
+
+    TEST("signal delivered on top of a handoff");
+    expect_signal_cancels_cleanly();
+
+    TEST("two threads execing at once");
+    expect_concurrent_execves_finish();
+
+    TEST("guest timeout expires under handoff pressure");
+    expect_timeout_still_expires();
+
+    TEST("connect under sustained handoff pressure");
+    expect_connect_survives_handoff();
+
+    SUMMARY("test-exec-handoff");
+    return fails > 0 ? 1 : 0;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -648,7 +648,31 @@ test_pipe()
 # There is no "core" vs "extended" split here; everything below runs in both
 # elfuse-aarch64 and qemu-aarch64 modes, and genuine, understood divergences
 # from the qemu reference kernel are called out via QEMU_SKIP with a comment
-# rather than silently dropped from this list.
+# rather than silently dropped from this list. The unit lane runs binaries this
+# repo builds, not fixtures it downloads, so an empty build/ is a setup mistake
+# rather than a run to report on. Without this every test fails on a missing
+# file and the summary reads like a hundred-odd regressions; "make clean"
+# followed by "make elfuse" is enough to produce it, because elfuse alone does
+# not build the test binaries. Name the cause once and stop, the way driver.sh
+# does with ALLOW_MISSING_BINARIES.
+require_unit_binaries()
+{
+    local bindir="$1"
+    local missing=0 probe
+
+    for probe in test-hello hello-musl echo-test test-comprehensive \
+        test-thread test-epoll test-signal test-exec-handoff; do
+        [ -x "$bindir/$probe" ] || missing=$((missing + 1))
+    done
+    [ "$missing" -eq 0 ] && return 0
+
+    printf '\n%s\n' "test-matrix: no test binaries in $bindir"
+    printf '%s\n' "  The unit lane needs them built first. Run 'make check'," \
+        "  or build the lane's binaries directly, then re-run this." \
+        "  Set ALLOW_MISSING_BINARIES=1 to run anyway."
+    return 1
+}
+
 run_unit_tests()
 {
     local runner="$1" bindir="$2"
@@ -1222,6 +1246,15 @@ run_suite()
         fi
         verify_expected_counts "$mode"
         return $?
+    fi
+
+    # Checked here rather than inside run_unit_tests so an empty build fails
+    # this lane through the caller's accounting. Exiting from inside the lane
+    # would take the whole script down with it under MODE=all, skipping the
+    # qemu lane and the rosetta one, which does not read GUEST_TEST_BINARIES.
+    if [ "${ALLOW_MISSING_BINARIES:-0}" != "1" ] \
+        && ! require_unit_binaries "$GUEST_TEST_BINARIES"; then
+        return 1
     fi
 
     run_unit_tests "$runner" "$GUEST_TEST_BINARIES"

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -761,6 +761,7 @@ run_unit_tests()
     test_rc "$runner" "test-threaded-exec" 0 "$bindir/test-threaded-exec"
     test_rc "$runner" "test-threaded-exec-worker" 0 \
         "$bindir/test-threaded-exec" worker
+    test_rc "$runner" "test-exec-handoff" 0 "$bindir/test-exec-handoff"
     test_rc "$runner" "test-mprotect-mt" 0 "$bindir/test-mprotect-mt"
 
     printf "\nNegative tests\n"

--- a/tests/test-socket.c
+++ b/tests/test-socket.c
@@ -7,28 +7,6 @@
  *
  * Verifies socket syscalls work by creating an AF_UNIX socketpair and
  * exchanging data. This avoids needing a network stack.
- *
- * Tests:
- * 1. socketpair(AF_UNIX, SOCK_STREAM) creates two connected fds
- * 2. write/read through socketpair transfers data correctly
- * 3. getsockopt(SO_TYPE) returns SOCK_STREAM
- * 4. getsockname/getpeername return the socketpair addresses
- * 5. sendmsg/recvmsg transfers a single iovec payload
- * 6. sendmsg/recvmsg transfers a two-iovec payload
- * 7. sendmmsg/recvmmsg transfers a single message
- * 8. sendto/recvfrom over an AF_UNIX datagram pair
- * 9. recvmsg single iovec preserves MSG_TRUNC
- * 10. getsockopt(SO_ERROR) read-and-clear
- * 11. shutdown(SHUT_WR) causes read to return 0 (EOF)
- * 12. socketpair(AF_UNIX, SOCK_SEQPACKET)
- * 13. socket(AF_UNIX, SOCK_SEQPACKET)
- * 14. zero-length recvmsg follows receive-readiness semantics (EAGAIN when
- *     nonblocking and empty, blocks when empty, 0 without consuming when
- *     data is pending)
- * 15. invalid recvmsg iov returns EFAULT immediately
- * 16. SEQPACKET peer close reads as EOF (0), not ECONNRESET (Rust spawn)
- * 17. genuine AF_UNIX datagram peer close is not folded to EOF
- * 18. recvmmsg(vlen>1) on a peer-closed SEQPACKET substitute does not hang
  */
 
 #include <signal.h>
@@ -389,6 +367,45 @@ int main(void)
             close(listener);
     }
 
+    /* Test 19: a fresh connect on an established stream returns EISCONN */
+    printf("test-socket: 19. second connect returns EISCONN... ");
+    {
+        int listener = socket(AF_INET, SOCK_STREAM, 0);
+        int client = socket(AF_INET, SOCK_STREAM, 0);
+        struct sockaddr_in addr = {
+            .sin_family = AF_INET,
+            .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+        };
+        socklen_t addrlen = sizeof(addr);
+
+        const char *step = NULL;
+        if (listener < 0 || client < 0)
+            step = "socket";
+        else if (bind(listener, (struct sockaddr *) &addr, sizeof(addr)) < 0)
+            step = "bind";
+        else if (listen(listener, 1) < 0)
+            step = "listen";
+        else if (getsockname(listener, (struct sockaddr *) &addr, &addrlen) < 0)
+            step = "getsockname";
+        else if (connect(client, (struct sockaddr *) &addr, sizeof(addr)) < 0)
+            step = "first connect";
+        else if (connect(client, (struct sockaddr *) &addr, sizeof(addr)) != -1)
+            step = "second connect returned 0";
+        else if (errno != EISCONN)
+            step = "second connect errno";
+
+        if (step) {
+            printf("FAIL at %s (errno=%d)\n", step, errno);
+            failures++;
+        } else {
+            printf("PASS\n");
+        }
+        if (listener >= 0)
+            close(listener);
+        if (client >= 0)
+            close(client);
+    }
+
     /* Test 11: shutdown + EOF */
     printf("test-socket: 11. shutdown(SHUT_WR) -> EOF... ");
     shutdown(sv[0], SHUT_WR);
@@ -688,6 +705,7 @@ int main(void)
             close(dsv[0]);
             char b[8];
             ssize_t dn = recv(dsv[1], b, sizeof(b), 0);
+
             /* Any error is acceptable (ECONNRESET on macOS/elfuse, EAGAIN on
              * Linux); a clean EOF(0) is the regression this guards.
              */
@@ -728,6 +746,7 @@ int main(void)
             }
             /* Blocking (no MSG_DONTWAIT): this is the path that would hang. */
             int mr = recvmmsg(msv[1], mm, 4, 0, NULL);
+
             /* elfuse stops at the first EOF (mr==1); Linux keeps reading the
              * persistent EOF and returns 4. Accept any mr>=1 with the first
              * message empty; the point is that it returned at all.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restarts only syscalls an execve handoff to the group leader interrupted, and forbids restart once time was spent or a request hit the wire. This removes spurious EINTRs, preserves deadlines, and makes connect() report like Linux under exec pressure.

- Arms a restart only on leader‑work stops; delivery of a signal or a successful handoff cancels it. Per‑vCPU record; `syscall_is_restarted` identifies re‑execution. Absolute‑deadline waits stay restartable; relative waits or on‑wire requests forbid restart (relative `nanosleep`; finite `ppoll`/`pselect6`/`epoll_pwait`; futex waits with relative deadlines; chunked `rt_sigtimedwait`; FUSE after `FUSE_INTERRUPT`). Readiness outranks leader work in `io_wait_fd_or_interrupted` (zero‑timeout probe, preserve futex interrupt) and epoll (keep already‑dequeued events). `connect()` resumes an in‑flight handshake on restart; swallows `EISCONN` only for a restarted call and treats `EALREADY` like Linux’s blocking path.
- Exec handoff: drop `mmap_lock` before waiting for the slot; wake the leader for work without consuming the futex interrupt; de‑thread joins in exec‑mode (keeps join claims, excludes vm‑clone slots) and is bounded by departures; `sys_waitid` now answers teardown; signals publish the restored `rt_sigreturn` mask with one release store; diagnostics record each thread’s in‑flight syscall for teardown logs.

**Build, tests, and CI**
- Gates `make check` on `scripts/check-eintr-contract.py` (classify every EINTR path; call `syscall_restart_forbid()` when any relative timeout was consumed or a request was sent).
- Build flavor guard: stamps effective CFLAGS, wipes only objects/depfiles on change, ignores a missing stamp, and fails on leftovers.
- Test harness: single entry point; retries one timeout only on a busy host; per‑attempt hang samples; ulimit failures are setup (exit 125); names failing socket steps; adds `test-exec-handoff`; requires unit binaries. `test-clone3` checks vfork/exec ordering without wall‑clock flakiness.
- Bench guardrail: fails the run when load prevents any variant from being measured and annotates unmeasured ceilings.
- CI: prover log uploads use `continue-on-error`; artifact transport failures no longer decide a proof lane.

<sup>Written for commit 3b763674bd3174b934a9d016dfc54c286497e544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

