### PR TITLE
Add contributing guide and enforce comment width via commentflow

### DIFF
--- a/.ci/check-commentflow.sh
+++ b/.ci/check-commentflow.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Reflow comments to the column limit, or check that they already are.
+#
+# clang-format breaks a comment line that runs past ColumnLimit but never
+# refills a short-wrapped one, so comment width is the one part of the house
+# style no other gate settles. commentflow reads the same ColumnLimit, which
+# keeps comment width and code width on one number.
+#
+# The selection below is the one both callers use, "make indent" through --write
+# and "make check-format" and the Lint workflow through the default, so what
+# gets rewritten is what gets checked. The extension list in that workflow's
+# cfpat decides whether the check runs at all, and has to track it.
+
+set -u -o pipefail
+
+case "${1:-}" in
+    "" | --check) write=0 ;;
+    --write) write=1 ;;
+    *)
+        echo "usage: $0 [--check | --write]" >&2
+        exit 2
+        ;;
+esac
+
+COMMENTFLOW="${COMMENTFLOW:-commentflow}"
+
+# Exit codes: 0 clean, 1 files would change, 2 the check could not run. The
+# reflow tool reports its own findings as 1, so nothing else may use it.
+if ! command -v "$COMMENTFLOW" > /dev/null 2>&1; then
+    echo "Error: $COMMENTFLOW not found" >&2
+    echo "Install it from https://github.com/sysprog21/commentflow" >&2
+    exit 2
+fi
+
+# Untracked but non-ignored files are included, so a new file is covered before
+# it is staged. A while-read loop because macOS ships bash 3.2, which has no
+# mapfile, and "make check-format" runs this locally.
+files=()
+while IFS= read -rd '' f; do
+    files+=("$f")
+done < <(git ls-files -z --cached --others --exclude-standard \
+    -- 'src/**/*.[ch]' 'src/*.[ch]' \
+    'tests/*.c' 'tests/*.h' \
+    'frama-c-stubs/**/*.h' 'frama-c-stubs/*.h' \
+    '*.sh' '*.bash' '*.S' '*.s')
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "Error: no files selected; the pathspec no longer matches the tree" >&2
+    exit 2
+fi
+
+printf '  CFLOW   %d files\n' "${#files[@]}"
+
+if [ "$write" -eq 1 ]; then
+    exec "$COMMENTFLOW" "${files[@]}"
+fi
+
+status=0
+"$COMMENTFLOW" --check "${files[@]}" || status=$?
+
+if [ "$status" -eq 0 ]; then
+    echo "Comment reflow clean."
+    exit 0
+fi
+
+# Exit 1 is the answer "these files would change"; anything else is the tool
+# failing to read them, which must not be reported as a style violation.
+if [ "$status" -ne 1 ]; then
+    echo "Error: $COMMENTFLOW exited $status (I/O or parse error)" >&2
+    exit "$status"
+fi
+
+echo "Run 'make indent' to reflow, or '$COMMENTFLOW --diff <file>' to see one." >&2
+exit 1

--- a/.ci/check-cppcheck.sh
+++ b/.ci/check-cppcheck.sh
@@ -16,7 +16,25 @@
 
 set -e -u -o pipefail
 
-mapfile -d '' SOURCES < <(git ls-files -z -- 'src/*.c' 'src/**/*.c')
+CPPCHECK="${CPPCHECK:-cppcheck}"
+
+# Exit codes: 0 clean, 1 findings, 2 the check could not run, anything else the
+# analyzer's own failure. 1 is spoken for by --error-exitcode=1 below, so a
+# missing binary must not borrow it: an environment problem would then read as a
+# defect in the code.
+if ! command -v "$CPPCHECK" > /dev/null 2>&1; then
+    echo "Error: $CPPCHECK not found" >&2
+    exit 2
+fi
+
+# Not version-pinned, so report the version: a finding nobody else can reproduce
+# is then traceable to the checker rather than to the code.
+"$CPPCHECK" --version
+
+SOURCES=()
+while IFS= read -rd '' f; do
+    SOURCES+=("$f")
+done < <(git ls-files -z -- 'src/*.c' 'src/**/*.c')
 
 if [ ${#SOURCES[@]} -eq 0 ]; then
     echo "No tracked C source files found."
@@ -36,8 +54,16 @@ static const unsigned char shim_bin[1] = {0};
 static const unsigned int shim_bin_len = 1;
 EOF
 
-# 120s is generous -- this should finish well below that with --max-configs=1.
-timeout 120 cppcheck \
+# A hang guard, not a budget. The job it runs in is capped at 10 minutes total
+# (see lint.yml), so a value above that would be killed at the job level first
+# and the 124 branch below could never report. The sweep measures about 50s on a
+# CI runner with -j.
+#
+# -j is safe here because unusedFunction, the one check cppcheck refuses to run
+# in parallel, is not among the enabled ones.
+status=0
+timeout 300 "$CPPCHECK" \
+    -j "$(getconf _NPROCESSORS_ONLN 2> /dev/null || echo 2)" \
     -I. -Isrc -I"$BUILD_DIR" \
     --platform=unix64 \
     --enable=warning \
@@ -48,4 +74,22 @@ timeout 120 cppcheck \
     --suppress=preprocessorErrorDirective \
     --suppress=missingInclude \
     -D_GNU_SOURCE -D__APPLE__ -D__aarch64__ \
-    "${SOURCES[@]}"
+    "${SOURCES[@]}" || status=$?
+
+case "$status" in
+    0)
+        echo "cppcheck clean across ${#SOURCES[@]} source file(s)."
+        ;;
+    1)
+        echo "cppcheck reported findings; see the diagnostics above." >&2
+        echo "Suppress a false positive inline, with a comment saying why." >&2
+        ;;
+    124)
+        echo "Error: cppcheck timed out after 300s; this is not a code finding." >&2
+        ;;
+    *)
+        echo "Error: cppcheck exited $status without analyzing cleanly." >&2
+        ;;
+esac
+
+exit "$status"

--- a/.ci/check-cppcheck.sh
+++ b/.ci/check-cppcheck.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-# Run cppcheck static analysis on elfuse host source files (src/ only).
-# Tests use raw-syscall stubs and are excluded.
+# Run cppcheck static analysis on elfuse host source files (src/ only). Tests
+# use raw-syscall stubs and are excluded.
 #
-# CI mode: --max-configs=1 + --enable=warning for speed. Generated headers
-# under build/ that the source #includes must exist before invocation:
+# CI mode: --max-configs=1 + --enable=warning for speed. Generated headers under
+# build/ that the source #includes must exist before invocation:
 #   build/dispatch.h    -- via scripts/gen-syscall-dispatch.py
 #   build/version.h     -- one-line #define
 #   build/shim_blob.h   -- empty stub (the byte array contents are opaque
 #                          to cppcheck and produce no useful findings)
 #
-# Generating real dispatch.h instead of stubbing it keeps cppcheck honest
-# about the syscall dispatch layer. Stubbing shim_blob.h is acceptable
-# because the file is just a byte array with no callable surface.
+# Generating real dispatch.h instead of stubbing it keeps cppcheck honest about
+# the syscall dispatch layer. Stubbing shim_blob.h is acceptable because the
+# file is just a byte array with no callable surface.
 
 set -e -u -o pipefail
 
@@ -28,8 +28,9 @@ trap 'rm -rf "$BUILD_DIR"' EXIT
 
 python3 scripts/gen-syscall-dispatch.py --output "$BUILD_DIR/dispatch.h"
 printf '#define ELFUSE_VERSION "ci"\n' > "$BUILD_DIR/version.h"
-# shim_blob.h declares an opaque byte array and its length; cppcheck
-# gains nothing from the real contents, so a minimal stub suffices.
+
+# shim_blob.h declares an opaque byte array and its length; cppcheck gains
+# nothing from the real contents, so a minimal stub suffices.
 cat > "$BUILD_DIR/shim_blob.h" << 'EOF'
 static const unsigned char shim_bin[1] = {0};
 static const unsigned int shim_bin_len = 1;

--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-# Verify clang-format conformance for all tracked C/H files in src/ and
-# tests/. The repository's .clang-format is calibrated against
-# clang-format-22; older versions produce different output and are
-# rejected to keep CI deterministic.
+# Verify clang-format conformance for all tracked C/H files in src/ and tests/.
+# The repository's .clang-format is calibrated against clang-format-22; older
+# versions produce different output and are rejected to keep CI deterministic.
 
 set -u -o pipefail
 

--- a/.ci/check-newline.sh
+++ b/.ci/check-newline.sh
@@ -6,9 +6,10 @@ set -e -u -o pipefail
 
 ret=0
 while IFS= read -rd '' f; do
-    # `-b` prints just the encoding (e.g. "us-ascii", "binary", "utf-8")
-    # without the filename, so a path containing the word "binary" can't
-    # cause a non-binary file to be skipped.
+
+    # `-b` prints just the encoding (e.g. "us-ascii", "binary", "utf-8") without
+    # the filename, so a path containing the word "binary" can't cause a
+    # non-binary file to be skipped.
     if [ "$(file -b --mime-encoding -- "$f")" != "binary" ]; then
         if [ -n "$(tail -c1 < "$f")" ]; then
             echo "Warning: No newline at end of file $f"

--- a/.claude/skills/elfuse-conventions/SKILL.md
+++ b/.claude/skills/elfuse-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elfuse-conventions
-description: elfuse conventions that are not guessable from the code: the seven-rule commit message style, ASCII-only source comments, kebab-case filenames, the type and return conventions at the ABI boundary, the untracked root working docs, and the rule that a tool checked out for evaluation never becomes a build dependency. Use when drafting a commit message or PR description, adding a new file or a new type, or wiring the build to anything a fresh clone would not have.
+description: elfuse conventions that CONTRIBUTING.md does not carry: the register a comment or commit message is written in, comment brevity, the type and return conventions at the ABI boundary, PR etiquette, the untracked root working docs, and the rule that a tool checked out for evaluation never becomes a build dependency. CONTRIBUTING.md is the tracked style guide and settles C style, formatter mechanics, and the gates; read it first and use this for what it leaves to a reviewer. Use when drafting a commit message or PR description, adding a new file or a new type, or wiring the build to anything a fresh clone would not have.
 ---
 
 # elfuse conventions
@@ -8,6 +8,17 @@ description: elfuse conventions that are not guessable from the code: the seven-
 Almost nothing here is enforced by a gate. `clang-format` settles formatting
 and `make check-format` settles the generated files, so those are not in this
 file; what is left is the set a reviewer would otherwise have to say out loud.
+
+`CONTRIBUTING.md` is the other half and the tracked one. It settles C style,
+which formatter and which version, what each gate actually covers, and the
+seven commit-message rules. Read it before writing C rather than working from
+a memory of typical C style, because several of its rules are not the common
+default: `#pragma once` over include guards, `/* */` with no `//` anywhere,
+the asterisk bound to the name, no VLA, and `(void)` for a function that takes
+nothing, since `-Wstrict-prototypes` rejects the empty `()` form and the build
+treats that warning as an error. This file does not restate it.
+Where both speak, `CONTRIBUTING.md` wins, and a rule that drifts apart between
+the two is a defect in this file.
 
 The one exception is these files themselves. `scripts/check-skill-refs.py`
 fails when a skill names a file, make target, docs section, or sibling skill
@@ -22,9 +33,14 @@ A contributor may keep untracked working docs at the repo root or under
 `.claude/`; which ones exist differs per clone. Never `git add`, commit,
 stage, gitignore, or delete another person's: untracked but visible in
 `git status` is deliberate. None of them survive a fresh clone, so nothing
-here defers to one; the load-bearing conventions are written out below,
-because on a clean checkout `docs/` and these skills are all a contributor
-gets.
+here defers to one.
+
+What a clean checkout does carry is `CONTRIBUTING.md`, `docs/`, and these
+skills, which is where every load-bearing convention has to be written. Note
+that `scripts/check-skill-refs.py` cannot tell those apart: a bare markdown
+name at the repo root is left unverifiable on purpose, since it may be a
+private working doc, so a pointer to `CONTRIBUTING.md` from a skill is not
+gate-protected the way a `src/` path is. Renaming it is a manual sweep.
 
 ## Style
 
@@ -91,6 +107,49 @@ Comments and commit messages are third-person: name the subject (the caller,
 this function) or use imperative phrasing.
 
 Filenames use kebab-case, never underscore. Symbol names use snake_case.
+
+## What the formatter settles, and what it cannot
+
+Do not hand-format. `clang-format` owns indentation, brace placement (the
+function brace on its own line, the control-structure brace on the same line),
+the pointer asterisk binding to the name, spacing, wrapping, and trailing
+commas in initializers. `commentflow` owns what clang-format
+half-does: it breaks an over-long comment line but never refills a
+short-wrapped one, so comment width is settled by reflowing to the same
+`ColumnLimit`. Write it reasonably,
+write the comment as a sentence, and let `make indent` place the breaks.
+
+The formatter is silent on the rest, so apply these while writing rather than
+after:
+
+- Include order. `.clang-format` sets `SortIncludes: Never`, so the formatter
+  neither sorts nor regroups what you wrote, and a wrong order stays wrong
+  through every gate. System headers first, then project headers, each group
+  separated by a blank line, the file's own header among the project group.
+- ASCII in comments, `/* */` with no `//`, kebab-case filenames, snake_case
+  symbols, `#pragma once`.
+- Fixed-width types on the guest side of the boundary, host types on the host
+  side, and `bool` versus `int` for what a function returns.
+- The banned libc calls, no VLA, no invented `_`-prefixed identifier. Those
+  fail in CI, not in the formatter.
+
+Two scripts check, and both run in CI: `.ci/check-format.sh` for clang-format
+over the C sources, `.ci/check-commentflow.sh` for comment width over the C,
+shell, and assembly sources. The second owns its file list for `make
+check-format` too, so the local target and the gate cannot drift apart on
+coverage. Both fail rather than skip when their tool is missing.
+
+`make indent` is a no-op on a clean tree, in both halves: every file clang-format
+selects already formats to itself, and every file commentflow selects already
+reflows to itself. That was not free. The tree's comments were wrapped by hand
+before the tool existed, and the one-time reflow rewrote 142 of the 353 C and
+header files, both assembly files, and 36 of the 41 shell scripts. It landed as
+its own commit because a mechanical change with no behavior in it cannot be
+reviewed alongside one that has some.
+
+The gate is what keeps it a no-op. If `make indent` ever hands you a diff in a
+file you did not touch, something reintroduced hand-wrapping, or your
+commentflow is not the version the gate runs.
 
 ## Code
 

--- a/.claude/skills/elfuse-refactor/SKILL.md
+++ b/.claude/skills/elfuse-refactor/SKILL.md
@@ -186,13 +186,21 @@ four-figure functions because nobody took it. But "in proportion" is the
 load-bearing half, and in this tree it has a mechanical edge that a good
 intention does not survive.
 
-Do not run `clang-format -i` on a whole file to tidy a small change. Files
-here are format-clean but their comment wrapping predates the current
-formatter, so a whole-file pass rewraps comments nowhere near your edit and
-buries the change in churn. Format the file only when you added code to it,
-and check `git diff --numstat` before calling the work done: a file you meant
-to touch in one line reporting twenty is churn, not cleanup. The same goes for
-a scripted edit that rewrites whole files.
+Do not run `clang-format -i` on a whole file to tidy a small change. On the
+current tree that pass is a no-op, since every file `make indent` selects
+formats to itself with no diff, so it buys nothing. What it can cost is
+everything: a clang-format that is not version 22 reformats the whole tree at
+once and buries the change, which is why `CONTRIBUTING.md` pins the version
+rather than asking for 22 or newer.
+
+`make indent` also runs `commentflow`, and since the one-time reflow landed it
+is a no-op too. Treat a tree-wide diff from either half as a signal rather than
+as cleanup: it means the formatter you have is not the one the gate runs.
+
+Format the file only when you added code to it, and check `git diff --numstat`
+before calling the work done: a file you meant to touch in one line reporting
+twenty is churn, not cleanup. The same goes for a scripted edit that rewrites
+whole files.
 
 The proportionality test is the diff, not the intent. A cleanup that lands in
 a file the task never needed to open is a separate change, and it costs the

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,6 +127,7 @@ jobs:
           run_everything() {
             echo "c=true" >> "$GITHUB_OUTPUT"
             echo "sh=true" >> "$GITHUB_OUTPUT"
+            echo "cf=true" >> "$GITHUB_OUTPUT"
             echo "$1; running every check"
             exit 0
           }
@@ -152,9 +153,21 @@ jobs:
           # regenerates build/dispatch.h from dispatch.tbl through the
           # generator before it analyzes anything. A pull request editing only
           # one of those would otherwise change a check without running it.
-          c=false; sh=false
+          c=false; sh=false; cf=false
           pat='\.(c|h)$|^\.clang-format$|^\.ci/|^src/syscall/dispatch\.tbl$'
           pat="$pat"'|^scripts/gen-syscall-dispatch\.py$'
+          # commentflow reads a wider set than clang-format: it reflows shell
+          # and assembly too, and it takes its column limit from .clang-format,
+          # so a change to that file moves every comment in the tree.
+          cfpat='\.(c|h|s|S|sh|bash)$|^\.clang-format$'
+          # This workflow pins both formatters, commentflow by checksum below
+          # and clang-format through LINT_PKGS, so editing it can change what
+          # either gate enforces. Re-checking the tree is the only way that
+          # shows up before the next contributor hits it, so both patterns
+          # carry the workflow itself.
+          selfpat='|^\.github/workflows/lint\.yml$'
+          cfpat="$cfpat$selfpat"
+          pat="$pat$selfpat"
           # A here-string, not a pipeline into grep. Under pipefail a "grep -q"
           # that matches early exits while the writer still has bytes to push,
           # the writer takes SIGPIPE, and the pipeline reports non-zero even
@@ -164,9 +177,33 @@ jobs:
           # exactly the diff that must not skip a check.
           if grep -qE "$pat" <<< "$files"; then c=true; fi
           if grep -qE '^\.ci/.*\.sh$' <<< "$files"; then sh=true; fi
+          if grep -qE "$cfpat" <<< "$files"; then cf=true; fi
           echo "c=$c" >> "$GITHUB_OUTPUT"
           echo "sh=$sh" >> "$GITHUB_OUTPUT"
-          echo "C sources changed: $c; .ci shell changed: $sh"
+          echo "cf=$cf" >> "$GITHUB_OUTPUT"
+          echo "C sources changed: $c; .ci shell changed: $sh; reflow inputs changed: $cf"
+
+      # commentflow ships as a release binary rather than an apt package, and
+      # its only tag is a rolling "latest", so the checksum below is what
+      # actually pins the version. A mismatch means upstream republished the
+      # tag: read what changed in the reflow rules before updating the hash,
+      # because a formatter that moves under CI rewrites the tree without a
+      # commit here saying so. This is the same reason clang-format is held at
+      # exactly 22 rather than "22 or newer".
+      - name: Install commentflow
+        if: ${{ !cancelled() && steps.changed.outputs.cf == 'true' }}
+        env:
+          COMMENTFLOW_URL: https://github.com/sysprog21/commentflow/releases/download/latest/commentflow-x86_64-unknown-linux-gnu.tar.gz
+          COMMENTFLOW_SHA256: b9723611440cdfac0b17a4d226d3f36c36dca87f37fc5c95b3f00274830834f5
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/commentflow.tar.gz "$COMMENTFLOW_URL"
+          echo "$COMMENTFLOW_SHA256  /tmp/commentflow.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/commentflow.tar.gz -C /usr/local/bin commentflow
+
+      - name: Comment reflow
+        if: ${{ !cancelled() && steps.changed.outputs.cf == 'true' }}
+        run: .ci/check-commentflow.sh
 
       - name: Cache apt packages
         if: ${{ !cancelled() && (steps.changed.outputs.c == 'true' || steps.changed.outputs.sh == 'true') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1242 @@
+# Contributing to `elfuse`
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to
+[elfuse](https://github.com/sysprog21/elfuse) hosted on GitHub.
+These are mostly guidelines, not rules.
+Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## Issues
+
+This project uses GitHub Issues to track ongoing development, discuss project plans, and keep track
+of bugs.
+Be sure to search for existing issues before you create another one.
+
+Initially, it is advisable to create an issue on GitHub for bug reports, feature requests, or
+substantial pull requests, as this offers a platform for discussion with both the community and
+project maintainers.
+
+Engaging in a conversation through a GitHub issue before making a contribution is crucial to ensure
+the acceptance of your work.
+We aim to prevent situations where significant effort is expended on a pull request that might not
+align with the project's design principles.
+For example, it might turn out that the feature you propose is more suited as an independent module
+that complements this project, in which case we would recommend that direction.
+
+For minor corrections, such as typo fixes, small refactoring, or updates to documentation/comments,
+filing an issue is not typically necessary.
+What constitutes a "minor" fix involves discretion; however, examples include:
+* Correcting spelling mistakes
+* Minor code refactoring
+* Updating or editing documentation and comments
+
+Nevertheless, there may be instances where, upon reviewing your pull requests, we might request an
+issue to be filed to facilitate discussion on broader design considerations.
+
+Visit our [Issues page on GitHub](https://github.com/sysprog21/elfuse/issues) to search and submit.
+
+## Ground Rules
+
+Contributions from developers across corporations, academia, and individuals are welcome.
+Participation requires adherence to a few ground rules:
+* Code follows the C coding style below.
+  There is some flexibility in basic style, but stay with the standard already in the file you are
+  editing.
+  Complex algorithmic constructs without explanatory comments will not be accepted.
+* Shell and Python scripts are formatted before submission, with the project's flags rather than
+  your own.
+  Run `make indent` and the flags are settled for you.
+* External pull requests document their intent in the pull request description.
+* Documentation, code comments, and other English material use the American English (`en_US`)
+  dialect: "initialize" over "initialise", "color" over "colour".
+
+## Formatting and Tooling
+
+Software requirements:
+* [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 22, exactly.
+  `.ci/check-format.sh` rejects any other version, because the output of a neighboring release
+  differs enough to fail a file that the pinned version considers clean.
+* [commentflow](https://github.com/sysprog21/commentflow), which reflows comments to the column
+  limit.
+  `make indent` requires it and fails with the project URL when it is missing, rather than
+  formatting the tree to a standard that depends on who ran it.
+* [shellcheck](https://www.shellcheck.net/), at warning severity.
+* [shfmt](https://github.com/mvdan/sh) and [black](https://github.com/psf/black), for shell and
+  Python.
+  Neither version is pinned; `make indent` uses whatever is on `PATH` and skips the step when the
+  tool is absent.
+
+To maintain a uniform style across languages, run:
+* `make indent` to rewrite in place: `commentflow` over the C, shell, and assembly sources first,
+  then clang-format over the C sources, `shfmt -ln=bash -i 4 -ci -bn -fn -sr` over the shell
+  scripts, `black` over the Python scripts.
+  The order is not arbitrary. clang-format breaks a comment line that runs past the limit but never
+  refills a short-wrapped one, so commentflow
+  runs first and clang-format normalizes whatever indentation the reflow produced; the pair
+  converges, and a file that has been through both is clean under both.
+* `make check-format` to verify without rewriting: comment reflow, clang-format compliance,
+  shellcheck over every script the repository carries, the syscall dispatch table, and the
+  test-matrix skip lists.
+
+Prefer these targets over invoking the formatters by hand.
+They select their inputs through `git ls-files` with an explicit pathspec, so vendored trees under
+`externals/` never reach a formatter.
+
+## Coding Style for Shell Script
+
+Shell scripts must be clean, consistent, and portable.
+The following `shfmt` rules (check `.editorconfig` file) are enforced project-wide:
+* Use spaces for indentation.
+* Indent with 4 spaces.
+* Use Unix-style line endings (LF).
+* Remove trailing whitespace at the end of lines.
+* Ensure the file ends with a newline.
+* Place the opening brace of a function on the next line.
+* Indent `case` statements within `switch` blocks.
+* Add spaces around redirection operators (e.g., `>`, `>>`).
+* Place binary operators (e.g., `&&`, `|`) on the next line when breaking lines.
+
+## Coding Style for Python
+
+Python scripts must be clean, consistent, and adhere to modern Python best practices.
+The following formatting rules are enforced project-wide using `black`:
+
+* Use 4 spaces for indentation (never tabs).
+* Limit lines to 80 characters maximum.
+* Use double quotes for strings (unless single quotes avoid escaping).
+* Use trailing commas in multi-line constructs.
+* Format imports according to PEP 8 guidelines.
+* Use Unix-style line endings (LF).
+* Remove trailing whitespace at the end of lines.
+* Ensure files end with a newline.
+
+## Coding Style for Modern C
+
+This coding style is a variant of the [K&R
+style](https://en.wikipedia.org/wiki/Indentation_style#K&R).
+Adhere to established practices while being open to innovation.
+Maintain consistency, adopt the latest C standards, and embrace modern compilers along with their
+advanced static analysis capabilities and sanitizers.
+
+The tree is C11 in practice: `_Thread_local`, `_Atomic`, and `_Static_assert` all appear in `src/`,
+and headers use `#pragma once`.
+No `-std=` flag is set, so the compiler default applies and GNU extensions are available; use one
+only where a platform header or an HVF construct leaves no choice.
+
+The build treats warnings as errors and turns on a set worth knowing before you write the code:
+`-Wall -Wextra -Wpedantic -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wformat=2
+-Wimplicit-fallthrough -Wundef -Wnull-dereference -Wno-unused-parameter`.
+The last of those is the one exemption: an unused parameter is expected at a callback signature the
+guest ABI fixes, so it does not have to be annotated away.
+Two of those make rules in this document compiler-enforced rather than advisory:
+`-Wstrict-prototypes` rejects the empty parameter list, and `-Wmissing-prototypes` rejects a
+non-static function with no prototype.
+`WERROR=0` exists for the case where a newer compiler invents a warning this tree has not seen yet;
+it is not a way to land a warning.
+
+One rule outranks every other rule in this document:
+
+> The single most important rule when writing code is this: check the surrounding code and try to
+> imitate it.
+
+Whatever the sections below recommend, when you patch existing code, keep the style already in that
+file even if it is not your favorite.
+A patch written in a style foreign to its surroundings costs the reviewer more than it saved the
+author.
+
+Three project-wide rules that no formatter will fix for you:
+* Source comments and commit messages are ASCII only.
+  No em dashes, no typographic quotes, no non-ASCII arrows.
+  Write `-`, `--`, or `:` instead, and drop the markdown: inside a comment a symbol or path is
+  written bare, as EPOLL_CTL_MOD or tests/foo.c, not wrapped in backticks.
+  This governs what goes into a `.c`, `.h`, or `.S` file and into a commit message.
+  Markdown documents, this one included, use ordinary markdown.
+* Comments use `/* ... */` exclusively.
+  `//` never appears, not even for a single line.
+* Filenames use kebab-case (`proc-state.c`), identifiers use snake_case (`proc_state`).
+  Keeping the underscore out of filenames avoids a visual collision between a symbol and the file
+  that holds it.
+
+### Indentation
+
+In this coding style guide, the use of 4 spaces for indentation instead of tabs is strongly enforced
+to ensure consistency.
+Always apply a single space before and after comparison and assignment operators to maintain
+readable code.
+Additionally, it is crucial to include a single space after every comma. e.g.,
+```c
+for (int i = 0; i < 10; i++) {
+    printf("%d\n", i);
+    /* some operations */
+}
+```
+
+The tab character (ASCII 0x9) should never appear within any source code file.
+When indentation is needed in the source code, align using spaces instead.
+The width of the tab character varies by text editor and programmer preference, making consistent
+visual layout a continual challenge during code reviews and maintenance.
+
+### Line length
+
+All lines should typically remain within 80 characters, with longer lines wrapped as needed.
+For code that limit is `.clang-format`'s `ColumnLimit`; for comment text it is `commentflow`, which
+reads the same key, so there is one number and not two.
+This practice is supported by several valid rationales:
+* It encourages developers to write concise code.
+* Smaller portions of information are easier for humans to process.
+* It assists users of vi/vim (and potentially other editors) who use vertical splits.
+* It is especially helpful for those who may want to print code on paper.
+
+### Comments
+
+Multi-line comments should have the opening and closing characters on separate lines, with the
+content lines prefixed by a space and an asterisk (`*`) for alignment, e.g.,
+```c
+/*
+ * This is a multi-line comment.
+ */
+
+/* One line comment. */
+```
+
+Use multi-line comments for more elaborate descriptions or before significant logical blocks of
+code.
+
+Do not hand-wrap comment text.
+`commentflow` reflows it to the column limit it reads out of `.clang-format`, which is the same 80
+the section above states, so the width rule has one owner rather than a rule in this document and a
+habit in your editor.
+Write the sentence and let `make indent` place the breaks.
+
+A labelled pair such as `Usage:` and `Example:` needs a blank comment line between the two blocks, or
+the reflow reads them as one paragraph and splices the two commands onto a single line.
+
+What it will not touch, so you can still lay these out by hand: blank lines inside a comment, the
+existing indentation, a preformatted region (a table, an ASCII diagram, a code fence), an SPDX
+identifier, and a tool directive such as `clang-format off`.
+An ASCII diagram of a race window or a byte layout survives the reflow intact.
+
+Single-line comments should be written in C89 style:
+```c
+    return (uintptr_t) val;  /* return a bitfield */
+```
+
+Leave two spaces between the statement and the inline comment.
+Avoid commenting out code directly.
+Instead, use `#if 0` ... `#endif` when it is intentional.
+
+All assumptions should be clearly explained in comments.
+Use the following markers to highlight issues and make them searchable:
+* `WARNING`: Alerts a maintainer to the risk of changing this code. e.g., a delay loop counter's
+  terminal value was determined empirically and may need adjustment when the code is ported or the
+  optimization level is tweaked.
+* `NOTE`: Provides descriptive comments about the "why" of a chunk of code, as opposed to the "how"
+  usually included in comments. e.g., a chunk of driver code may deviate from the datasheet due to a
+  known erratum in the chip, or an assumption made by the original programmer is explained.
+* `TODO`: Indicates an area of the code that is still under construction and explains what remains
+  to be done.
+  When appropriate, include an all-caps programmer name or set of initials before the word `TODO`.
+
+Keep the documentation as close to the code as possible.
+
+### Spacing and brackets
+
+Ensure that the keywords `if`, `while`, `for`, `switch`, and `return` are always followed by a
+single space when there is additional code on the same line.
+Follow these spacing guidelines:
+* Place one space after the keyword in a conditional or loop.
+* Do not use spaces around the parentheses in conditionals or loops.
+* Insert one space before the opening curly bracket.
+
+For example:
+```c
+do {
+    /* some operations */
+} while (condition);
+```
+
+Functions (their declarations or calls), `sizeof` operator or similar macros shall not have a space
+after their name/keyword or around the brackets, e.g.,
+```c
+unsigned total_len = offsetof(obj_t, items[n]);
+unsigned obj_len = sizeof(obj_t);
+```
+
+Use brackets to avoid ambiguity and with operators such as `sizeof`, but otherwise avoid redundant
+or excessive brackets.
+
+Assignment operators (`=`, `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, and `>>=`) should
+always have a space before and after them.
+For example:
+```c
+count += 1;
+```
+
+Binary operators (`+`, `-`, `*`, `/`, `%`, `<`, `<=`, `>`, `>=`, `==`, `!=`, `<<`, `>>`, `&`, `|`,
+`^`, `&&`, and `||`) should also be surrounded by spaces.
+For example:
+```c
+current_conf = prev_conf | (1 << START_BIT);
+```
+
+Unary operators (`++`, `--`, `!`, and `~`) should be written without spaces between the operator and
+the operand.
+For example:
+```c
+bonus++;
+if (!play)
+    return STATE_QUIET;
+```
+
+The ternary operator (`?` and `:`) should have spaces on both sides.
+For example:
+```c
+static uint32_t max(uint32_t a, uint32_t b)
+{
+    return (a > b) ? a : b;
+}
+```
+
+Structure pointer (`->`) and member (`.`) operators should not have surrounding spaces.
+Similarly, array subscript operators (`[` and `]`) and function call parentheses should be written
+without spaces around them.
+
+### Parentheses
+
+Avoid relying on C's operator precedence rules, as they may not be immediately clear to those
+maintaining the code.
+To ensure clarity, always use parentheses to enforce the correct execution order within a sequence
+of operations, or break long statements into multiple lines if necessary.
+
+When using logical AND (`&&`) and logical OR (`||`) operators, each operand should be enclosed in
+parentheses, unless it is a single identifier or constant.
+For example:
+```c
+if ((count > 100) && (detected == false)) {
+    character = C_ASSASSIN;
+}
+```
+
+### Variable names and declarations
+
+Ensure that functions, variables, and comments are consistently named using English words.
+Global variables should have descriptive names, while local variables can have shorter names.
+It is important to strike a balance between being descriptive and concise.
+Each variable's name should clearly reflect its purpose.
+
+Use [snake_case](https://en.wikipedia.org/wiki/Snake_case) for naming conventions, and avoid using
+"camelCase." Additionally, do not use Hungarian notation or any other unnecessary prefixes or
+suffixes.
+
+When declaring pointers, follow these spacing conventions:
+```c
+const char *name;             /* Pointer to const data */
+conf_t *const cfg;            /* Const pointer to mutable data */
+const uint8_t *const charmap; /* Const pointer to const data */
+const void *restrict key;     /* Restrict pointer to const data; does not alias */
+```
+
+The asterisk binds to the name, never to the type, and no space separates it from what follows it.
+This is not a preference you can spell the other way: `.clang-format` sets `PointerAlignment:
+Right`, so `conf_t * const cfg` is rewritten to `conf_t *const cfg` and the unformatted spelling
+fails the check.
+
+Declare a local variable where it is first used rather than at the top of the function (see
+[Initialization](#initialization)).
+When several variables of the same type are introduced at the same point, declare them on one line:
+```c
+void func(void)
+{
+    char a, b;  /* OK: introduced together */
+
+    char a;
+    char b;     /* Avoid: same type, same point, split over two lines */
+}
+```
+
+Do not fold a function call into a declaration that introduces more than one variable.
+The reader cannot tell at a glance which variable the call initializes:
+```c
+int len, ret = compute();  /* Avoid */
+
+int len;
+int ret = compute();       /* OK */
+```
+
+Do not invent an identifier that begins with `_` or `__`.
+Those forms are reserved for the implementation, and a collision with a libc or compiler internal
+surfaces as a diagnostic nowhere near the declaration that caused it.
+This constrains only the names you define.
+Spelling one the toolchain already provides (`__attribute__`, `_Atomic`, `_Static_assert`,
+`__atomic_load_n`) is exactly how those features are reached.
+
+Always include a trailing comma in the last element of a structure initialization, including its
+nested elements, to help `clang-format` correctly format the structure.
+However, this comma can be omitted in very simple and short structures.
+```c
+typedef struct {
+    int width, height;
+} screen_t;
+
+screen_t s = {
+    .width = 640,
+    .height = 480,   /* comma here */
+};
+```
+
+### Type definitions
+
+Declarations shall be on the same line, e.g.,
+```c
+typedef void (*dir_iter_t)(void *, const char *, struct dirent *);
+```
+
+_Typedef_ structures rather than pointers.
+Note that structures can be kept opaque if they are not dereferenced outside the translation unit
+where they are defined.
+Pointers can be _typedefed_ only if there is a very compelling reason.
+
+New types may be suffixed with `_t`.
+Structure name, when used within the translation unit, may be omitted, e.g.:
+
+```c
+typedef struct {
+    unsigned if_index;
+    unsigned addr_len;
+    addr_t next_hop;
+} route_info_t;
+```
+
+### Initialization
+
+Do not initialize static and global variables to `0`; the compiler will do this.
+When a variable is declared inside a function, it is not automatically initialized.
+
+```c
+static uint8_t a;  /* Global variable 'a' is set to 0 by the compiler */
+
+void foo(void)
+{
+    /* 'b' is uninitialized and set to whatever happens to be in memory */
+    uint8_t b;
+    ...
+}
+```
+
+Embrace C99 structure initialization where reasonable, e.g.,
+```c
+static const crypto_ops_t openssl_ops = {
+    .create = openssl_crypto_create,
+    .destroy = openssl_crypto_destroy,
+    .encrypt = openssl_crypto_encrypt,
+    .decrypt = openssl_crypto_decrypt,
+    .hmac = openssl_crypto_hmac,
+};
+```
+
+Embrace C99 array initialization, especially for the state machines, e.g.,
+```c
+static const uint8_t tcp_fsm[TCP_NSTATES][2][TCPFC_COUNT] = {
+    [TCPS_CLOSED] = {
+        [FLOW_FORW] = {
+            /* Handshake (1): initial SYN. */
+            [TCPFC_SYN] = TCPS_SYN_SENT,
+        },
+    },
+    ...
+};
+```
+
+An automatic pointer variable that has no initial address should be explicitly initialized to
+`NULL`.
+This practice helps prevent undefined behavior caused by dereferencing uninitialized pointers.
+The rule above about leaving statics and globals alone still holds: those already start as null
+pointers, and writing the initializer out only obscures which of them the code means to set later.
+
+Static analysis runs over the whole tree before each build and warns about a variable used before it
+is initialized, which is the bug this section exists to prevent.
+
+### Control structures
+
+Try to make the control flow easy to follow.
+Avoid long convoluted logic expressions; try to split them where possible (into inline functions,
+separate if-statements, etc).
+
+The control structure keyword and the expression in the brackets should be separated by a single
+space.
+The opening curly bracket shall be in the same line, also separated by a single space.
+Example:
+
+```c
+    for (;;) {
+        obj = get_first();
+        while ((obj = get_next(obj))) {
+            ...
+        }
+        if (done)
+            break;
+    }
+```
+
+A loop with an empty body carries an explicit pair of brackets, so that neither a reader nor
+`-Wempty-body` has to decide whether the semicolon was a typo:
+```c
+    while (!ready()) {}   /* OK */
+    while (!ready());     /* Wrong */
+```
+
+Do not add inner spaces around the brackets.
+There should be one space after the semicolon when `for` has expressions:
+```c
+    for (unsigned i = 0; i < ARRAY_SIZE(items); i++) {
+        ...
+    }
+```
+
+#### Avoid unnecessary nesting levels
+
+It is generally preferred to place the shorter clause (measured in lines of code) first in `if` and
+`else if` statements.
+Long clauses can distract the reader from the core decision-making logic, making the code harder to
+follow.
+By placing the shorter clause first, the decision path becomes clearer and easier to understand,
+which can help reduce bugs.
+
+Avoid nesting `if`-`else` statements deeper than two levels.
+Instead, consider using function calls or `switch` statements to simplify the logic and enhance
+readability.
+Deeply nested `if`-`else` statements often indicate a complex and fragile state machine
+implementation, which can be refactored into a safer and more maintainable structure.
+
+For example, avoid this:
+```c
+int inspect(obj_t *obj)
+{
+    if (cond) {
+        ...
+        /* long code block */
+        ...
+        return 0;
+    }
+    return -1;
+}
+```
+
+Instead, consider this approach:
+```c
+int inspect(obj_t *obj)
+{
+    if (!cond)
+        return -1;
+    ...
+    return 0;
+}
+```
+
+However, be careful not to make the logic more convoluted in an attempt to simplify nesting.
+
+### `if` statements
+
+Curly brackets and spacing follow the K&R style:
+```c
+    if (a == b) {
+        ...
+    } else if (a < b) {
+        ...
+    } else {
+        ...
+    }
+```
+
+Simple and succinct one-line `if` statements may omit curly brackets:
+```c
+    if (!valid)
+        return -1;
+```
+
+However, do prefer curly brackets with multi-line or more complex statements.
+If one branch uses curly brackets, then all other branches shall use the curly brackets too.
+
+Wrap long conditions to the if-statement indentation adding extra 4 spaces:
+```c
+    if (some_long_expression &&
+        another_expression) {
+        ...
+    }
+```
+
+#### Avoid redundant `else`
+
+Avoid:
+```c
+    if (flag & F_FEATURE_X) {
+        ...
+        return 0;
+    } else {
+        return -1;
+    }
+```
+
+Consider:
+```c
+    if (flag & F_FEATURE_X) {
+        ...
+        return 0;
+    }
+    return -1;
+```
+
+### `switch` statements
+
+Switch statements should have the `case` blocks at the same indentation level, e.g.:
+```c
+    switch (expr) {
+    case A:
+        ...
+        break;
+    case B:
+        /* fallthrough */
+    case C:
+        ...
+        break;
+    }
+```
+
+If the case block does not break, then it is strongly recommended to add a comment containing
+"fallthrough" to indicate it.
+Modern compilers can also be configured to require such comment (see gcc `-Wimplicit-fallthrough`).
+Alternatively, consider using C23 `[[fallthrough]]` declaration.
+
+### Function definitions
+
+The opening and closing curly brackets shall also be in the separate lines (K&R style).
+
+```c
+ssize_t hex_write(FILE *stream, const void *buf, size_t len)
+{
+    ...
+}
+```
+
+Do not use old K&R style C definitions.
+A function that takes no parameters is declared and defined with `(void)`, never with empty
+parentheses:
+```c
+int32_t get_status(void);  /* OK */
+int32_t get_status();      /* Wrong: declares an unspecified parameter list, not zero parameters */
+```
+
+Every function reachable from outside its translation unit needs a prototype in the matching header.
+Everything else is `static`.
+
+Introduced in C99, `restrict` is a pointer qualifier that informs the compiler no other pointer will
+access the same object during its lifetime, enabling optimizations such as vectorization.
+Violating this assumption leads to undefined behavior.
+Use `restrict` judiciously.
+
+For function parameters, place one space after each comma, except at the end of a line.
+
+### Function-like macros
+
+When using function-like macros (parameterized macros), adhere to the following guidelines:
+* For expression macros, enclose the entire macro body in parentheses.
+* Surround each parameter usage with parentheses.
+* Limit the use of each parameter to no more than once within the macro to avoid unintended side
+  effects.
+* Never include control flow statements (e.g., `return`) within a macro.
+* If the macro involves multiple statements, encapsulate them within a `do`-`while (0)` construct
+  instead of parentheses.
+
+For example:
+```c
+#define SET_POINT(p, x, y)      \
+    do {                        \
+        (p)->px = (x);          \
+        (p)->py = (y);          \
+    } while (0)
+```
+
+While the extensive use of parentheses, as shown above, helps minimize some risks, it cannot prevent
+issues like unintended double increments from calls such as `MAX(i++, j++)`.
+
+Other risks associated with macros include comparing signed and unsigned data or testing
+floating-point values.
+Additionally, macros are not visible at runtime, making them impossible to step into with a
+debugger.
+Therefore, use them with caution.
+
+In general, macro names are typically written in all capitals, except in cases where readability is
+improved by using lowercase.
+For example:
+```c
+#define countof(a)   (sizeof(a) / sizeof(*(a)))
+#define lengthof(s)  (countof(s) - 1)
+```
+
+Although all capitals are generally preferred for constants, lowercase can be used for function-like
+macros to improve readability.
+These function-like macros do not share the same namespace concerns as other macros.
+
+For example, consider the implementation of a simple memory allocator.
+An arena can be represented by a memory buffer and an offset that begins at zero.
+To allocate an object, record the pointer at the current offset, advance the offset by the size of
+the object, and return the pointer.
+Additional considerations, such as alignment and checking for available space, are also required.
+```c
+#define new(a, n, t)  alloc(a, n, sizeof(t), _Alignof(t))
+
+typedef struct {
+    char *begin, *end;
+} arena_t;
+
+static void *alloc(arena_t *a, ptrdiff_t count, ptrdiff_t size, ptrdiff_t align)
+{
+    ptrdiff_t pad = -(uintptr_t)a->begin & (align - 1);
+    assert(count < (a->end - a->begin - pad) / size);
+
+    void *result = a->begin + pad;
+    a->begin += pad + (count * size);
+    return memset(result, 0, count * size);
+}
+```
+
+Using the `new` macro helps prevent several common errors in C programs.
+If types are mixed up, the compiler generates errors or warnings.
+Moreover, naming a macro `new()` does not conflict with variables or fields named `new`, because the
+macro form does not resemble a function call.
+
+### Preprocessor directives
+
+Prefer `#if defined(X)` over `#ifdef X`, since only the former composes with `&&`, `||`, and `!`
+without rewriting the directive when a second condition appears.
+
+Annotate `#else` and `#endif` with the condition they close.
+A conditional block long enough to scroll is a conditional block whose `#endif` is otherwise
+unattributable:
+```c
+#if defined(__aarch64__)
+/* ... */
+#else /* defined(__aarch64__) */
+/* ... */
+#endif /* !defined(__aarch64__) */
+```
+
+Do not indent the `#` of a nested directive.
+The nesting is already visible in the conditions themselves, and a leading-space form is not
+accepted by every preprocessor in equal measure.
+
+### Use `const` and `static` effectively
+
+The `static` keyword should be used for any variables that do not need to be accessible outside the
+module where they are declared.
+This is particularly important for global variables defined in C files.
+Declaring variables and functions as `static` at the module level protects them from external
+access, reducing coupling between modules and improving encapsulation.
+
+For functions that do not need to be accessible outside the module, use the `static` keyword.
+This is especially important for private functions, where `static` should always be applied.
+
+For example:
+```c
+static bool verify_range(uint16_t x, uint16_t y);
+```
+
+The `const` keyword is essential for several key purposes:
+* Declaring variables that should not change after initialization.
+* Defining fields within a `struct` that must remain immutable, such as those in memory-mapped I/O
+  peripheral registers.
+* Serving as a strongly typed alternative to `#define` for read-only variables.
+
+For example, instead of using:
+```c
+#define MAX_SKILL_LEVEL (100U)
+```
+
+Use:
+```c
+const uint8_t max_skill_level = 100;
+```
+
+Maximizing the use of `const` provides the advantage of compiler-enforced protection against
+unintended modifications to data that should be read-only, thereby enhancing code reliability and
+safety.
+
+Additionally, when one of your function arguments is a pointer to data that will not be modified
+within the function, you should use the `const` keyword.
+This is particularly useful when comparing a character array with predefined strings without
+altering the array's contents.
+
+For example:
+```c
+static bool is_valid_cmd(const char *cmd);
+```
+
+### Object abstraction
+
+Objects are often "emulated" by the C programmers with a `struct` and its "public API".
+To enforce the information hiding principle, it is a good idea to define the structure in the source
+file (translation unit) and provide only the _declaration_ in the header.
+For example, `obj.c`:
+
+```c
+#include "obj.h"
+
+struct obj {
+    int value;
+    ...
+};
+
+obj_t *obj_create(void)
+{
+    return calloc(1, sizeof(obj_t));
+}
+
+void obj_destroy(obj_t *obj)
+{
+    free(obj);
+}
+```
+
+With an example `obj.h`:
+```c
+#pragma once
+
+typedef struct obj obj_t;
+
+obj_t *obj_create(void);
+void obj_destroy(obj_t *);
+```
+
+Headers use `#pragma once`.
+Every compiler this project targets supports it, and it removes a class of bugs that hand-written
+guards invite: a misspelled macro, or the same guard name copied into a second header.
+Note also that a guard spelled `_OBJ_H_` would be doubly wrong, since a leading underscore followed
+by an uppercase letter is reserved for the implementation.
+
+Such structuring will prevent direct access of the `obj_t` members outside the `obj.c` source file.
+The implementation (of such "class" or "module") may be large and abstracted within separate source
+files.
+In such case, consider separating structures and "methods" into separate headers (think of different
+visibility), for example `obj_impl.h` (private) and `obj.h` (public).
+
+Consider `crypto_impl.h`:
+```c
+#pragma once
+
+#if !defined(CRYPTO_PRIVATE)
+#error "only to be used by the crypto modules"
+#endif
+
+#include "crypto.h"
+
+struct crypto {
+    crypto_cipher_t cipher;
+    void *key;
+    size_t key_len;
+    ...
+};
+```
+
+And `crypto.h` (public API):
+
+```c
+#pragma once
+
+typedef struct crypto crypto_t;
+
+crypto_t *crypto_create(crypto_cipher_t);
+void crypto_destroy(crypto_t *);
+...
+```
+
+### Include order
+
+A source file includes system headers first, then project headers, each group separated by a blank
+line:
+```c
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/guest.h"
+#include "syscall/internal.h"
+```
+
+A `.c` file includes its own header among the project headers, so that a header missing one of its
+own dependencies fails in the translation unit that owns it rather than in whichever caller happens
+to include it second.
+Headers include what they use and nothing more; prefer a forward declaration when the full
+definition is not needed.
+
+Never include a `.c` file from another `.c` file.
+
+### Use reasonable types
+
+Use `unsigned` for general iterators; use `size_t` for general sizes; use `ssize_t` to return a size
+which may include an error.
+Of course, consider possible overflows.
+
+Avoid using fixed-width types like `uint8_t`, `uint16_t`, or other smaller integer types for general
+iterators or similar cases unless there is a specific need for size-constrained operations, such as
+in fixed-width data processing or resource-limited environments.
+
+C has rather peculiar _type promotion rules_ and unnecessary use of sub-word types might contribute
+to a bug once in a while.
+
+Boolean variables should be declared using the `bool` type.
+Non-Boolean values should be converted to Boolean by using relational operators (e.g., `<` or `!=`)
+rather than by casting.
+
+For example:
+```c
+#include <stdbool.h>
+...
+bool inside = (value < expected_range);
+```
+
+### Dynamic memory
+
+Do not use variable-length arrays.
+A length that a caller controls becomes a stack extension the compiler cannot bound, and the failure
+mode is a corrupted frame rather than a null return.
+Allocate on the heap and check the result.
+
+Size an allocation from the object it will hold, not from a type name repeated at the call site.
+Written this way, the expression stays correct when the declaration of `arr` changes:
+```c
+int32_t *arr = malloc(sizeof(*arr) * count);  /* OK */
+int32_t *arr = malloc(sizeof(int32_t) * count);  /* Fragile: repeats the type */
+```
+
+Do not cast the result of `malloc` or any other function returning `void *`.
+In C the conversion is implicit, and the cast only hides a missing declaration.
+
+After passing a pointer to `free`, set it to `NULL` when the variable remains in scope.
+This turns a later double free or use-after-free into a null dereference at the point of the bug.
+
+### Embrace portability
+
+#### Byte-order
+
+Do not assume x86 or little-endian architecture.
+Use endian conversion functions for operating the on-disk and on-the-wire structures or other cases
+where it is appropriate.
+
+#### Types
+
+Do not assume a particular 32-bit or 64-bit architecture; for example, do not assume the size of
+`long` or `unsigned long`.
+Instead, use `int64_t` or `uint64_t` for 8-byte integers.
+
+Fixed-width types, such as `uint32_t`, are particularly useful when memory size is critical, as in
+embedded systems, communication protocols requiring specific data sizes, or when interacting with
+hardware registers that require precise bit-width operations.
+In these scenarios, fixed-width types ensure consistent behavior across different platforms and
+compilers.
+
+Do not assume `char` is signed; its signedness is implementation-defined and varies by platform and
+compiler (e.g., unsigned by default on many Arm toolchains).
+
+Avoid defining bit-fields within signed integer types.
+Additionally, do not use bitwise operators (such as `&`, `|`, `~`, `^`, `<<`, and `>>`) on signed
+integer data.
+Refrain from combining signed and unsigned integers in comparisons or expressions, as this can lead
+to unpredictable results.
+
+When using `#define` to declare decimal constants, append a `U` to ensure they are treated as
+unsigned.
+For example:
+```c
+#define SOME_CONSTANT (6U)
+
+uint16_t unsigned_a = 6;
+int16_t  signed_b = -9;
+if (unsigned_a + signed_b < 4) {
+    /* This block might appear logically correct, as -9 + 6 is -3 */
+    ...
+}
+/* but compilers with 16-bit int may legally interpret it as (0x10000 - 9) + 6. */
+```
+
+It is important to note that certain aspects of manipulating binary data within signed integer
+containers are implementation-defined behaviors according to ISO C standards.
+Additionally, mixing signed and unsigned integers can lead to data-dependent results, as
+demonstrated in the example above.
+
+Use C99 macros for constant prefixes or formatting of the fixed-width types.
+
+Use:
+```c
+#define SOME_CONSTANT (UINT64_C(1) << 48)
+printf("val %" PRIu64 "\n", SOME_CONSTANT);
+```
+
+Do not use:
+```c
+#define SOME_CONSTANT (1ULL << 48)
+printf("val %lld\n", SOME_CONSTANT);
+```
+
+#### Avoid unaligned access
+
+Avoid assuming that unaligned access is safe.
+It is not safe on architectures like Arm, POWER, and others, where it may cause a fault.
+Additionally, even on x86, unaligned access can be slower.
+
+#### Structures and unions
+
+Care should be taken to prevent the compiler from inserting padding bytes within `struct` or `union`
+types, as this can affect memory layout and portability.
+To control padding and alignment, consider using structure packing techniques specific to your
+compiler.
+
+Additionally, take precautions to ensure that the compiler does not alter the intended order of bits
+within bit-fields.
+This is particularly important when working with hardware registers or communication protocols where
+bit order is crucial.
+
+According to the C standard, the layout of structures, including padding and bit-field ordering, is
+implementation-defined, meaning it can vary between different compilers and platforms.
+Therefore, it is essential to verify that the structure's layout meets your expectations, especially
+when writing portable code.
+
+For example:
+```c
+typedef struct {
+    uint16_t count;         /* offset 0 */
+    uint16_t max_count;     /* offset 2 */
+    uint16_t unused0;       /* offset 4 */
+    uint16_t enable    : 2; /* offset 6 bits 15-14 */
+    uint16_t interrupt : 1; /* offset 6 bit 13     */
+    uint16_t unused1   : 7; /* offset 6 bits 12-6  */
+    uint16_t complete  : 1; /* offset 6 bit 5      */
+    uint16_t unused2   : 4; /* offset 6 bits 4-1   */
+    uint16_t periodic  : 1; /* offset 6 bit 0      */
+} mytimer_t;
+
+_Static_assert(sizeof(mytimer_t) == 8,
+               "mytimer_t struct size incorrect (expected 8 bytes)");
+```
+
+To enhance portability, use standard-defined types (e.g., `uint16_t`, `uint32_t`) and avoid relying
+on compiler-specific behavior.
+Where precise control over memory layout is required, such as in embedded systems or when
+interfacing with hardware, always verify the structure size and layout using static assertions.
+
+#### Avoid extreme portability
+
+Unless programming for micro-controllers or exotic CPU architectures, focus on the common
+denominator of the modern CPU architectures, avoiding the very maximum portability that can make the
+code unnecessarily cumbersome.
+
+Some examples:
+* It is fair to assume `sizeof(int) == 4` since it is the case on all modern mainstream
+  architectures.
+  PDP-11 era is long gone.
+* Using `1U` instead of `UINT32_C(1)` or `(uint32_t) 1` is also fine.
+* It is fair to assume that `NULL` is matching `(uintptr_t) 0` and it is fair to `memset()`
+  structures with zero.
+  Non-zero `NULL` is for retro computing.
+
+#### Zero-based numbering
+
+Generally, stick with zero-based numbering and 0 ≤ i < N intervals, unless there is a very
+compelling reason not to.
+It is universally accepted by the C developers.
+Also, see EWD 831 (Dijkstra, 1982).
+
+## Before Submitting
+
+Run these locally before opening a pull request:
+
+| Command | What it covers |
+|---------|----------------|
+| `make check-format` | comment reflow, clang-format compliance, shellcheck over every script the repository carries, syscall dispatch table consistency, test-matrix skip lists |
+| `make check` | unit tests, the busybox suite, syscall test coverage, the EINTR restart contract, lock-order documentation |
+| `make verify` | the Frama-C proof obligations behind `src/proved/` |
+| `bash tests/test-matrix.sh all` | the guest matrix; the `elfuse-aarch64` lane must stay green |
+
+When the comment-width gate fails it names the fix: run `make indent`, or `commentflow --diff
+<file>` to read one file's reflow before taking it.
+
+### What CI checks, and how it differs
+
+CI runs some of these targets and reimplements others.
+`build.yml` invokes `make check` and `bash tests/test-matrix.sh all` directly, and `verify.yml` runs the
+proofs.
+Formatting is the exception: CI calls the `.ci/` scripts rather than `make check-format`, and narrows
+several steps to the files a pull request touched.
+A local run is therefore the wider net for formatting and the same net for the rest.
+CI is also the only run that happens on a Linux host.
+
+The layers do not cover the same ground:
+* `.ci/check-format.sh` is clang-format alone, over the C sources in `src/` and `tests/`.
+* `.ci/check-commentflow.sh` is the comment-width gate.
+  That script owns the file list for both callers, so `make check-format` and CI cover the same set:
+  C and headers, every shell script, and the assembly sources.
+  CI installs a checksum-pinned commentflow release, for the same reason clang-format is held at one
+  version.
+* shellcheck runs over `.ci/*.sh` only.
+  `make check-format` covers every script the repository carries, tracked or merely
+  untracked-and-unignored, which is the wider net, and today that wider net is red:
+  several scripts under `tests/` carry pre-existing warnings, which is why CI narrows the step
+  rather than gating on them.
+  The bar for a pull request is that it adds no new warning to a script it touches, not that the
+  target passes outright.
+* Nothing gates `shfmt` or `black`.
+  Their rules are conventions a reviewer applies, not a check that will catch you.
+* cppcheck runs over the C sources (`.ci/check-cppcheck.sh`).
+
+CI also rejects a few things no formatter reports:
+* Banned libc calls anywhere in `src/`: `gets`, `sprintf`, `vsprintf`, `strcpy`, `stpcpy`, `strcat`,
+  `atoi`, `atol`, `atoll`, `atof`, `mktemp`, `tmpnam`, `tempnam`.
+  Use the bounded or checked form instead.
+* `#undef` or `#define` of `_FORTIFY_SOURCE 0` or `__SSP__`, which would disable a hardening default
+  for the whole translation unit.
+* A tracked file with no trailing newline.
+* A new `dispatch.tbl` entry that no test references.
+* A new file-scope mutex that the lock-ordering block at the top of `src/syscall/internal.h` does
+  not name.
+
+## Git Commit Style
+
+Effective version control is critical to modern software development.
+Git's powerful features, such as granular commits, branching, and a versatile staging area, offer
+unparalleled flexibility.
+However, this flexibility can sometimes lead to disorganized commit histories and merge conflicts if
+not managed with clear, consistent practices.
+
+By committing often, writing clear messages, and adhering to a common workflow, developers can not
+only reduce the potential for errors but also simplify collaboration and future maintenance.
+We encourage every team to tailor these best practices to their specific needs while striving for a
+shared standard that promotes efficiency and code quality.
+
+Below are the detailed guidelines that build on these principles.
+* Group Related Changes Together: Each commit should encapsulate a single, coherent change. e.g., if
+  you are addressing two separate bugs, create two distinct commits.
+  This approach produces focused, small commits that simplify understanding, enable quick rollbacks,
+  and foster efficient peer reviews.
+  By taking advantage of Git's staging area and selective file staging, you can craft granular
+  commits that make collaboration smoother and more transparent.
+* Commit Frequently: Making commits often ensures that your changes remain concise and logically
+  grouped.
+  Frequent commits not only help maintain a clean history but also allow you to share your progress
+  with your teammates regularly.
+  This regular sharing keeps everyone in sync, minimizes merge conflicts, and promotes a
+  collaborative environment where integration happens seamlessly.
+* Avoid Committing Work in Progress: Only commit code when a logical component is in a stable,
+  ready-to-integrate state.
+  Break your feature's development into manageable segments that reach a functional milestone
+  quickly, so you can commit regularly without compromising quality.
+  If you feel the urge to commit merely to clear your working directory for actions like switching
+  branches or pulling changes, use Git's stash feature instead.
+  This practice helps maintain a stable repository and ensures that your team reviews well-tested,
+  coherent code.
+* Test Your Code Before Committing: Before committing, ensure that your code has been thoroughly
+  tested.
+  Rather than assuming your changes are ready, run comprehensive tests to confirm they work as
+  intended without unintended side effects.
+  Testing is especially critical when sharing your code with others, as it maintains the overall
+  stability of the project and builds trust among collaborators.
+* Utilize Branches for Parallel Development: Branches are a powerful tool that enables developers to
+  isolate different lines of work, whether you are developing new features, fixing bugs, or
+  exploring innovative ideas.
+  By using branches extensively, you can work on your tasks independently and merge only after
+  careful review and testing.
+  This not only keeps the main branch stable but also encourages collaborative code reviews and a
+  more organized integration process.
+
+Clear and descriptive commit messages are crucial for maintaining a transparent history of changes
+and for facilitating effective debugging and tracking.
+Please adhere to the guidelines outlined in [How to Write a Git Commit
+Message](https://cbea.ms/git-commit/).
+1. Separate the subject from the body with a blank line.
+2. Limit the subject line to 50 characters.
+3. Capitalize the subject line.
+4. Do not end the subject line with a period.
+5. Use the imperative mood in the subject line.
+6. Wrap the body at 72 characters.
+7. Use the body to explain what and why, not how.
+
+An example (derived from Chris' blog post) looks like the following:
+```text
+Summarize changes in around 50 characters or less
+
+More detailed explanatory text, if necessary. Wrap it to about 72
+characters or so. In some contexts, the first line is treated as the
+subject of the commit and the rest of the text as the body. The
+blank line separating the summary from the body is critical (unless
+you omit the body entirely); various tools like `log`, `shortlog`
+and `rebase` can get confused if you run the two together.
+
+Explain the problem that this commit is solving. Focus on why you
+are making this change as opposed to how (the code explains that).
+Are there side effects or other unintuitive consequences of this
+change? Here's the place to explain them.
+
+Further paragraphs come after blank lines.
+
+- Bullet points are okay, too
+
+- Typically a hyphen or asterisk is used for the bullet, preceded
+  by a single space, with blank lines in between, but conventions
+  vary here
+
+If you use an issue tracker, put references to them at the bottom,
+like this:
+Close #123
+```
+
+Another illustration of effective practice.
+```text
+commit f1775422bb5a1aa6e79a685dfa7cb54a852b567b
+Author: Jim Huang <jserv@ccns.ncku.edu.tw>
+Date:   Mon Feb 24 13:08:32 2025 +0800
+
+    Introduce CPU architecture filtering in scheduler
+
+    In environments with mixed CPU architectures, it is crucial to ensure
+    that an instance runs only on a host with a compatible CPU
+    type, preventing, for example, a RISC-V instance from being scheduled on
+    an Arm host.
+
+    This new scheduler filter enforces that requirement by comparing an
+    instance's architecture against the host's allowed architectures. For
+    the libvirt driver, the host's guest capabilities are queried, and the
+    permitted architectures are recorded in the permitted_instances_types
+    list within the host's cpu_info dictionary.
+
+    The filter systematically excludes hosts that do not support the
+    instance's CPU architecture. Additionally, RISC-V has been added to the
+    set of acceptable architectures for scheduling.
+
+    Note that the CPU architecture filter is disabled by default.
+```
+
+The above is a clear, unformatted description provided in plain text.
+
+In addition, this project expects contributors to follow these additional rules:
+* If there is important, useful, or essential conversation or information, include a reference or
+  copy it.
+* Do not write single-word commits.
+  Provide a descriptive subject.
+* Avoid using abusive words.
+* Avoid using backticks in commit subjects.
+  Backticks can be easily confused with single quotes on some terminals, reducing readability.
+  Plain text or single quotes provide sufficient clarity and emphasis.
+* Avoid using parentheses in commit subjects.
+  Excessive use of parentheses "()" can clutter the subject line, making it harder to quickly grasp
+  the essential message.
+
+These conventions are enforced by continuous integration rather than by
+[githooks](https://git-scm.com/docs/githooks); see `.github/workflows/lint.yml` for the checks a
+pull request has to clear.
+
+## References
+* [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html)
+* Tilen Majerle, [Recommended C style and coding rules](https://github.com/MaJerle/c-code-style)
+* 1999, Brian W.
+  Kernighan and Rob Pike, The Practice of Programming, Addison-Wesley.
+* 1993, Bill Shannon, [C Style and Coding Standards for
+  SunOS](https://devnull-cz.github.io/unix-linux-prog-in-c/cstyle.ms.pdf)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ The build signs `build/elfuse` before use. Override the signing identity with
   reference -- runtime lifecycle, HVF constraints, EL1 shim and HVC
   protocol, page-table splitting, syscall translation tables, threads
   / futex, fork / clone IPC, signals, ptrace, and the GDB stub.
+- [CONTRIBUTING.md](CONTRIBUTING.md): the coding style, the formatters
+  and what each gate enforces, and the commit-message rules.
 
 ## Build And Validation
 
@@ -192,6 +194,24 @@ do.
 - `uname` and `/proc/version` report Linux 6.18 LTS, a floor for
   version-gated userspace; `src/syscall/dispatch.tbl` states what is
   implemented.
+
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) first. It is the tracked style
+guide: the C conventions this tree actually follows, which formatter
+owns which part of a file, what CI gates and what it does not, and the
+seven commit-message rules the log is written to.
+
+Two things settle most review comments before they are written:
+
+```sh
+make indent        # apply every formatter, comment reflow included
+make check-format  # verify without rewriting
+```
+
+File an issue before a substantial change, so the design discussion
+happens before the effort does. Typo fixes, small refactors, and
+comment or documentation edits need no issue.
 
 ## License
 

--- a/frama-c-stubs/Hypervisor/Hypervisor.h
+++ b/frama-c-stubs/Hypervisor/Hypervisor.h
@@ -16,12 +16,12 @@
  * the SDK header the binary must link against. Up here nothing but
  * FRAMAC_STUB_DIR in mk/verify.mk can reach it.
  *
- * This is reached only through mk/verify.mk, never by a compile. Nothing
- * proved reads any constant defined here, so the values matter only in that
- * they must not collide: HV_REG_X0 + n is how src/hvutil.h names a register,
- * which needs the X registers consecutive and in order, and the rest are
- * distinct placeholders. A wrong value here cannot weaken a proof, but it can
- * make a walked switch look degenerate, so keep them apart.
+ * This is reached only through mk/verify.mk, never by a compile. Nothing proved
+ * reads any constant defined here, so the values matter only in that they must
+ * not collide: HV_REG_X0 + n is how src/hvutil.h names a register, which needs
+ * the X registers consecutive and in order, and the rest are distinct
+ * placeholders. A wrong value here cannot weaken a proof, but it can make a
+ * walked switch look degenerate, so keep them apart.
  *
  * The set is what the parsing sources actually reference. Widening the proof
  * surface to a source that names one more will fail with "Cannot resolve
@@ -87,9 +87,9 @@ typedef uint32_t hv_simd_fp_reg_t;
 
 #define HV_SIMD_FP_REG_Q0 0
 
-/* The real type is a 16-byte vector. Frama-C rejects the vector_size
- * attribute, and no proved function reads a lane, so a struct of the same
- * width and alignment stands in.
+/* The real type is a 16-byte vector. Frama-C rejects the vector_size attribute,
+ * and no proved function reads a lane, so a struct of the same width and
+ * alignment stands in.
  */
 typedef struct {
     unsigned char v[16];

--- a/mk/format.mk
+++ b/mk/format.mk
@@ -13,8 +13,19 @@ SHELL_SCRIPTS := $(shell git ls-files --cached --others --exclude-standard \
 PYTHON_FORMAT_FILES := $(shell git ls-files --cached --others \
                                --exclude-standard -- '*.py')
 
-## Check formatting: C (clang-format --dry-run) + shell (shellcheck)
+# Comment reflow. clang-format breaks an over-long comment line but never
+# refills a short-wrapped one, so commentflow settles comment width and runs
+# first; clang-format then normalizes the indentation it produced. Required
+# rather than best-effort, unlike shfmt and black below: a run that skips it
+# formats to a different standard than the last one did.
+#
+# .ci/check-commentflow.sh holds the file list for both this target and the
+# gate, so the set rewritten is the set checked.
+COMMENTFLOW ?= commentflow
+
+## Check formatting: comments (commentflow) + C (clang-format --dry-run) + shell (shellcheck)
 check-format: check-syscall-dispatch
+	$(Q)COMMENTFLOW=$(COMMENTFLOW) bash .ci/check-commentflow.sh
 	@echo "  FMT     src/ tests/ (check)"
 	$(Q)$(CLANG_FORMAT) --dry-run --Werror $(C_FORMAT_FILES)
 	@echo "  MATRIX  skip lists"
@@ -39,6 +50,7 @@ check-format: check-syscall-dispatch
 
 ## Indent all C, shell, and Python files in-place
 indent: gen-syscall-dispatch
+	$(Q)COMMENTFLOW=$(COMMENTFLOW) bash .ci/check-commentflow.sh --write
 	@echo "  FMT     src/ tests/"
 	$(Q)$(CLANG_FORMAT) -i $(C_FORMAT_FILES)
 	@if command -v shfmt >/dev/null 2>&1; then \

--- a/src/core/elf.c
+++ b/src/core/elf.c
@@ -285,10 +285,10 @@ static int elf_record_load(const elf64_phdr_t *ph,
 {
     /* Linux ignores a PT_LOAD that maps no bytes, and so does the mapper.
      * Recording it anyway would still feed load_min/load_max, the boot region
-     * tables and /proc/self/maps: a zero-memsz segment at p_vaddr ==
-     * guest_size satisfies the extent bound (gpa > guest_size - memsz is false
-     * when memsz is 0), so load_max reaches the end of the slab and brk_base
-     * follows it there.
+     * tables and /proc/self/maps: a zero-memsz segment at p_vaddr == guest_size
+     * satisfies the extent bound (gpa > guest_size - memsz is false when memsz
+     * is 0), so load_max reaches the end of the slab and brk_base follows it
+     * there.
      */
     if (ph->p_memsz == 0)
         return 0;
@@ -409,9 +409,9 @@ int elf_load_fd(int fd, const char *display_path, elf_info_t *info)
     /* Collect only the program headers that affect process startup. */
     int seg_count = 0;
     for (uint16_t i = 0; i < ehdr.e_phnum; i++) {
-        /* Zero-initialized so the phdr scratch is never read uninitialized
-         * on a path Pulse cannot follow; three of the suppressed Infer
-         * findings were here. One 56-byte clear per program header.
+        /* Zero-initialized so the phdr scratch is never read uninitialized on a
+         * path Pulse cannot follow; three of the suppressed Infer findings were
+         * here. One 56-byte clear per program header.
          */
         elf64_phdr_t ph = {0};
         if (!elf_phdr_fetch(ph_buf, ph_total, i, ehdr.e_phentsize, &ph)) {
@@ -452,15 +452,13 @@ int elf_load_fd(int fd, const char *display_path, elf_info_t *info)
      *
      * Requiring the whole table inside one segment's file data is what lets
      * elf_map_segments_fd deliver it with no separate copy and no second
-     * destination to bound-check.
-     */
-    /* A segment that covers e_phoff but whose p_vaddr + rel is
-     * unrepresentable is skipped rather than distinguished, so in principle
-     * the table could be attributed to a later segment. Unreachable: such a
-     * p_vaddr sits within a few bytes of UINT64_MAX, and elf_segment_extent
-     * rejects it at map time because every accepted segment satisfies
-     * gpa <= guest_size - memsz with guest_size at most 1 TiB, so phdr_gpa
-     * never reaches build_linux_stack.
+     * destination to bound-check. A segment that covers e_phoff but whose
+     * p_vaddr + rel is unrepresentable is skipped rather than distinguished, so
+     * in principle the table could be attributed to a later segment.
+     * Unreachable: such a p_vaddr sits within a few bytes of UINT64_MAX, and
+     * elf_segment_extent rejects it at map time because every accepted segment
+     * satisfies gpa <= guest_size - memsz with guest_size at most 1 TiB, so
+     * phdr_gpa never reaches build_linux_stack.
      */
     for (int i = 0; i < seg_count; i++) {
         if (elf_phdr_gpa_in_segment(ehdr.e_phoff, ph_total,

--- a/src/core/elf.h
+++ b/src/core/elf.h
@@ -113,8 +113,8 @@ typedef struct {
     } segments[ELF_MAX_SEGMENTS];
 } elf_info_t;
 
-/* Where a loaded image lands: a segment at p_vaddr goes to
- * target_base + (p_vaddr - va_base).
+/* Where a loaded image lands: a segment at p_vaddr goes to target_base +
+ * (p_vaddr - va_base).
  *
  * A struct rather than two uint64_t parameters on purpose. They were adjacent
  * same-typed arguments once, and a signature change left three call sites
@@ -143,13 +143,14 @@ int elf_load_fd(int fd, const char *display_path, elf_info_t *info);
  *
  * Guest images pass a window of {0, load_base} (load_base 0 for ET_EXEC at its
  * link address, non-zero for ET_DYN). Rosetta passes its own va_base so its
- * 0x800000000000 link address maps low without relying on unsigned
- * wraparound. infra_lo and infra_hi
- * delimit the runtime infra reserve (page-table pool, shim text, shim_data,
- * vDSO). Any PT_LOAD copy whose destination intersects [infra_lo, infra_hi) is
- * rejected: those writes go through host_base directly and would otherwise
- * bypass the EL1-only page-table protection on shim_data. Pass 0,0 only when
- * the guest_t is not yet built. Returns 0 on success, -1 on failure.
+ * 0x800000000000 link address maps low without relying on unsigned wraparound.
+ * infra_lo and infra_hi delimit the runtime infra reserve (page-table pool,
+ * shim text, shim_data, vDSO). Any PT_LOAD copy whose destination intersects
+ * [infra_lo, infra_hi) is rejected: those writes go through host_base directly
+ * and would otherwise bypass the EL1-only page-table protection on shim_data.
+ * Pass 0,0 only when the guest_t is not yet built.
+ *
+ * Returns 0 on success, -1 on failure.
  */
 int elf_map_segments(const elf_info_t *info,
                      const char *path,

--- a/src/core/guest-env.c
+++ b/src/core/guest-env.c
@@ -27,8 +27,8 @@ static size_t override_key_len(const char *ov)
 }
 
 /* Name length of a "KEY=VALUE" entry, or 0 when @entry is not one: it carries
- * no '=', or its name is empty. Both make the entry unmatchable by an
- * override, which is why guest_env_build drops rather than forwards them.
+ * no '=', or its name is empty. Both make the entry unmatchable by an override,
+ * which is why guest_env_build drops rather than forwards them.
  */
 static size_t entry_key_len(const char *entry)
 {
@@ -88,9 +88,10 @@ char **guest_env_build(char *const *host_env,
     if (!clear_env) {
         for (int i = 0; i < n_host; i++) {
             size_t klen = entry_key_len(host_env[i]);
-            /* env_find() rescans envp[0 .. n) per entry, so this is
-             * quadratic over an environment of tens of entries. A hash would
-             * cost more to build than the scan costs to run at that size.
+
+            /* env_find() rescans envp[0 .. n) per entry, so this is quadratic
+             * over an environment of tens of entries. A hash would cost more to
+             * build than the scan costs to run at that size.
              */
             if (klen == 0 || env_find(envp, n, host_env[i], klen) >= 0)
                 continue;

--- a/src/core/guest-env.h
+++ b/src/core/guest-env.h
@@ -7,9 +7,9 @@
  * elfuse builds the guest's "KEY=VALUE" array, which build_linux_stack copies
  * onto the initial guest stack, from the host environment plus the --env /
  * --clear-env flags, following `docker run -e` so an OCI front end can hand a
- * guest exactly the environment an image config asks for. The host
- * environment arrives as a parameter rather than from environ, so tests can
- * hand guest_env_build arbitrary base vectors, malformed entries included.
+ * guest exactly the environment an image config asks for. The host environment
+ * arrives as a parameter rather than from environ, so tests can hand
+ * guest_env_build arbitrary base vectors, malformed entries included.
  */
 
 #pragma once
@@ -19,23 +19,23 @@
 /* Build the guest environment vector from @host_env and the --env overrides.
  *
  * @host_env (NULL-terminated) fills two roles: the base the overrides merge
- * into (unless @clear_env), and the source a bare "KEY" override imports
- * from. They stay separate because `docker run -e KEY` imports from the
- * launcher's environment even when the base was cleared. NULL empties both.
+ * into (unless @clear_env), and the source a bare "KEY" override imports from.
+ * They stay separate because `docker run -e KEY` imports from the launcher's
+ * environment even when the base was cleared. NULL empties both.
  *
- * @overrides holds @n_overrides entries. "KEY=VALUE" replaces that key in
- * place when present and appends otherwise; a bare "KEY" imports the host
- * value, and a name the host does not set is skipped rather than imported as
- * empty. The value is everything after the first '='.
+ * @overrides holds @n_overrides entries. "KEY=VALUE" replaces that key in place
+ * when present and appends otherwise; a bare "KEY" imports the host value, and
+ * a name the host does not set is skipped rather than imported as empty. The
+ * value is everything after the first '='.
  *
- * Returns a malloc'd NULL-terminated array, entry count in *out_n, freed
- * with strv_free (src/utils.h). Every entry carries a '=' and a unique
- * non-empty name; @host_env entries violating that are dropped, or a later
- * override would append beside the entry it meant to replace. Because the
- * drop sanitizes, a caller that wants @host_env forwarded unchanged skips
- * the call (launch_args_t.envp of NULL already means that) rather than
- * passing no overrides. On allocation failure or an empty override name (as
- * setenv(3)) returns NULL, logged, with *out_n untouched.
+ * Returns a malloc'd NULL-terminated array, entry count in *out_n, freed with
+ * strv_free (src/utils.h). Every entry carries a '=' and a unique non-empty
+ * name; @host_env entries violating that are dropped, or a later override would
+ * append beside the entry it meant to replace. Because the drop sanitizes, a
+ * caller that wants @host_env forwarded unchanged skips the call
+ * (launch_args_t.envp of NULL already means that) rather than passing no
+ * overrides. On allocation failure or an empty override name (as setenv(3))
+ * returns NULL, logged, with *out_n untouched.
  */
 char **guest_env_build(char *const *host_env,
                        char *const *overrides,

--- a/src/core/launch.h
+++ b/src/core/launch.h
@@ -1,24 +1,24 @@
-/* elfuse VM launch entry: post-CLI bring-up + run loop + teardown
+/*
+ * elfuse VM launch entry: post-CLI bring-up + run loop + teardown
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * elfuse_launch is the single entry point for "run a guest binary in a
- * fresh HVF VM until it exits". main() is its only caller; keeping bring-up
- * behind one struct is what lets a front end select the guest identity, cwd,
- * and environment through the CLI instead of growing a second bring-up.
+ * elfuse_launch is the single entry point for "run a guest binary in a fresh
+ * HVF VM until it exits". main() is its only caller; keeping bring-up behind
+ * one struct is what lets a front end select the guest identity, cwd, and
+ * environment through the CLI instead of growing a second bring-up.
  *
  * The function owns the guest_t, the vCPU, the GDB stub, the run loop, the
- * diagnostic dumps, and guest teardown; it does NOT own the elf_path /
- * sysroot / guest_argv / envp / cwd_guest heap copies or the sysroot_mount
- * the host CLI may have provisioned. Those stay with the caller so behaviors
- * that need the original CLI argv (proctitle rewriting, --create-sysroot
- * detach on exit, host cwd save+restore) stay coherent however the launch was
- * kicked off.
+ * diagnostic dumps, and guest teardown; it does NOT own the elf_path / sysroot
+ * / guest_argv / envp / cwd_guest heap copies or the sysroot_mount the host CLI
+ * may have provisioned. Those stay with the caller so behaviors that need the
+ * original CLI argv (proctitle rewriting, --create-sysroot detach on exit, host
+ * cwd save+restore) stay coherent however the launch was kicked off.
  *
- * The caller owns every pointer in launch_args_t for the duration of the
- * call; elfuse_launch reads but never frees them. Per-field lifetime and
- * ownership notes live on the struct members below.
+ * The caller owns every pointer in launch_args_t for the duration of the call;
+ * elfuse_launch reads but never frees them. Per-field lifetime and ownership
+ * notes live on the struct members below.
  */
 
 #pragma once
@@ -34,21 +34,21 @@ typedef struct {
 
     /* elf_path is a FUSE-materialized temp to unlink once
      * guest_bootstrap_prepare has loaded it (kept for Rosetta guests, which
-     * reopen the path). Ownership of the unlink transfers to elfuse_launch
-     * at the call: every failure path inside it, refusals before the
-     * prepare call included, unlinks a temp elf_path.
+     * reopen the path). Ownership of the unlink transfers to elfuse_launch at
+     * the call: every failure path inside it, refusals before the prepare call
+     * included, unlinks a temp elf_path.
      */
     bool elf_host_temp;
 
-    /* Host filesystem path to the sysroot the guest sees as / (absolute),
-     * or NULL when the guest runs without a sysroot.
+    /* Host filesystem path to the sysroot the guest sees as / (absolute), or
+     * NULL when the guest runs without a sysroot.
      */
     const char *sysroot;
 
-    /* Argv the guest sees. guest_argv[0] is the guest-visible entrypoint
-     * path (what the guest reads back via /proc/self/exe and argv[0]); it
-     * differs from elf_path (the resolved host path) under path translation
-     * or a FUSE-materialized temp.
+    /* Argv the guest sees. guest_argv[0] is the guest-visible entrypoint path
+     * (what the guest reads back via /proc/self/exe and argv[0]); it differs
+     * from elf_path (the resolved host path) under path translation or a
+     * FUSE-materialized temp.
      */
     int guest_argc;
     const char **guest_argv;
@@ -66,13 +66,13 @@ typedef struct {
     bool has_creds;
     uint32_t uid, gid;
 
-    /* Guest-absolute initial working directory, resolved under sysroot.
-     * NULL inherits the host cwd.
+    /* Guest-absolute initial working directory, resolved under sysroot. NULL
+     * inherits the host cwd.
      */
     const char *cwd_guest;
 
-    /* GDB Remote Serial Protocol port (0 disables the stub) and whether
-     * to halt before the first guest instruction.
+    /* GDB Remote Serial Protocol port (0 disables the stub) and whether to halt
+     * before the first guest instruction.
      */
     int gdb_port;
     bool gdb_stop_on_entry;
@@ -92,8 +92,10 @@ typedef struct {
     "--gdb is not supported for x86_64 guests; the current stub " \
     "only exposes the translated aarch64 view"
 
-/* Bring up the guest VM, run it to exit / signal / timeout, tear down,
- * return the exit code. Returns 1 on bring-up failure (with a log
- * message) and the guest's exit status otherwise.
+/* Bring up the guest VM, run it to exit / signal / timeout, tear down, return
+ * the exit code.
+ *
+ * Returns 1 on bring-up failure (with a log message) and the guest's exit
+ * status otherwise.
  */
 int elfuse_launch(const launch_args_t *args);

--- a/src/core/rosetta.h
+++ b/src/core/rosetta.h
@@ -51,8 +51,8 @@
  * VZ environment. Without affirmative responses, rosetta prints "Rosetta is
  * only intended to run on Apple Silicon ..." and exits.
  *
- * Reverse-engineered from the rosetta binary; values captured via strace in
- * a VZ Linux VM.
+ * Reverse-engineered from the rosetta binary; values captured via strace in a
+ * VZ Linux VM.
  */
 #define ROSETTA_VZ_CHECK 0x80456125 /* Returns 69-byte signature */
 #define ROSETTA_VZ_CAPS 0x80806123  /* Returns 128-byte capability blob */

--- a/src/core/shim.S
+++ b/src/core/shim.S
@@ -1,13 +1,14 @@
-/* EL1 kernel shim
+/*
+ * EL1 kernel shim
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Loaded at g->shim_base (a 16MiB infra reserve placed just below
- * g->interp_base; computed at guest_init time). Runs at EL1.
- * All system registers (VBAR, MAIR, TCR, TTBR0, SCTLR, etc.) are configured by
- * the host before vCPU start. The shim entry point transitions to EL0 via ERET.
+ * g->interp_base; computed at guest_init time). Runs at EL1. All system
+ * registers (VBAR, MAIR, TCR, TTBR0, SCTLR, etc.) are configured by the host
+ * before vCPU start. The shim entry point transitions to EL0 via ERET.
  * Exception vectors handle SVC #0 (Linux syscall) forwarding to the host via
  * HVC #5.
  *
@@ -63,17 +64,19 @@
  * save and restore ALL 31 GPRs.
  */
 
-/* RVAE1IS is part of FEAT_TLBIRANGE (the tlb-rmi architectural extension).
+/*
+ * RVAE1IS is part of FEAT_TLBIRANGE (the tlb-rmi architectural extension).
  * Apple as defaults to the host CPU's baseline feature set and otherwise
  * rejects this mnemonic even though the shim executes only on Apple Silicon
- * CPUs that provide the instruction.  Declare the extension locally so the
- * assembler accepts the architectural instruction encoding. */
+ * CPUs that provide the instruction. Declare the extension locally so the
+ * assembler accepts the architectural instruction encoding.
+ */
 .arch_extension tlb-rmi
 
 .text
 
-/* SAVE_GPRS: push all 31 GPRs onto a 256-byte EL1 stack frame.
- * Layout: [sp+0]  x0,x1   [sp+16] x2,x3   [sp+32] x4,x5
+/* SAVE_GPRS: push all 31 GPRs onto a 256-byte EL1 stack frame. Layout: [sp+0]
+ * x0,x1 [sp+16] x2,x3 [sp+32] x4,x5
  *         [sp+48] x6,x7   [sp+64] x8,x9   ... [sp+240] x30,(pad)
  */
 .macro SAVE_GPRS
@@ -96,9 +99,9 @@
     str x30, [sp, #240]
 .endm
 
-/* LOAD_GPRS: load X0-X30 from the saved frame WITHOUT popping it.
- * Used at handle_svc_0 entry so the host can read the EL0 state via the vCPU
- * registers, while the frame remains live for the post-HVC restore.
+/* LOAD_GPRS: load X0-X30 from the saved frame WITHOUT popping it. Used at
+ * handle_svc_0 entry so the host can read the EL0 state via the vCPU registers,
+ * while the frame remains live for the post-HVC restore.
  */
 .macro LOAD_GPRS
     ldp x0, x1, [sp, #0]
@@ -125,8 +128,8 @@
     add sp, sp, #256
 .endm
 
-/* RESTORE_GPRS_KEEP_X0: load X1-X30 from the saved frame and pop it, leaving
- * X0 unchanged (so the syscall return value placed in X0 by the host survives).
+/* RESTORE_GPRS_KEEP_X0: load X1-X30 from the saved frame and pop it, leaving X0
+ * unchanged (so the syscall return value placed in X0 by the host survives).
  * Linux preserves X1-X30 across SVC #0.
  */
 .macro RESTORE_GPRS_KEEP_X0
@@ -151,14 +154,14 @@
 
 /* RESTORE_GPRS_KEEP_SIGFRAME: load X3-X29 from the saved frame and pop it,
  * leaving X0/X1/X2/X30 untouched. signal_deliver writes the signum, siginfo
- * pointer, ucontext pointer, and sa_restorer address into those live regs
- * via hv_vcpu_set_reg before returning from HVC #11; the standard
- * RESTORE_GPRS_KEEP_X0 tail would clobber X1/X2/X30 with their pre-fault
- * EL0 values. Used by the HVC #11 post-handler so the lazy-materialize
- * path can run TLBI ops (which clobber X11/X12/X13 as scratch) while
- * still preserving signal_deliver's register writes on the SIGSEGV /
- * SIGILL delivery path. The caller is responsible for setting X8 = 0
- * if no TLBI is needed; X8 is loaded from the frame here regardless.
+ * pointer, ucontext pointer, and sa_restorer address into those live regs via
+ * hv_vcpu_set_reg before returning from HVC #11; the standard
+ * RESTORE_GPRS_KEEP_X0 tail would clobber X1/X2/X30 with their pre-fault EL0
+ * values. Used by the HVC #11 post-handler so the lazy-materialize path can run
+ * TLBI ops (which clobber X11/X12/X13 as scratch) while still preserving
+ * signal_deliver's register writes on the SIGSEGV / SIGILL delivery path. The
+ * caller is responsible for setting X8 = 0 if no TLBI is needed; X8 is loaded
+ * from the frame here regardless.
  */
 .macro RESTORE_GPRS_KEEP_SIGFRAME
     ldr x3, [sp, #24]
@@ -186,8 +189,8 @@
 .endm
 
 /* Counter byte offsets within shim_data. Mirror SHIM_COUNTER_* indices in
- * src/core/shim-globals.h; the static_asserts in shim-globals.c keep both
- * sides locked together. Byte offset = SHIM_COUNTERS_OFF + 8 * slot_index.
+ * src/core/shim-globals.h; the static_asserts in shim-globals.c keep both sides
+ * locked together. Byte offset = SHIM_COUNTERS_OFF + 8 * slot_index.
  *
  * SHIM_COUNTERS_OFF is 0x10C8, beyond AArch64's 12-bit add immediate range.
  * Split it explicitly so COUNTER_INC can fold the carry into one shifted add
@@ -198,10 +201,10 @@
 .equ SHIM_COUNTERS_OFF_LO12, 0xC8
 
 /* Gate byte (uint8) inside the attention/identity padding. Loaded by
- * COUNTER_INC; zero (the default after shim_globals_init) skips the
- * counter body so disabled stats pay one cache-hot ldrb instead of a
- * full load-add-store on the shared counter line. The host publishes
- * via shim_globals_publish_stats_gate during bring-up.
+ * COUNTER_INC; zero (the default after shim_globals_init) skips the counter
+ * body so disabled stats pay one cache-hot ldrb instead of a full
+ * load-add-store on the shared counter line. The host publishes via
+ * shim_globals_publish_stats_gate during bring-up.
  */
 .equ SHIM_STATS_EN_OFF,      0x04
 
@@ -216,36 +219,36 @@
 .equ CB_URANDOM_HIT,         72
 .equ CB_GETRANDOM_HIT,       80
 .equ CB_PGSID_HIT,           88
-/* Slot 48 (SHIM_COUNTER_URANDOM_RING_WRAP) deliberately omitted: wrap
- * is handled inline by urandom_copy_loop, so no assembly path bumps it.
- * The C-side enum keeps the index for ABI stability.
+
+/* Slot 48 (SHIM_COUNTER_URANDOM_RING_WRAP) deliberately omitted: wrap is
+ * handled inline by urandom_copy_loop, so no assembly path bumps it. The C-side
+ * enum keeps the index for ABI stability.
  */
 
-/* COUNTER_INC: bump diagnostic counter at byte offset
- * (SHIM_COUNTERS_OFF_LO12 + \byte_off) from TPIDR_EL1 by 1, only when
- * the host has published a nonzero stats gate at SHIM_STATS_EN_OFF.
+/* COUNTER_INC: bump diagnostic counter at byte offset (SHIM_COUNTERS_OFF_LO12 +
+ * \byte_off) from TPIDR_EL1 by 1, only when the host has published a nonzero
+ * stats gate at SHIM_STATS_EN_OFF.
  *
- * The gate keeps every fast-path tail from touching the counter cache
- * line in the common case (ELFUSE_SHIM_STATS unset). Without it, each
- * getpid / getuid / urandom hit drove a non-atomic load-add-store on
- * a single shared line, generating multi-vCPU coherence ping-pong on
- * top of the unconditional five-instruction tax.
+ * The gate keeps every fast-path tail from touching the counter cache line in
+ * the common case (ELFUSE_SHIM_STATS unset). Without it, each getpid / getuid /
+ * urandom hit drove a non-atomic load-add-store on a single shared line,
+ * generating multi-vCPU coherence ping-pong on top of the unconditional
+ * five-instruction tax.
  *
- * One shifted add carries the SHIM_COUNTERS_OFF_HI (#0x1000) high half;
- * the ldr/str fold the LO12 + slot-byte offset into the immediate (well
- * within the imm12*8 = 32760 byte range).
+ * One shifted add carries the SHIM_COUNTERS_OFF_HI (#0x1000) high half; the
+ * ldr/str fold the LO12 + slot-byte offset into the immediate (well within the
+ * imm12*8 = 32760 byte range).
  *
- * Non-atomic ldr/add/str. Even with the gate enabled, multi-vCPU
- * concurrent bails may race and lose a small fraction of counts;
- * acceptable for diagnostic ratios. The gate-disabled tail expands to
- * three instructions (mrs + ldrb + cbz); the gate-enabled tail adds
- * the original five.
+ * Non-atomic ldr/add/str. Even with the gate enabled, multi-vCPU concurrent
+ * bails may race and lose a small fraction of counts; acceptable for diagnostic
+ * ratios. The gate-disabled tail expands to three instructions (mrs + ldrb +
+ * cbz); the gate-enabled tail adds the original five.
  *
- * x29/x30 are clobbered. svc_restore_eret's RESTORE_GPRS_KEEP_X0
- * reloads X1..X30 from the saved frame, so the clobber is safe on any
- * fast path. The end label uses GAS .L\@ macro-local naming so every
- * expansion gets a unique symbol -- nested or interleaved macros
- * cannot collide with a bare numeric label.
+ * x29/x30 are clobbered. svc_restore_eret's RESTORE_GPRS_KEEP_X0 reloads
+ * X1..X30 from the saved frame, so the clobber is safe on any fast path. The
+ * end label uses GAS .L\@ macro-local naming so every expansion gets a unique
+ * symbol -- nested or interleaved macros cannot collide with a bare numeric
+ * label.
  */
 .macro COUNTER_INC byte_off
     mrs x29, tpidr_el1
@@ -258,9 +261,9 @@
 .Lctr_skip_\@:
 .endm
 
-/* BAD_VEC: vector-table entry that reports an unexpected exception.
- * Each table slot is 128 bytes; the leading .align 7 places this entry at the
- * next 128-byte boundary.
+/* BAD_VEC: vector-table entry that reports an unexpected exception. Each table
+ * slot is 128 bytes; the leading .align 7 places this entry at the next
+ * 128-byte boundary.
  */
 .macro BAD_VEC offset
     .align 7
@@ -268,9 +271,9 @@
     b bad_exception
 .endm
 
-/* SVC_VEC: vector-table entry for synchronous exceptions (SVC #0).
- * Must NOT clobber any GPR before svc_handler saves them, since the Linux ABI
- * preserves X1-X30 across SVC.
+/* SVC_VEC: vector-table entry for synchronous exceptions (SVC #0). Must NOT
+ * clobber any GPR before svc_handler saves them, since the Linux ABI preserves
+ * X1-X30 across SVC.
  */
 .macro SVC_VEC
     .align 7
@@ -295,12 +298,12 @@ _start:
     /* TLB + I-cache invalidation: ensure clean translation state before
      * enabling the MMU. Runs with SCTLR.M=0, so this fetch cannot be
      * misdirected by stale TLB state -- which is exactly why the execve
-     * re-entry path lands here instead of resuming the interrupted
-     * svc_handler frame: after guest_reset recycles the PT pool in place,
-     * stale walk-cache entries can poison any translated fetch, and the
-     * only architecturally safe point to drop them is before MMU-on.
-     * IC IALLUIS covers stale I-cache lines from a pre-exec image that
-     * loaded code at the same addresses (no-op cost at cold boot).
+     * re-entry path lands here instead of resuming the interrupted svc_handler
+     * frame: after guest_reset recycles the PT pool in place, stale walk-cache
+     * entries can poison any translated fetch, and the only architecturally
+     * safe point to drop them is before MMU-on. IC IALLUIS covers stale I-cache
+     * lines from a pre-exec image that loaded code at the same addresses (no-op
+     * cost at cold boot).
      */
     tlbi vmalle1is
     ic ialluis
@@ -318,13 +321,13 @@ _start:
 
     eret
 
-/* Exception Vector Table
- * Must be 2KiB (0x800) aligned. Each entry is 128 bytes (0x80).
+/* Exception Vector Table Must be 2KiB (0x800) aligned. Each entry is 128 bytes
+ * (0x80).
  *
  * bad_exception vectors: mov x5, #offset + b bad_exception
  *   X5 carries the vector offset for host-side debugging.
  *   This is safe because bad_exception halts, so no register preservation
-     needed.
+ * needed.
  *
  * svc_handler vectors: b svc_handler (NO mov x5!)
  *   These MUST NOT clobber any GPR before svc_handler saves them. The Linux
@@ -335,7 +338,7 @@ _start:
  */
 .align 11
 vectors:
-    /* Current EL, SP0:                         0x000 Sync, 0x080 IRQ,
+    /* Current EL, SP0: 0x000 Sync, 0x080 IRQ,
      *                                          0x100 FIQ,  0x180 SError
      */
     BAD_VEC 0x000
@@ -361,7 +364,7 @@ vectors:
     BAD_VEC 0x500
     BAD_VEC 0x580
 
-    /* Lower EL, AArch32:                       0x600 Sync, 0x680 IRQ,
+    /* Lower EL, AArch32: 0x600 Sync, 0x680 IRQ,
      *                                          0x700 FIQ,  0x780 SError
      */
     BAD_VEC 0x600
@@ -369,8 +372,7 @@ vectors:
     BAD_VEC 0x700
     BAD_VEC 0x780
 
-/* bad_exception: Report unexpected exception to host and halt
- */
+/* bad_exception: Report unexpected exception to host and halt */
 bad_exception:
     mrs x0, esr_el1
     mrs x1, far_el1
@@ -403,8 +405,8 @@ svc_handler:
     /* Save all 31 general-purpose registers on the EL1 stack */
     SAVE_GPRS
 
-    /* Decode exception class from ESR_EL1.
-     * X9-X11 are now scratch (saved on stack above).
+    /* Decode exception class from ESR_EL1. X9-X11 are now scratch (saved on
+     * stack above).
      */
     mrs x9, esr_el1
     lsr x10, x9, #26         /* EC = bits [31:26] */
@@ -415,8 +417,8 @@ svc_handler:
     /* Extract SVC immediate (bits [15:0]) */
     and x11, x9, #0xFFFF
 
-    /* Inverted from "b.eq handle_svc_0" so the SVC #0 fast-path
-     * dispatch can fall through without an extra branch.
+    /* Inverted from "b.eq handle_svc_0" so the SVC #0 fast-path dispatch can
+     * fall through without an extra branch.
      */
     cmp x11, #0
     b.ne restore_and_bad
@@ -465,10 +467,10 @@ gettid_fast:
     COUNTER_INC CB_IDENTITY_HIT
     b svc_restore_eret
 
-/* getpgid_fast / getsid_fast: serve getpgid(0) and getsid(0) from
- * shim-globals slots. Any non-zero pid argument or set attention bit
- * falls through to the host so per-pid lookups and post-setpgid/setsid
- * publish ordering remain authoritative.
+/* getpgid_fast / getsid_fast: serve getpgid(0) and getsid(0) from shim-globals
+ * slots. Any non-zero pid argument or set attention bit falls through to the
+ * host so per-pid lookups and post-setpgid/setsid publish ordering remain
+ * authoritative.
  */
 getpgid_fast:
     ldr x14, [sp, #0]                /* saved X0 = pid arg */
@@ -490,14 +492,14 @@ getsid_fast:
     COUNTER_INC CB_PGSID_HIT
     b svc_restore_eret
 
-    /* Urandom-read fast path. Serves read(urandom_fd, buf, len) with
-     * len in [1, SHIM_URANDOM_INLINE_LIMIT (256)] by popping len bytes
-     * from the shim-globals entropy ring (TPIDR_EL1 base + 0xC0) into
-     * the guest-supplied buffer (X1), advancing the ring head
-     * atomically. The 4 KiB ring boundary is handled inline via a
-     * split-copy with a one-shot wrap flag. If the requested fd is not
-     * FD_URANDOM or the ring is below the requested fill, falls through
-     * to handle_svc_0 so the host serves the read and refills the ring.
+    /* Urandom-read fast path. Serves read(urandom_fd, buf, len) with len in [1,
+     * SHIM_URANDOM_INLINE_LIMIT (256)] by popping len bytes from the
+     * shim-globals entropy ring (TPIDR_EL1 base + 0xC0) into the guest-supplied
+     * buffer (X1), advancing the ring head atomically. The 4 KiB ring boundary
+     * is handled inline via a split-copy with a one-shot wrap flag. If the
+     * requested fd is not FD_URANDOM or the ring is below the requested fill,
+     * falls through to handle_svc_0 so the host serves the read and refills the
+     * ring.
      *
      * Layout offsets (match core/shim-globals.h SHIM_URANDOM_OFF_*):
      *   0x0038  URANDOM_FD_BITMAP   1024 bits = 128 bytes
@@ -528,27 +530,27 @@ urandom_read_fast:
     tbz w17, #0, urandom_fd_bmiss_bail
 
     ldr x20, [sp, #8]                /* saved X1 = buf */
-    /* Probe the guest buffer for stage-1 EL0-write translations before
-     * doing any EL1 store. PROT_NONE or unmapped pages bail to the
-     * slow path here; the host's sys_read returns -EFAULT.
+
+    /* Probe the guest buffer for stage-1 EL0-write translations before doing
+     * any EL1 store. PROT_NONE or unmapped pages bail to the slow path here;
+     * the host's sys_read returns -EFAULT.
      *
-     * The probe handles the STATIC case (buffer already unmapped at
-     * entry). The DYNAMIC case where a sibling vCPU munmaps the buffer
-     * in the window between probe and strb is caught later by the
-     * EL1 data abort vector routing into handle_el1_data_abort_recover
-     * (which discards the reserved entropy, releases the lock, and
-     * returns -EFAULT to EL0; the ring head is not rolled back -- the
-     * already-published bytes are simply skipped on the next read).
-     * Without that recovery the EL1 strb would fault into BAD_VEC and
-     * halt the VM.
+     * The probe handles the STATIC case (buffer already unmapped at entry). The
+     * DYNAMIC case where a sibling vCPU munmaps the buffer in the window
+     * between probe and strb is caught later by the EL1 data abort vector
+     * routing into handle_el1_data_abort_recover (which discards the reserved
+     * entropy, releases the lock, and returns -EFAULT to EL0; the ring head is
+     * not rolled back -- the already-published bytes are simply skipped on the
+     * next read). Without that recovery the EL1 strb would fault into BAD_VEC
+     * and halt the VM.
      *
-     * len is in [1, SHIM_URANDOM_INLINE_LIMIT=256]. Probing the first
-     * and last byte covers every page the inline copy can touch: even
-     * at the smaller 4 KiB host page size a 256-byte buffer straddles
-     * at most one page boundary, so probe(buf) + probe(buf+len-1) hits
-     * both pages. The second probe is skipped when buf and buf+len-1
-     * fall in the same 4 KiB page -- the dominant case for small
-     * crypto/SSH-handshake reads. Detected via xor + mask.
+     * len is in [1, SHIM_URANDOM_INLINE_LIMIT=256]. Probing the first and last
+     * byte covers every page the inline copy can touch: even at the smaller 4
+     * KiB host page size a 256-byte buffer straddles at most one page boundary,
+     * so probe(buf) + probe(buf+len-1) hits both pages. The second probe is
+     * skipped when buf and buf+len-1 fall in the same 4 KiB page -- the
+     * dominant case for small crypto/SSH-handshake reads. Detected via xor +
+     * mask.
      */
     sub x16, x15, #1                 /* len - 1 */
     adds x17, x20, x16               /* last_byte = buf + len - 1 */
@@ -557,10 +559,10 @@ urandom_read_fast:
     isb
     mrs x16, par_el1
     tbnz x16, #0, urandom_probe_fail_bail
-    /* Same 4 KiB page? If (buf ^ last_byte) & ~0xFFF == 0, skip the
-     * second probe. eor + tst against the page mask is two scalar ops
-     * and one fused branch; cheaper than the full AT/ISB/MRS sequence
-     * (~5-15 ns).
+
+    /* Same 4 KiB page? If (buf ^ last_byte) & ~0xFFF == 0, skip the second
+     * probe. eor + tst against the page mask is two scalar ops and one fused
+     * branch; cheaper than the full AT/ISB/MRS sequence (~5-15 ns).
      */
     eor x18, x20, x17
     tst x18, #~0xFFF
@@ -571,19 +573,18 @@ urandom_read_fast:
     tbnz x16, #0, urandom_probe_fail_bail
 7:
 
-    /* Serialize host refill against the shim's reserve-then-copy window.
-     * Lock word lives after the 4096-byte ring at offset 0x10C0.
+    /* Serialize host refill against the shim's reserve-then-copy window. Lock
+     * word lives after the 4096-byte ring at offset 0x10C0.
      */
     add x19, x12, #0x1, lsl #12      /* base + 0x1000 */
     add x19, x19, #0xC0              /* &ring_lock */
     mov w18, #1
 urandom_lock_spin:
-    /* LSE swpal: atomic exchange. w17 receives the previous lock value;
-     * w18 (1) is stored unconditionally. If the previous was 0, we
-     * acquired. If it was 1, a sibling holds it; yield and retry.
-     * Apple Silicon implements ARMv8.1 LSE atomics, so swpal is one
-     * instruction (vs the prior ldaxr/stxr exclusive sequence). Release
-     * on unlock stays as stlr wzr, [x19].
+    /* LSE swpal: atomic exchange. w17 receives the previous lock value; w18 (1)
+     * is stored unconditionally. If the previous was 0, we acquired. If it was
+     * 1, a sibling holds it; yield and retry. Apple Silicon implements ARMv8.1
+     * LSE atomics, so swpal is one instruction (vs the prior ldaxr/stxr
+     * exclusive sequence). Release on unlock stays as stlr wzr, [x19].
      */
     swpal w18, w17, [x19]
     cbnz w17, urandom_lock_busy
@@ -608,32 +609,31 @@ urandom_locked:
     stxr w28, w27, [x21]
     cbnz w28, 0b
 
-    /* Head reserved; lock held. Snapshot ELR_EL1 + SPSR_EL1 into a
-     * recovery slot below the EL1 stack frame so the EL1 data abort
-     * recovery handler (handle_el1_data_abort_recover, below) can
-     * restore them if a subsequent strb faults. A sibling vCPU can
-     * munmap the guest buffer in the window between the AT probe and
-     * the byte copy; without this slot the resulting EL1 data abort
-     * overwrites ELR_EL1 with the strb PC and there is no way to
-     * resume EL0 at the post-SVC instruction. Both success exits
-     * pop the slot before svc_restore_eret.
+    /* Head reserved; lock held. Snapshot ELR_EL1 + SPSR_EL1 into a recovery
+     * slot below the EL1 stack frame so the EL1 data abort recovery handler
+     * (handle_el1_data_abort_recover, below) can restore them if a subsequent
+     * strb faults. A sibling vCPU can munmap the guest buffer in the window
+     * between the AT probe and the byte copy; without this slot the resulting
+     * EL1 data abort overwrites ELR_EL1 with the strb PC and there is no way to
+     * resume EL0 at the post-SVC instruction. Both success exits pop the slot
+     * before svc_restore_eret.
      */
     mrs x29, elr_el1
     mrs x30, spsr_el1
     stp x29, x30, [sp, #-16]!
 
-    /* Copy bytes from ring[pos] to buf. len is in [1, 256].
-     * w26 holds pos in [0, 4096); writing to w26 above zero-extends
-     * into x26, so a plain reg add (no extension) is correct.
+    /* Copy bytes from ring[pos] to buf. len is in [1, 256]. w26 holds pos in
+     * [0, 4096); writing to w26 above zero-extends into x26, so a plain reg add
+     * (no extension) is correct.
      */
     add  x16, x12, #0xC0             /* ring base */
     add  x16, x16, x26                /* ring + pos */
     cmp  x15, #1
     b.ne urandom_copy_loop
 
-    /* Common case: 1-byte read. Single byte transfer. 1-byte reads
-     * never wrap (a single byte at pos is always within the ring),
-     * so the split-copy logic in urandom_copy_loop is skipped.
+    /* Common case: 1-byte read. Single byte transfer. 1-byte reads never wrap
+     * (a single byte at pos is always within the ring), so the split-copy logic
+     * in urandom_copy_loop is skipped.
      */
 .globl urandom_strb_1byte_start
 .globl urandom_strb_1byte_end
@@ -644,11 +644,11 @@ urandom_strb_1byte_end:
     add  sp, sp, #16                 /* pop ELR/SPSR recovery slot */
     mov  x0, #1
     stlr wzr, [x19]                  /* release ring_lock */
-    /* x10 still holds the syscall nr loaded by the svc_handler
-     * dispatcher; none of the urandom/getrandom fast-path body writes
-     * x10, so it remains 63 for read and 278 for getrandom. Use it to
-     * pick the matching hit counter without burning a scratch register.
-     * RESTORE_GPRS_KEEP_X0 reloads x10 from the saved frame.
+    /* x10 still holds the syscall nr loaded by the svc_handler dispatcher; none
+     * of the urandom/getrandom fast-path body writes x10, so it remains 63 for
+     * read and 278 for getrandom. Use it to pick the matching hit counter
+     * without burning a scratch register. RESTORE_GPRS_KEEP_X0 reloads x10 from
+     * the saved frame.
      */
     cmp  x10, #63
     b.ne 1f
@@ -658,41 +658,38 @@ urandom_strb_1byte_end:
     b svc_restore_eret
 
 urandom_copy_loop:
-    /* Bulk + tail copy for len in [2, 256] with split-at-4-KiB wrap
-     * handling.
+    /* Bulk + tail copy for len in [2, 256] with split-at-4-KiB wrap handling.
      *
-     * Bulk pass moves 16 bytes per ldp/stp on Apple Silicon; tail
-     * peels the remaining 0..15 bytes via tbz on the bits of the
-     * residue. The wrap split runs the same code twice with rebased
-     * dst/src/limit. Unaligned ldp/stp on normal memory is supported
-     * by M-series with minimal penalty (one extra cycle when crossing
-     * a 64-byte cache line); the small penalty is dwarfed by the win
-     * from collapsing the byte loop's ~5 inst/byte into ldp/stp at
+     * Bulk pass moves 16 bytes per ldp/stp on Apple Silicon; tail peels the
+     * remaining 0..15 bytes via tbz on the bits of the residue. The wrap split
+     * runs the same code twice with rebased dst/src/limit. Unaligned ldp/stp on
+     * normal memory is supported by M-series with minimal penalty (one extra
+     * cycle when crossing a 64-byte cache line); the small penalty is dwarfed
+     * by the win from collapsing the byte loop's ~5 inst/byte into ldp/stp at
      * 16 bytes/cycle peak.
      *
      * handle_el1_data_abort_recover covers a single PC range
-     * (urandom_strb_loop_start..urandom_strb_loop_end) that spans both
-     * the bulk loop and the tail copies, so any sibling-vCPU munmap
-     * mid-copy still routes to the EFAULT recovery path.
+     * (urandom_strb_loop_start..urandom_strb_loop_end) that spans both the bulk
+     * loop and the tail copies, so any sibling-vCPU munmap mid-copy still
+     * routes to the EFAULT recovery path.
      */
     mov  w17, #4096
     sub  w17, w17, w26                /* w17 = 4096 - pos */
     cmp  w15, w17
     csel w17, w15, w17, ls            /* w17 = first segment length */
-    /* Wrap-done flag: 0 on the first segment, set to 1 before re-
-     * entering for the second segment. With len <= 256 and ring size
-     * 4096, exactly one wrap is possible, so the flag guarantees the
-     * loop runs at most twice (vs comparing x17 to x15, which would
-     * infinitely re-wrap once the segment counter is rebased).
+    /* Wrap-done flag: 0 on the first segment, set to 1 before re- entering for
+     * the second segment. With len <= 256 and ring size 4096, exactly one wrap
+     * is possible, so the flag guarantees the loop runs at most twice (vs
+     * comparing x17 to x15, which would infinitely re-wrap once the segment
+     * counter is rebased).
      */
     mov  w14, #0
 urandom_copy_segment:
-    /* Inputs: x16 = src cursor, x20 = dst cursor, x17 = segment bytes.
-     * ldp/stp lack a register-offset form, so we use post-incremented
-     * addressing. x16 and x20 advance through the segment; the wrap
-     * rebase below recomputes x16 (ring base) and lets x20 keep its
-     * post-increment position (exactly where segment 2 must start
-     * writing).
+    /* Inputs: x16 = src cursor, x20 = dst cursor, x17 = segment bytes. ldp/stp
+     * lack a register-offset form, so we use post-incremented addressing. x16
+     * and x20 advance through the segment; the wrap rebase below recomputes x16
+     * (ring base) and lets x20 keep its post-increment position (exactly where
+     * segment 2 must start writing).
      */
     cmp  x17, #16
     b.lo urandom_copy_tail_entry      /* < 16 bytes -> tail only */
@@ -725,9 +722,9 @@ urandom_copy_segment_done:
     cbnz w14, urandom_loop_done       /* second segment already ran */
     cmp  x17, x15                     /* first_copy_len == total? */
     b.eq urandom_loop_done            /* yes: no wrap needed */
-    /* Wrap rebase: src goes back to ring base; dst is already at
-     * (original buf + first_len) thanks to post-increment, so no
-     * rebase needed there. Segment limit becomes the remaining count.
+    /* Wrap rebase: src goes back to ring base; dst is already at (original buf
+     * + first_len) thanks to post-increment, so no rebase needed there. Segment
+     * limit becomes the remaining count.
      */
     mov  w14, #1
     add  x16, x12, #0xC0              /* ring base = tpidr_el1 + 0xC0 */
@@ -744,18 +741,17 @@ urandom_loop_done:
 1:  COUNTER_INC CB_GETRANDOM_HIT
     b svc_restore_eret
 
-/* Named bail labels: branch targets for every fast-path exit that gives
- * up. Each increments the matching diagnostic counter and routes into
- * the right slow-path predecessor: probe failures jump into the no-
- * clrex tail (no exclusive monitor was opened); ring_low jumps into
- * the clrex tail (the LDXR opened a monitor and the lock is held).
- * Ring wrap is no longer a bail reason now that urandom_copy_loop
- * splits the byte copy at the 4 KiB boundary inline.
+/* Named bail labels: branch targets for every fast-path exit that gives up.
+ * Each increments the matching diagnostic counter and routes into the right
+ * slow-path predecessor: probe failures jump into the no- clrex tail (no
+ * exclusive monitor was opened); ring_low jumps into the clrex tail (the LDXR
+ * opened a monitor and the lock is held). Ring wrap is no longer a bail reason
+ * now that urandom_copy_loop splits the byte copy at the 4 KiB boundary inline.
  *
- * attn_bail is shared by identity/pgsid/urandom/getrandom because the
- * ATTN check predates any path-specific state setup; routing every
- * attention-set fast path through the same CB_ATTN_BAIL counter and
- * the same handle_svc_0 branch keeps the bail cluster compact.
+ * attn_bail is shared by identity/pgsid/urandom/getrandom because the ATTN
+ * check predates any path-specific state setup; routing every attention-set
+ * fast path through the same CB_ATTN_BAIL counter and the same handle_svc_0
+ * branch keeps the bail cluster compact.
  */
 attn_bail:
     COUNTER_INC CB_ATTN_BAIL
@@ -777,45 +773,44 @@ urandom_probe_fail_bail:
     b urandom_slow_no_clrex
 urandom_ring_low_bail:
     /* Release the spinlock and clear the exclusive monitor BEFORE the
-     * stats-mode counter bump. Otherwise a sibling vCPU waiting on the
-     * lock pays for this vCPU's counter cache-line ping-pong while it
-     * spins -- the counter write lands on a line the sibling does not
-     * need but the lock holder does not release until after the bump.
-     * Bailing through urandom_clrex_slow only clears the monitor and
-     * drops the lock; it does no further work that depends on the
-     * counter slot, so hoisting the unlock above COUNTER_INC is safe.
+     * stats-mode counter bump. Otherwise a sibling vCPU waiting on the lock
+     * pays for this vCPU's counter cache-line ping-pong while it spins -- the
+     * counter write lands on a line the sibling does not need but the lock
+     * holder does not release until after the bump. Bailing through
+     * urandom_clrex_slow only clears the monitor and drops the lock; it does no
+     * further work that depends on the counter slot, so hoisting the unlock
+     * above COUNTER_INC is safe.
      */
     clrex
     stlr wzr, [x19]                  /* release ring_lock */
     COUNTER_INC CB_URANDOM_RING_LOW
     b handle_svc_0
-    /* SHIM_COUNTER_URANDOM_RING_WRAP (C-side index 6) has no assembly
-     * binding now that urandom_copy_loop splits the byte copy at the
-     * 4 KiB ring boundary inline. The slot stays in the C enum for
-     * ABI stability; a non-zero dump reading flags a regression that
-     * re-introduced a wrap bail.
+
+    /* SHIM_COUNTER_URANDOM_RING_WRAP (C-side index 6) has no assembly binding
+     * now that urandom_copy_loop splits the byte copy at the 4 KiB ring
+     * boundary inline. The slot stays in the C enum for ABI stability; a
+     * non-zero dump reading flags a regression that re-introduced a wrap bail.
      */
 
 urandom_slow_no_clrex:
-    /* Probe-failure bails land here with no exclusive monitor open and
-     * no lock held; route into handle_svc_0 so the host's HVC #5
-     * sys_read either returns -EFAULT for the bad pointer or fulfills
-     * the read normally. The post-lock ring_low bails handle their own
-     * clrex + unlock inline so the stats counter bump stays outside the
-     * spinlock critical section; they branch straight to handle_svc_0.
+    /* Probe-failure bails land here with no exclusive monitor open and no lock
+     * held; route into handle_svc_0 so the host's HVC #5 sys_read either
+     * returns -EFAULT for the bad pointer or fulfills the read normally. The
+     * post-lock ring_low bails handle their own clrex + unlock inline so the
+     * stats counter bump stays outside the spinlock critical section; they
+     * branch straight to handle_svc_0.
      */
     b handle_svc_0
 
-/* getrandom_fast: serve getrandom(buf, len, flags) with len in
- * [1, SHIM_URANDOM_INLINE_LIMIT (256)] and flags in {0, GRND_NONBLOCK
- * (0x1)} by reusing the same urandom ring as the /dev/urandom fast
- * path. Shares the copy + ring epilogue at urandom_strb_1byte_start
- * and urandom_copy_loop (including the 4 KiB wrap split); the success
- * path discriminates GETRANDOM_HIT vs URANDOM_HIT off the syscall
- * number left in x10 by the dispatcher. Any other flag bit set
- * (GRND_RANDOM, GRND_INSECURE, conflicting combinations, or any
- * future kernel flag) falls through to sys_getrandom so the host
- * preserves the full Linux contract.
+/* getrandom_fast: serve getrandom(buf, len, flags) with len in [1,
+ * SHIM_URANDOM_INLINE_LIMIT (256)] and flags in {0, GRND_NONBLOCK (0x1)} by
+ * reusing the same urandom ring as the /dev/urandom fast path. Shares the copy
+ * + ring epilogue at urandom_strb_1byte_start and urandom_copy_loop (including
+ * the 4 KiB wrap split); the success path discriminates GETRANDOM_HIT vs
+ * URANDOM_HIT off the syscall number left in x10 by the dispatcher. Any other
+ * flag bit set (GRND_RANDOM, GRND_INSECURE, conflicting combinations, or any
+ * future kernel flag) falls through to sys_getrandom so the host preserves the
+ * full Linux contract.
  */
 getrandom_fast:
     mrs x12, tpidr_el1
@@ -828,19 +823,21 @@ getrandom_fast:
     b.hi getrandom_len_over_bail
 
     ldr x16, [sp, #16]               /* saved X2 = flags */
+
     /* Accept flags == 0 and flags == GRND_NONBLOCK (0x1); both behave
-     * identically against our arc4random-backed ring (always non-
-     * blocking, always seeded). Any other bit set -- GRND_RANDOM (0x2),
-     * GRND_INSECURE (0x4), the invalid combination of the two, or any
-     * future kernel flag -- falls through to sys_getrandom so the host
-     * preserves the full Linux contract (EINVAL on conflict, etc.).
+     * identically against our arc4random-backed ring (always non- blocking,
+     * always seeded). Any other bit set -- GRND_RANDOM (0x2), GRND_INSECURE
+     * (0x4), the invalid combination of the two, or any future kernel flag --
+     * falls through to sys_getrandom so the host preserves the full Linux
+     * contract (EINVAL on conflict, etc.).
      */
     cmp x16, #1
     b.hi handle_svc_0
 
     ldr x20, [sp, #0]                /* saved X0 = buf */
-    /* See urandom_read_fast for the probe rationale; same shape, with
-     * the single-page skip path so single-page reads pay only one AT.
+
+    /* See urandom_read_fast for the probe rationale; same shape, with the
+     * single-page skip path so single-page reads pay only one AT.
      */
     sub x16, x15, #1
     adds x17, x20, x16
@@ -904,9 +901,9 @@ getrandom_probe_fail_bail:
     COUNTER_INC CB_URANDOM_PROBE_FAIL
     b urandom_slow_no_clrex
 getrandom_ring_low_bail:
-    /* Same hoist as urandom_ring_low_bail: drop the lock + clrex first
-     * so the counter ping-pong in stats-enabled mode stays outside the
-     * spinlock critical section.
+    /* Same hoist as urandom_ring_low_bail: drop the lock + clrex first so the
+     * counter ping-pong in stats-enabled mode stays outside the spinlock
+     * critical section.
      */
     clrex
     stlr wzr, [x19]                  /* release ring_lock */
@@ -918,34 +915,31 @@ not_svc:
     cmp x10, #0x18
     b.eq handle_sysreg_trap
 
-    /* EC=0x20: Instruction abort from lower EL.
-     * W^X demand toggle: when JIT code pages are mapped RW (for writing),
-     * instruction fetch fails. Toggle to RX and retry.
+    /* EC=0x20: Instruction abort from lower EL. W^X demand toggle: when JIT
+     * code pages are mapped RW (for writing), instruction fetch fails. Toggle
+     * to RX and retry.
      */
     cmp x10, #0x20
     b.eq handle_inst_abort
 
-    /* EC=0x24: Data abort from lower EL.
-     * W^X demand toggle: when JIT code pages are mapped RX (for execution),
-     * writes fail. Toggle to RW and retry.
+    /* EC=0x24: Data abort from lower EL. W^X demand toggle: when JIT code pages
+     * are mapped RX (for execution), writes fail. Toggle to RW and retry.
      */
     cmp x10, #0x24
     b.eq handle_data_abort
 
-    /* EC=0x3C: BRK from AArch64 lower EL.
-     * JIT translators use BRK instructions as trampolines.
-     * The guest registers a SIGTRAP handler via rt_sigaction to catch these.
-     * Forward to host for signal delivery.
+    /* EC=0x3C: BRK from AArch64 lower EL. JIT translators use BRK instructions
+     * as trampolines. The guest registers a SIGTRAP handler via rt_sigaction to
+     * catch these. Forward to host for signal delivery.
      */
     cmp x10, #0x3C
     b.eq handle_brk
 
-    /* EC=0x25: Data abort taken without a change in Exception level.
-     * The only legitimate source today is the urandom fast path: a
-     * sibling vCPU can munmap the guest buffer between the AT probe
-     * and the EL1 strb, faulting the store. Recover by returning
-     * -EFAULT to the guest instead of halting the VM (which is what
-     * the EL1-from-EL1 default below would do).
+    /* EC=0x25: Data abort taken without a change in Exception level. The only
+     * legitimate source today is the urandom fast path: a sibling vCPU can
+     * munmap the guest buffer between the AT probe and the EL1 strb, faulting
+     * the store. Recover by returning -EFAULT to the guest instead of halting
+     * the VM (which is what the EL1-from-EL1 default below would do).
      */
     cmp x10, #0x25
     b.eq handle_el1_data_abort_recover
@@ -958,8 +952,8 @@ not_svc:
     cbnz x11, restore_and_bad   /* EL1 (M>=4): genuine shim bug */
     b handle_el0_fault           /* EL0 (M=0): forward for signal delivery */
 
-/* handle_el1_data_abort_recover: tag a data abort whose faulting PC sits
- * inside the urandom-copy strb region as a recoverable EFAULT.
+/* handle_el1_data_abort_recover: tag a data abort whose faulting PC sits inside
+ * the urandom-copy strb region as a recoverable EFAULT.
  *
  * Layout invariants exploited here:
  *   - SAVE_GPRS allocated 256 bytes for THIS (inner) entry on top of
@@ -970,8 +964,8 @@ not_svc:
  *   - The lock at TPIDR_EL1 + 0x10C0 is held by this vCPU at the
  *     time the strb faulted, so release before transferring out.
  *
- * If the fault PC is outside the urandom strb ranges this is a genuine
- * shim bug; fall back to restore_and_bad.
+ * If the fault PC is outside the urandom strb ranges this is a genuine shim
+ * bug; fall back to restore_and_bad.
  */
 handle_el1_data_abort_recover:
     mrs x11, elr_el1
@@ -990,23 +984,26 @@ handle_el1_data_abort_recover:
 1:
     /* Drop the inner SAVE_GPRS frame; SP back at the urandom recovery slot. */
     add sp, sp, #256
-    /* Pop the saved EL0 return state. ldp/post-index restores SP to the
-     * outer SAVE_GPRS frame top so svc_restore_eret's RESTORE_GPRS_KEEP_X0
-     * pulls the original EL0 GPR values.
+
+    /* Pop the saved EL0 return state. ldp/post-index restores SP to the outer
+     * SAVE_GPRS frame top so svc_restore_eret's RESTORE_GPRS_KEEP_X0 pulls the
+     * original EL0 GPR values.
      */
     ldp x9, x10, [sp], #16
     msr elr_el1, x9
     msr spsr_el1, x10
-    /* Release the urandom ring_lock at TPIDR_EL1 + 0x10C0 (held by this
-     * vCPU since urandom_locked acquired it before the byte copy).
+
+    /* Release the urandom ring_lock at TPIDR_EL1 + 0x10C0 (held by this vCPU
+     * since urandom_locked acquired it before the byte copy).
      */
     mrs x11, tpidr_el1
     add x11, x11, #0x1, lsl #12
     add x11, x11, #0xC0
     stlr wzr, [x11]
-    /* Drop any open exclusive monitor (the byte loop does not hold one
-     * after the head STXR retired, but CLREX is cheap and removes a
-     * latent footgun for future readers of this code).
+
+    /* Drop any open exclusive monitor (the byte loop does not hold one after
+     * the head STXR retired, but CLREX is cheap and removes a latent footgun
+     * for future readers of this code).
      */
     clrex
     /* Linux EFAULT = 14; the kernel returns -14 to userspace. */
@@ -1016,9 +1013,9 @@ handle_el1_data_abort_recover:
 /* handle_sysreg_trap: EC=0x18: MSR/MRS / system instruction
  *
  * MRS reads (Direction=1): forward to host via HVC #7 to read the system
- * register value (e.g., ID_AA64MMFR1_EL1, CNTFRQ_EL0).
- * MSR/SYS writes (Direction=0): execute IC IALLU as safety net for cache
- * maintenance instructions that trap despite SCTLR.UCI=1.
+ * register value (e.g., ID_AA64MMFR1_EL1, CNTFRQ_EL0). MSR/SYS writes
+ * (Direction=0): execute IC IALLU as safety net for cache maintenance
+ * instructions that trap despite SCTLR.UCI=1.
  */
 handle_sysreg_trap:
     tst x9, #1
@@ -1050,8 +1047,8 @@ handle_sysreg_trap:
      *   = 0x12DC08 + (Rt << 5)
      */
 
-    /* Check for DC ZVA: extract fields around Rt and compare.
-     * DC ZVA ISS: Op0[21:20]=01 Op2[19:17]=001 Op1[16:14]=011
+    /* Check for DC ZVA: extract fields around Rt and compare. DC ZVA ISS:
+     * Op0[21:20]=01 Op2[19:17]=001 Op1[16:14]=011
      *             CRn[13:10]=0111 Rt[9:5]=xxxxx CRm[4:1]=0100 Dir[0]=0
      * The code checks ISS[21:10] = 0x4B7 and ISS[4:0] = 0x08.
      */
@@ -1063,8 +1060,8 @@ handle_sysreg_trap:
     cmp x10, #0x08                 /* CRm=0100,Dir=0 -> 01000 = 0x08 */
     b.ne 5f                        /* Not DC ZVA -> skip to cache maint */
 
-    /* DC ZVA emulation: zero 64 bytes at aligned address from Xt.
-     * Extract Rt register number and load the VA from saved frame.
+    /* DC ZVA emulation: zero 64 bytes at aligned address from Xt. Extract Rt
+     * register number and load the VA from saved frame.
      */
     ubfx x10, x9, #5, #5          /* Rt = ISS[9:5] */
     cmp x10, #31
@@ -1120,9 +1117,9 @@ handle_inst_abort:
     cmp x11, #0x0C            /* Permission fault? (0b0011xx) */
     b.eq 1f
 
-    /* Non-permission fault (translation, access flag, etc.) from EL0.
-     * Restore all GPRs and forward to host for SIGSEGV delivery.
-     * x9 still holds ESR_EL1 for the host to decode fault type.
+    /* Non-permission fault (translation, access flag, etc.) from EL0. Restore
+     * all GPRs and forward to host for SIGSEGV delivery. x9 still holds ESR_EL1
+     * for the host to decode fault type.
      */
     b handle_el0_fault
 
@@ -1169,16 +1166,15 @@ handle_data_abort:
  *
  * Restore all GPRs from the stack frame (host needs the original EL0 state for
  * the signal frame), then forward to host via HVC #11. The host decodes the EC
- * from ESR_EL1: EC=0x20/0x24 -> SIGSEGV,
- * EC=0x00 (undefined) or other -> SIGILL.
+ * from ESR_EL1: EC=0x20/0x24 -> SIGSEGV, EC=0x00 (undefined) or other ->
+ * SIGILL.
  */
 handle_el0_fault:
-    /* Load EL0 GPRs from the saved frame WITHOUT popping it. The frame
-     * must stay live across HVC #11 so the post-HVC dispatch below can
-     * restore X3-X29 via the frameless RESTORE_GPRS_KEEP_SIGFRAME tail
-     * after the host has overwritten X0/X1/X2/X30 via hv_vcpu_set_reg
-     * (signal_deliver) and the inline TLBI handlers have clobbered
-     * X11/X12/X13 as scratch.
+    /* Load EL0 GPRs from the saved frame WITHOUT popping it. The frame must
+     * stay live across HVC #11 so the post-HVC dispatch below can restore
+     * X3-X29 via the frameless RESTORE_GPRS_KEEP_SIGFRAME tail after the host
+     * has overwritten X0/X1/X2/X30 via hv_vcpu_set_reg (signal_deliver) and the
+     * inline TLBI handlers have clobbered X11/X12/X13 as scratch.
      */
     LOAD_GPRS
 
@@ -1191,9 +1187,9 @@ handle_el0_fault:
      *       X8/X9/X10/X11 per the same wire protocol the SVC #5 epilogue
      *       uses. Single-shot RVAE1IS via X8=4 is included.
      *
-     * The dispatch below mirrors handle_svc_0's TLBI dispatch. exec_drop
-     * (X8=2) is rejected on this path (the host never sets it here); fall
-     * through to the conservative full flush rather than silently skip.
+     * The dispatch below mirrors handle_svc_0's TLBI dispatch. exec_drop (X8=2)
+     * is rejected on this path (the host never sets it here); fall through to
+     * the conservative full flush rather than silently skip.
      */
     hvc #11
 
@@ -1220,12 +1216,13 @@ handle_el0_fault:
     b .Lel0_fault_eret_restore
 
 .Lel0_fault_tlbi_sel:
-    /* Selective per-page TLBI VAE1IS loop. X9 = page-aligned VA,
-     * X10 = page count (1..TLBI_SELECTIVE_MAX_PAGES). X11 carries the
-     * I-cache hint on entry; save into X13 before the loop clobbers X11.
-     * ubfx (not plain lsr) pins the VA to the 44-bit [43:0] field so a
-     * future LPA2 / TTL / tagged-address change cannot leak high bits
-     * into the operand's TTL [47:44] or ASID [63:48] fields. */
+    /* Selective per-page TLBI VAE1IS loop. X9 = page-aligned VA, X10 = page
+     * count (1..TLBI_SELECTIVE_MAX_PAGES). X11 carries the I-cache hint on
+     * entry; save into X13 before the loop clobbers X11. ubfx (not plain lsr)
+     * pins the VA to the 44-bit [43:0] field so a future LPA2 / TTL /
+     * tagged-address change cannot leak high bits into the operand's TTL
+     * [47:44] or ASID [63:48] fields.
+     */
     cbz x10, .Lel0_fault_eret_only
     mov x13, x11
     ubfx x11, x9, #12, #44
@@ -1255,37 +1252,37 @@ handle_el0_fault:
     /* fall through */
 
 .Lel0_fault_eret_restore:
-    /* TLBI clobbered X11/X12/X13 (and possibly X9/X10 in the selective
-     * path). Reload X3-X29 from the saved frame so the EL0 retry sees the
-     * same scratch state as pre-fault; skip X0/X1/X2/X30 in case
-     * signal delivery set them. On lazy materialization and conservative
-     * unknown-X8 fallback paths, the skipped registers still match the frame.
+    /* TLBI clobbered X11/X12/X13 (and possibly X9/X10 in the selective path).
+     * Reload X3-X29 from the saved frame so the EL0 retry sees the same scratch
+     * state as pre-fault; skip X0/X1/X2/X30 in case signal delivery set them.
+     * On lazy materialization and conservative unknown-X8 fallback paths, the
+     * skipped registers still match the frame.
      */
     RESTORE_GPRS_KEEP_SIGFRAME
     eret
 
 .Lel0_fault_eret_only:
-    /* X8 == 0: no TLBI requested. signal-delivery and no-delivery paths
-     * land here after the host wrote X8 as the post-HVC protocol value.
-     * Reload X3-X29 so EL0 sees the pre-fault scratch state, while keeping
+    /* X8 == 0: no TLBI requested. signal-delivery and no-delivery paths land
+     * here after the host wrote X8 as the post-HVC protocol value. Reload
+     * X3-X29 so EL0 sees the pre-fault scratch state, while keeping
      * X0/X1/X2/X30 live for a materialized signal handler.
      */
     RESTORE_GPRS_KEEP_SIGFRAME
     eret
 
-/* Shared exit paths for exception handlers
- */
+/* Shared exit paths for exception handlers */
 tlbi_restore_eret:
-    /* Single-page TLB flush after a W^X permission toggle. Only one page
-     * (the one that triggered the HVC #9 fault, FAR_EL1 still in scope)
-     * changed permissions, so per-VA TLBI VAE1IS is sufficient and avoids
-     * blowing away unrelated TLB entries. The HVC #9 host handler does not
-     * raise further exceptions, so FAR_EL1 is preserved.
+    /* Single-page TLB flush after a W^X permission toggle. Only one page (the
+     * one that triggered the HVC #9 fault, FAR_EL1 still in scope) changed
+     * permissions, so per-VA TLBI VAE1IS is sufficient and avoids blowing away
+     * unrelated TLB entries. The HVC #9 host handler does not raise further
+     * exceptions, so FAR_EL1 is preserved.
      */
     mrs x0, far_el1
-    /* TLBI VAE1IS operand: VA[55:12] held in bits [43:0]. ubfx pins the
-     * 44-bit width so future LPA2 / TTL / tagged-address support cannot
-     * leak VA bits into the TTL [47:44] or ASID [63:48] operand fields.
+
+    /* TLBI VAE1IS operand: VA[55:12] held in bits [43:0]. ubfx pins the 44-bit
+     * width so future LPA2 / TTL / tagged-address support cannot leak VA bits
+     * into the TTL [47:44] or ASID [63:48] operand fields.
      */
     ubfx x0, x0, #12, #44
     tlbi vae1is, x0
@@ -1303,9 +1300,9 @@ restore_eret:
 restore_and_bad:
     RESTORE_GPRS
 
-    /* Determine correct vector offset for bad_exception reporting.
-     * After restore, X5 holds the EL0 caller's value, not the vector.
-     * Check SPSR_EL1.M[3:0]: 0=EL0t (Lower EL -> 0x400), 4/5=EL1 (-> 0x200).
+    /* Determine correct vector offset for bad_exception reporting. After
+     * restore, X5 holds the EL0 caller's value, not the vector. Check
+     * SPSR_EL1.M[3:0]: 0=EL0t (Lower EL -> 0x400), 4/5=EL1 (-> 0x200).
      */
     mrs x5, spsr_el1
     and x5, x5, #0xF
@@ -1317,15 +1314,14 @@ restore_and_bad:
 
 /* handle_brk: BRK instruction from EL0 (EC=0x3C)
  *
- * JIT translators use BRK instructions as patching trampolines
- * and debug hooks. The guest registers a SIGTRAP
- * handler via rt_sigaction. The shim restores all GPRs and forwards to
- * the host via HVC #10 for signal delivery.
+ * JIT translators use BRK instructions as patching trampolines and debug hooks.
+ * The guest registers a SIGTRAP handler via rt_sigaction. The shim restores all
+ * GPRs and forwards to the host via HVC #10 for signal delivery.
  *
- * Host reads ESR_EL1 (BRK immediate), ELR_EL1 (BRK PC), and
- * current GPRs from the vCPU. If a SIGTRAP handler is registered,
- * the host builds a signal frame and redirects PC to the handler.
- * Otherwise, the host performs the default SIGTRAP action (terminate).
+ * Host reads ESR_EL1 (BRK immediate), ELR_EL1 (BRK PC), and current GPRs from
+ * the vCPU. If a SIGTRAP handler is registered, the host builds a signal frame
+ * and redirects PC to the handler. Otherwise, the host performs the default
+ * SIGTRAP action (terminate).
  */
 handle_brk:
     /* Restore all GPRs from stack frame (host needs current state) */
@@ -1334,23 +1330,22 @@ handle_brk:
     /* Forward to host for SIGTRAP delivery */
     hvc #10
 
-    /* Host has set up signal frame (if handler registered) or
-     * flagged for termination. Either way, ERET to new PC.
+    /* Host has set up signal frame (if handler registered) or flagged for
+     * termination. Either way, ERET to new PC.
      */
     eret
 
 /* handle_svc_0: Linux syscall forwarding
  *
- * Restore ALL EL0 registers from the stack frame before HVC #5,
- * so the host can read X8 (syscall nr) and X0-X5 (args) directly
- * from vCPU registers. The host writes the result to X0 and
- * resumes the vCPU. The shim then ERET to EL0 with X0=result and all
- * other registers (X1-X30) in their original EL0 state.
+ * Restore ALL EL0 registers from the stack frame before HVC #5, so the host can
+ * read X8 (syscall nr) and X0-X5 (args) directly from vCPU registers. The host
+ * writes the result to X0 and resumes the vCPU. The shim then ERET to EL0 with
+ * X0=result and all other registers (X1-X30) in their original EL0 state.
  */
 handle_svc_0:
-    /* Restore all 31 GPRs to their EL0 values, but keep the saved frame
-     * intact: after HVC #5 the post-syscall restore re-reads X1-X30 from
-     * it (the host only writes back X0).
+    /* Restore all 31 GPRs to their EL0 values, but keep the saved frame intact:
+     * after HVC #5 the post-syscall restore re-reads X1-X30 from it (the host
+     * only writes back X0).
      */
     LOAD_GPRS
 
@@ -1367,8 +1362,8 @@ handle_svc_0:
      */
     hvc #5
 
-    /* Dispatch on X8. Encoded so the common case (X8 == 0, no flush) hits
-     * the cbz fast path; the other branches sort by frequency thereafter.
+    /* Dispatch on X8. Encoded so the common case (X8 == 0, no flush) hits the
+     * cbz fast path; the other branches sort by frequency thereafter.
      */
     cbz x8, 1f
     cmp x8, #1
@@ -1385,11 +1380,11 @@ handle_svc_0:
 tlbi_full:
     /* Broadcast TLB + (conditional) I-cache flush. Used for page-table edits
      * whose affected range exceeds the selective cap, or any time the host
-     * could not bound the change. X11 carries the I-cache hint: non-zero
-     * means the host introduced executable content visible to EL0 (new X
-     * mapping, NX->X mprotect, lazy materialize from a region that may
-     * include exec), so the shim must IC IALLU; zero means a data-only
-     * PT change and the I-cache invalidation is skipped.
+     * could not bound the change. X11 carries the I-cache hint: non-zero means
+     * the host introduced executable content visible to EL0 (new X mapping,
+     * NX->X mprotect, lazy materialize from a region that may include exec), so
+     * the shim must IC IALLU; zero means a data-only PT change and the I-cache
+     * invalidation is skipped.
      */
     tlbi vmalle1is
     dsb ish
@@ -1405,25 +1400,26 @@ tlbi_selective:
      *   x9  = page-aligned VA of the first page to invalidate
      *   x10 = page count (1..TLBI_SELECTIVE_MAX_PAGES, see core/guest.h)
      *   x11 = I-cache hint (see tlbi_full above)
-     * TLBI VAE1IS takes a Xt operand of (VA[55:12] | (ASID << 48)). The
-     * guest runs single-ASID at EL0, so just shift the VA right by 12.
-     * Issue all TLBI ops, then DSB ISH + (conditional) IC IALLU + DSB + ISB.
+     * TLBI VAE1IS takes a Xt operand of (VA[55:12] | (ASID << 48)). The guest
+     * runs single-ASID at EL0, so just shift the VA right by 12. Issue all TLBI
+     * ops, then DSB ISH + (conditional) IC IALLU + DSB + ISB.
      *
-     * Defensive: if x10 == 0, skip the loop. The per-vCPU host-side
-     * accumulator (cpu_tlbi_req in core/guest.h) never sets pages == 0
-     * alongside kind == TLBI_RANGE, but if a future helper bug or a stray
-     * write ever produced the pair X8=3, X10=0, the subs x12, x12, #1
-     * below would underflow to 0xFFFFFFFFFFFFFFFF and the b.ne would loop
-     * ~2^64 iterations, hanging this vCPU. Cheap guard.
+     * Defensive: if x10 == 0, skip the loop. The per-vCPU host-side accumulator
+     * (cpu_tlbi_req in core/guest.h) never sets pages == 0 alongside kind ==
+     * TLBI_RANGE, but if a future helper bug or a stray write ever produced the
+     * pair X8=3, X10=0, the subs x12, x12, #1 below would underflow to
+     * 0xFFFFFFFFFFFFFFFF and the b.ne would loop ~2^64 iterations, hanging this
+     * vCPU. Cheap guard.
      *
-     * x11 is the I-cache hint on entry but the per-page TLBI operand is
-     * also computed from x9 -- save the hint into x13 before clobbering.
+     * x11 is the I-cache hint on entry but the per-page TLBI operand is also
+     * computed from x9 -- save the hint into x13 before clobbering.
      */
     cbz x10, 1f
     mov x13, x11              /* x13 = saved I-cache hint */
-    /* TLBI VAE1IS operand: VA[55:12] held in bits [43:0]. ubfx pins the
-     * 44-bit width so future LPA2 / TTL / tagged-address support cannot
-     * leak VA bits into the TTL [47:44] or ASID [63:48] operand fields. */
+    /* TLBI VAE1IS operand: VA[55:12] held in bits [43:0]. ubfx pins the 44-bit
+     * width so future LPA2 / TTL / tagged-address support cannot leak VA bits
+     * into the TTL [47:44] or ASID [63:48] operand fields.
+     */
     ubfx x11, x9, #12, #44    /* x11 = VA[55:12] (current page operand) */
     mov x12, x10              /* x12 = remaining page counter */
 3:  tlbi vae1is, x11
@@ -1439,12 +1435,12 @@ tlbi_selective:
     b svc_restore_eret
 
 tlbi_range_large:
-    /* Single-shot TLBI RVAE1IS (FEAT_TLBIRANGE, ARMv8.4+). The host has
-     * encoded the full operand in X9: baddr (VA >> 12), TTL=0, NUM in bits
-     * [43:39], SCALE=0, ASID=0. One instruction covers up to 64 pages,
-     * avoiding the broadcast TLBI VMALLE1IS that the prior selective cap
-     * forced for 17..64-page ranges. X11 carries the I-cache hint as in
-     * tlbi_full / tlbi_selective.
+    /* Single-shot TLBI RVAE1IS (FEAT_TLBIRANGE, ARMv8.4+). The host has encoded
+     * the full operand in X9: baddr (VA >> 12), TTL=0, NUM in bits [43:39],
+     * SCALE=0, ASID=0. One instruction covers up to 64 pages, avoiding the
+     * broadcast TLBI VMALLE1IS that the prior selective cap forced for
+     * 17..64-page ranges. X11 carries the I-cache hint as in tlbi_full /
+     * tlbi_selective.
      */
     tlbi rvae1is, x9
     dsb ish
@@ -1457,20 +1453,20 @@ tlbi_range_large:
 
 svc_restore_eret:
 1:
-    /* Restore all guest registers except X0, which now holds the syscall
-     * return value.  Linux preserves X1-X30, including X8.
+    /* Restore all guest registers except X0, which now holds the syscall return
+     * value. Linux preserves X1-X30, including X8.
      *
-     * Named alias for the cross-function jump from the identity fast
-     * path in svc_handler. A bare 'b 1f' from up there would resolve
-     * to the next forward '1:' -- which sits inside handle_inst_abort
-     * -- and silently re-route the identity result into a W^X toggle.
-     * Caught the hard way during the prior P2 attempt; keep the
-     * named symbol to make the intent explicit.
+     * Named alias for the cross-function jump from the identity fast path in
+     * svc_handler. A bare 'b 1f' from up there would resolve to the next
+     * forward '1:' -- which sits inside handle_inst_abort -- and silently
+     * re-route the identity result into a W^X toggle. Caught the hard way
+     * during the prior P2 attempt; keep the named symbol to make the intent
+     * explicit.
      */
     RESTORE_GPRS_KEEP_X0
 
-    /* Return to EL0. X0 now holds the syscall return value,
-     * X1-X30 retain their original EL0 values.
+    /* Return to EL0. X0 now holds the syscall return value, X1-X30 retain their
+     * original EL0 values.
      */
     eret
 

--- a/src/core/stack.h
+++ b/src/core/stack.h
@@ -58,8 +58,8 @@ typedef struct {
  * that string from the execve filename rather than from argv[0], and the two
  * differ whenever the caller passed an alternate argv[0] or the kernel
  * prepended a binfmt_misc interpreter, so callers pass it explicitly instead of
- * leaving it to be inferred from argv's shape. NULL falls back to argv[0].
- * If auxv_out is non-NULL, it receives the exact auxv words written to guest
+ * leaving it to be inferred from argv's shape. NULL falls back to argv[0]. If
+ * auxv_out is non-NULL, it receives the exact auxv words written to guest
  * memory, in the same order exposed by /proc/self/auxv.
  * Returns the initial SP (stack pointer) to pass to the guest.
  */

--- a/src/core/startup-trace.h
+++ b/src/core/startup-trace.h
@@ -63,6 +63,7 @@ static inline void startup_trace_resolve(void)
     const char *v = getenv("ELFUSE_STARTUP_TRACE");
     if (!v || !v[0] || !strcmp(v, "0"))
         return;
+
     /* The legacy "1" knob enables steps. Recognize it both as the whole value
      * and as a token so compound forms like "1,syscalls" still keep the step
      * trace on alongside the histogram, instead of silently dropping it.

--- a/src/core/startup-trace.h
+++ b/src/core/startup-trace.h
@@ -21,8 +21,7 @@
  * can ask for one without paying for the other.
  */
 
-#ifndef ELFUSE_STARTUP_TRACE_H
-#define ELFUSE_STARTUP_TRACE_H
+#pragma once
 
 #include <pthread.h>
 #include <stdbool.h>
@@ -99,5 +98,3 @@ static inline void startup_trace_step(const char *label, uint64_t start_ns)
     fprintf(stderr, "startup %-28s %8.3f ms\n", label,
             (double) (end_ns - start_ns) / 1000000.0);
 }
-
-#endif /* ELFUSE_STARTUP_TRACE_H */

--- a/src/core/vdso.c
+++ b/src/core/vdso.c
@@ -147,6 +147,7 @@ static uint8_t *vdso_host_page(guest_t *g)
  * is loaded with the rest.
  */
 #define VDSO_OFF_EHDR 0x000
+
 /* NT_GNU_ABI_TAG note data lives at the old PHDR slot; 32 bytes fits
  * comfortably inside the 112-byte gap up to VVAR.
  */
@@ -217,6 +218,7 @@ static uint8_t *vdso_host_page(guest_t *g)
 #define TEXT_OFF_GETCPU (TEXT_OFF_GETTOD + TEXT_GETTOD_SIZE)
 #define TEXT_GETCPU_SIZE 0x34
 #define TEXT_END (TEXT_OFF_GETCPU + TEXT_GETCPU_SIZE)
+
 /* Offset of the SVC instruction inside __kernel_clock_gettime's svc_fallback
  * (svc_fallback opens at instruction 39 of 42, i.e. byte 0x9C; the SVC is the
  * second instruction of the fallback, at byte 0xA0). The host's
@@ -225,6 +227,7 @@ static uint8_t *vdso_host_page(guest_t *g)
  * trustworthy CNTVCT in X9.
  */
 #define VDSO_CLOCK_GETTIME_SVC_PC (TEXT_OFF_GETTIME + 0xA0)
+
 /* gettimeofday svc_fallback opens at instruction 37 of 40 (byte 0x94); SVC at
  * byte 0x98.
  */
@@ -688,6 +691,7 @@ static void emit_clock_gettime_trampoline(uint32_t *code,
     code[20] = enc_lsr_x_imm(7, 6, VDSO_ANCHOR_AGE_SHIFT);
     /* lsr x7, x6, #ANCHOR_AGE_SHIFT */
     code[21] = enc_cbnz_x(7, svc_fallback_off - 0x54);
+
     /* cbnz x7, svc_fallback (age cap) delta_ns = (delta * 699050666) >> 24.
      * 699050666 is floor((1e9 << 24) / 24e6), the mult+shift form Linux's arm64
      * vDSO uses for CNTFRQ = 24 MHz; an LSR (~1 cycle) in place of any 64-bit
@@ -808,6 +812,7 @@ static void emit_gettimeofday_trampoline(uint32_t *code,
     code[12] = enc_bcond_imm19(COND_LO, svc_fallback_off - 0x30);
     code[13] = enc_lsr_x_imm(7, 6, VDSO_ANCHOR_AGE_SHIFT);
     code[14] = enc_cbnz_x(7, svc_fallback_off - 0x38);
+
     /* Same mult+shift CNTVCT-to-ns conversion as clock_gettime; see
      * emit_clock_gettime_trampoline for the multiplier rationale.
      */
@@ -1333,6 +1338,7 @@ bool vdso_anchor_is_seeded(guest_t *g)
     uint8_t *page = vdso_host_page(g);
     if (!page)
         return false;
+
     /* A seeded-and-stable anchor has seq != 0 && (seq & 1) == 0 (see the vvar
      * layout block for the state machine). Acquire pairs with the release store
      * at the tail of vdso_seed_anchor.
@@ -1348,6 +1354,7 @@ void vdso_attention_or(guest_t *g, uint32_t bits)
         return;
     uint32_t *attention =
         (uint32_t *) (page + VDSO_OFF_VVAR + VVAR_OFF_ATTENTION);
+
     /* SEQ_CST mirrors shim_globals_attn_or: the EL0 fast paths read this word
      * without going through HVC, so a reader that LDARs attn=0 must not observe
      * later publish_creds stores. Release-acquire alone only orders the forward

--- a/src/core/vdso.h
+++ b/src/core/vdso.h
@@ -21,6 +21,7 @@
 /* Guest address where the vDSO is placed (one 4KiB page, below PT pool) */
 #define VDSO_BASE 0x0000F000ULL
 #define VDSO_SIZE 0x00001000ULL /* 4KiB */
+
 /* Offset of __kernel_rt_sigreturn (the signal trampoline glibc/musl jumps to
  * via X30/LR after the handler returns). Must match TEXT_OFF_SIGRET in
  * src/core/vdso.c; kept here so signal.c can target it without including the

--- a/src/debug/crashreport.c
+++ b/src/debug/crashreport.c
@@ -335,6 +335,7 @@ void crash_report(hv_vcpu_t vcpu,
 
     sysctl_str("kern.osproductversion", os_version, sizeof(os_version));
     sysctl_str("kern.osrelease", os_release, sizeof(os_release));
+
     /* machdep.cpu.brand_string is absent on Apple Silicon. Fall back to
      * hw.model so the report still names the host hardware.
      */

--- a/src/debug/syscall-hist.h
+++ b/src/debug/syscall-hist.h
@@ -16,8 +16,7 @@
  * atomic adds.
  */
 
-#ifndef ELFUSE_SYSCALL_HIST_H
-#define ELFUSE_SYSCALL_HIST_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -69,5 +68,3 @@ void syscall_hist_disable(void);
  * may run more than once.
  */
 void syscall_hist_dump(void);
-
-#endif /* ELFUSE_SYSCALL_HIST_H */

--- a/src/dynamic-array.c
+++ b/src/dynamic-array.c
@@ -114,8 +114,9 @@ int dynamic_array_init_with_capacity(dynamic_array_t *array,
         return dynamic_array_invalid();
 
     /* Establish a safe zero state before any fallible allocation. This is a
-     * fresh initializer, so an existing allocation must have been destroyed
-     * by the caller rather than silently leaked here. */
+     * fresh initializer, so an existing allocation must have been destroyed by
+     * the caller rather than silently leaked here.
+     */
     *array = (dynamic_array_t) {0};
 
     size_t bytes;

--- a/src/dynamic-array.h
+++ b/src/dynamic-array.h
@@ -45,12 +45,14 @@ static inline int dynamic_array_typed_prepare(dynamic_array_t *array,
 
 /* Initialize an array for elements of element_size bytes without allocation.
  * This fresh initializer is safe on an uninitialized automatic object; destroy
- * an existing array before reinitializing it. */
+ * an existing array before reinitializing it.
+ */
 int dynamic_array_init(dynamic_array_t *array, size_t element_size);
 
-/* Initialize and reserve initial_capacity element slots. This fresh
- * initializer is safe on an uninitialized automatic object; destroy an
- * existing array before reinitializing it. */
+/* Initialize and reserve initial_capacity element slots. This fresh initializer
+ * is safe on an uninitialized automatic object; destroy an existing array
+ * before reinitializing it.
+ */
 int dynamic_array_init_with_capacity(dynamic_array_t *array,
                                      size_t element_size,
                                      size_t initial_capacity);
@@ -64,8 +66,9 @@ int dynamic_array_reserve(dynamic_array_t *array, size_t extra);
 /* Set the logical element count. Newly exposed elements are zeroed. */
 int dynamic_array_resize(dynamic_array_t *array, size_t count);
 
-/* Append one element, or count elements when the three-argument form is
- * used. The macro keeps both forms available to callers. */
+/* Append one element, or count elements when the three-argument form is used.
+ * The macro keeps both forms available to callers.
+ */
 int dynamic_array_append_one(dynamic_array_t *array, const void *data);
 int dynamic_array_append_n(dynamic_array_t *array,
                            const void *data,
@@ -96,11 +99,11 @@ int dynamic_array_insert_n(dynamic_array_t *array,
 void *dynamic_array_at(dynamic_array_t *array, size_t index);
 const void *dynamic_array_at_const(const dynamic_array_t *array, size_t index);
 
-/* Generate a small type-safe facade over the raw container. The facade owns
- * no additional state; all growth and copying remains in dynamic-array.c.
- * A typed object must be zero-initialized before first-touch operations such
- * as append, insert, reserve, or resize; the explicit init functions are safe
- * on a fresh automatic object and establish the metadata themselves.
+/* Generate a small type-safe facade over the raw container. The facade owns no
+ * additional state; all growth and copying remains in dynamic-array.c. A typed
+ * object must be zero-initialized before first-touch operations such as append,
+ * insert, reserve, or resize; the explicit init functions are safe on a fresh
+ * automatic object and establish the metadata themselves.
  */
 #define DYNAMIC_ARRAY_DEFINE(name, type)                                       \
     typedef struct name {                                                      \

--- a/src/elfuse-limits.h
+++ b/src/elfuse-limits.h
@@ -4,8 +4,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Keep the descriptor accounting in one header.  Shell test runners derive
- * their limits from this file instead of copying the arithmetic from main.c.
+ * Keep the descriptor accounting in one header. Shell test runners derive their
+ * limits from this file instead of copying the arithmetic from main.c.
  */
 
 #pragma once
@@ -16,9 +16,8 @@
 /* Host descriptors kept available for elfuse's internal operations. Blocking
  * I/O may hold two duplicated descriptors per guest thread (for example,
  * copy_file_range()), while another bounded slice covers runtime pipes, fork
- * IPC, debugger sockets, and sysroot/FUSE plumbing. Operations whose
- * descriptor use grows with their input set, such as ppoll(), require separate
- * accounting.
+ * IPC, debugger sockets, and sysroot/FUSE plumbing. Operations whose descriptor
+ * use grows with their input set, such as ppoll(), require separate accounting.
  */
 #define HOST_FD_RESERVE 256
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,8 +13,8 @@
  *   - Syscall handlers that translate Linux syscalls to macOS equivalents.
  *
  * Usage: elfuse [options] <elf-path> [args...]; `elfuse --help` lists the
- * options. The flag list lives once in ELFUSE_USAGE_BODY below; --help and
- * the argument-error paths render it differently but cannot drift apart.
+ * options. The flag list lives once in ELFUSE_USAGE_BODY below; --help and the
+ * argument-error paths render it differently but cannot drift apart.
  */
 
 #include <errno.h>
@@ -200,15 +200,15 @@ static int host_dc_zva_assert(void)
     return 0;
 }
 
-/* Usage synopsis: one flag list, two renderings. @sep joins the groups,
- * with a space for ELFUSE_USAGE and a newline plus an indent to the column
- * after "usage: elfuse " for ELFUSE_USAGE_WRAPPED.
+/* Usage synopsis: one flag list, two renderings. @sep joins the groups, with a
+ * space for ELFUSE_USAGE and a newline plus an indent to the column after
+ * "usage: elfuse " for ELFUSE_USAGE_WRAPPED.
  *
- * The error paths need the flat form because log_error stamps a timestamp
- * and a source location on the first line only, so a wrapped string prints
- * ragged under the prefix; --help has no prefix and takes the wrapped form,
- * which fits 80 columns. Sharing one body keeps the flag list from drifting
- * between them (one copy had already lost the --gdb flags).
+ * The error paths need the flat form because log_error stamps a timestamp and a
+ * source location on the first line only, so a wrapped string prints ragged
+ * under the prefix; --help has no prefix and takes the wrapped form, which fits
+ * 80 columns. Sharing one body keeps the flag list from drifting between them
+ * (one copy had already lost the --gdb flags).
  */
 #define ELFUSE_USAGE_BODY(sep)                                             \
     "usage: elfuse [--verbose] [--timeout N] [--sysroot PATH]" sep         \
@@ -250,6 +250,7 @@ int main(int argc, char **argv)
     int n_env_overrides = 0;
     bool clear_env = false;
     int arg_start = 1;
+
     /* Everything the shared cleanup label reads is declared and initialized
      * here, above the option loop, so any later error path can `goto cleanup`:
      * a goto that skipped an initializer would leave the unwind reading
@@ -425,8 +426,8 @@ int main(int argc, char **argv)
             arg_start += 2;
         } else if (!strcmp(argv[arg_start], "--workdir") &&
                    arg_start + 1 < argc) {
-            /* A relative path resolves against the host cwd, silently
-             * starting the guest outside the intended tree. strdup because
+            /* A relative path resolves against the host cwd, silently starting
+             * the guest outside the intended tree. strdup because
              * runtime_set_process_title() clobbers the argv block.
              */
             if (argv[arg_start + 1][0] != '/') {
@@ -443,8 +444,8 @@ int main(int argc, char **argv)
             arg_start += 2;
         } else if (!strcmp(argv[arg_start], "--env") && arg_start + 1 < argc) {
             /* Tokens are borrowed from argv; guest_env_build strdups what it
-             * keeps (the ordering rationale sits at its call site). argc
-             * bounds the flag count, so one allocation needs no growth path.
+             * keeps (the ordering rationale sits at its call site). argc bounds
+             * the flag count, so one allocation needs no growth path.
              */
             if (!env_overrides) {
                 env_overrides = (char **) calloc((size_t) argc, sizeof(char *));
@@ -536,10 +537,10 @@ int main(int argc, char **argv)
                                timeout_sec);
 
     /* Before runtime_set_process_title clobbers the argv block env_overrides
-     * borrows from, and before --create-sysroot would provision a
-     * sparsebundle for a launch a malformed --env is about to refuse. With
-     * neither flag given envp stays NULL, which launch_args_t defines as the
-     * host environ, unchanged.
+     * borrows from, and before --create-sysroot would provision a sparsebundle
+     * for a launch a malformed --env is about to refuse. With neither flag
+     * given envp stays NULL, which launch_args_t defines as the host environ,
+     * unchanged.
      */
     if (n_env_overrides > 0 || clear_env) {
         envp = guest_env_build(environ, env_overrides, n_env_overrides,
@@ -719,8 +720,8 @@ int main(int argc, char **argv)
 
     /* Hand the bring-up, run loop, and guest teardown to elfuse_launch. main()
      * retains ownership of the original argv (proctitle above), the sysroot
-     * mount (detached at the cleanup label after the guest exits so the
-     * mount stays live for the whole run), host cwd, and the heap elf_path /
+     * mount (detached at the cleanup label after the guest exits so the mount
+     * stays live for the whole run), host cwd, and the heap elf_path /
      * sysroot_path / guest_argv / envp / workdir copies.
      */
     launch_args_t largs = {
@@ -739,8 +740,9 @@ int main(int argc, char **argv)
         .timeout_sec = timeout_sec,
         .verbose = verbose,
     };
-    /* Ownership of the temp unlink transfers here (contract in launch.h);
-     * drop main()'s claim so the shared cleanup below cannot double-unlink.
+
+    /* Ownership of the temp unlink transfers here (contract in launch.h); drop
+     * main()'s claim so the shared cleanup below cannot double-unlink.
      */
     elf_host_temp = false;
     exit_code = elfuse_launch(&largs);
@@ -750,10 +752,9 @@ cleanup:
      * caller-owned heap copies, detaches the sysroot mount, restores the host
      * cwd, and drops a still-owned FUSE-materialized temp ELF. This must run
      * even after a bring-up whose HVF teardown guest_destroy deferred to
-     * process exit, because process exit reclaims neither the sysroot mount
-     * nor the temp ELF. The guest itself belongs to elfuse_launch, which
-     * destroys it on every exit path, so nothing here touches HVF or guest
-     * memory.
+     * process exit, because process exit reclaims neither the sysroot mount nor
+     * the temp ELF. The guest itself belongs to elfuse_launch, which destroys
+     * it on every exit path, so nothing here touches HVF or guest memory.
      */
     rosettad_clear_binary_path();
     if (have_host_cwd && host_cwd[0] != '\0' && chdir(host_cwd) < 0)

--- a/src/main.c
+++ b/src/main.c
@@ -448,7 +448,7 @@ int main(int argc, char **argv)
              * the flag count, so one allocation needs no growth path.
              */
             if (!env_overrides) {
-                env_overrides = (char **) calloc((size_t) argc, sizeof(char *));
+                env_overrides = calloc((size_t) argc, sizeof(char *));
                 if (!env_overrides) {
                     log_error("out of memory");
                     goto cleanup;
@@ -564,7 +564,7 @@ int main(int argc, char **argv)
     bool have_sysroot = (sysroot != NULL || create_sysroot != NULL);
     const char *sysroot_src = create_sysroot ? create_sysroot : sysroot;
     if (have_sysroot) {
-        sysroot_path = (char *) calloc(LINUX_PATH_MAX, 1);
+        sysroot_path = calloc(LINUX_PATH_MAX, 1);
         if (sysroot_path) {
             size_t src_len =
                 str_copy_trunc(sysroot_path, sysroot_src, LINUX_PATH_MAX);
@@ -577,7 +577,7 @@ int main(int argc, char **argv)
     }
     sysroot = sysroot_path;
     guest_argc = argc - arg_start;
-    guest_argv = (const char **) calloc((size_t) guest_argc, sizeof(char *));
+    guest_argv = calloc((size_t) guest_argc, sizeof(char *));
     if (!elf_path || (have_sysroot && !sysroot_path) || !guest_argv) {
         log_error("out of memory");
         goto cleanup;

--- a/src/proved/fdset.h
+++ b/src/proved/fdset.h
@@ -35,8 +35,8 @@
  * Several bitmaps in the tree run 64 bits to a word over the same fd table:
  * pselect6's three guest bitmasks in poll.c, the free-fd allocator's
  * fd_free_bitmap in fdtable.c, and the urandom bitmap in shim-globals.c. They
- * share the constants here, but not every one of them should route its
- * indexing through the helpers below.
+ * share the constants here, but not every one of them should route its indexing
+ * through the helpers below.
  *
  * The bound belongs here when it is a fact about the input: pselect6's nfds
  * arrives from the guest, so the reject branch is a branch the code has to take

--- a/src/proved/gva.h
+++ b/src/proved/gva.h
@@ -93,11 +93,10 @@
  * merely its first byte. "*off < guest_size" would be satisfied by off ==
  * guest_size - 8, which puts l1[511] past the end of the slab.
  *
- * The reject path leaves off alone, stated as a postcondition because
- * "assigns" permits writing it: without that clause a conforming
- * implementation could scribble on it before returning 0, and a caller reading
- * it on the failure path would be relying on the body rather than the
- * contract.
+ * The reject path leaves off alone, stated as a postcondition because "assigns"
+ * permits writing it: without that clause a conforming implementation could
+ * scribble on it before returning 0, and a caller reading it on the failure
+ * path would be relying on the body rather than the contract.
  */
 #define GVA_PT_TABLE_BYTES 4096ULL
 

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -983,8 +983,9 @@ int fork_ipc_recv_process_state(int ipc_fd, guest_t *g, signal_state_t *sig)
         return -1;
 
     g->nregions = (int) recv_regions;
-    /* Every VMA present in the serialized parent snapshot is inherited by
-     * this child, regardless of whether the parent itself created it after an
+
+    /* Every VMA present in the serialized parent snapshot is inherited by this
+     * child, regardless of whether the parent itself created it after an
      * earlier fork. New mappings added in this process start unmarked through
      * guest_region_add_ex_owned[_gpa].
      */

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -377,7 +377,7 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
         return 0;
     }
 
-    ipc_fd_entry_t *fd_entries = calloc(num_fds, sizeof(ipc_fd_entry_t));
+    ipc_fd_entry_t *fd_entries = calloc(num_fds, sizeof(*fd_entries));
     if (!fd_entries)
         return -1;
 

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -306,10 +306,11 @@ int fork_child_main(int ipc_fd,
     signal_state_t sig;
     if (fork_ipc_recv_process_state(ipc_fd, &g, &sig) < 0) {
         log_error("fork-child: failed to receive process state");
-        /* Give back the credit the parent added for this child before
-         * bailing: nothing here reaches the teardown that normally
-         * returns it, and a child that never runs must not leave the
-         * pty looking busy to the master the parent still holds.
+
+        /* Give back the credit the parent added for this child before bailing:
+         * nothing here reaches the teardown that normally returns it, and a
+         * child that never runs must not leave the pty looking busy to the
+         * master the parent still holds.
          */
         proc_pty_release_process_slaves();
         guest_destroy(&g);
@@ -318,10 +319,11 @@ int fork_child_main(int ipc_fd,
 
     if (chown_overlay_recv(ipc_fd) < 0) {
         log_error("fork-child: failed to receive chown overlay");
-        /* Give back the credit the parent added for this child before
-         * bailing: nothing here reaches the teardown that normally
-         * returns it, and a child that never runs must not leave the
-         * pty looking busy to the master the parent still holds.
+
+        /* Give back the credit the parent added for this child before bailing:
+         * nothing here reaches the teardown that normally returns it, and a
+         * child that never runs must not leave the pty looking busy to the
+         * master the parent still holds.
          */
         proc_pty_release_process_slaves();
         guest_destroy(&g);
@@ -338,10 +340,11 @@ int fork_child_main(int ipc_fd,
             0 ||
         admission_ready != 1) {
         log_error("fork-child: parent did not commit child admission");
-        /* Give back the credit the parent added for this child before
-         * bailing: nothing here reaches the teardown that normally
-         * returns it, and a child that never runs must not leave the
-         * pty looking busy to the master the parent still holds.
+
+        /* Give back the credit the parent added for this child before bailing:
+         * nothing here reaches the teardown that normally returns it, and a
+         * child that never runs must not leave the pty looking busy to the
+         * master the parent still holds.
          */
         proc_pty_release_process_slaves();
         guest_destroy(&g);
@@ -398,10 +401,10 @@ int fork_child_main(int ipc_fd,
      * the single-threaded child at this point).
      */
     if (shim_globals_install_per_vcpu(vcpu, &g, hdr.child_pid) < 0) {
-        /* Give back the credit the parent added for this child before
-         * bailing: nothing here reaches the teardown that normally
-         * returns it, and a child that never runs must not leave the
-         * pty looking busy to the master the parent still holds.
+        /* Give back the credit the parent added for this child before bailing:
+         * nothing here reaches the teardown that normally returns it, and a
+         * child that never runs must not leave the pty looking busy to the
+         * master the parent still holds.
          */
         proc_pty_release_process_slaves();
         guest_destroy(&g);

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -764,7 +764,7 @@ static int64_t sys_clone_thread(hv_vcpu_t parent_vcpu,
         return -LINUX_ENOMEM;
     }
 
-    thread_create_args_t *tca = calloc(1, sizeof(thread_create_args_t));
+    thread_create_args_t *tca = calloc(1, sizeof(*tca));
     if (!tca) {
         thread_deactivate(t);
         pthread_cond_destroy(&startup.cond);
@@ -1193,7 +1193,7 @@ static int64_t sys_clone_vm(hv_vcpu_t parent_vcpu,
         return -LINUX_ENOMEM;
     }
 
-    thread_create_args_t *tca = calloc(1, sizeof(thread_create_args_t));
+    thread_create_args_t *tca = calloc(1, sizeof(*tca));
     if (!tca) {
         thread_deactivate(t);
         return -LINUX_ENOMEM;

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -10,13 +10,13 @@
  * (caller falls through to real syscall).
  */
 
-/* Initial capacity for the transient /proc/self/maps and /proc/self/smaps VMA
+/*
+ * Initial capacity for the transient /proc/self/maps and /proc/self/smaps VMA
  * snapshot. The region tracker documents that coalescing leaves typical
  * workloads at roughly 50 tracked regions (see core/guest.h), so 64 avoids an
  * immediate growth in that case. The array grows as needed while mmap_lock is
- * held; keep a hard ceiling tied to the guest's region tables so maps/smaps
- * can enumerate every tracked VMA while keeping transient snapshot memory
- * bounded.
+ * held; keep a hard ceiling tied to the guest's region tables so maps/smaps can
+ * enumerate every tracked VMA while keeping transient snapshot memory bounded.
  */
 #define MAPS_ENTRY_INITIAL_CAP 64
 #define MAPS_ENTRY_MAX \
@@ -106,15 +106,18 @@ typedef struct {
     uint64_t offset;
     bool inherited_at_fork;
     char name[64];
-    /* Preserve the producer order for equal-start entries when qsort() is
-     * used below. Existing snapshots placed equal-start entries after one
-     * another in append order, and keeping that order avoids changing the
-     * handling of malformed/overlapping shadow metadata. */
+
+    /* Preserve the producer order for equal-start entries when qsort() is used
+     * below. Existing snapshots placed equal-start entries after one another in
+     * append order, and keeping that order avoids changing the handling of
+     * malformed/overlapping shadow metadata.
+     */
     size_t order;
 } maps_entry_t;
 
 /* A growable VMA snapshot. The generated facade keeps element-size and
- * allocation bookkeeping in the generic array implementation. */
+ * allocation bookkeeping in the generic array implementation.
+ */
 DYNAMIC_ARRAY_DEFINE(maps_entries, maps_entry_t)
 
 /* Round a VMA endpoint up to the 4 KiB granularity exposed by procfs without
@@ -184,11 +187,12 @@ static int maps_entries_append_entry(maps_entries_t *entries,
     return maps_entries_append_value(entries, value);
 }
 
-/* The live-region and shadow-gap producers are each ordered, but their
- * outputs interleave. Append both streams while holding mmap_lock and sort
- * once after all gaps have been generated. This avoids shifting an already
- * populated array for every split shadow gap (the old insertion path was
- * quadratic for fragmented snapshots). */
+/* The live-region and shadow-gap producers are each ordered, but their outputs
+ * interleave. Append both streams while holding mmap_lock and sort once after
+ * all gaps have been generated. This avoids shifting an already populated array
+ * for every split shadow gap (the old insertion path was quadratic for
+ * fragmented snapshots).
+ */
 static int maps_entries_compare_start(const void *lhs, const void *rhs)
 {
     const maps_entry_t *a = lhs;
@@ -230,10 +234,11 @@ static void maps_entries_merge_adjacent(maps_entries_t *entries)
     (void) maps_entries_resize(entries, out + 1);
 }
 
-/* Add only the portions of a preannounced interval not covered by live VMAs.
- * A shadow VMA must never overlap a realized VMA: strict smaps consumers treat
+/* Add only the portions of a preannounced interval not covered by live VMAs. A
+ * shadow VMA must never overlap a realized VMA: strict smaps consumers treat
  * overlapping headers as a malformed snapshot. Both inputs are page-rounded
- * because that is the granularity exposed by /proc/self/maps. */
+ * because that is the granularity exposed by /proc/self/maps.
+ */
 static int maps_entries_append_shadow_gaps(maps_entries_t *entries,
                                            const guest_region_t *shadow,
                                            const guest_region_t *live_regions,
@@ -1696,8 +1701,8 @@ static void proc_task_collect_cb(thread_entry_t *t, void *arg)
 /* Build the VMA list shared by /proc/self/maps and /proc/self/smaps. Merges
  * contiguous regions[] runs that came from one mmap, then folds in the
  * uncovered pieces of preannounced[] shadow entries around live coverage.
- * Producers append entries while the lock is held; one sort/merge pass puts
- * the interleaved live and shadow streams back into VMA order.
+ * Producers append entries while the lock is held; one sort/merge pass puts the
+ * interleaved live and shadow streams back into VMA order.
  *
  * The region and preannounced arrays are mutable from guest mmap/mprotect/
  * munmap operations. Snapshot and merge while mmap_lock is held, then release
@@ -1719,8 +1724,8 @@ static int proc_build_maps_entries(const guest_t *g,
     pthread_mutex_lock(&mmap_lock);
 
     /* Convert regions[] to maps entries. regions[] is already sorted by start
-     * address. The MAP_SHARED/MAP_ANONYMOUS/MAP_NORESERVE bits are preserved
-     * in r->flags, which is the single source of truth for the proc snapshot.
+     * address. The MAP_SHARED/MAP_ANONYMOUS/MAP_NORESERVE bits are preserved in
+     * r->flags, which is the single source of truth for the proc snapshot.
      */
     int nregions = g->nregions;
     if (nregions < 0)
@@ -1750,7 +1755,8 @@ static int proc_build_maps_entries(const guest_t *g,
     /* Add only uncovered portions of each preannounced interval. Keeping the
      * shadow VMA whole when a live mapping realizes its middle produces
      * overlapping maps/smaps headers; subtract every covered live interval
-     * instead, preserving any reserved-but-not-realized gaps. */
+     * instead, preserving any reserved-but-not-realized gaps.
+     */
     int npreannounced = g->npreannounced;
     if (npreannounced < 0)
         npreannounced = 0;
@@ -1876,14 +1882,14 @@ out:
     return proc_finish_maps_output(result, &entries, &builder);
 }
 
-/* Emit a Linux-shaped /proc/self/smaps approximation. The runtime tracks
- * guest VMAs and logical fork snapshots, but it cannot observe kernel page
- * residency or dirty bits on the host. Writable private anonymous VMAs that
- * were present in the most recent fork snapshot report their full VMA size as
- * Shared_Dirty, Rss, Pss, and Pss_Dirty; keeping those counters aligned avoids
- * a self-contradictory snapshot while retaining a coarse fork-compatibility
- * signal. Newly-created VMAs are excluded. All other fields that require
- * kernel page accounting are stable zeroes.
+/* Emit a Linux-shaped /proc/self/smaps approximation. The runtime tracks guest
+ * VMAs and logical fork snapshots, but it cannot observe kernel page residency
+ * or dirty bits on the host. Writable private anonymous VMAs that were present
+ * in the most recent fork snapshot report their full VMA size as Shared_Dirty,
+ * Rss, Pss, and Pss_Dirty; keeping those counters aligned avoids a
+ * self-contradictory snapshot while retaining a coarse fork-compatibility
+ * signal. Newly-created VMAs are excluded. All other fields that require kernel
+ * page accounting are stable zeroes.
  */
 static int proc_open_self_smaps(const guest_t *g)
 {
@@ -1935,6 +1941,7 @@ static int proc_open_self_smaps(const guest_t *g)
             vmflags_len += token_len;                        \
         }                                                    \
     } while (0)
+
         /* Only flags directly evidenced by the tracked VMA are reported. In
          * particular, do not invent Linux max-permission/accounting flags
          * (mr/mw/me/ac/sd/etc.) that the emulator cannot observe.
@@ -2005,8 +2012,8 @@ out:
  * two different machines outright, never mind two instants -- meminfo reported
  * the host's real memory while sysinfo capped it at a hardcoded 4GiB -- and
  * that guest underflowed. busybox free takes total and free from sysinfo and
- * buff/cache from here, so a Cached larger than the sysinfo total made
- * used = total - free - cached wrap into a 24-digit figure.
+ * buff/cache from here, so a Cached larger than the sysinfo total made used =
+ * total - free - cached wrap into a 24-digit figure.
  *
  * Returns a host fd, or -1. Split out of proc_intercept_open to keep that
  * dispatcher readable.
@@ -2045,12 +2052,12 @@ static int proc_open_meminfo(void)
     /* Cached has to fit in what MemFree leaves, not merely be smaller than the
      * total. The Mach counters do not partition: a purgeable page is also
      * counted in inactive, so free + inactive + purgeable can exceed physical
-     * memory however the total is derived. A guest computing
-     * used = total - free - cached wraps on that excess, which is the failure
-     * reporting one total is meant to end. Cached gives up the precision rather
-     * than MemFree, since MemFree is what sysinfo reports as freeram and the
-     * two have to keep matching. free_kb needs no clamp of its own: it comes
-     * from sys_guest_ram_free(), which is already held below the total.
+     * memory however the total is derived. A guest computing used = total -
+     * free - cached wraps on that excess, which is the failure reporting one
+     * total is meant to end. Cached gives up the precision rather than MemFree,
+     * since MemFree is what sysinfo reports as freeram and the two have to keep
+     * matching. free_kb needs no clamp of its own: it comes from
+     * sys_guest_ram_free(), which is already held below the total.
      */
     if (cached_kb > total_kb - free_kb)
         cached_kb = total_kb - free_kb;
@@ -2627,8 +2634,8 @@ int proc_intercept_open(const guest_t *g,
     if (!strcmp(path, "/proc/self/maps"))
         return proc_open_self_maps(g);
 
-    /* /proc/self/smaps -> Linux-shaped VMA blocks with tracked VMA metadata
-     * and the coarse fork Shared_Dirty/Rss/Pss/Pss_Dirty compatibility signal.
+    /* /proc/self/smaps -> Linux-shaped VMA blocks with tracked VMA metadata and
+     * the coarse fork Shared_Dirty/Rss/Pss/Pss_Dirty compatibility signal.
      */
     if (!strcmp(path, "/proc/self/smaps"))
         return proc_open_self_smaps(g);

--- a/src/runtime/procemu.h
+++ b/src/runtime/procemu.h
@@ -111,8 +111,8 @@ int proc_dev_shm_resolve(const char *guest_suffix,
  */
 void proc_pty_close_keepalive(int master_host_fd);
 
-/* Record a slave fd the guest now holds, so the master knows it is not yet
- * hung up. Both guest-facing slave opens report through this: the /dev/pts/N
+/* Record a slave fd the guest now holds, so the master knows it is not yet hung
+ * up. Both guest-facing slave opens report through this: the /dev/pts/N
  * intercept and the TIOCGPTPEER ioctl.
  */
 void proc_pty_note_guest_slave(int slave_host_fd, uint32_t linux_pts_num);

--- a/src/string-builder.c
+++ b/src/string-builder.c
@@ -21,9 +21,9 @@ static int string_builder_invalid(void)
     return -1;
 }
 
-/* Initialize storage and establish an empty, NUL-terminated builder. This
- * fresh initializer is safe on an uninitialized automatic object; destroy an
- * existing builder before reinitializing it.
+/* Initialize storage and establish an empty, NUL-terminated builder. This fresh
+ * initializer is safe on an uninitialized automatic object; destroy an existing
+ * builder before reinitializing it.
  */
 int string_builder_init(string_builder_t *builder, size_t initial_capacity)
 {
@@ -58,7 +58,8 @@ int string_builder_reserve(string_builder_t *builder, size_t extra)
         return 0;
 
     /* The dynamic array counts payload elements. Reserve one additional char
-     * for the string builder's trailing NUL. */
+     * for the string builder's trailing NUL.
+     */
     if (extra == SIZE_MAX) {
         errno = EOVERFLOW;
         return -1;
@@ -71,7 +72,8 @@ int string_builder_reserve(string_builder_t *builder, size_t extra)
 }
 
 /* Locate a source span that aliases the builder allocation. The offset must be
- * captured before reserve because reserve may move the allocation. */
+ * captured before reserve because reserve may move the allocation.
+ */
 static int string_builder_source_offset(const string_builder_t *builder,
                                         const void *source,
                                         size_t length,
@@ -161,9 +163,11 @@ int string_builder_appendf(string_builder_t *builder, const char *format, ...)
     errno = saved_errno;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
+
     /* A non-NULL destination keeps static analyzers from treating the
      * standards-sanctioned n == 0 sizing call as a null dereference. The
-     * destination is never written when its size is zero. */
+     * destination is never written when its size is zero.
+     */
     formatted_len = vsnprintf(&sizing_sink, 0, format, sizing);
 #pragma clang diagnostic pop
     va_end(sizing);

--- a/src/string-builder.h
+++ b/src/string-builder.h
@@ -21,11 +21,13 @@ typedef struct string_builder {
     string_builder_storage_t storage;
 } string_builder_t;
 
-/* Initialize a builder, reserving initial_capacity bytes including the NUL.
- * A zero capacity leaves storage unallocated for lazy growth. This fresh
- * initializer is safe on an uninitialized automatic object; destroy an
- * existing builder before reinitializing it. Returns 0 on success or -1 with
- * errno set on invalid input or allocation failure.
+/* Initialize a builder, reserving initial_capacity bytes including the NUL. A
+ * zero capacity leaves storage unallocated for lazy growth. This fresh
+ * initializer is safe on an uninitialized automatic object; destroy an existing
+ * builder before reinitializing it.
+ *
+ * Returns 0 on success or -1 with errno set on invalid input or allocation
+ * failure.
  */
 int string_builder_init(string_builder_t *builder, size_t initial_capacity);
 

--- a/src/syscall/asyncio.h
+++ b/src/syscall/asyncio.h
@@ -70,8 +70,8 @@ void asyncio_disarm(int host_fd);
  * drain the notify pipe first, which drops the edge -- and with it the only
  * SIGIO a one-shot request like FUSE_INIT will ever produce. Linux fires
  * kill_fasync synchronously at enqueue time for the same reason. Revalidates
- * O_ASYNC and the owner against the live slot; a duplicate delivery against
- * the watcher's coalesces in the pending mask like any standard signal.
+ * O_ASYNC and the owner against the live slot; a duplicate delivery against the
+ * watcher's coalesces in the pending mask like any standard signal.
  */
 void asyncio_fire(int guest_fd);
 

--- a/src/syscall/casefold-walk.c
+++ b/src/syscall/casefold-walk.c
@@ -42,8 +42,8 @@ typedef enum {
      * Kept apart from PROBE_ABSENT because the two answer differently for a
      * caller deciding whether the sysroot has a claim on the path: resolution
      * stopped inside the tree (path_resolution(7)), so the path is the
-     * sysroot's to answer for and owes ENOTDIR rather than falling through to
-     * a host file that merely shares the literal spelling.
+     * sysroot's to answer for and owes ENOTDIR rather than falling through to a
+     * host file that merely shares the literal spelling.
      */
     PROBE_NOTDIR = 4
 } probe_result_t;
@@ -119,8 +119,9 @@ const char *casefold_attr_stored_name(const void *reply,
 
     if (reply_cap < sizeof(total))
         return NULL;
-    /* memcpy, not a cast: the reply struct is packed and nothing guarantees
-     * the caller's buffer aligns its fields.
+
+    /* memcpy, not a cast: the reply struct is packed and nothing guarantees the
+     * caller's buffer aligns its fields.
      */
     memcpy(&total, reply, sizeof(total));
 
@@ -168,6 +169,7 @@ static probe_result_t probe_exact(host_fd_t base_fd,
         .commonattr =
             ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_OBJTYPE | ATTR_CMN_NAME,
     };
+
     /* Fixed-size attributes come back in ascending bit order, so ATTR_CMN_NAME
      * (0x1) precedes ATTR_CMN_OBJTYPE (0x8) and the variable-length name data
      * follows both. Ordering these fields any other way silently misreads every
@@ -196,12 +198,12 @@ static probe_result_t probe_exact(host_fd_t base_fd,
                 (size_t) ((const char *) &attr_buf.name_ref -
                           (const char *) &attr_buf));
         if (stored) {
-            /* Read here, not before the test: obj_type only sits at this
-             * offset because name_ref precedes it, and it does so only when
-             * the name was returned inside the reply's own bounds. With the
-             * name withheld or the reply malformed the field would be read
-             * past where the volume wrote it, and a garbage VLNK sends the
-             * walk chasing a link that is not there.
+            /* Read here, not before the test: obj_type only sits at this offset
+             * because name_ref precedes it, and it does so only when the name
+             * was returned inside the reply's own bounds. With the name
+             * withheld or the reply malformed the field would be read past
+             * where the volume wrote it, and a garbage VLNK sends the walk
+             * chasing a link that is not there.
              */
             size_t usable = attr_buf.length < sizeof(attr_buf)
                                 ? attr_buf.length
@@ -216,13 +218,14 @@ static probe_result_t probe_exact(host_fd_t base_fd,
             }
             if (!strcmp(stored, leaf))
                 return PROBE_EXACT;
-            /* A mismatch is not yet a fold. For a second hard link to a
-             * symlink the volume reports the primary link's name here rather
-             * than the one just looked up (observed on APFS; a second link to
-             * a regular file reports itself), so an entry spelled exactly as
-             * asked can still come back under another name. Only the listing
-             * tells an aliased name from a genuinely folded one, and only a
-             * mismatch pays for the scan.
+
+            /* A mismatch is not yet a fold. For a second hard link to a symlink
+             * the volume reports the primary link's name here rather than the
+             * one just looked up (observed on APFS; a second link to a regular
+             * file reports itself), so an entry spelled exactly as asked can
+             * still come back under another name. Only the listing tells an
+             * aliased name from a genuinely folded one, and only a mismatch
+             * pays for the scan.
              *
              * The listing carries no type, and this call typed the entry the
              * volume named, not the one the listing finds, so withdraw it:
@@ -232,10 +235,11 @@ static probe_result_t probe_exact(host_fd_t base_fd,
             *type_known = false;
             return probe_by_readdir(base_fd, path, leaf);
         }
-        /* The call succeeded but the volume withheld the name or handed back
-         * a reply whose bounds do not hold it, so there is no spelling to
-         * compare. Say so rather than dispatching on an errno no one set,
-         * which would pick a verdict out of whatever ran last.
+
+        /* The call succeeded but the volume withheld the name or handed back a
+         * reply whose bounds do not hold it, so there is no spelling to
+         * compare. Say so rather than dispatching on an errno no one set, which
+         * would pick a verdict out of whatever ran last.
          */
         errno = ENOTSUP;
     }
@@ -252,10 +256,10 @@ static probe_result_t probe_exact(host_fd_t base_fd,
          * same: the name has to be escaped.
          *
          * EINVAL can also mean a malformed request rather than a malformed
-         * name, and the two are indistinguishable here. It does not matter:
-         * the attrlist is a compile-time constant, so a malformed one would
-         * fail every probe in every directory rather than this one, which no
-         * lookup in the suite would survive.
+         * name, and the two are indistinguishable here. It does not matter: the
+         * attrlist is a compile-time constant, so a malformed one would fail
+         * every probe in every directory rather than this one, which no lookup
+         * in the suite would survive.
          */
         return PROBE_UNUSABLE;
     case ENOTSUP:
@@ -333,8 +337,8 @@ static int name_by_rule(const char *guest, char *out, size_t outsz)
 }
 
 /* Probe @cand appended to the parent in @out[0..len), restoring @out to that
- * prefix on every exit. append_component writes the separator before the
- * length check, so an unrestored buffer would keep a trailing '/'.
+ * prefix on every exit. append_component writes the separator before the length
+ * check, so an unrestored buffer would keep a trailing '/'.
  */
 static probe_result_t probe_candidate(host_fd_t base_fd,
                                       char *out,
@@ -358,9 +362,9 @@ static probe_result_t probe_candidate(host_fd_t base_fd,
 
 /* Spell one component, given the parent already spelled in @out. The entry is
  * there exactly when the verdict is PROBE_EXACT; the host spelling goes to
- * @host either way. @out doubles as the probe buffer. A candidate that does
- * not fit reports ENAMETOOLONG exactly as the final spelling would, an escape
- * never being shorter than the literal it stands for.
+ * @host either way. @out doubles as the probe buffer. A candidate that does not
+ * fit reports ENAMETOOLONG exactly as the final spelling would, an escape never
+ * being shorter than the literal it stands for.
  */
 static probe_result_t resolve_component(host_fd_t base_fd,
                                         char *out,
@@ -405,9 +409,9 @@ static probe_result_t resolve_component(host_fd_t base_fd,
      * simply nothing there), the escape is the only other place the name can
      * live, so ask whether it does.
      *
-     * The escape cannot fail: casefold.h sizes @host by
-     * CASEFOLD_HOST_NAME_MAX for any name path_component_copy delivers, so a
-     * failure is a broken precondition and fails closed.
+     * The escape cannot fail: casefold.h sizes @host by CASEFOLD_HOST_NAME_MAX
+     * for any name path_component_copy delivers, so a failure is a broken
+     * precondition and fails closed.
      */
     if (casefold_escape(guest, host, hostsz) < 0)
         return PROBE_ERROR;
@@ -429,13 +433,14 @@ static probe_result_t resolve_component(host_fd_t base_fd,
      */
     if (verdict == PROBE_ABSENT || verdict == PROBE_NOTDIR)
         return name_by_rule(guest, host, hostsz) < 0 ? PROBE_ERROR : verdict;
+
     /* The slot is taken by a different spelling, or refused outright, so the
      * name belongs at its escape even though nothing is there yet. Reported as
      * folded rather than absent: the two differ to a caller deciding whether
      * the sysroot has a claim on this path.
      *
-     * A refused name converges on the same answer as an occupied slot, which
-     * is why PROBE_UNUSABLE needs no separate verdict of its own. Both mean the
+     * A refused name converges on the same answer as an occupied slot, which is
+     * why PROBE_UNUSABLE needs no separate verdict of its own. Both mean the
      * sysroot owns this path and the caller must not look for it on the host.
      * The difference is why the literal spelling is unavailable, and no caller
      * asks that. Deliberately fail-closed: the alternative sends a guest asking
@@ -546,6 +551,7 @@ casefold_verdict_t casefold_resolve_at(host_fd_t base_fd,
                     return CASEFOLD_SYMLINK;
                 }
             }
+
             /* A fold means the sysroot holds an entry where the guest asked,
              * under a spelling the guest did not use. Recorded for the caller
              * because it is the one absent verdict that must not fall through
@@ -553,11 +559,12 @@ casefold_verdict_t casefold_resolve_at(host_fd_t base_fd,
              */
             if (verdict == PROBE_FOLDED)
                 walk->folded = true;
-            /* Resolution stopped at a component that is not a directory, so
-             * the sysroot has answered and the caller must not look for the
-             * path on the host. Recorded rather than returned immediately so
-             * out still receives the remaining components: a caller reporting
-             * the error issues its own syscall against the whole spelling.
+
+            /* Resolution stopped at a component that is not a directory, so the
+             * sysroot has answered and the caller must not look for the path on
+             * the host. Recorded rather than returned immediately so out still
+             * receives the remaining components: a caller reporting the error
+             * issues its own syscall against the whole spelling.
              */
             if (verdict == PROBE_NOTDIR)
                 walk->notdir = true;
@@ -572,10 +579,10 @@ casefold_verdict_t casefold_resolve_at(host_fd_t base_fd,
         return CASEFOLD_ABSENT;
 
     /* The probe deliberately stops at a symlink rather than following it, so a
-     * caller that asked about the target has to say so. A link pointing
-     * nowhere is absent for that caller, which is what an access(2) probe
-     * would report. A typed leaf is a known non-link (a known link returned
-     * CASEFOLD_SYMLINK above), so the probe adds nothing and is skipped.
+     * caller that asked about the target has to say so. A link pointing nowhere
+     * is absent for that caller, which is what an access(2) probe would report.
+     * A typed leaf is a known non-link (a known link returned CASEFOLD_SYMLINK
+     * above), so the probe adds nothing and is skipped.
      */
     if (follow_final && !walk->leaf_type_known &&
         faccessat(base_fd, out, F_OK, 0) < 0)

--- a/src/syscall/casefold-walk.h
+++ b/src/syscall/casefold-walk.h
@@ -47,14 +47,16 @@ typedef enum {
 
 typedef struct {
     /* Every component but the last resolved. Answers the create resolver's
-     * question "can this be created here", which a plain access(2) on a
-     * naively concatenated parent gets wrong, because that folds case.
+     * question "can this be created here", which a plain access(2) on a naively
+     * concatenated parent gets wrong, because that folds case.
      */
     bool parent_found;
+
     /* Offset in out of the final component, so a caller can split parent from
      * leaf without a strrchr that could walk back into the host prefix.
      */
     size_t leaf_offset;
+
     /* Length of out before the final component was appended: truncating there
      * yields the parent's spelling exactly. Recorded by the walk because only
      * it knows whether a separator was inserted before the leaf. A prefix that
@@ -63,12 +65,14 @@ typedef struct {
      * where the parent is the root.
      */
     size_t parent_offset;
+
     /* Some component's slot is held by an entry spelled differently, or by one
      * the volume refuses to store. The path is absent to a byte-exact reader
      * but the sysroot does hold something there, so a caller must report ENOENT
      * rather than treat the path as unclaimed and look for it on the host.
      */
     bool folded;
+
     /* Some component of the path is not a directory, so resolution stopped
      * there (path_resolution(7)) and everything below it owes ENOTDIR. Absent
      * for the same reason folded is: the path is not there, but the sysroot
@@ -76,27 +80,31 @@ typedef struct {
      * path as unclaimed and look for it on the host.
      */
     bool notdir;
-    /* Set with CASEFOLD_SYMLINK: the byte offset in the guest path at which
-     * the components after the link begin, or the path length when the link
-     * was the final component.
+
+    /* Set with CASEFOLD_SYMLINK: the byte offset in the guest path at which the
+     * components after the link begin, or the path length when the link was the
+     * final component.
      */
     size_t link_rest_offset;
+
     /* Offset in the guest path of the link component itself, so the caller can
      * rebuild the directory a relative target is measured from.
      */
     size_t link_guest_offset;
+
     /* Object type the leaf's probe answered. False when the readdir fallback
      * answered, whose listing carries no type, and for dot components, which
      * are never probed.
      */
     bool leaf_type_known;
     bool leaf_is_link;
+
     /* True when every component that resolved was typed by its probe, so no
-     * symlink can hide in the resolved path; only the readdir fallback,
-     * whose listing carries no type, can pass one unseen. Dot components
-     * navigate rather than name an entry, and components below an absent one
-     * name nothing, so neither withholds a type. A FOUND path with this set
-     * cannot resolve outside the prefix it was built under.
+     * symlink can hide in the resolved path; only the readdir fallback, whose
+     * listing carries no type, can pass one unseen. Dot components navigate
+     * rather than name an entry, and components below an absent one name
+     * nothing, so neither withholds a type. A FOUND path with this set cannot
+     * resolve outside the prefix it was built under.
      */
     bool all_types_known;
 } casefold_walk_t;
@@ -104,8 +112,8 @@ typedef struct {
 /* Resolve @guest_path, interpreted relative to @base_fd, into its host spelling
  * in @out. @out is seeded with @base_host_prefix (the sysroot for an absolute
  * guest path, the empty string for a dirfd-relative one) and grown a component
- * at a time. Nothing is opened: each probe is a getattrlistat against
- * the prefix accumulated so far, so the walk holds no descriptors and has no
+ * at a time. Nothing is opened: each probe is a getattrlistat against the
+ * prefix accumulated so far, so the walk holds no descriptors and has no
  * cleanup path.
  *
  * Per component, once the parent is spelled in @out:
@@ -130,9 +138,9 @@ typedef struct {
  *
  * @walk may be NULL when the caller needs only the verdict and @out.
  *
- * @out doubles as the walk's probe scratch, so it must not overlap
- * @guest_path or @base_host_prefix, and it holds nothing meaningful once
- * CASEFOLD_ERROR is returned.
+ * @out doubles as the walk's probe scratch, so it must not overlap @guest_path
+ * or @base_host_prefix, and it holds nothing meaningful once CASEFOLD_ERROR is
+ * returned.
  */
 casefold_verdict_t casefold_resolve_at(host_fd_t base_fd,
                                        const char *base_host_prefix,
@@ -144,16 +152,17 @@ casefold_verdict_t casefold_resolve_at(host_fd_t base_fd,
 
 /* Validate and locate the variable-length ATTR_CMN_NAME payload in a
  * getattrlist reply. getattrlist(2) documents that a truncated reply can carry
- * an attrreference whose data starts or ends past the buffer, so nothing in
- * the reply may be dereferenced on the kernel's word alone; APFS stays inside
- * the documented bound, but --sysroot accepts network mounts that need not.
+ * an attrreference whose data starts or ends past the buffer, so nothing in the
+ * reply may be dereferenced on the kernel's word alone; APFS stays inside the
+ * documented bound, but --sysroot accepts network mounts that need not.
  *
  * @reply is the buffer handed to getattrlistat, whose first u_int32_t is the
  * length the kernel claims; @reply_cap is that buffer's size; @ref_off is the
- * byte offset of the name's attrreference_t within it. Returns the
- * NUL-terminated stored name, or NULL when any bound fails or no NUL exists
- * inside the referenced bytes. Non-static only for the host unit test, which
- * cannot forge a malformed reply through a real volume.
+ * byte offset of the name's attrreference_t within it.
+ *
+ * Returns the NUL-terminated stored name, or NULL when any bound fails or no
+ * NUL exists inside the referenced bytes. Non-static only for the host unit
+ * test, which cannot forge a malformed reply through a real volume.
  */
 const char *casefold_attr_stored_name(const void *reply,
                                       size_t reply_cap,

--- a/src/syscall/casefold.c
+++ b/src/syscall/casefold.c
@@ -18,8 +18,8 @@
 #include "syscall/casefold.h"
 
 /* Payload alphabet for the long tier: one symbol per CASEFOLD_SYM_BITS value,
- * drawn from the CJK Unified Ideographs starting at U+4E00. The block is
- * chosen because these code points have no case mappings and no canonical or
+ * drawn from the CJK Unified Ideographs starting at U+4E00. The block is chosen
+ * because these code points have no case mappings and no canonical or
  * compatibility decompositions, so no two payloads can fold onto each other
  * however aggressive the volume's matching is. Neighboring blocks are not
  * interchangeable: CJK Compatibility Ideographs (U+F900) do normalize, Hangul
@@ -61,8 +61,10 @@ bool casefold_needs_escape(const char *name)
     return casefold_is_escaped(name);
 }
 
-/* Read one payload symbol at @p. Returns its value, or -1 when @p does not
- * begin a three-byte sequence inside the payload block.
+/* Read one payload symbol at @p.
+ *
+ * Returns its value, or -1 when @p does not begin a three-byte sequence inside
+ * the payload block.
  */
 static int symbol_read(const unsigned char *p)
 {
@@ -95,10 +97,12 @@ static unsigned bit_at(const unsigned char *bytes, size_t len, size_t pos)
     return (bytes[pos / 8] >> (7 - pos % 8)) & 1u;
 }
 
-/* Decode an escaped host name. Returns the decoded length in bytes, or -1 when
- * @host is not a well-formed escape. @out must hold CASEFOLD_GUEST_NAME_MAX
- * bytes; the result is not NUL-terminated here because a decoded name may not
- * be a legal component, which the caller checks.
+/* Decode an escaped host name.
+ *
+ * Returns the decoded length in bytes, or -1 when @host is not a well-formed
+ * escape. @out must hold CASEFOLD_GUEST_NAME_MAX bytes; the result is not
+ * NUL-terminated here because a decoded name may not be a legal component,
+ * which the caller checks.
  */
 static int decode_payload(const char *host, unsigned char *out)
 {
@@ -177,6 +181,7 @@ static int decode_payload(const char *host, unsigned char *out)
     }
     if (produced != n)
         return -1;
+
     /* Padding past the last byte must be zero, or one name would have several
      * spellings and a listing could show the same file twice.
      */
@@ -229,6 +234,7 @@ int casefold_escape(const char *guest, char *out, size_t outsz)
         errno = EINVAL;
         return -1;
     }
+
     /* "." and ".." navigate rather than name an entry, so no directory can hold
      * one and an escape standing for one could never be created. Refusing here
      * keeps the codec total: everything it accepts has a real slot to live in.

--- a/src/syscall/casefold.h
+++ b/src/syscall/casefold.h
@@ -46,16 +46,16 @@
 #define CASEFOLD_HEX_MAX ((CASEFOLD_UNIT_MAX - CASEFOLD_PREFIX_LEN) / 2)
 
 /* Bits each long-tier payload symbol carries: twelve packs three input bytes
- * into two symbols, so a 255-byte name spends 170 payload symbols and stays
- * far inside the 255-unit budget. The alphabet size and the symbol-count
- * formula both derive from this one constant, so changing the packing moves
- * every consumer together or trips the asserts below.
+ * into two symbols, so a 255-byte name spends 170 payload symbols and stays far
+ * inside the 255-unit budget. The alphabet size and the symbol-count formula
+ * both derive from this one constant, so changing the packing moves every
+ * consumer together or trips the asserts below.
  */
 #define CASEFOLD_SYM_BITS 12u
 
 /* Symbols the long tier spends on a guest name of n bytes: one carrying the
- * length, then one per CASEFOLD_SYM_BITS of payload. Computed in size_t
- * because the result sizes buffers.
+ * length, then one per CASEFOLD_SYM_BITS of payload. Computed in size_t because
+ * the result sizes buffers.
  */
 #define CASEFOLD_SYMBOLS(n) \
     ((size_t) 1 +           \
@@ -72,10 +72,10 @@
 /* Every escape has to fit the volume's per-name limit, and both tiers spend
  * exactly one unit per output character: the hex tier emits ASCII digits, the
  * long tier BMP code points. The margin is wide today, so the arithmetic is
- * easy to disturb without noticing: raising CASEFOLD_GUEST_NAME_MAX,
- * widening CASEFOLD_PREFIX or shrinking CASEFOLD_SYM_BITS would each push the
- * long tier over, and the volume would then refuse names the guest is entitled
- * to create. Fail the build instead.
+ * easy to disturb without noticing: raising CASEFOLD_GUEST_NAME_MAX, widening
+ * CASEFOLD_PREFIX or shrinking CASEFOLD_SYM_BITS would each push the long tier
+ * over, and the volume would then refuse names the guest is entitled to create.
+ * Fail the build instead.
  */
 _Static_assert(CASEFOLD_PREFIX_LEN + 2 * CASEFOLD_HEX_MAX <= CASEFOLD_UNIT_MAX,
                "hex-tier escape exceeds the per-name UTF-16 unit limit");

--- a/src/syscall/chown-overlay.c
+++ b/src/syscall/chown-overlay.c
@@ -117,10 +117,11 @@ int chown_overlay_set(uint64_t dev,
         }
         e->dev = dev;
         e->ino = ino;
+
         /* Initialise with the sentinel (uint32_t)-1, meaning "no override
-         * recorded for this field yet".  The apply path skips sentinel
-         * fields, so a partial chown that only touches one of uid/gid does
-         * not corrupt the other field with a stale physical host value.
+         * recorded for this field yet". The apply path skips sentinel fields,
+         * so a partial chown that only touches one of uid/gid does not corrupt
+         * the other field with a stale physical host value.
          */
         e->uid = (uint32_t) -1;
         e->gid = (uint32_t) -1;
@@ -136,9 +137,9 @@ int chown_overlay_set(uint64_t dev,
     if (new_group != (uint32_t) -1)
         e->gid = new_group;
 
-    /* A sentinel field means "keep whatever cur reports".  Resolve before
-     * comparing so the no-op check is evaluated in the guest-virtual ID
-     * space on both sides.
+    /* A sentinel field means "keep whatever cur reports". Resolve before
+     * comparing so the no-op check is evaluated in the guest-virtual ID space
+     * on both sides.
      */
     uint32_t effective_uid = e->uid == (uint32_t) -1 ? cur_uid : e->uid;
     uint32_t effective_gid = e->gid == (uint32_t) -1 ? cur_gid : e->gid;
@@ -175,8 +176,8 @@ void chown_overlay_apply(struct stat *st)
     overlay_entry_t *e =
         find_locked((uint64_t) st->st_dev, (uint64_t) st->st_ino);
     if (e) {
-        /* Skip sentinel fields: (uint32_t)-1 means "no override recorded"
-         * for that field, so leave the host value untouched.
+        /* Skip sentinel fields: (uint32_t)-1 means "no override recorded" for
+         * that field, so leave the host value untouched.
          */
         if (e->uid != (uint32_t) -1)
             st->st_uid = e->uid;
@@ -203,6 +204,7 @@ int chown_overlay_send(int ipc_sock)
     pthread_rwlock_rdlock(&overlay_lock);
 
     size_t n = atomic_load_explicit(&entry_count, memory_order_acquire);
+
     /* The cap is well above any realistic chown-heavy workload (dpkg, OCI layer
      * commit). Hitting it indicates a runaway table or a bug, not a legitimate
      * parent; refuse to truncate-on-success and fail the fork so the caller

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -196,9 +196,9 @@ static int fd_bitmap_find_free(int minfd)
     if (!fdset_slot(minfd, &word, &bit))
         return -1;
 
-    /* Bits below minfd drop out of the first word; every later word is whole.
-     * A word index under FD_BITMAP_WORDS and a bit index under 64 put the
-     * result below FD_TABLE_SIZE, so no ceiling is needed on the way out.
+    /* Bits below minfd drop out of the first word; every later word is whole. A
+     * word index under FD_BITMAP_WORDS and a bit index under 64 put the result
+     * below FD_TABLE_SIZE, so no ceiling is needed on the way out.
      */
     for (uint64_t mask = ~0ULL << bit; word < FD_BITMAP_WORDS;
          word++, mask = ~0ULL) {
@@ -502,9 +502,9 @@ int fd_alloc_at_relaxed(int fd,
     return fd;
 }
 
-/* Internal: mark fd closed with fd_lock already held. Requires
- * 0 <= fd < FD_TABLE_SIZE; it indexes fd_table and the free bitmap without
- * rechecking, so a caller that has not established that corrupts both.
+/* Internal: mark fd closed with fd_lock already held. Requires 0 <= fd <
+ * FD_TABLE_SIZE; it indexes fd_table and the free bitmap without rechecking, so
+ * a caller that has not established that corrupts both.
  *
  * Clear host_fd and dir BEFORE marking the slot free in the bitmap. Otherwise
  * another thread could fd_alloc() this slot, populate it with a new

--- a/src/syscall/fuse.h
+++ b/src/syscall/fuse.h
@@ -20,11 +20,13 @@ int fuse_proc_stat(struct stat *st);
 
 int64_t fuse_open_path(guest_t *g, const char *path, int linux_flags, int mode);
 bool fuse_path_matches_mount(const char *path);
+
 /* Returns the mount_id of the FUSE mount containing path, or -1 if path is not
  * inside any live or tombstoned FUSE mount. Distinct FUSE mounts have distinct
  * mount_ids; used by RESOLVE_NO_XDEV to detect cross-mount paths.
  */
 int fuse_path_mount_id(const char *path);
+
 /* Stat a FUSE-mounted path. at_flags carries the Linux AT_* mask from the
  * caller; only LINUX_AT_SYMLINK_NOFOLLOW is consulted today. When the daemon
  * returns S_IFLNK for the final component and the caller did not request

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -106,11 +106,11 @@
  * beside the rest of the leaves, and it acquires nothing itself, so it closes
  * no cycle.
  *
- * pt_lock, thread_lock, sfd_lock, pid_lock and pidfd_lock are leaves today
- * too. They stay in the ordered list because each is named as an inner lock
- * above, so the order they would be acquired in is the load-bearing fact about
- * them. sig_lock is not one of them: signal_queue_thread_common takes
- * thread_lock under it.
+ * pt_lock, thread_lock, sfd_lock, pid_lock and pidfd_lock are leaves today too.
+ * They stay in the ordered list because each is named as an inner lock above,
+ * so the order they would be acquired in is the load-bearing fact about them.
+ * sig_lock is not one of them: signal_queue_thread_common takes thread_lock
+ * under it.
  */
 
 #pragma once

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -1643,6 +1643,7 @@ int64_t sys_writev(guest_t *g, int fd, uint64_t iov_gva, int iovcnt)
 {
     if (iovcnt == 0)
         return vec_zero_iovcnt(fd, true, false);
+
     /* Ahead of the single-entry shortcut: a one-entry writev of nothing reports
      * 0, while the write(2) the shortcut would reach reports ENODATA.
      */

--- a/src/syscall/io.h
+++ b/src/syscall/io.h
@@ -46,10 +46,10 @@ int64_t io_wait_fd_or_interrupted(int host_fd, short events);
  * returned the instant the resource freed, so the ceiling is the added latency
  * a guest pays after the holder releases: 2 ms costs at most 500 wakeups/s on a
  * thread that is otherwise asleep, and keeps the worst case an order of
- * magnitude below what the execve teardown budget (200 ms of pokes plus a
- * 500 ms join) would tolerate. The floor is short because the common case is a
- * lock held for microseconds; io_retry_backoff yields once before sleeping at
- * all, which catches a holder that releases inside the same quantum.
+ * magnitude below what the execve teardown budget (200 ms of pokes plus a 500
+ * ms join) would tolerate. The floor is short because the common case is a lock
+ * held for microseconds; io_retry_backoff yields once before sleeping at all,
+ * which catches a holder that releases inside the same quantum.
  */
 #define IO_RETRY_BACKOFF_START_US 50
 #define IO_RETRY_BACKOFF_MAX_US 2000

--- a/src/syscall/net-absock.h
+++ b/src/syscall/net-absock.h
@@ -15,21 +15,23 @@ int absock_is_abstract_unix(const uint8_t *linux_sa, uint32_t addrlen);
 
 /* Convert a guest sockaddr to the host form. Pathname AF_UNIX addresses go
  * through sysroot path translation (create semantics for bind, lookup for
- * connect/sendto/sendmsg), with over-long translated paths diverted through
- * a short symlink in the private absock dir; every other family delegates to
- * linux_to_mac_sockaddr. Returns the mac sockaddr length, or a negative
- * LINUX errno usable directly as the syscall result.
+ * connect/sendto/sendmsg), with over-long translated paths diverted through a
+ * short symlink in the private absock dir; every other family delegates to
+ * linux_to_mac_sockaddr.
+ *
+ * Returns the mac sockaddr length, or a negative LINUX errno usable directly as
+ * the syscall result.
  */
 int net_sockaddr_to_mac(const uint8_t *linux_sa,
                         uint32_t addrlen,
                         bool create,
                         struct sockaddr_storage *mac_sa);
 
-/* Convert a host sockaddr back to the guest form. Pathname AF_UNIX
- * addresses are reverse-mapped through path_host_to_guest (undoing the
- * over-length shortening symlink first) so the guest reads back the
- * spelling it bound or connected with; every other family delegates to
- * mac_to_linux_sockaddr. Same return convention as mac_to_linux_sockaddr.
+/* Convert a host sockaddr back to the guest form. Pathname AF_UNIX addresses
+ * are reverse-mapped through path_host_to_guest (undoing the over-length
+ * shortening symlink first) so the guest reads back the spelling it bound or
+ * connected with; every other family delegates to mac_to_linux_sockaddr. Same
+ * return convention as mac_to_linux_sockaddr.
  */
 int net_sockaddr_from_mac(const struct sockaddr *mac_sa,
                           uint32_t mac_len,
@@ -56,13 +58,15 @@ int absock_reverse_lookup(const char *fs_path,
  * absock_encode_name spells the backing filename for an abstract-socket name
  * under @dir: hex of the bytes when it fits, else a literal prefix plus a
  * 64-bit FNV-1a tail. Deterministic across processes, which
- * absock_rewrite_connect requires: a connect must re-derive the path a bind
- * in another process produced.
+ * absock_rewrite_connect requires: a connect must re-derive the path a bind in
+ * another process produced.
  *
  * absock_link_name spells a shortening-link name for @host_path under @dir,
  * pid-scoped so no two live processes ever share a link and every exit-time
- * unlink is provably of the process's own property. Returns 0, or -1 with
- * errno set to ENAMETOOLONG when @out cannot hold the digest.
+ * unlink is provably of the process's own property.
+ *
+ * Returns 0, or -1 with errno set to ENAMETOOLONG when @out cannot hold the
+ * digest.
  */
 void absock_encode_name(const char *dir,
                         const uint8_t *name,

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -1073,11 +1073,11 @@ int64_t sys_recvmmsg(guest_t *g,
             /* Same conversion as ppoll and pselect6. Truncating turned a
              * sub-millisecond timeout into poll(0) and an immediate EAGAIN.
              *
-             * Deliberately the finite conversion, unlike epoll_pwait2: the
-             * wait below is one poll with nothing to re-arm it, so a -1 here
-             * would block forever with no way back out, on a call the guest
-             * asked to bound. timespec_to_poll_ms saturates instead, which is
-             * still far past any real timeout but is reached.
+             * Deliberately the finite conversion, unlike epoll_pwait2: the wait
+             * below is one poll with nothing to re-arm it, so a -1 here would
+             * block forever with no way back out, on a call the guest asked to
+             * bound. timespec_to_poll_ms saturates instead, which is still far
+             * past any real timeout but is reached.
              */
             int timeout_ms = timespec_to_poll_ms(ts.tv_sec, ts.tv_nsec);
             struct pollfd pfd = {.fd = host_ref.fd, .events = POLLIN};

--- a/src/syscall/net.h
+++ b/src/syscall/net.h
@@ -168,9 +168,9 @@ int64_t net_wait_or_interrupted(int host_fd, short events, int msg_flags);
 
 /* Readiness gate for a zero-payload recv/recvfrom/recvmsg: Linux clamps the
  * receive low-water target to one byte, so an empty socket blocks (EINTR on
- * guest signal) or fails EAGAIN when nonblocking, rather than returning 0
- * like the macOS host call. Call before the host receive when the resolved
- * payload length is zero.
+ * guest signal) or fails EAGAIN when nonblocking, rather than returning 0 like
+ * the macOS host call. Call before the host receive when the resolved payload
+ * length is zero.
  *
  * Returns 0 to proceed or a negative Linux errno (EINTR/EAGAIN).
  */
@@ -228,11 +228,11 @@ int64_t netlink_read(int guest_fd,
 
 int64_t netlink_send(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t len);
 
-/* Vectored forms of the two above, taking the guest iovec array they stage.
- * One netlink request, and one response, spans the whole iovec: the send
- * gathers every entry into one request and the receive fills every entry from
- * one response, so neither stops at the first entry the way the scalar special
- * fds do.
+/* Vectored forms of the two above, taking the guest iovec array they stage. One
+ * netlink request, and one response, spans the whole iovec: the send gathers
+ * every entry into one request and the receive fills every entry from one
+ * response, so neither stops at the first entry the way the scalar special fds
+ * do.
  */
 int64_t netlink_writev(int guest_fd, guest_t *g, uint64_t iov_gva, int iovcnt);
 

--- a/src/syscall/netlink.c
+++ b/src/syscall/netlink.c
@@ -541,9 +541,9 @@ static void nl_parse_link_filter(const uint8_t *req,
 
     size_t off = NLMSG_HDRLEN + netlink_align_up(sizeof(ifinfomsg_t));
 
-    /* The invariant bounds off itself, not just off relative to total.
-     * Without it the C loop test "off + RTA_HDRLEN <= total" is not known to be
-     * free of unsigned wrap, and every goal under the loop inherits that doubt.
+    /* The invariant bounds off itself, not just off relative to total. Without
+     * it the C loop test "off + RTA_HDRLEN <= total" is not known to be free of
+     * unsigned wrap, and every goal under the loop inherits that doubt.
      */
     /*@
       loop invariant off <= reqlen + NETLINK_ALIGNTO;
@@ -691,11 +691,11 @@ static int64_t nl_msg_iovcnt(const linux_msghdr_t *mhdr, int *iovcnt)
 /* The send half of sendmsg(2), sendto(2), write(2) and writev(2) on a netlink
  * socket.
  *
- * One request spans the whole iovec, so it is gathered before it is parsed.
- * A gathered length between one byte and one nlmsghdr transfers and does
- * nothing: the loop in netlink_rcv_skb() is entered only from
- * nlmsg_total_size(0) bytes up, and the send reports the byte count rather
- * than an error. Measured against Linux 6.18 under qemu-aarch64.
+ * One request spans the whole iovec, so it is gathered before it is parsed. A
+ * gathered length between one byte and one nlmsghdr transfers and does nothing:
+ * the loop in netlink_rcv_skb() is entered only from nlmsg_total_size(0) bytes
+ * up, and the send reports the byte count rather than an error. Measured
+ * against Linux 6.18 under qemu-aarch64.
  */
 static int64_t netlink_send_iov(int guest_fd,
                                 guest_t *g,
@@ -994,6 +994,7 @@ static int64_t netlink_recv_iov(int guest_fd,
         done += moved;
         if (moved < chunk) {
             pthread_mutex_unlock(&nl_lock);
+
             /* Bytes already placed are transferred; reporting EFAULT over them
              * would lose them, since buf_pos has moved past.
              */

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -205,6 +205,7 @@ int path_parse_proc_name(const char *name)
 {
     if (!name || !*name)
         return -1;
+
     /* Linux rejects a leading zero on any name longer than one character, so
      * "0" names descriptor 0 but "00" and "03" name nothing.
      */
@@ -223,9 +224,8 @@ int path_parse_proc_name(const char *name)
 }
 
 /* Parse an absolute fd magic link to the guest descriptor it names. This
- * accepts
- * "/proc/self/fd/<n>", the equivalent spelling with this process's own pid, and
- * the /dev aliases Linux exposes as symlinks to procfs.
+ * accepts "/proc/self/fd/<n>", the equivalent spelling with this process's own
+ * pid, and the /dev aliases Linux exposes as symlinks to procfs.
  *
  * Linux makes that a magic symlink, so a path-based syscall against it acts on
  * the file the descriptor holds. It is the standard way to reach a file through
@@ -303,8 +303,8 @@ int path_fd_magiclink_dup(const char *path)
         snap.type != FD_PATH && snap.type != FD_STDIO)
         return -1;
 
-    /* dup under fd_lock: a sibling vCPU closing this slot would otherwise
-     * leave the number free for the next open to claim.
+    /* dup under fd_lock: a sibling vCPU closing this slot would otherwise leave
+     * the number free for the next open to claim.
      */
     return fd_to_host_dup(fd);
 }
@@ -315,8 +315,8 @@ int path_fd_magiclink_dup(const char *path)
  * descriptor has no host path (a pipe, socket, or anonymous fd, where F_GETPATH
  * fails and the caller's own /proc intercepts remain the right answer).
  *
- * Callers that can act on a descriptor should prefer path_fd_magiclink_dup():
- * a pathname taken here and used later is a TOCTOU, since a rename or an
+ * Callers that can act on a descriptor should prefer path_fd_magiclink_dup(): a
+ * pathname taken here and used later is a TOCTOU, since a rename or an
  * unlink-and-recreate in between leaves it naming a different inode, where
  * Linux resolves the link inside the syscall and cannot be redirected.
  */
@@ -410,11 +410,11 @@ int path_translate_at(guest_fd_t dirfd,
      * spelling. open, stat and readlink never reach host_path for these paths:
      * proc_intercept_open dups the descriptor, proc_intercept_stat fstats it,
      * and proc_intercept_readlink reports its path, and none of the three fall
-     * through to the host on a fd magic link that names an open slot (a
-     * closed one fails as EBADF rather than falling through). What this changes
-     * is every other follow-style operation -- chmod, chown, utimensat,
-     * truncate, access -- which now acts on the file the descriptor holds, the
-     * way Linux does when it resolves the magic link.
+     * through to the host on a fd magic link that names an open slot (a closed
+     * one fails as EBADF rather than falling through). What this changes is
+     * every other follow-style operation -- chmod, chown, utimensat, truncate,
+     * access -- which now acts on the file the descriptor holds, the way Linux
+     * does when it resolves the magic link.
      *
      * Returning before sysroot resolution is not a containment claim about the
      * path: F_GETPATH reports where the descriptor's file actually lives, which
@@ -1609,10 +1609,10 @@ out:
     return rc;
 }
 
-/* Returns 1 when the reconstruction climbed the guest root, so the caller
- * opens @host_out instead of walking from dirfd; 0 when it stays beneath; -1
- * with errno set. @in_sysroot reports whether the sysroot claims the path;
- * @host_out is filled for a climbed or in-sysroot path, NULL to opt out.
+/* Returns 1 when the reconstruction climbed the guest root, so the caller opens
+ * @host_out instead of walking from dirfd; 0 when it stays beneath; -1 with
+ * errno set. @in_sysroot reports whether the sysroot claims the path; @host_out
+ * is filled for a climbed or in-sysroot path, NULL to opt out.
  */
 static int path_check_relative_sysroot_containment(guest_fd_t dirfd,
                                                    const char *path,
@@ -1681,6 +1681,7 @@ static int path_check_relative_sysroot_containment(guest_fd_t dirfd,
      * prefix of its own to make that call from.
      */
     *in_sysroot = checked != abs_path;
+
     /* Handing the resolution back rather than letting a caller re-derive it
      * keeps the two flag mappings from drifting. A path that clamped at the
      * guest root needs it either way: both spellings are absolute, so the
@@ -1832,9 +1833,9 @@ static int reset_walk_fd(host_fd_t *current_fd, host_fd_t root_fd)
  * Outside a sysroot, and for any name needing no escape, this is the name
  * itself.
  *
- * @is_link: -1 unknown (the caller must stat), 0 not a symlink or not there,
- * 1 a symlink. Only the readdir fallback, whose listing carries no type,
- * leaves it unknown.
+ * @is_link: -1 unknown (the caller must stat), 0 not a symlink or not there, 1
+ * a symlink. Only the readdir fallback, whose listing carries no type, leaves
+ * it unknown.
  */
 static int host_component_spelling(host_fd_t dirfd,
                                    const char *guest,
@@ -1856,9 +1857,10 @@ static int host_component_spelling(host_fd_t dirfd,
         casefold_resolve_at(dirfd, "", guest, false, out, outsz, &walk);
     if (verdict == CASEFOLD_ERROR)
         return -1;
-    /* Any non-FOUND verdict here means not there: @guest is one component
-     * with follow_final false, so CASEFOLD_SYMLINK, which the walk returns
-     * only for a link it must pass through, cannot come back.
+
+    /* Any non-FOUND verdict here means not there: @guest is one component with
+     * follow_final false, so CASEFOLD_SYMLINK, which the walk returns only for
+     * a link it must pass through, cannot come back.
      */
     if (verdict != CASEFOLD_FOUND)
         *is_link = 0;
@@ -1983,8 +1985,8 @@ int path_openat2_crosses_mount(guest_fd_t dirfd,
                                         sizeof(host_name), &leaf_link) < 0)
                 goto out;
 
-            /* ENOENT still yields a verdict: nothing there can be a link.
-             * Any other errno leaves link-ness undecided, and an undecided
+            /* ENOENT still yields a verdict: nothing there can be a link. Any
+             * other errno leaves link-ness undecided, and an undecided
              * component must not be walked through as a directory.
              */
             if (host_walk && leaf_link < 0) {
@@ -2024,9 +2026,9 @@ int path_openat2_crosses_mount(guest_fd_t dirfd,
                 }
                 target[target_len] = '\0';
 
-                /* No prefix: an absolute target re-anchors the walk fd
-                 * below, and a relative one continues from current_fd,
-                 * which already names the link's directory.
+                /* No prefix: an absolute target re-anchors the walk fd below,
+                 * and a relative one continues from current_fd, which already
+                 * names the link's directory.
                  */
                 if (path_splice_link_target(NULL, 0, target, walk, pending,
                                             sizeof(pending)) < 0)

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1058,7 +1058,7 @@ int64_t sys_epoll_create1(int flags)
     }
 
     /* Allocate per-instance registration table */
-    epoll_instance_t *inst = calloc(1, sizeof(epoll_instance_t));
+    epoll_instance_t *inst = calloc(1, sizeof(*inst));
     if (!inst) {
         close(kq);
         return -LINUX_ENOMEM;

--- a/src/syscall/proc-identity.c
+++ b/src/syscall/proc-identity.c
@@ -94,8 +94,8 @@ void proc_identity_init(void)
         gid = 0;
     }
 
-    /* A staged --user wins over the defaults and over fakeroot; consumed
-     * here so it applies to one bring-up only (contract in proc.h).
+    /* A staged --user wins over the defaults and over fakeroot; consumed here
+     * so it applies to one bring-up only (contract in proc.h).
      */
     if (atomic_exchange(&initial_ids_staged, false)) {
         uid = atomic_load(&initial_uid);

--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -36,6 +36,7 @@ static bool shim_blob_owned = false;
 /* Current ELF and launcher paths. */
 static char elf_path[LINUX_PATH_MAX] = {0};
 static char elfuse_path[LINUX_PATH_MAX] = {0};
+
 /* Serializes proc_set_elf_path against readers that consume the string. Without
  * this, an execve on one vCPU can tear the buffer underneath a sibling vCPU
  * resolving /proc/self/exe.
@@ -56,11 +57,13 @@ static char sysroot_path[LINUX_PATH_MAX] = {0};
  * the snprintf input buffer underneath that thread.
  */
 static pthread_mutex_t sysroot_lock = PTHREAD_MUTEX_INITIALIZER;
+
 /* Atomic, not guarded by sysroot_lock: published once at startup and to a
  * forked child before any vCPU thread issues a syscall, and no other state is
  * kept consistent with it.
  */
 static _Atomic bool sysroot_casefold = false;
+
 /* True when proc_set_sysroot's realpath succeeded, so containment checks can
  * copy sysroot_path instead of re-deriving it; false leaves them the per-call
  * realpath. Atomic for the same reason as the fold flag above.
@@ -452,19 +455,19 @@ bool proc_sysroot_casefold_enabled(void)
 /* True when realpath(3) failed because the path stopped resolving rather than
  * because it resolves somewhere it should not. A sibling thread or process can
  * unlink or rename the entry between the resolver's existence probe and this
- * recheck, and canonicalizing a vanished path dies with ENOENT (or ENOTDIR
- * when a component was replaced by a file). Nothing can be reached through a
- * path that no longer resolves, so the caller may keep the sysroot spelling
- * and let its own syscall report the truth; turning the failure into a veto
- * manufactures ELOOP for a plain concurrent unlink. Every other realpath
- * errno stays a veto: a loop really is ELOOP, and denying on EACCES or EIO is
- * the conservative side of a containment check.
+ * recheck, and canonicalizing a vanished path dies with ENOENT (or ENOTDIR when
+ * a component was replaced by a file). Nothing can be reached through a path
+ * that no longer resolves, so the caller may keep the sysroot spelling and let
+ * its own syscall report the truth; turning the failure into a veto
+ * manufactures ELOOP for a plain concurrent unlink. Every other realpath errno
+ * stays a veto: a loop really is ELOOP, and denying on EACCES or EIO is the
+ * conservative side of a containment check.
  *
  * The reasoning covers the sysroot argument as much as the path under it: a
  * sysroot renamed out from under a running guest leaves nothing reachable
- * beneath it either, so the caller's own syscall owes the same ENOENT. There
- * is no containment question left to answer once the root of the comparison
- * is gone.
+ * beneath it either, so the caller's own syscall owes the same ENOENT. There is
+ * no containment question left to answer once the root of the comparison is
+ * gone.
  */
 static bool realpath_vanished(void)
 {
@@ -497,6 +500,7 @@ static bool sysroot_path_is_contained(const char *resolved_path,
             return realpath_vanished();
     } else {
         const char *base = strrchr(resolved_path, '/');
+
         /* "." and ".." basenames navigate the directory tree and cannot
          * themselves be symlinks, so realpath the full path: appending the
          * literal basename onto realpath(parent) would let "${sysroot}/x/.."
@@ -512,6 +516,7 @@ static bool sysroot_path_is_contained(const char *resolved_path,
 
             str_copy_trunc(parent, resolved_path, sizeof(parent));
             slash = strrchr(parent, '/');
+
             /* resolved_path is always ${sysroot}${guest_path} where sysroot is
              * non-empty (caller short-circuits otherwise) and guest_path starts
              * with '/'. The result therefore contains at least two '/' bytes,
@@ -627,8 +632,8 @@ static bool lexical_normalize_absolute_path(char *dest,
 
 /* Rewrite the '..' components that would climb above the guest root, and only
  * those. Linux clamps '..' at the root a process resolves from
- * (path_resolution(7)), but the sysroot is a directory on the host, so the
- * host kernel would happily walk out of it.
+ * (path_resolution(7)), but the sysroot is a directory on the host, so the host
+ * kernel would happily walk out of it.
  *
  * Everything else is copied byte for byte, including interior '..', '.', and
  * runs of slashes. Collapsing those would hand the host a path whose popped
@@ -649,6 +654,7 @@ static bool clamp_dotdot_at_guest_root(char *dest,
 
     const char *scan = src;
     const char *comp;
+
     /* The separators before the component about to be read, which travel with
      * it: a dropped component must not leave its slashes behind. Once the walk
      * ends this is the trailing run, which states that the path names a
@@ -693,10 +699,10 @@ static bool clamp_dotdot_at_guest_root(char *dest,
 }
 
 /* Snapshot the sysroot, clamp @path, and spell the host path it names.
- * Returns 1 with @buf, @sr, and @clamped filled, 0 when sysroot resolution
- * does not apply and the caller owes its input back, or -1 with errno set.
- * On 0 the outputs are indeterminate: a relative path opts out before the
- * snapshot runs, so @sr is not even the empty string.
+ * Returns 1 with @buf, @sr, and @clamped filled, 0 when sysroot resolution does
+ * not apply and the caller owes its input back, or -1 with errno set. On 0 the
+ * outputs are indeterminate: a relative path opts out before the snapshot runs,
+ * so @sr is not even the empty string.
  */
 static int sysroot_seed_host_path(const char *path,
                                   char *buf,
@@ -864,10 +870,10 @@ static casefold_verdict_t resolve_through_links(const char *sr,
         }
 
         /* @depth counts links actually crossed, so the guard sits with the
-         * readlink it bounds; the terminal iteration resolves without
-         * following anything and consumes no budget. Linux resolves a 40-link
-         * chain and fails following the 41st (path_resolution(7)), the same
-         * accounting path_openat2_crosses_mount uses.
+         * readlink it bounds; the terminal iteration resolves without following
+         * anything and consumes no budget. Linux resolves a 40-link chain and
+         * fails following the 41st (path_resolution(7)), the same accounting
+         * path_openat2_crosses_mount uses.
          */
         if (depth >= MAXSYMLINKS) {
             errno = ELOOP;
@@ -892,10 +898,11 @@ static casefold_verdict_t resolve_through_links(const char *sr,
             return CASEFOLD_ERROR;
         if (followed_relative_out && target[0] != '/')
             *followed_relative_out = true;
-        /* A target may carry '..' that climbs above the guest root, which
-         * the walk would append literally and follow out of the sysroot. Clamp
-         * it exactly as an entry path is clamped; an interior '..' stays for
-         * the host to resolve against the directory the link named.
+
+        /* A target may carry '..' that climbs above the guest root, which the
+         * walk would append literally and follow out of the sysroot. Clamp it
+         * exactly as an entry path is clamped; an interior '..' stays for the
+         * host to resolve against the directory the link named.
          */
         if (!clamp_dotdot_at_guest_root(norm, splice, sizeof(norm))) {
             errno = ENAMETOOLONG;
@@ -907,8 +914,8 @@ static casefold_verdict_t resolve_through_links(const char *sr,
 
 /* After a walk that may have followed links, point @path at the guest path it
  * finally named. Reports whether a link was actually crossed, because the
- * host-fallback decision downstream is different for a path the guest typed
- * and one a link handed it; shared by both resolvers so the two cannot drift.
+ * host-fallback decision downstream is different for a path the guest typed and
+ * one a link handed it; shared by both resolvers so the two cannot drift.
  */
 static bool rebase_after_link(const char **path, const char *followed)
 {
@@ -1040,6 +1047,7 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
         sysroot_seed_host_path(path, buf, bufsz, sr, clamped, follow_final);
     if (seeded <= 0)
         return seeded < 0 ? NULL : path;
+
     /* Moves to the link's target once one is followed, so everything below
      * decides from where resolution actually ended up.
      */
@@ -1057,8 +1065,8 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
      * host spelling? On a volume that folds case those are one question: the
      * walk decides each component's stored spelling and reports whether the
      * whole path resolved, so its verdict is the existence answer and its
-     * output is the host path. On a byte-exact volume the guest spelling is
-     * the host spelling, and a concatenation plus one probe answers both.
+     * output is the host path. On a byte-exact volume the guest spelling is the
+     * host spelling, and a concatenation plus one probe answers both.
      */
     bool present;
     bool folded = false;
@@ -1077,25 +1085,28 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
         present = verdict == CASEFOLD_FOUND;
         folded = walk.folded;
         walk_typed_all = present && walk.all_types_known;
-        /* The walk stopped at a component that is not a directory, which is
-         * the answer the byte-exact branch below reads off ENOTDIR: resolution
+
+        /* The walk stopped at a component that is not a directory, which is the
+         * answer the byte-exact branch below reads off ENOTDIR: resolution
          * fails there (path_resolution(7)) and the host fallback must not run,
          * or "file/tail" would be reported against an unrelated host path,
-         * ENOENT where Linux owes ENOTDIR. The caller's own syscall against
-         * the sysroot spelling reproduces the right errno. The containment
-         * check is skipped for the reason the folded return below gives:
-         * nothing past the offending component is ever reached.
+         * ENOENT where Linux owes ENOTDIR. The caller's own syscall against the
+         * sysroot spelling reproduces the right errno. The containment check is
+         * skipped for the reason the folded return below gives: nothing past
+         * the offending component is ever reached.
          */
         if (!present && walk.notdir)
             return buf;
+
         /* An all-slash guest path names the root, which always exists, is
-         * trivially contained, and has no parent for the containment check
-         * to split off: with the sysroot at "/" the resolved path is the
+         * trivially contained, and has no parent for the containment check to
+         * split off: with the sysroot at "/" the resolved path is the
          * one-character prefix itself, and treating that shape as impossible
          * reports ELOOP for lstat("/").
          */
         if (present && walk.leaf_offset == 0)
             return buf;
+
         /* Everything below decides between the sysroot and the host, and after
          * a link that decision belongs to where the link pointed, not to where
          * the guest started. An absolute target is then treated exactly like
@@ -1111,15 +1122,16 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
             return NULL;
         present = verdict == CASEFOLD_FOUND;
         followed_link = rebase_after_link(&lookup, followed);
-        /* A probe that dies with ENOTDIR found a sysroot component that is
-         * not a directory. Linux resolves left to right and fails there with
-         * ENOTDIR (path_resolution(7)), so the sysroot has answered: the
-         * host fallback below must not run, or "file/" and "file/tail" would
-         * be reported against an unrelated host path, ENOENT where Linux
-         * owes ENOTDIR. The caller's own syscall against the sysroot
-         * spelling reproduces the right errno on the host. The containment
-         * check is skipped for the reason the folded return below gives:
-         * resolution never reaches anything past the offending component.
+
+        /* A probe that dies with ENOTDIR found a sysroot component that is not
+         * a directory. Linux resolves left to right and fails there with
+         * ENOTDIR (path_resolution(7)), so the sysroot has answered: the host
+         * fallback below must not run, or "file/" and "file/tail" would be
+         * reported against an unrelated host path, ENOENT where Linux owes
+         * ENOTDIR. The caller's own syscall against the sysroot spelling
+         * reproduces the right errno on the host. The containment check is
+         * skipped for the reason the folded return below gives: resolution
+         * never reaches anything past the offending component.
          */
         if (!present && errno == ENOTDIR)
             return buf;
@@ -1132,10 +1144,10 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
 
     if (present) {
         /* A walk that typed every component has proven containment: '..' was
-         * clamped before it ran and no unseen symlink can hide in a fully
-         * typed path, so realpath() would re-derive the same bytes. The
-         * recheck remains for a readdir-answered component and for the
-         * byte-exact arm, which runs no walk.
+         * clamped before it ran and no unseen symlink can hide in a fully typed
+         * path, so realpath() would re-derive the same bytes. The recheck
+         * remains for a readdir-answered component and for the byte-exact arm,
+         * which runs no walk.
          */
         if (walk_typed_all)
             return buf;
@@ -1146,9 +1158,9 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
         return buf;
     }
 
-    /* The sysroot holds an entry where this path asked, spelled differently,
-     * so the path is absent to a byte-exact reader but the sysroot has a claim
-     * on it, and the answer Linux owes is ENOENT. Falling through would open an
+    /* The sysroot holds an entry where this path asked, spelled differently, so
+     * the path is absent to a byte-exact reader but the sysroot has a claim on
+     * it, and the answer Linux owes is ENOENT. Falling through would open an
      * unrelated host file that merely shares the name, which is how a
      * wrong-case lookup escapes the tree entirely.
      *
@@ -1156,8 +1168,8 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
      * component's escape does not exist, every component before it resolved
      * case-exactly without passing through a link, and resolution proceeds
      * component by component from the left (path_resolution(7)), so the
-     * caller's syscall dies with ENOENT at the folded component before
-     * anything after it could be reached, contained or not.
+     * caller's syscall dies with ENOENT at the folded component before anything
+     * after it could be reached, contained or not.
      */
     if (folded)
         return buf;
@@ -1171,13 +1183,13 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
             return path;
     }
 
-    /* Prevent escaping guest system paths to macOS host paths, which leads
-     * to host contamination and permission failures (e.g. SIP/EPERM).
-     * Classification reads the fully collapsed spelling, so "/usr/../home/x"
-     * is judged as "/home/x" rather than prefix-matching "/usr".
-     * Resolution stops at the sysroot spelling for both classes. The caller's
-     * own syscall reports the path absent when the sysroot does not hold it,
-     * which is what it is in the guest's namespace.
+    /* Prevent escaping guest system paths to macOS host paths, which leads to
+     * host contamination and permission failures (e.g. SIP/EPERM).
+     * Classification reads the fully collapsed spelling, so "/usr/../home/x" is
+     * judged as "/home/x" rather than prefix-matching "/usr". Resolution stops
+     * at the sysroot spelling for both classes. The caller's own syscall
+     * reports the path absent when the sysroot does not hold it, which is what
+     * it is in the guest's namespace.
      */
     char norm_path[LINUX_PATH_MAX];
     bool has_norm =
@@ -1189,9 +1201,9 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
 
     /* A path reached by following a symlink has already been rebased to the
      * target's guest spelling. For non-forced paths, keep the same host
-     * fallback rule as a path the guest typed directly: if the target exists
-     * on the host, hand that resolved target to the caller; otherwise leave
-     * the syscall on the sysroot spelling so dangling links report normally.
+     * fallback rule as a path the guest typed directly: if the target exists on
+     * the host, hand that resolved target to the caller; otherwise leave the
+     * syscall on the sysroot spelling so dangling links report normally.
      */
     if (followed_link) {
         if (!followed_relative_link &&
@@ -1230,14 +1242,15 @@ const char *proc_resolve_sysroot_create_path(const char *path,
     int seeded = sysroot_seed_host_path(path, buf, bufsz, sr, clamped, false);
     if (seeded <= 0)
         return seeded < 0 ? NULL : path;
+
     /* Moves to the link's target once one is followed, so everything below
      * decides from where resolution actually ended up.
      */
     const char *lookup = clamped;
 
-    /* An all-slash guest path ("/", "///", and anything clamping to them)
-     * names the root, which always exists and has no parent to check; trimming
-     * it would walk strrchr into the sysroot prefix and trip the containment
+    /* An all-slash guest path ("/", "///", and anything clamping to them) names
+     * the root, which always exists and has no parent to check; trimming it
+     * would walk strrchr into the sysroot prefix and trip the containment
      * guard.
      *
      * Return buf as-is.
@@ -1249,10 +1262,10 @@ const char *proc_resolve_sysroot_create_path(const char *path,
     bool parent_present;
 
     /* The target does not exist yet, so what has to be decided is where it
-     * would go: the host spelling of every component leading to it, and
-     * whether that parent is there. On a folding volume a concatenated parent
-     * answers neither: a parent stored escaped reads as absent, and a
-     * wrong-case one folds onto a directory the create would then land in.
+     * would go: the host spelling of every component leading to it, and whether
+     * that parent is there. On a folding volume a concatenated parent answers
+     * neither: a parent stored escaped reads as absent, and a wrong-case one
+     * folds onto a directory the create would then land in.
      */
     bool followed_link = false;
     bool followed_relative_link = false;
@@ -1274,16 +1287,18 @@ const char *proc_resolve_sysroot_create_path(const char *path,
             errno = ENAMETOOLONG;
             return NULL;
         }
+
         /* An all-slash guest path names the root, which always exists and has
          * no parent to check.
          */
         if (walk.leaf_offset == 0)
             return buf;
+
         /* The walk records where the parent's spelling ends, so truncating
          * there needs no correction for the separator: only the walk knows
-         * whether it inserted one, and with the sysroot at "/" it did not:
-         * the parent is the root, not the empty string a leaf_offset - 1
-         * truncation would leave.
+         * whether it inserted one, and with the sysroot at "/" it did not: the
+         * parent is the root, not the empty string a leaf_offset - 1 truncation
+         * would leave.
          */
         parent[walk.parent_offset] = '\0';
         parent_present = walk.parent_found;
@@ -1291,8 +1306,8 @@ const char *proc_resolve_sysroot_create_path(const char *path,
         /* A fold above the leaf means the parent the guest named is not the
          * entry the volume matched, so that parent does not exist. Both other
          * answers are wrong: falling through puts the create on the host, and
-         * returning the sysroot spelling puts it inside the folded entry,
-         * which is a directory this sysroot did not create under that name.
+         * returning the sysroot spelling puts it inside the folded entry, which
+         * is a directory this sysroot did not create under that name.
          */
         if (walk.folded && !parent_present) {
             errno = ENOENT;
@@ -1311,6 +1326,7 @@ const char *proc_resolve_sysroot_create_path(const char *path,
             return buf;
 
         str_copy_trunc(parent, buf, sizeof(parent));
+
         /* Trailing slashes name the same directory (POSIX); drop them so the
          * final separator splits off the leaf component rather than matching
          * the trailing slash itself, which would leave the target as its own
@@ -1325,11 +1341,12 @@ const char *proc_resolve_sysroot_create_path(const char *path,
 
         *slash = '\0';
         parent_present = access(parent, F_OK) == 0;
+
         /* access() failed for a reason other than "parent missing" (e.g.
          * EACCES, ELOOP, ENAMETOOLONG, EIO). Treating those as "parent absent"
-         * would let the redirect logic auto-create or silently fall back to
-         * the host literal, which can bypass sysroot resolution. Surface the
-         * real error.
+         * would let the redirect logic auto-create or silently fall back to the
+         * host literal, which can bypass sysroot resolution. Surface the real
+         * error.
          */
         if (!parent_present && errno != ENOENT && errno != ENOTDIR)
             return NULL;

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1421,8 +1421,8 @@ int proc_send_guest_signal(pid_t host_pid, int64_t target_guest_pid, int signum)
 {
     /* Refuse to signal a host pid that is not (or is no longer) an elfuse
      * process: if it was recycled onto an unrelated program, a raw SIGUSR2
-     * would terminate it. This narrows -- but a sub-microsecond exit+reuse race
-     * before kill() remains -- see the signal-transport TODO.
+     * would terminate it. A sub-microsecond exit and pid reuse between this
+     * check and kill() still lands the signal on the wrong process.
      */
     int our_len;
     const char *our_path = elfuse_self_path(&our_len);
@@ -1581,7 +1581,7 @@ void proc_process_exit(int wait_status)
     free(registry);
     lifecycle_unlock_close(fd);
 
-    for (uint32_t i = 0; i < nreparented; i++) {
+    for (uint32_t i = 0; reparented && i < nreparented; i++) {
         if (reparented[i].exited) {
             /* The exiting process is not necessarily a child of the adopter, so
              * its own SIGCHLD goes elsewhere. Notify the adopter explicitly for

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -3187,9 +3187,9 @@ static void vcpu_handle_mrs_trap(hv_vcpu_t vcpu,
     uint64_t value = 0;
 
     /* ID register emulation: return VZ-sanitized values BEFORE trying HVF.
-     * HVF's hv_vcpu_get_sys_reg succeeds for ID
-     * registers but returns raw hardware values, which include features the
-     * hypervisor does not actually virtualize.
+     * HVF's hv_vcpu_get_sys_reg succeeds for ID registers but returns raw
+     * hardware values, which include features the hypervisor does not actually
+     * virtualize.
      *
      * Values captured from a Lima VZ VM on Apple Silicon via inline MRS from
      * EL0 (kernel trap-and-emulate). These are checked first, before the HVF

--- a/src/syscall/sys.h
+++ b/src/syscall/sys.h
@@ -16,10 +16,10 @@
 #include "core/guest.h"
 
 /* Guest-visible kernel identity for uname(2) and /proc/version;
- * tests/test-proc.c pins the two surfaces to each other. The release names
- * the 6.18 LTS baseline and tracks no test image; syscall/dispatch.tbl
- * states what elfuse implements. glibc rejects only a release below its
- * build-time floor, so a high floor is the safe side.
+ * tests/test-proc.c pins the two surfaces to each other. The release names the
+ * 6.18 LTS baseline and tracks no test image; syscall/dispatch.tbl states what
+ * elfuse implements. glibc rejects only a release below its build-time floor,
+ * so a high floor is the safe side.
  */
 #define GUEST_KERNEL_RELEASE "6.18.0"
 #define GUEST_KERNEL_VERSION "#1 SMP PREEMPT_DYNAMIC"
@@ -65,9 +65,9 @@ int64_t sys_prlimit64(guest_t *g,
  * A guest that reads two surfaces subtracts one against the other, and there
  * the underflow happens beyond any saturating arithmetic elfuse does on its own
  * side. busybox free is exactly this reader: it takes total and free from
- * sysinfo(2) and buff/cache from /proc/meminfo, then computes
- * used = total - free - cached. So the total and the free both have to come
- * from here rather than being sampled once per surface.
+ * sysinfo(2) and buff/cache from /proc/meminfo, then computes used = total -
+ * free - cached. So the total and the free both have to come from here rather
+ * than being sampled once per surface.
  *
  * sys_guest_ram_bytes() is the total to report as MemTotal/totalram: the host's
  * real memory, or a plausible stand-in if the sysctl fails, never zero.
@@ -77,9 +77,9 @@ int64_t sys_prlimit64(guest_t *g,
 uint64_t sys_guest_ram_bytes(void);
 uint64_t sys_guest_ram_free(void);
 
-/* Snapshot/restore the guest-visible RLIMIT_NOFILE across the posix_spawn
- * fork boundary. The host limit is internal capacity and is deliberately not
- * exposed through these helpers.
+/* Snapshot/restore the guest-visible RLIMIT_NOFILE across the posix_spawn fork
+ * boundary. The host limit is internal capacity and is deliberately not exposed
+ * through these helpers.
  */
 void sys_nofile_snapshot(uint64_t *cur, uint64_t *max);
 int sys_nofile_restore(uint64_t cur, uint64_t max);

--- a/src/syscall/wakeup-pipe.c
+++ b/src/syscall/wakeup-pipe.c
@@ -5,9 +5,9 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * The self-pipe every indefinite host poll/select/kevent waits on alongside
- * its real fds. Free of syscall-layer dependencies, so the concurrency
- * contract in wakeup-pipe.h can be tested on its own.
+ * The self-pipe every indefinite host poll/select/kevent waits on alongside its
+ * real fds. Free of syscall-layer dependencies, so the concurrency contract in
+ * wakeup-pipe.h can be tested on its own.
  */
 
 #include <fcntl.h>

--- a/src/syscall/wakeup-pipe.h
+++ b/src/syscall/wakeup-pipe.h
@@ -18,8 +18,8 @@
  */
 void wakeup_pipe_init(void);
 
-/* Wake every thread parked on the read end. Safe from a signal-handling
- * thread; a missing pipe is a no-op.
+/* Wake every thread parked on the read end. Safe from a signal-handling thread;
+ * a missing pipe is a no-op.
  */
 void wakeup_pipe_signal(void);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -104,8 +104,8 @@ static inline size_t str_copy_trunc(char *dst, const char *src, size_t dst_size)
 
 /* Free @n owned strings and the array holding them. Every slot must be a heap
  * copy, never a borrowed environ or argv pointer; a NULL @v is a no-op. The
- * count is a parameter rather than a NULL terminator because the guest argv
- * is counted rather than terminated.
+ * count is a parameter rather than a NULL terminator because the guest argv is
+ * counted rather than terminated.
  */
 static inline void strv_free(const char **v, int n)
 {

--- a/tests/bench-fork-cost.sh
+++ b/tests/bench-fork-cost.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+
 # Per-fork wall-clock cost for aarch64 vs x86_64-via-Rosetta
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Measures the per-fork wall-clock cost of clone(SIGCHLD) (subshell fork
-# without exec) at a few resident-memory levels, on the same host, comparing:
+# Measures the per-fork wall-clock cost of clone(SIGCHLD) (subshell fork without
+# exec) at a few resident-memory levels, on the same host, comparing:
 #
 #   - aarch64-musl static busybox  (CoW shm fast path in forkipc.c)
 #   - x86_64-musl  static busybox  (Rosetta helper path; APFS clonefile-backed
@@ -93,10 +94,12 @@ trap 'rm -rf "$SHORTDIR"' EXIT
 
 # Capture best-of-N wall-clock for one configuration. Runs are retried up to
 # MAX_TRIES per slot; only runs that exit 0 AND print the "OK" sentinel are
-# accepted. Returns "FAIL" on stdout when no run succeeds, so the caller can
-# mark the cell as unreliable rather than reporting a phantom-best time
-# captured from a crash or out-of-memory bail.
-# Args: <iter_count> <rss_bytes> <stagedir> [extra elfuse flags...]
+# accepted.
+#
+# Returns "FAIL" on stdout when no run succeeds, so the caller can mark the cell
+# as unreliable rather than reporting a phantom-best time captured from a crash
+# or out-of-memory bail. Args: <iter_count> <rss_bytes> <stagedir> [extra elfuse
+# flags...]
 run_one()
 {
     local iters="$1" rss="$2" stagedir="$3"

--- a/tests/bench-rosetta.sh
+++ b/tests/bench-rosetta.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
+
 # bench-rosetta.sh - Wall-clock benchmark harness for x86_64-via-Rosetta
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Measures wall-clock time for a curated set of static x86_64 workloads
-# running under elfuse + Rosetta. The intent is a stable reproducible
-# regression baseline; absolute numbers are noisy on macOS so the script
-# prints best-of-N runs and a coefficient of variation.
+# Measures wall-clock time for a curated set of static x86_64 workloads running
+# under elfuse + Rosetta. The intent is a stable reproducible regression
+# baseline; absolute numbers are noisy on macOS so the script prints best-of-N
+# runs and a coefficient of variation.
 #
 # The bench deliberately stays self-contained:
 #   - workloads come from the Alpine x86_64 staticbin tree
 #   - no external comparison runs (those need separate hardware access)
 #
-# To compare against native x86_64 hardware or aarch64 hosts, capture the
-# same workloads' wall-clock there and paste them into the output yourself.
+# To compare against native x86_64 hardware or aarch64 hosts, capture the same
+# workloads' wall-clock there and paste them into the output yourself.
 #
 # Usage: tests/bench-rosetta.sh [path/to/elfuse] [iterations]
 
@@ -62,9 +63,10 @@ trap 'rm -rf "$SHORTDIR"' EXIT
 data="${SHORTDIR}/data/in.bin"
 dd if=/dev/urandom of="$data" bs=1024 count=64 status=none
 
-# Capture wall-clock in nanoseconds across N iterations of CMD. Returns
-# the best (minimum) sample and a basic spread (max - min).
-# Args: <label> <cmd...>
+# Capture wall-clock in nanoseconds across N iterations of CMD.
+#
+# Returns the best (minimum) sample and a basic spread (max - min). Args:
+# <label> <cmd...>
 run_bench()
 {
     local label="$1"
@@ -104,8 +106,8 @@ printf 'elfuse:     %s\n' "$ELFUSE"
 printf 'rosetta:    %s\n' "$ROSETTA_PATH"
 printf 'iterations: %d per workload\n\n' "$ITERS"
 
-# Warm the rosetta AOT cache. The first launch of any binary pays a
-# translation cost; subsequent launches hit ~/.cache/elfuse-rosettad/.
+# Warm the rosetta AOT cache. The first launch of any binary pays a translation
+# cost; subsequent launches hit ~/.cache/elfuse-rosettad/.
 printf 'Warming AOT cache:\n'
 for app in echo seq factor sha256sum md5sum sha512sum sort wc; do
     "$ELFUSE" "${SHORTDIR}/bin/${app}" --help > /dev/null 2>&1 || true
@@ -127,9 +129,9 @@ run_bench "md5-64k" "$ELFUSE" "${SHORTDIR}/bin/md5sum" "$data"
 run_bench "sha512-64k" "$ELFUSE" "${SHORTDIR}/bin/sha512sum" "$data"
 run_bench "wc-64k" "$ELFUSE" "${SHORTDIR}/bin/wc" "-c" "$data"
 
-# Compare against the aarch64 equivalent so the cost of rosetta vs native
-# guest translation is visible. The aarch64 staticbin tree is the source
-# of truth (same Alpine version, different arch).
+# Compare against the aarch64 equivalent so the cost of rosetta vs native guest
+# translation is visible. The aarch64 staticbin tree is the source of truth
+# (same Alpine version, different arch).
 aarch64_bin="${FIXTURES}/aarch64-musl/staticbin/bin/busybox"
 if [ -x "$aarch64_bin" ]; then
     printf '\nAarch64 reference (same workload, native elfuse path):\n'

--- a/tests/casefold-vectors.h
+++ b/tests/casefold-vectors.h
@@ -9,10 +9,10 @@
  * names spelled this way, so a row may change only together with a deliberate
  * format migration, never to make a test pass. The codec's own tests all read
  * through the codec and therefore stay green across any self-consistent format
- * change; only a comparison against these frozen literals fails when the
- * format moves. test-casefold-host.c asserts every row in both directions,
- * and the mk/tests.mk corpus recipe stages a subset host-side for the guest
- * corpus test to read back.
+ * change; only a comparison against these frozen literals fails when the format
+ * moves. test-casefold-host.c asserts every row in both directions, and the
+ * mk/tests.mk corpus recipe stages a subset host-side for the guest corpus test
+ * to read back.
  */
 
 #pragma once
@@ -49,8 +49,8 @@
 #define CFV_H64 CFV_H32 CFV_H32
 #define CFV_H125 CFV_H64 CFV_H32 CFV_H16 CFV_H8 CFV_H4 "58"
 
-/* Long-tier symbols, one UTF-8 literal per code point. The tier packs the
- * name MSB-first into 12-bit groups and adds U+4E00 to each; a leading symbol
+/* Long-tier symbols, one UTF-8 literal per code point. The tier packs the name
+ * MSB-first into 12-bit groups and adds U+4E00 to each; a leading symbol
  * carries the byte length. 'X' = 0x58 repeated gives the periodic groups
  * 0x585/0x858 -> U+5385/U+5658, so one two-symbol pair covers three payload
  * bytes: 126 bytes = 1008 bits = exactly 42 pairs, 255 bytes = 2040 bits =

--- a/tests/copy-arg.c
+++ b/tests/copy-arg.c
@@ -32,6 +32,7 @@ int main(int argc, char **argv)
     int out = open(argv[2], O_CREAT | O_WRONLY | O_TRUNC, 0755);
     if (out < 0)
         return perror(argv[2]), 1;
+
     /* write_fd_all, not a bare write: the destination goes through the FUSE
      * write path, where a short count is a success that must be resumed, and
      * write(2) leaves errno untouched on one. The read retries EINTR for the

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -278,10 +278,10 @@ evaluate_result()
 
 # Run one test binary and record the outcome in rc and output.
 #
-# One function for the first attempt and the host-load retry both. Not
-# tidiness: the two drifted the moment they were written apart, and the retry
-# went in without the descriptor limit the first attempt applies, so a
-# constrained test was re-run as a different test.
+# One function for the first attempt and the host-load retry both. Not tidiness:
+# the two drifted the moment they were written apart, and the retry went in
+# without the descriptor limit the first attempt applies, so a constrained test
+# was re-run as a different test.
 #
 # ulimit runs in the subshell that produces output, and a failure to raise it
 # exits that subshell with 125 rather than chaining into timeout. A && chain
@@ -321,6 +321,7 @@ report_case()
         ok) printf "%-45s [ ${GREEN}OK${RESET} ]%s\n" "$name" "$detail" ;;
         fail) printf "%-45s [ ${RED}FAIL${RESET} ]%s\n" "$name" "$detail" ;;
         skip) printf "%-45s [ ${YELLOW}SKIP${RESET} ]%s\n" "$name" "$detail" ;;
+
         # No bracketed verdict, because the test has not been decided yet and
         # every other state here is one the summary counts. The blanks are as
         # wide as the FAIL and SKIP tags, which is the closest a single width

--- a/tests/exec-arg.c
+++ b/tests/exec-arg.c
@@ -7,9 +7,9 @@
  * Replace this process with argv[1], handing it argv[2..] as its own argv.
  * argv[2] is the target's argv[0], separate from the path because a multicall
  * binary dispatches on it. Sysroot recipes run this as a guest so the target
- * goes through the guest execve path: the initial process is loaded by the
- * core bootstrap, which resolves PT_INTERP by literal concatenation plus the
- * /lib fallback only, so a lane about interpreter resolution through escaped
+ * goes through the guest execve path: the initial process is loaded by the core
+ * bootstrap, which resolves PT_INTERP by literal concatenation plus the /lib
+ * fallback only, so a lane about interpreter resolution through escaped
  * spellings has to exec from inside the guest.
  */
 

--- a/tests/fetch-fixtures.sh
+++ b/tests/fetch-fixtures.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # fetch-fixtures.sh -- Download Alpine packages and assemble a qemu/elfuse test
 # fixture tree under externals/test-fixtures/.
 #
@@ -41,11 +42,12 @@ set -euo pipefail
 
 ALPINE_VERSION="${ALPINE_VERSION:-3.21}"
 
-# The oracle kernel resolves from its own Alpine release: 3.23 ships
-# linux-virt 6.18, the LTS line elfuse reports to the guest, while the
-# userland pins stay on ALPINE_VERSION. The linux-virt apk carries the
-# kernel and its lib/modules tree, so both move together.
+# The oracle kernel resolves from its own Alpine release: 3.23 ships linux-virt
+# 6.18, the LTS line elfuse reports to the guest, while the userland pins stay
+# on ALPINE_VERSION. The linux-virt apk carries the kernel and its lib/modules
+# tree, so both move together.
 KERNEL_ALPINE_VERSION="${KERNEL_ALPINE_VERSION:-3.23}"
+
 # Empty by default -- the exact point release is resolved from the live releases
 # listing at fetch time (see resolve_minirootfs), then written back here so the
 # x86_64 path reuses the same patch. Set explicitly to pin one.
@@ -252,6 +254,7 @@ resolve_versions()
         idxtgz="${CACHE}/APKINDEX-${repo}.tar.gz"
         idxfile="${CACHE}/APKINDEX-${repo}.versions"
         log "resolve versions ($repo)"
+
         # Always try to refresh the index -- tracking the live mirror is the
         # point -- but fall back to a cached copy so warm re-runs work offline.
         # APKINDEX records are blank-line separated; P: is the package name, V:
@@ -512,6 +515,7 @@ EOF
         log "stage dyn-bin aggregate"
         rm -rf "$dynbin"
         mkdir -p "$dynbin"
+
         # ${dynbin} is at <fixtures>/aarch64-musl/dyn-bin; rootfs is at
         # <fixtures>/rootfs. The relative path back is "../../rootfs/...".
         for sub in bin usr/bin; do

--- a/tests/hello.S
+++ b/tests/hello.S
@@ -1,11 +1,12 @@
-/* Minimal aarch64-linux assembly hello world
+/*
+ * Minimal aarch64-linux assembly hello world
  *
  * Copyright 2026 elfuse contributors
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Exercises Tier 1 syscalls: write(2) and exit(2).
- * Assemble and link as a static aarch64-linux ELF:
+ * Exercises Tier 1 syscalls: write(2) and exit(2). Assemble and link as a
+ * static aarch64-linux ELF:
  *   aarch64-unknown-linux-musl-as -o hello.o hello.S
  *   aarch64-unknown-linux-musl-ld -T simple.ld -o hello hello.o
  */

--- a/tests/host-test-util.h
+++ b/tests/host-test-util.h
@@ -24,8 +24,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-/* Pass/fail bookkeeping for the host lanes. Counters in a header are safe
- * here because each host binary is a single translation unit.
+/* Pass/fail bookkeeping for the host lanes. Counters in a header are safe here
+ * because each host binary is a single translation unit.
  */
 static int host_passes;
 static int host_fails;
@@ -57,10 +57,12 @@ static inline int host_summary(const char *name)
     return host_fails ? 1 : 0;
 }
 
-/* Make a scratch root named after @tag under @argv1, $TMPDIR, or /tmp, in
- * that order. Returns 0 with the path in @out, or -1 after reporting why
- * under @lane, the caller's argv[0]: in a CI log the failure line is the
- * only thing naming which test died, and the tag does not.
+/* Make a scratch root named after @tag under @argv1, $TMPDIR, or /tmp, in that
+ * order.
+ *
+ * Returns 0 with the path in @out, or -1 after reporting why under @lane, the
+ * caller's argv[0]: in a CI log the failure line is the only thing naming which
+ * test died, and the tag does not.
  */
 static inline int host_scratch_root(const char *lane,
                                     const char *tag,
@@ -116,14 +118,15 @@ static inline int utf8_put(char *o, unsigned cp)
  * a spelling that is not what is stored, so only asking for the name back can
  * tell "exists as spelled" from "exists under a spelling that folded onto it".
  * FSOPT_NOFOLLOW because a symlink's own name is the question, not its
- * target's. Returns a pointer to static storage, valid until the next call.
+ * target's.
+ *
+ * Returns a pointer to static storage, valid until the next call.
  *
  * The reply is bounds-checked before the reference and the name are read:
  * attr_dataoffset and attr_length come from the filesystem, and --sysroot may
  * name an SMB or NFS mount that need not fill them the way APFS does. This
- * mirrors casefold_attr_stored_name rather than calling it: of the three
- * lanes including this header, only test-casefold-walk-host links
- * casefold-walk.o.
+ * mirrors casefold_attr_stored_name rather than calling it: of the three lanes
+ * including this header, only test-casefold-walk-host links casefold-walk.o.
  */
 static inline const char *disk_name(const char *dir, const char *name)
 {
@@ -168,6 +171,7 @@ static inline const char *disk_name(const char *dir, const char *name)
         return NULL;
 
     const char *stored = (const char *) &buf + name_off;
+
     /* No NUL inside the declared length means the name is not a C string, and
      * "%s" would read past what the volume wrote.
      */

--- a/tests/lib/coreutils-common.sh
+++ b/tests/lib/coreutils-common.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Shared helpers for coreutils shell suites
 #
 # Copyright 2026 elfuse contributors

--- a/tests/lib/coreutils-suite.sh
+++ b/tests/lib/coreutils-suite.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Shared GNU coreutils suite definitions
 #
 # Copyright 2026 elfuse contributors
@@ -47,12 +48,13 @@ coreutils_suite_extended_text()
 coreutils_suite_basic_encoding()
 {
     coreutils_print_section "Encoding / hashing"
-    # Optional binaries (base32/basenc/sha224sum/sha384sum/b2sum/sum) are
-    # gated by test_skip_missing_tool inside run_check: when the wrapper
-    # sets TEST_SKIP_MISSING_TOOLS=1 they report SKIP with accounting,
-    # otherwise the missing binary surfaces as a hard FAIL. The previous
-    # raw "if [ -e ... ]; then" blocks bypassed both paths, silently
-    # erasing assertions whenever the binary was absent.
+
+    # Optional binaries (base32/basenc/sha224sum/sha384sum/b2sum/sum) are gated
+    # by test_skip_missing_tool inside run_check: when the wrapper sets
+    # TEST_SKIP_MISSING_TOOLS=1 they report SKIP with accounting, otherwise the
+    # missing binary surfaces as a hard FAIL. The previous raw "if [ -e ... ];
+    # then" blocks bypassed both paths, silently erasing assertions whenever the
+    # binary was absent.
     run_check base32 "NBSWY" "$TMPDIR/hello.txt"
     run_check base64 "aGVsbG8" "$TMPDIR/hello.txt"
     run_check basenc "aGVsbG8" "--base64" "$TMPDIR/hello.txt"
@@ -158,8 +160,9 @@ coreutils_suite_basic_math()
     run_check seq "5" "1" "5"
     run_check expr "3" "1" "+" "2"
     run_check factor "2 2 3" "12"
-    # numfmt is optional in some packages; rely on test_skip_missing_tool
-    # so absence becomes a SKIP under TEST_SKIP_MISSING_TOOLS=1 and a FAIL
+
+    # numfmt is optional in some packages; rely on test_skip_missing_tool so
+    # absence becomes a SKIP under TEST_SKIP_MISSING_TOOLS=1 and a FAIL
     # otherwise, rather than a silent omission.
     run_check numfmt "1\\.0[kK]" "--to=si" "1000"
 }

--- a/tests/lib/report.sh
+++ b/tests/lib/report.sh
@@ -2,18 +2,16 @@
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
-#
 # shellcheck shell=bash
-#
-# Sources tests/lib/test-runner.sh and exposes report_pass / report_fail
-# / report_skip on top of test_report so per-binary output matches the
-# matrix runner's aarch64 format ([ OK ] / [ FAIL ] / [ SKIP ] aligned
-# to TEST_LABEL_WIDTH). Each script still owns its pass/fail
-# /skip/total counters; this lib only centralizes the report sites and
-# the trailing Results: summary line that tests/test-matrix.sh scrapes.
+# Sources tests/lib/test-runner.sh and exposes report_pass / report_fail /
+# report_skip on top of test_report so per-binary output matches the matrix
+# runner's aarch64 format ([ OK ] / [ FAIL ] / [ SKIP ] aligned to
+# TEST_LABEL_WIDTH). Each script still owns its pass/fail /skip/total counters;
+# this lib only centralizes the report sites and the trailing Results: summary
+# line that tests/test-matrix.sh scrapes.
 
-# Align the LABEL column with tests/test-matrix.sh so the aggregated
-# matrix output looks uniform across aarch64 and x86_64 modes.
+# Align the LABEL column with tests/test-matrix.sh so the aggregated matrix
+# output looks uniform across aarch64 and x86_64 modes.
 : "${TEST_LABEL_WIDTH:=45}"
 
 _report_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -21,9 +19,9 @@ _report_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${_report_lib_dir}/test-runner.sh"
 
 # report_pass / report_fail / report_skip accept a single label argument
-# matching the original Rosetta helpers' single-string contract; the
-# whole label (including any embedded "rc=..." detail) is shown in the
-# LABEL column so existing call sites do not need a manual split.
+# matching the original Rosetta helpers' single-string contract; the whole label
+# (including any embedded "rc=..." detail) is shown in the LABEL column so
+# existing call sites do not need a manual split.
 
 report_pass()
 {
@@ -44,10 +42,9 @@ report_skip()
 }
 
 # Emit the canonical Results line that tests/test-matrix.sh's
-# suite_summary_fields regex consumes. Optional first argument
-# overrides the (of N) field when the script tracks total
-# independently of pass+fail+skip (the existing Rosetta scripts
-# do, because in-script skips do not bump total).
+# suite_summary_fields regex consumes. Optional first argument overrides the (of
+# N) field when the script tracks total independently of pass+fail+skip (the
+# existing Rosetta scripts do, because in-script skips do not bump total).
 report_summary()
 {
     local total="${1:-$((pass + fail + skip))}"
@@ -56,11 +53,10 @@ report_summary()
         "$pass" "$fail" "$skip" "$total"
 }
 
-# Locate timeout(1) on macOS hosts: not built in, but Homebrew coreutils
-# ships it as 'timeout' (and the legacy 'gtimeout' alias). Sets the
-# TIMEOUT shell variable in the caller. On failure, prints an install
-# hint and exits 77 (suite-skip), matching what every per-script copy
-# of this block used to do.
+# Locate timeout(1) on macOS hosts: not built in, but Homebrew coreutils ships
+# it as 'timeout' (and the legacy 'gtimeout' alias). Sets the TIMEOUT shell
+# variable in the caller. On failure, prints an install hint and exits 77
+# (suite-skip), matching what every per-script copy of this block used to do.
 require_timeout()
 {
     TIMEOUT="$(command -v timeout 2> /dev/null \

--- a/tests/lib/test-runner.sh
+++ b/tests/lib/test-runner.sh
@@ -97,6 +97,7 @@ test_report()
         fail) printf "%s [ ${RED}FAIL${RESET} ]%s\n" "$name" "$detail" ;;
         skip) printf "%s [ ${YELLOW}SKIP${RESET} ]%s\n" "$name" "$detail" ;;
         xfail) printf "%s [ ${YELLOW}XFAIL${RESET} ]%s\n" "$name" "$detail" ;;
+
         # No bracketed verdict, because the test has not been decided yet and
         # every other state here is one the summary counts. The blanks are as
         # wide as the FAIL and SKIP tags, which is the closest a single width
@@ -183,6 +184,7 @@ run()
     # file so the first attempt's stack, taken in the state that produced the
     # timeout, survives.
     if [ "$harness_timed_out" -eq 1 ] && test_host_is_busy; then
+
         # Informational, not a verdict: the test has not been decided yet, so
         # this must not advance the skip counter the summary reports.
         test_report info "$tool" " (timeout under host load; re-running)"

--- a/tests/linux-openat2.h
+++ b/tests/linux-openat2.h
@@ -4,10 +4,10 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The cross toolchains that build the guest tests predate openat2 in their
- * libc headers, so the syscall number, struct open_how, and the RESOLVE_*
- * flags (include/uapi/linux/openat2.h) are spelled here once for every test
- * that calls the syscall raw.
+ * The cross toolchains that build the guest tests predate openat2 in their libc
+ * headers, so the syscall number, struct open_how, and the RESOLVE_* flags
+ * (include/uapi/linux/openat2.h) are spelled here once for every test that
+ * calls the syscall raw.
  */
 
 #pragma once
@@ -28,8 +28,8 @@ struct open_how {
 
 /* Linux's symlink budget (MAXSYMLINKS, include/linux/namei.h) counts links
  * actually followed; a link-free path has no component limit at all
- * (path_resolution(7)). Tests size their directory chains against it to
- * expose a walker that charges the budget once per component instead. Not
- * named MAXSYMLINKS because glibc claims that name in sys/param.h.
+ * (path_resolution(7)). Tests size their directory chains against it to expose
+ * a walker that charges the budget once per component instead. Not named
+ * MAXSYMLINKS because glibc claims that name in sys/param.h.
  */
 #define WALK_MAXSYMLINKS 40

--- a/tests/probe-volume-naming.c
+++ b/tests/probe-volume-naming.c
@@ -55,8 +55,9 @@ static const char *verdict(const char *dir, const char *name)
 
     if (!d)
         return errno == ENOENT || errno == ENOTDIR ? "ABSENT" : "ERROR";
-    /* The probe reports the leaf's stored spelling, so compare against the
-     * leaf of what was asked for and not against the whole relative path.
+
+    /* The probe reports the leaf's stored spelling, so compare against the leaf
+     * of what was asked for and not against the whole relative path.
      */
     return !strcmp(d, leaf ? leaf + 1 : name) ? "EXACT" : "FOLDED";
 }

--- a/tests/qemu-runner.sh
+++ b/tests/qemu-runner.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
+
 # qemu-runner.sh -- Boot qemu-system-aarch64 with the elfuse test fixtures
 # initramfs and provide qemu_exec() for command execution over ssh.
 #
-# Sourced by tests/test-matrix.sh (for the qemu-aarch64 mode) but also
-# usable interactively:
+# Sourced by tests/test-matrix.sh (for the qemu-aarch64 mode) but also usable
+# interactively:
 #   . tests/qemu-runner.sh
 #   qemu_start
 #   qemu_exec uname -a
 #   qemu_stop
 #
-# The booted VM mounts the host repo root at /mnt/host via virtio-9p,
-# so any path under the repo is reachable from the VM as
-# /mnt/host/<relative-path>.
+# The booted VM mounts the host repo root at /mnt/host via virtio-9p, so any
+# path under the repo is reachable from the VM as /mnt/host/<relative-path>.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -23,10 +23,11 @@ QEMU_BIN="${QEMU_BIN:-qemu-system-aarch64}"
 QEMU_PORT="${QEMU_PORT:-2222}"
 QEMU_MEM="${QEMU_MEM:-2048}"
 QEMU_SMP="${QEMU_SMP:-4}"
+
 # Accelerator + CPU model are auto-selected at qemu_start time: HVF + cpu=host
 # on Apple Silicon when the qemu build supports it, otherwise TCG + cortex-a72
-# (slower but portable to non-aarch64 hosts and qemu builds without HVF).
-# Either can be forced via QEMU_ACCEL=tcg / QEMU_CPU=cortex-a72.
+# (slower but portable to non-aarch64 hosts and qemu builds without HVF). Either
+# can be forced via QEMU_ACCEL=tcg / QEMU_CPU=cortex-a72.
 QEMU_ACCEL="${QEMU_ACCEL:-}"
 QEMU_CPU="${QEMU_CPU:-}"
 QEMU_BOOT_TIMEOUT="${QEMU_BOOT_TIMEOUT:-90}"
@@ -65,8 +66,8 @@ qemu_ensure_fixtures()
     done
 }
 
-# Pick a free localhost TCP port for ssh forwarding (avoids collisions
-# when several test-matrix runs overlap or QEMU_PORT is in use).
+# Pick a free localhost TCP port for ssh forwarding (avoids collisions when
+# several test-matrix runs overlap or QEMU_PORT is in use).
 qemu_pick_port()
 {
     if command -v python3 > /dev/null 2>&1; then
@@ -160,17 +161,17 @@ qemu_start()
     done
 
     # The Alpine initramfs keeps /tmp on "rootfs", which busybox df cannot
-    # resolve to a /proc/mounts entry ("df: ...: can't find mount point").
-    # Mount a dedicated tmpfs, as any regular system has, so paths under
-    # /tmp map to a resolvable st_dev. Guarded so a repeated qemu_start
-    # against a running VM does not stack mounts.
+    # resolve to a /proc/mounts entry ("df: ...: can't find mount point"). Mount
+    # a dedicated tmpfs, as any regular system has, so paths under /tmp map to a
+    # resolvable st_dev. Guarded so a repeated qemu_start against a running VM
+    # does not stack mounts.
     _qemu_ssh_raw 'grep -q " /tmp tmpfs " /proc/mounts || mount -t tmpfs tmpfs /tmp'
 }
 
-# Each call opens a fresh ssh connection.  Avoids ControlMaster pitfalls
-# (master dying mid-suite cascades rc=255 to every later command) at the
-# cost of ~100ms handshake overhead per call -- a flat ~15s across the
-# full matrix, well within the suite's tolerance.
+# Each call opens a fresh ssh connection. Avoids ControlMaster pitfalls (master
+# dying mid-suite cascades rc=255 to every later command) at the cost of ~100ms
+# handshake overhead per call -- a flat ~15s across the full matrix, well within
+# the suite's tolerance.
 _qemu_ssh_raw()
 {
     ssh -o StrictHostKeyChecking=no \
@@ -185,11 +186,11 @@ _qemu_ssh_raw()
         root@127.0.0.1 "$@"
 }
 
-# Run a command in the VM.  Any argument that is an absolute path under the
-# host repo root is rewritten to its /mnt/host/... in-VM equivalent so the
-# guest can dereference it through the virtio-9p share.  Cwd is forced to
-# /mnt/host so test arguments using paths like "tests/foo" work the same
-# as they do when run on the macOS host.
+# Run a command in the VM. Any argument that is an absolute path under the host
+# repo root is rewritten to its /mnt/host/... in-VM equivalent so the guest can
+# dereference it through the virtio-9p share. Cwd is forced to /mnt/host so test
+# arguments using paths like "tests/foo" work the same as they do when run on
+# the macOS host.
 qemu_exec()
 {
     local args=() a
@@ -229,8 +230,8 @@ qemu_stop()
 }
 
 # When sourced, register a cleanup trap that does not clobber the caller's
-# existing trap chain.  When executed directly, the EXIT trap fires on
-# script exit.
+# existing trap chain. When executed directly, the EXIT trap fires on script
+# exit.
 trap 'qemu_stop' EXIT
 
 # CLI driver: when run directly, support 'qemu-runner.sh start|exec|stop'.

--- a/tests/test-absock-cleanup.c
+++ b/tests/test-absock-cleanup.c
@@ -29,8 +29,8 @@
  *
  * Needs a plain-dir sysroot on a case-insensitive volume: the four escaped
  * levels below push the host path past the 104-byte macOS sun_path so the
- * shortening link is actually created, while the guest spelling stays under
- * the 108-byte Linux limit.
+ * shortening link is actually created, while the guest spelling stays under the
+ * 108-byte Linux limit.
  */
 
 #include <errno.h>
@@ -95,8 +95,8 @@ static int bind_abstract(const char *name, size_t len)
  * bound and listening. The root cannot report the outcome because it must exit
  * first, and the child cannot report it through the exit status either, since
  * the runtime reports the root's. It prints a marker line the recipe greps for;
- * a verdict file would be stored escaped and unreadable by name from the
- * host side.
+ * a verdict file would be stored escaped and unreadable by name from the host
+ * side.
  */
 static int owner_sweep_mode(void)
 {
@@ -148,13 +148,13 @@ static int owner_sweep_mode(void)
 /* Namespace-outlives-owner: the root creates the namespace dir and exits; a
  * child that already touched the namespace (so its "directory exists" flag is
  * cached) then binds an over-long socket. The root's last-one-out rmdir has
- * removed the directory by then, so the mint must notice and recreate it
- * rather than fail with ENOENT, and the child's own exit must unlink the link
- * it minted, or the link (and with it the directory) leaks forever: no later
+ * removed the directory by then, so the mint must notice and recreate it rather
+ * than fail with ENOENT, and the child's own exit must unlink the link it
+ * minted, or the link (and with it the directory) leaks forever: no later
  * process is the namespace owner. The recipe's before/after directory count
- * catches the leak; the marker line reports the mint. Same reporting scheme
- * as owner_sweep_mode(): the root must exit first, so the child prints and
- * the recipe greps.
+ * catches the leak; the marker line reports the mint. Same reporting scheme as
+ * owner_sweep_mode(): the root must exit first, so the child prints and the
+ * recipe greps.
  */
 static int child_after_owner_mode(void)
 {
@@ -173,8 +173,8 @@ static int child_after_owner_mode(void)
         close(gone[1]);
 
         /* Touch the namespace while the root is alive, so this process caches
-         * the directory as created; close right away so the root's rmdir
-         * finds the directory empty and the cached flag really goes stale.
+         * the directory as created; close right away so the root's rmdir finds
+         * the directory empty and the cached flag really goes stale.
          */
         int warm = bind_abstract(CHILD_ABS, sizeof(CHILD_ABS) - 1);
         bool ok = warm >= 0;
@@ -209,8 +209,9 @@ static int child_after_owner_mode(void)
     char b;
     if (read(ready[0], &b, 1) != 1)
         return 1;
-    /* exit(), not _exit(): the rmdir that strands the child is an atexit
-     * hook, and the scenario needs it to have really run.
+
+    /* exit(), not _exit(): the rmdir that strands the child is an atexit hook,
+     * and the scenario needs it to have really run.
      */
     exit(0);
 }

--- a/tests/test-absock-names-host.c
+++ b/tests/test-absock-names-host.c
@@ -4,19 +4,19 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Over-long pathname AF_UNIX socket paths and long abstract names both derive
- * a short filename from a digest, and absock_shorten_path treats a same-named
- * link whose target differs as stale and repoints it. A digest narrow enough
- * to collide in practice therefore aims one socket's live link at another's
+ * Over-long pathname AF_UNIX socket paths and long abstract names both derive a
+ * short filename from a digest, and absock_shorten_path treats a same-named
+ * link whose target differs as stale and repoints it. A digest narrow enough to
+ * collide in practice therefore aims one socket's live link at another's
  * target, which is cross-socket misdirection, not a cosmetic clash. The old
  * 32-bit tail collides at the birthday bound of ~2^16 names, cheap enough to
  * brute-force below; the 64-bit tail must tell such a pair apart.
  *
  * Code under test: absock_encode_name and absock_link_name in
- * src/syscall/net-absock.c, through the header's unit-test seam; no real
- * volume can be made to produce the collision on demand, so the naming
- * functions are fed directly. A regression narrows the digest or truncates it
- * out of the name.
+ * src/syscall/net-absock.c, through the header's unit-test seam; no real volume
+ * can be made to produce the collision on demand, so the naming functions are
+ * fed directly. A regression narrows the digest or truncates it out of the
+ * name.
  *
  * What a pass does not prove: 64-bit collisions still exist at their own
  * birthday bound (~2^32 names); the guarantee bought here is the width, not
@@ -98,8 +98,8 @@ static uint32_t fnv1a32(const char *s)
 }
 
 /* All candidates share this 20-byte prefix, mimicking two sockets under one
- * sysroot: the literal prefix bytes of the derived name are then identical,
- * so the digest tail carries all of the distinction.
+ * sysroot: the literal prefix bytes of the derived name are then identical, so
+ * the digest tail carries all of the distinction.
  */
 #define SHARED_PREFIX "/Shared.Sysroot.Pre/"
 
@@ -123,8 +123,8 @@ static void spell_candidate(uint32_t idx, char *out, size_t outsz)
      * fixed-position window stay collision-free far past the birthday bound,
      * because FNV-1a mixes so little that the window maps near-injectively.
      * Varying the length moves every later byte's position instead. The
-     * shortest candidate is still well past the hex tier, so the digest
-     * branch is the one exercised.
+     * shortest candidate is still well past the hex tier, so the digest branch
+     * is the one exercised.
      */
     char pad[24];
     size_t pad_len = idx % 23;
@@ -138,8 +138,8 @@ static void spell_candidate(uint32_t idx, char *out, size_t outsz)
 
 /* Find two distinct strings, sharing the 20-byte prefix, whose 32-bit FNV-1a
  * over the whole string collides. ~2^16 uniformly hashed candidates reach the
- * birthday bound; 400k found one at ~207k when this was written, so failing
- * to find one signals the generator regressed, not bad luck.
+ * birthday bound; 400k found one at ~207k when this was written, so failing to
+ * find one signals the generator regressed, not bad luck.
  */
 static bool find_fnv32_collision(char *a, char *b, size_t bufsz)
 {
@@ -202,8 +202,8 @@ int main(void)
     host_check(strlen(name_a) < 104, "link budget",
                "link name must fit sun_path");
 
-    /* Pid scoping: the marker that makes every exit-time unlink provably of
-     * the process's own property.
+    /* Pid scoping: the marker that makes every exit-time unlink provably of the
+     * process's own property.
      */
     {
         char marker[32];
@@ -213,8 +213,8 @@ int main(void)
                    "link name must embed the minting pid");
     }
 
-    /* The digest never truncates: with a tight buffer the literal prefix
-     * gives way, and the 16-hex-digit tail survives in full.
+    /* The digest never truncates: with a tight buffer the literal prefix gives
+     * way, and the 16-hex-digit tail survives in full.
      */
     {
         char tight[64];

--- a/tests/test-busybox.sh
+++ b/tests/test-busybox.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-busybox.sh -- Busybox 1.37.0 applet smoke tests for elfuse
 #
 # Copyright 2026 elfuse contributors
@@ -38,19 +39,20 @@ test_tool_path()
 }
 
 # Probe which applets this busybox binary actually carries. The Debian
-# busybox-static drops a handful of applets (e.g. comm) compared to a
-# full build, and tests for them must skip rather than fail. Hard-fail
-# the whole suite if the probe itself fails so a broken elfuse/busybox
-# does not silently degrade to "all SKIP".
+# busybox-static drops a handful of applets (e.g. comm) compared to a full
+# build, and tests for them must skip rather than fail. Hard-fail the whole
+# suite if the probe itself fails so a broken elfuse/busybox does not silently
+# degrade to "all SKIP".
 if ! _bb_list=$(timeout "$TEST_TIMEOUT" "$ELFUSE" "$BB" --list 2>&1); then
     printf "test-busybox: probing '%s --list' under elfuse failed:\n%s\n" \
         "$BB" "$_bb_list" >&2
     exit 1
 fi
 BB_APPLETS=" $(printf '%s\n' "$_bb_list" | tr '\n' ' ') "
-# Sanity: a usable busybox should expose at least one of these common
-# applets. A reduced build may legitimately omit sh, so accept any of
-# the small universal set; only fail if --list produced nothing usable.
+
+# Sanity: a usable busybox should expose at least one of these common applets. A
+# reduced build may legitimately omit sh, so accept any of the small universal
+# set; only fail if --list produced nothing usable.
 case "$BB_APPLETS" in
     *" sh "* | *" echo "* | *" cat "* | *" ls "* | *" true "*) ;;
     *)
@@ -259,11 +261,12 @@ run_check find "hello.txt" "$TMPDIR" "-name" "hello.txt"
 # Networking
 printf '\n%s── Networking ──%s\n' "$BLUE" "$RESET"
 run_check nslookup "Address" "example.com"
+
 # wget pulls a real document from example.com. In sandboxed CI / corporate
-# networks where outbound HTTP is filtered, this fails with "No route to
-# host" through no fault of busybox itself. Probe TCP reachability from
-# the host first and skip cleanly rather than report a misleading failure.
-# /dev/tcp/host/port is bash-specific; nc -z is more portable here.
+# networks where outbound HTTP is filtered, this fails with "No route to host"
+# through no fault of busybox itself. Probe TCP reachability from the host first
+# and skip cleanly rather than report a misleading failure. /dev/tcp/host/port
+# is bash-specific; nc -z is more portable here.
 if nc -z -w 2 example.com 80 2> /dev/null; then
     run_check wget "Example" "-q" "-O" "-" "http://example.com/"
 else

--- a/tests/test-case-collision.c
+++ b/tests/test-case-collision.c
@@ -7,8 +7,8 @@
  * Names that a case-folding volume would merge must stay separate files to the
  * guest, and every syscall that names a file has to agree about which one it
  * means. This walks the whole surface (open, rename, renameat2 with EXCHANGE
- * and NOREPLACE, linkat, symlinkat, getdents64, statx, xattr) against a set
- * of names differing only in case.
+ * and NOREPLACE, linkat, symlinkat, getdents64, statx, xattr) against a set of
+ * names differing only in case.
  *
  * Code under test: the resolver in src/syscall/casefold-walk.c reached through
  * src/syscall/path.c. A regression shows up as two guest names resolving to one
@@ -147,10 +147,10 @@ static int getdents_contains_after_partial(const char *dir_path,
 }
 
 /* One linkat case over a symlink: create @target_name, point @link_name at it
- * (spelled relative or absolute by @absolute_target), and hard-link the
- * symlink with @flags. @expect_link says which node the new name must be: the
- * link itself without AT_SYMLINK_FOLLOW, the target with it. The hard-link
- * names are case-protected, so on a folding sysroot every case exercises the
+ * (spelled relative or absolute by @absolute_target), and hard-link the symlink
+ * with @flags. @expect_link says which node the new name must be: the link
+ * itself without AT_SYMLINK_FOLLOW, the target with it. The hard-link names are
+ * case-protected, so on a folding sysroot every case exercises the
  * escaped-create path through linkat rather than through open.
  */
 static void check_linkat(const char *base,
@@ -424,17 +424,16 @@ int main(void)
         }
     }
 
-    /* AT_SYMLINK_FOLLOW hard-links what the symlink points at, so the result
-     * is a regular file; without it linkat(2) links the symlink itself, and
-     * that holds for an absolute target too: nothing has to resolve the
-     * target to copy the link.
+    /* AT_SYMLINK_FOLLOW hard-links what the symlink points at, so the result is
+     * a regular file; without it linkat(2) links the symlink itself, and that
+     * holds for an absolute target too: nothing has to resolve the target to
+     * copy the link.
      *
      * The followed target is spelled relative in one case and absolute in the
      * other: a symlink stores the bytes the guest wrote, so the two spellings
      * reach the target through different resolution paths (the relative one
      * against the translated parent, the absolute one through the
-     * guest-namespace splice), and only running both shows linkat follows
-     * each.
+     * guest-namespace splice), and only running both shows linkat follows each.
      */
     TEST("linkat AT_SYMLINK_FOLLOW links the target, not the symlink");
     check_linkat(base, "real-target", "real-link", "REAL-HARD", false,

--- a/tests/test-casefold-host.c
+++ b/tests/test-casefold-host.c
@@ -19,9 +19,9 @@
  *
  * Code under test: src/syscall/casefold.c. A regression shows up as a guest
  * name that comes back as a different name, two distinct names sharing one
- * encoding, or a name elfuse emits that the volume then refuses to create.
- * Each of those would surface inside a guest much later as a missing or a
- * wrong file.
+ * encoding, or a name elfuse emits that the volume then refuses to create. Each
+ * of those would surface inside a guest much later as a missing or a wrong
+ * file.
  *
  * Native macOS binary; no HVF entitlement needed.
  */
@@ -44,9 +44,9 @@
 #include "host-test-util.h"
 #include "syscall/casefold.h"
 
-/* True when @s is well-formed UTF-8: no overlong forms, no surrogates,
- * nothing above U+10FFFF. APFS refuses to create a name that is not, so an
- * ill-formed name has to be escaped rather than stored.
+/* True when @s is well-formed UTF-8: no overlong forms, no surrogates, nothing
+ * above U+10FFFF. APFS refuses to create a name that is not, so an ill-formed
+ * name has to be escaped rather than stored.
  */
 static bool casefold_utf8_valid(const char *s)
 {
@@ -84,10 +84,10 @@ static bool casefold_utf8_valid(const char *s)
             cp = (cp << 6) | (cc & 0x3Fu);
         }
 
-        /* Reject the forms that encode a code point in more bytes than
-         * needed, the UTF-16 surrogate range, and anything past the Unicode
-         * maximum. Each has more than one byte sequence otherwise, which
-         * would break the one-spelling-per-name property.
+        /* Reject the forms that encode a code point in more bytes than needed,
+         * the UTF-16 surrogate range, and anything past the Unicode maximum.
+         * Each has more than one byte sequence otherwise, which would break the
+         * one-spelling-per-name property.
          */
         if (extra == 2 && cp < 0x800u)
             return false;
@@ -197,6 +197,7 @@ static void check_not_escaped(const char *label, const char *host)
         dump("host", host);
         return;
     }
+
     /* An unrecognized shape must pass through as itself, or a listing would
      * report a name the guest cannot open.
      */
@@ -254,10 +255,10 @@ static void fill(char *buf, size_t n, char c)
 
 /* The frozen table is the one check that fails when the format moves: every
  * other section reads its expectations back through the codec, so a
- * self-consistent format change keeps them green while orphaning every
- * sysroot already on disk. Each escaped row is asserted byte-exact in both
- * directions; a red row here means the on-disk format broke, and the remedy
- * is a format migration, not a new literal.
+ * self-consistent format change keeps them green while orphaning every sysroot
+ * already on disk. Each escaped row is asserted byte-exact in both directions;
+ * a red row here means the on-disk format broke, and the remedy is a format
+ * migration, not a new literal.
  */
 static void section_golden(void)
 {
@@ -433,6 +434,7 @@ static void section_shapes(void)
     check_not_escaped("decodes to dotdot", ".ef=2e2e");
     check_not_escaped("decodes to an embedded NUL", ".ef=610062");
     check_not_escaped("empty decode", ".ef=");
+
     /* U+4E00 is a payload symbol, but a lone one is not a valid frame: the
      * first symbol carries a length, and 0 is not a legal name length.
      */
@@ -595,6 +597,7 @@ static void section_i18n(void)
         char a[CASEFOLD_HOST_NAME_MAX + 1];
         if (!casefold_needs_escape(i18n_corpus[i]))
             continue;
+
         /* An encoder that refused these names would skip every comparison and
          * reach the host_ok() below having proved nothing, so a refusal is the
          * failure rather than a reason to move on.
@@ -744,11 +747,12 @@ static void section_accept(const char *root)
             } else {
                 snprintf(host, sizeof(host), "%s", names[k]);
             }
-            /* EEXIST is a failure, not a tolerated outcome. Every name in
-             * this sweep is distinct, so a second create landing on an entry
-             * that is already there means two guest names reached one slot,
-             * precisely the collision the encoding exists to prevent, and
-             * exactly what tolerating EEXIST would hide.
+
+            /* EEXIST is a failure, not a tolerated outcome. Every name in this
+             * sweep is distinct, so a second create landing on an entry that is
+             * already there means two guest names reached one slot, precisely
+             * the collision the encoding exists to prevent, and exactly what
+             * tolerating EEXIST would hide.
              */
             rc = create_in(dir, host);
             if (rc < 0) {
@@ -828,8 +832,8 @@ static void section_accept(const char *root)
 }
 
 /* The three volume behaviors the resolver is built on. If a macOS release
- * changes any of them the design needs revisiting, so each gets its own
- * message rather than a generic assertion failure.
+ * changes any of them the design needs revisiting, so each gets its own message
+ * rather than a generic assertion failure.
  */
 static void section_volume(const char *root)
 {

--- a/tests/test-casefold-walk-host.c
+++ b/tests/test-casefold-walk-host.c
@@ -249,14 +249,14 @@ static void section_symlink(void)
           "link.to.lowdir");
 
     /* A link the walk does have to pass through stops it, and the walk says so
-     * rather than letting the host follow the stored bytes: those name a
-     * guest path, whose components may be escaped and whose absolute form
-     * starts at the sysroot, so the host would look somewhere else. The caller
-     * resolves the target in the guest namespace and comes back.
+     * rather than letting the host follow the stored bytes: those name a guest
+     * path, whose components may be escaped and whose absolute form starts at
+     * the sysroot, so the host would look somewhere else. The caller resolves
+     * the target in the guest namespace and comes back.
      *
-     * link_rest_offset points at what is left to resolve, and
-     * link_guest_offset at the link itself, so a relative target can be joined
-     * to the directory holding it.
+     * link_rest_offset points at what is left to resolve, and link_guest_offset
+     * at the link itself, so a relative target can be joined to the directory
+     * holding it.
      */
     static const char through_link[] = "/link.to.lowdir/inner.txt";
     if (casefold_resolve_at(AT_FDCWD, root, through_link, false, out,
@@ -287,12 +287,11 @@ static void section_symlink(void)
         host_fail("following a dangling link stops at the link",
                   "expected CASEFOLD_SYMLINK with nothing left to resolve");
 
-    /* A second hard link to a symlink is that same link under another name,
-     * and it resolves by the name the caller used. The volume reports the
-     * primary link's name for such an entry, so a probe that trusts the
-     * reported spelling alone rules it a fold and the walk reports absent,
-     * which is how linkat(2) of a symlink produced an entry lstat could not
-     * see.
+    /* A second hard link to a symlink is that same link under another name, and
+     * it resolves by the name the caller used. The volume reports the primary
+     * link's name for such an entry, so a probe that trusts the reported
+     * spelling alone rules it a fold and the walk reports absent, which is how
+     * linkat(2) of a symlink produced an entry lstat could not see.
      */
     check("fold-stable second link to a symlink", "/second-link",
           CASEFOLD_FOUND, "second-link");
@@ -301,8 +300,8 @@ static void section_symlink(void)
 
     /* Same entry, asked about the report rather than the spelling. A directory
      * listing carries no object type, so a walk the fallback answered cannot
-     * claim to know the leaf's, and the NO_XDEV walker skips its own fstatat
-     * on the strength of that flag.
+     * claim to know the leaf's, and the NO_XDEV walker skips its own fstatat on
+     * the strength of that flag.
      */
     if (casefold_resolve_at(AT_FDCWD, root, "/second-link", false, out,
                             sizeof(out), &walk) == CASEFOLD_FOUND &&
@@ -400,9 +399,9 @@ static void section_limits(void)
 }
 
 /* Forged getattrlist replies. No real volume produces these here, and
- * getattrlist(2) documents that a truncated reply can reference data beyond
- * the buffer, so the bounds check is exercised directly rather than through
- * the filesystem. Code under test: casefold_attr_stored_name(). A regression
+ * getattrlist(2) documents that a truncated reply can reference data beyond the
+ * buffer, so the bounds check is exercised directly rather than through the
+ * filesystem. Code under test: casefold_attr_stored_name(). A regression
  * dereferences the kernel-claimed offset unchecked and, on a volume that
  * misbehaves (an SMB or NFS --sysroot), reads past the probe's stack buffer.
  */
@@ -471,8 +470,8 @@ static void section_reply_bounds(void)
         host_fail("reply bounds",
                   "reference beyond the claimed length accepted");
 
-    /* A claimed length larger than the buffer must be capped at the buffer:
-     * the kernel never writes more than attrBufSize, whatever length says.
+    /* A claimed length larger than the buffer must be capped at the buffer: the
+     * kernel never writes more than attrBufSize, whatever length says.
      */
     f.length = (u_int32_t) sizeof(f) + 64;
     f.name_ref.attr_length = (u_int32_t) sizeof(f);

--- a/tests/test-chown-overlay.c
+++ b/tests/test-chown-overlay.c
@@ -200,6 +200,7 @@ static void test_open_removed_dir_keeps_overlay_until_last_close(void)
 static void test_lchown_on_symlink(void)
 {
     TEST("lchown(link) leaves target unchanged");
+
     /* Reset target ownership through the existing path so test ordering does
      * not leak overrides from earlier asserts.
      */

--- a/tests/test-comprehensive.c
+++ b/tests/test-comprehensive.c
@@ -49,8 +49,9 @@ int main(int argc, char *argv[])
     /* x86_64 test binary: uname returns "x86_64" */
     CHECK(!strcmp(uts.machine, "x86_64"), "machine == x86_64");
 #endif
-    /* elfuse pins its reported release to the 6.18 LTS baseline. Under the
-     * qemu reference lane the kernel is a real one and reports its own.
+
+    /* elfuse pins its reported release to the 6.18 LTS baseline. Under the qemu
+     * reference lane the kernel is a real one and reports its own.
      */
     if (!strcmp(uts.nodename, "elfuse")) {
         int major = 0, minor = 0;

--- a/tests/test-config-cli.sh
+++ b/tests/test-config-cli.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Verify test-config.sh distinguishes execution from sourcing.
 #
 # Copyright 2026 elfuse contributors
@@ -27,9 +28,9 @@ if [ "$direct" != "$expected" ]; then
     exit 1
 fi
 
-# A sourced helper must not interpret the caller's positional parameters as
-# its own. This reproduces the collision that previously printed an extra
-# line when the caller's first argument was --host-nofile.
+# A sourced helper must not interpret the caller's positional parameters as its
+# own. This reproduces the collision that previously printed an extra line when
+# the caller's first argument was --host-nofile.
 sourced="$(CONFIG_PATH="$CONFIG" env -u ELFUSE_HOST_NOFILE_MIN bash -c '
     set -e
     set -- --host-nofile

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+
 # Shared test limits derived from the runtime's capacity header.
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Source this file from a test runner, or invoke it with --host-nofile to print
-# the computed minimum for a Make recipe.  Keeping the arithmetic here derived
+# the computed minimum for a Make recipe. Keeping the arithmetic here derived
 # from src/elfuse-limits.h prevents shell and Make callers from drifting away
 # from the values compiled into elfuse.
 
@@ -58,9 +59,9 @@ elfuse_resolve_host_nofile()
     esac
 }
 
-# Read the host-limit annotation for a test from the manifest.  The matrix
-# runner and the data-driven driver therefore use the same metadata instead of
-# growing independent name-qualified branches.
+# Read the host-limit annotation for a test from the manifest. The matrix runner
+# and the data-driven driver therefore use the same metadata instead of growing
+# independent name-qualified branches.
 elfuse_test_host_nofile()
 {
     local manifest="$1"
@@ -82,8 +83,8 @@ elfuse_test_host_nofile()
 
 # A sourced configuration inherits the caller's positional parameters. Only
 # inspect --host-nofile when this file itself is the executed script; otherwise
-# a test runner whose first argument happens to match the CLI flag would emit
-# an unexpected value while being initialized.
+# a test runner whose first argument happens to match the CLI flag would emit an
+# unexpected value while being initialized.
 if [ "$_test_config_script" = "$0" ] \
     && [ "${1:-}" = "--host-nofile" ]; then
     printf '%s\n' "$ELFUSE_HOST_NOFILE_MIN"

--- a/tests/test-coreutils.sh
+++ b/tests/test-coreutils.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
+
 # test-coreutils.sh -- GNU coreutils integration suite for elfuse
 #
 # Copyright 2026 elfuse contributors
 # Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
 # SPDX-License-Identifier: Apache-2.0
-#
 # shellcheck disable=SC1091,SC2034,SC2059,SC2154
-#
 # Shared entry point for both smoke and full coreutils coverage.
 #
 # Usage: tests/test-coreutils.sh <elfuse-binary> <coreutils-bin-dir> [sysroot]
-# Example: tests/test-coreutils.sh build/elfuse /path/to/coreutils/bin /path/to/sysroot
+# Example: tests/test-coreutils.sh build/elfuse /path/to/coreutils/bin
+# /path/to/sysroot
 
 set -euo pipefail
 

--- a/tests/test-cross-fork-mapshared.c
+++ b/tests/test-cross-fork-mapshared.c
@@ -145,6 +145,7 @@ static void test_file_backed_cross_fork(void)
         FAIL("mkstemp");
         return;
     }
+
     /* Keep the file present so child can re-open via /proc semantics is
      * unnecessary -- the child inherits fd from CLOEXEC=off and we map via the
      * inherited fd. Unlink keeps the file on the FS but invisible via path;

--- a/tests/test-dev-shm-paths.c
+++ b/tests/test-dev-shm-paths.c
@@ -6,8 +6,8 @@
  *
  * Every path syscall must resolve /dev/shm/<name> to the same per-UID host
  * backing object that open() creates. The regression: LTP's setup_ipc
- * (lib/tst_test.c) does open(O_CREAT|O_EXCL) then chmod() on a /dev/shm path;
- * a split resolution turns the chmod into ENOENT and aborts every test.
+ * (lib/tst_test.c) does open(O_CREAT|O_EXCL) then chmod() on a /dev/shm path; a
+ * split resolution turns the chmod into ENOENT and aborts every test.
  *
  * The containment half checks that no shm op follows a symlink planted at a
  * leaf: the backing store is a host directory, so a followed link escapes onto
@@ -55,7 +55,8 @@ static char fixture_suffix[16];
 
 /* Guest PIDs restart from the same value in each independent elfuse process.
  * Reserve a host-unique suffix so concurrent runtime jobs cannot unlink or
- * replace one another's /dev/shm fixtures. */
+ * replace one another's /dev/shm fixtures.
+ */
 static int name_fixtures(void)
 {
     char seed[] = "/tmp/elfuse-shm-seed-XXXXXX";
@@ -211,6 +212,7 @@ static void test_statfs_root_reports_tmpfs(void)
         FAIL("/dev/shm statfs is not TMPFS_MAGIC");
         return;
     }
+
     /* A trailing slash names the same mount root (stat accepts it), so statfs
      * must answer identically rather than falling through to the host.
      */
@@ -363,8 +365,9 @@ static void test_fifo_truncate_fast(void)
         FAIL("unlink FIFO");
         return;
     }
-    /* Accept EINVAL (Linux truncate-on-FIFO). The critical property is that
-     * the call returned at all rather than hanging.
+
+    /* Accept EINVAL (Linux truncate-on-FIFO). The critical property is that the
+     * call returned at all rather than hanging.
      */
     EXPECT_TRUE(rc == -1 && saved == EINVAL,
                 "truncate on FIFO did not fail with EINVAL");
@@ -535,6 +538,7 @@ static void test_symlink_dir_chdir_contained(void)
         FAIL("unlink symlink");
         return;
     }
+
     /* Either the chdir failed (ELOOP/ENOTDIR), or if it somehow succeeded the
      * cwd must not have escaped; the strong assertion is that it failed.
      */
@@ -618,9 +622,9 @@ static void test_imported_symlink_contained(void)
     EXPECT_TRUE(ok, "chmod followed an imported shm symlink");
 }
 
-/* execve of a symlink leaf pointing at a host binary must not run the target;
- * a real binary copied into /dev/shm must still run. Both are checked in a
- * child so a successful exec does not replace the test process.
+/* execve of a symlink leaf pointing at a host binary must not run the target; a
+ * real binary copied into /dev/shm must still run. Both are checked in a child
+ * so a successful exec does not replace the test process.
  */
 static void test_execve_symlink_contained(void)
 {
@@ -686,6 +690,7 @@ static void test_execve_real_binary_runs(const char *self)
         FAIL("copy self into /dev/shm");
         return;
     }
+
     /* Grant world-execute so elfuse's exec-permission model (which compares the
      * emulated euid against the host file's owner) admits the copy regardless
      * of the runner's host uid. Without this the check is owner-only (0700) and

--- a/tests/test-devpts.c
+++ b/tests/test-devpts.c
@@ -1,4 +1,5 @@
-/* devpts identification and Unix98 pty allocation.
+/*
+ * devpts identification and Unix98 pty allocation.
  *
  * glibc's posix_openpt() opens /dev/ptmx and then confirms devpts is mounted
  * before handing the master back (sysdeps/unix/sysv/linux/getpt.c). If statfs
@@ -65,8 +66,8 @@ int main(void)
 
     /* No assertion on fstatfs(master): Linux answers from whatever filesystem
      * provides /dev/ptmx, which is devpts only when it is the bind-mounted
-     * /dev/pts/ptmx and tmpfs or devtmpfs otherwise. There is no portable
-     * value to expect.
+     * /dev/pts/ptmx and tmpfs or devtmpfs otherwise. There is no portable value
+     * to expect.
      *
      * The slave fd is not ambiguous that way -- on Linux it really does live on
      * devpts -- and elfuse still does not answer devpts for it. That is left
@@ -109,10 +110,10 @@ int main(void)
         } else {
             /* Raw mode: in canonical mode the slave read would block until a
              * newline arrives, and ECHO would race the payload back at the
-             * master. Both would hang the run rather than fail it, so a
-             * termios failure has to stop here -- carrying on would spend the
-             * whole alarm window below only to report a round-trip failure
-             * that is really a setup failure.
+             * master. Both would hang the run rather than fail it, so a termios
+             * failure has to stop here -- carrying on would spend the whole
+             * alarm window below only to report a round-trip failure that is
+             * really a setup failure.
              */
             struct termios tio;
             if (tcgetattr(slave, &tio) != 0) {
@@ -128,6 +129,7 @@ int main(void)
                 close(slave);
                 goto round_trip_done;
             }
+
             /* Belt and braces: a stuck read must fail the test, not wedge CI.
              */
             signal(SIGALRM, on_alarm);
@@ -138,10 +140,10 @@ int main(void)
             char buf[sizeof(msg)];
             memset(buf, 0, sizeof(buf));
 
-            /* A pty may transfer fewer bytes per call than asked for, in
-             * either direction, so drive both to completion instead of
-             * assuming one call moves the whole payload -- a legal short read
-             * would otherwise fail a working pair. The alarm above bounds the
+            /* A pty may transfer fewer bytes per call than asked for, in either
+             * direction, so drive both to completion instead of assuming one
+             * call moves the whole payload -- a legal short read would
+             * otherwise fail a working pair. The alarm above bounds the
              * exchange, so a stall still fails rather than looping forever.
              */
             size_t sent = 0;
@@ -180,9 +182,9 @@ int main(void)
     {
         /* The last four are aliases of a live slave that strtoul would take:
          * leading zeros, a sign, leading whitespace. Linux answers ENOENT for
-         * every one of them, and accepting any would let one slave answer
-         * under several names -- for stat, for devpts identity, and for
-         * whether chmod and chown are intercepted at all.
+         * every one of them, and accepting any would let one slave answer under
+         * several names -- for stat, for devpts identity, and for whether chmod
+         * and chown are intercepted at all.
          */
         char alias_zero[64], alias_plus[64], alias_space[64];
         snprintf(alias_zero, sizeof(alias_zero), "/dev/pts/0%s",
@@ -204,8 +206,8 @@ int main(void)
                 bad++;
             } else if (errno != ENOENT) {
                 /* Failing is not enough: EACCES or ENOTDIR would mean the
-                 * lookup went wrong somewhere else rather than the slave
-                 * simply not existing.
+                 * lookup went wrong somewhere else rather than the slave simply
+                 * not existing.
                  */
                 printf("FAIL (%s errno=%d (%s), want ENOENT) ", bogus[i], errno,
                        strerror(errno));

--- a/tests/test-dynamic-array-host.c
+++ b/tests/test-dynamic-array-host.c
@@ -110,7 +110,8 @@ static void test_invalid_and_overflow(void)
     dynamic_array_destroy(&raw);
 
     /* A malformed metadata state must not let failed byte-size calculations
-     * feed uninitialized offsets into memory operations. */
+     * feed uninitialized offsets into memory operations.
+     */
     dynamic_array_t resize_overflow = {
         .data = NULL,
         .count = 0,

--- a/tests/test-dynamic-coreutils.sh
+++ b/tests/test-dynamic-coreutils.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
-# test-dynamic-coreutils.sh -- Dynamically-linked GNU coreutils test suite for elfuse
+
+# test-dynamic-coreutils.sh -- Dynamically-linked GNU coreutils test suite for
+# elfuse
 #
 # Copyright 2026 elfuse contributors
 # Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
 # SPDX-License-Identifier: Apache-2.0
-#
 # shellcheck disable=SC1091,SC2034,SC2059,SC2154
-#
 # Shared entry point for dynamic coreutils coverage through elfuse --sysroot.
 #
-# Usage: tests/test-dynamic-coreutils.sh <elfuse-binary> <sysroot-dir> <coreutils-bin-dir>
-# Example: tests/test-dynamic-coreutils.sh build/elfuse $GUEST_SYSROOT $GUEST_DYNAMIC_COREUTILS/bin
+# Usage:
+#   tests/test-dynamic-coreutils.sh <elfuse-binary> <sysroot-dir> \
+#       <coreutils-bin-dir>
+#
+# Example:
+#   tests/test-dynamic-coreutils.sh build/elfuse $GUEST_SYSROOT \
+#       $GUEST_DYNAMIC_COREUTILS/bin
 
 set -euo pipefail
 

--- a/tests/test-env-dump.c
+++ b/tests/test-env-dump.c
@@ -4,9 +4,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Prints environ verbatim and in order so tests/test-launch-flags.sh can
- * hold the vector build_linux_stack copied to what --env asked for, entry
- * for entry.
+ * Prints environ verbatim and in order so tests/test-launch-flags.sh can hold
+ * the vector build_linux_stack copied to what --env asked for, entry for entry.
  */
 
 #include <stdio.h>

--- a/tests/test-epoll-mt.c
+++ b/tests/test-epoll-mt.c
@@ -68,6 +68,7 @@ static int expect_ready_edge(int epfd, int fd, void (*make_ready)(int), int arg)
     make_ready(arg);
 
     struct epoll_event out[4];
+
     /* 2s budget: the bug manifests as an indefinite miss, so any generous
      * finite timeout distinguishes pass from fail without flaking.
      */

--- a/tests/test-epoll-refcount.c
+++ b/tests/test-epoll-refcount.c
@@ -60,8 +60,10 @@ static int sibling_fn(void *arg)
         int e = shared_epfd;
         if (e >= 0) {
             struct epoll_event evs[4];
+
             /* epoll_pwait(epfd, events, maxevents, timeout_ms, sigmask,
-             * sigsetsize); 5ms timeout keeps the spin tight against close(). */
+             * sigsetsize); 5ms timeout keeps the spin tight against close().
+             */
             raw_syscall6(__NR_epoll_pwait, (long) e, (long) evs, 4, 5, 0, 0);
         } else {
             struct {
@@ -80,7 +82,8 @@ int main(void)
 
     long flags = 0x00000100 | 0x00000200 | 0x00000400 | 0x00000800 |
                  0x00010000 | 0x00200000; /* CLONE_VM|FS|FILES|SIGHAND|THREAD|
-                                             CHILD_CLEARTID */
+                                             CHILD_CLEARTID
+                                             */
     volatile uint32_t child_tid = 1;
     long ret = raw_syscall5(__NR_clone, flags,
                             (long) (sibling_stack + sizeof(sibling_stack)), 0,
@@ -123,7 +126,8 @@ int main(void)
 
         /* Retract, then close under the sibling's in-flight pwait. Closing efd
          * first fires the close hook (epoll_note_fd_closed) on the instance the
-         * sibling is still waiting on. */
+         * sibling is still waiting on.
+         */
         shared_epfd = -1;
         if (efd >= 0)
             close(efd);

--- a/tests/test-exit-group-teardown.c
+++ b/tests/test-exit-group-teardown.c
@@ -4,8 +4,8 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * exit_group must terminate the process even when a thread is parked on one
- * of the runtime's internal condvars, which neither the wakeup pipe nor the
+ * exit_group must terminate the process even when a thread is parked on one of
+ * the runtime's internal condvars, which neither the wakeup pipe nor the
  * hv_vcpus_exit kick can reach:
  *
  *   wait: the main thread blocks in wait4 on a SEIZEd tracee that never
@@ -27,11 +27,11 @@
  *         progress; the teardown broadcast frees them directly.
  *
  * All scenarios must exit with code 42, carried by exit_group from whichever
- * thread raced the park. PTRACE_SEIZE on a same-thread-group thread fails
- * with EPERM on real Linux (it works on elfuse, where ptrace is scoped to
- * the emulated process); the ptrace scenarios treat SEIZE failure as "park
- * cannot be constructed" and fall through to a plain exit_group(42) so the
- * expected exit code holds under differential testing.
+ * thread raced the park. PTRACE_SEIZE on a same-thread-group thread fails with
+ * EPERM on real Linux (it works on elfuse, where ptrace is scoped to the
+ * emulated process); the ptrace scenarios treat SEIZE failure as "park cannot
+ * be constructed" and fall through to a plain exit_group(42) so the expected
+ * exit code holds under differential testing.
  *
  * Syscalls: clone(220), ptrace(117), wait4(260), nanosleep(101),
  * sched_yield(124), exit(93), exit_group(94)
@@ -63,8 +63,8 @@ static void msleep(long ms)
     raw_syscall4(101, (long) &ts, 0, 0, 0); /* nanosleep */
 }
 
-/* Terminates the process group from a worker thread after a delay, so the
- * park under test is in place when the exit-group flag is set.
+/* Terminates the process group from a worker thread after a delay, so the park
+ * under test is in place when the exit-group flag is set.
  */
 static int killer_fn(void)
 {
@@ -74,8 +74,8 @@ static int killer_fn(void)
     return 0;
 }
 
-/* Spins on sched_yield so the thread is always either inside hv_vcpu_run or
- * at a run-loop preemption point (where it can enter ptrace-stop or the fork
+/* Spins on sched_yield so the thread is always either inside hv_vcpu_run or at
+ * a run-loop preemption point (where it can enter ptrace-stop or the fork
  * barrier). Never stops, never exits on its own.
  */
 static int spin_fn(void)
@@ -125,8 +125,8 @@ static int scenario_wait(void)
     return 0;
 }
 
-/* stop: hold a tracee in ptrace-stop (parked on resume_cond), then
- * exit_group from the tracer without ever calling PTRACE_CONT.
+/* stop: hold a tracee in ptrace-stop (parked on resume_cond), then exit_group
+ * from the tracer without ever calling PTRACE_CONT.
  */
 static int scenario_stop(void)
 {
@@ -136,6 +136,7 @@ static int scenario_stop(void)
 
     if (raw_syscall4(117, PTRACE_SEIZE, tracee, 0, 0) == 0) {
         raw_syscall4(117, PTRACE_INTERRUPT, tracee, 0, 0);
+
         /* Blocks until the tracee reaches ptrace-stop, i.e. is parked on
          * resume_cond with nobody left to CONT it after this thread exits.
          */
@@ -157,9 +158,9 @@ static int scenario_fork(void)
     while (!killer_armed)
         raw_syscall0(124);
 
-    /* Fork continuously so a barrier is likely in flight when the killer
-     * fires; each child exits immediately and is reaped to keep the process
-     * table bounded. The loop only ends when exit_group tears it down.
+    /* Fork continuously so a barrier is likely in flight when the killer fires;
+     * each child exits immediately and is reaped to keep the process table
+     * bounded. The loop only ends when exit_group tears it down.
      */
     for (;;) {
         /* clone with flags=SIGCHLD: plain fork */

--- a/tests/test-exit-group-worker.c
+++ b/tests/test-exit-group-worker.c
@@ -4,24 +4,24 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Regression test for the exit_group teardown race: when a worker thread
- * calls exit_group while its siblings are mid-iteration, the main thread
- * must join the workers before unmapping guest memory. A regression shows
- * up as the process dying of a host-level SIGSEGV (status 139) instead of
- * reporting the exit_group code.
+ * Regression test for the exit_group teardown race: when a worker thread calls
+ * exit_group while its siblings are mid-iteration, the main thread must join
+ * the workers before unmapping guest memory. A regression shows up as the
+ * process dying of a host-level SIGSEGV (status 139) instead of reporting the
+ * exit_group code.
  *
- * Phase 1 forks N children; in each child a worker thread calls
- * exit_group(42) while sibling workers occupy every blocking state a thread
- * can be torn down from -- spinners hammering guest memory (in hv_vcpu_run),
- * a worker parked in a timed FUTEX_WAIT_BITSET with a distant absolute
- * deadline (the condvar wait path glibc's sem_timedwait and
- * pthread_cond_timedwait sit in), and a worker parked in a blocking pipe
- * read (the interruptible io wait). The parent verifies the child exited 42
- * (fork children tear down through guest_destroy). Phase 2 repeats the
- * pattern in the top-level process itself, so this test's own exit code 0 is
- * produced by a worker-initiated exit_group through main()'s teardown path.
- * The parked variants regress the bounded-quantum futex waits: an uncapped
- * sleep would outlive the join cap, get detached, and race the unmap.
+ * Phase 1 forks N children; in each child a worker thread calls exit_group(42)
+ * while sibling workers occupy every blocking state a thread can be torn down
+ * from -- spinners hammering guest memory (in hv_vcpu_run), a worker parked in
+ * a timed FUTEX_WAIT_BITSET with a distant absolute deadline (the condvar wait
+ * path glibc's sem_timedwait and pthread_cond_timedwait sit in), and a worker
+ * parked in a blocking pipe read (the interruptible io wait). The parent
+ * verifies the child exited 42 (fork children tear down through guest_destroy).
+ * Phase 2 repeats the pattern in the top-level process itself, so this test's
+ * own exit code 0 is produced by a worker-initiated exit_group through main()'s
+ * teardown path. The parked variants regress the bounded-quantum futex waits:
+ * an uncapped sleep would outlive the join cap, get detached, and race the
+ * unmap.
  *
  * Syscalls: clone(220), exit_group(94), wait4(260), sched_yield(124),
  * futex(98), read(63), pipe2(59)
@@ -62,8 +62,8 @@ static void *spinner_fn(void *arg)
 /* Park in a timed futex wait far in the future. FUTEX_WAIT_BITSET takes an
  * absolute deadline and is what glibc timed waits issue; on elfuse it maps to
  * the condvar wait path rather than the os_sync one, so this exercises the
- * bounded-quantum teardown re-check. Re-arm on any spurious wake; exit_group
- * is the only way out.
+ * bounded-quantum teardown re-check. Re-arm on any spurious wake; exit_group is
+ * the only way out.
  */
 static void *futex_parker_fn(void *arg)
 {
@@ -81,8 +81,8 @@ static void *futex_parker_fn(void *arg)
 }
 
 /* Park in a blocking read on a pipe that never gets written (the write end
- * stays open so the read cannot see EOF). Exercises the interruptible io
- * wait's teardown re-check.
+ * stays open so the read cannot see EOF). Exercises the interruptible io wait's
+ * teardown re-check.
  */
 static void *read_parker_fn(void *arg)
 {
@@ -99,19 +99,20 @@ static void *killer_fn(void *arg)
     int code = (int) (long) arg;
     while (__sync_fetch_and_add(&workers_ready, 0) < N_WORKERS)
         sched_yield();
+
     /* Give the parkers a moment to actually enter their blocking waits (the
      * ready increment happens just before the call). Not required for
-     * correctness -- a parker that enters its wait after the exit-group flag
-     * is set still notices it within one bounded quantum -- but it makes the
-     * test exercise the parked states rather than the entry races.
+     * correctness -- a parker that enters its wait after the exit-group flag is
+     * set still notices it within one bounded quantum -- but it makes the test
+     * exercise the parked states rather than the entry races.
      */
     usleep(20000);
     syscall(SYS_exit_group, code);
     return NULL;
 }
 
-/* Spawn the worker set plus a thread that calls exit_group(code), then spin
- * on the main thread. Never returns: exit_group ends the process.
+/* Spawn the worker set plus a thread that calls exit_group(code), then spin on
+ * the main thread. Never returns: exit_group ends the process.
  */
 static void run_victim(int code)
 {
@@ -169,9 +170,9 @@ summary:
     if (fails)
         return 1;
 
-    /* Phase 2: our own exit code 0 must come from a worker-initiated
-     * exit_group in the top-level process. Flush first: exit_group does not
-     * flush stdio buffers.
+    /* Phase 2: our own exit code 0 must come from a worker-initiated exit_group
+     * in the top-level process. Flush first: exit_group does not flush stdio
+     * buffers.
      */
     fflush(NULL);
     run_victim(0);

--- a/tests/test-fakeroot-exec.c
+++ b/tests/test-fakeroot-exec.c
@@ -187,6 +187,7 @@ static int copy_program(const char *src, char *dst, size_t dst_sz)
         close(in);
         return -1;
     }
+
     /* mkstemp creates 0600. The copy needs the other-execute bit: its host
      * owner is the real macOS uid, which never matches the emulated guest uid,
      * so check_exec_permission only ever consults the other bits.
@@ -221,6 +222,7 @@ static int copy_program(const char *src, char *dst, size_t dst_sz)
         perror("copy: close dst");
         rc = -1;
     }
+
     /* One drop site for the staged file: mkstemp already created it, so every
      * failure from here on has to leave nothing behind in the shared /tmp.
      */

--- a/tests/test-fault-signal-mt.c
+++ b/tests/test-fault-signal-mt.c
@@ -1,12 +1,13 @@
-/* Multi-threaded synchronous-fault delivery test
+/*
+ * Multi-threaded synchronous-fault delivery test
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * Regression lock-in for synchronous fault (SIGSEGV) delivery in a
  * multi-threaded guest. Faults were routed through the process-wide pending
- * bitmask (signal_queue + signal_deliver), so a fault raised by one vCPU
- * thread could be dequeued and delivered by another: the other thread had no
+ * bitmask (signal_queue + signal_deliver), so a fault raised by one vCPU thread
+ * could be dequeued and delivered by another: the other thread had no
  * thread-local fault info, so the kernel-visible siginfo became si_code=SI_USER
  * with no si_addr instead of SEGV_MAPERR. A JVM treats such a SIGSEGV as a
  * fatal external signal rather than a recoverable implicit null check, so javac
@@ -22,8 +23,8 @@
  * faults: a synchronous SIGSEGV whose disposition is SIG_IGN, or which is
  * blocked, resets to SIG_DFL + unblocked and terminates the process. Without
  * the reset, SIG_IGN resumes at the faulting PC and re-faults forever, and a
- * blocked fault either stalls the same way or runs a handler the guest asked
- * to block. Each case runs in a forked child that must die by SIGSEGV.
+ * blocked fault either stalls the same way or runs a handler the guest asked to
+ * block. Each case runs in a forked child that must die by SIGSEGV.
  *
  * Syscalls exercised: rt_sigaction, rt_sigprocmask, clone (pthreads), fork,
  * wait4, the fault delivery path.
@@ -46,14 +47,16 @@ int passes = 0, fails = 0;
 #define NFAULTS 4000
 
 /* The bad address every thread reads. Page zero is never mapped, so the read
- * faults with a translation fault -> SEGV_MAPERR and si_addr == FAULT_ADDR. */
+ * faults with a translation fault -> SEGV_MAPERR and si_addr == FAULT_ADDR.
+ */
 #define FAULT_ADDR ((volatile int *) (uintptr_t) 0x8)
 
 static _Thread_local sigjmp_buf recover;
 static _Thread_local volatile int armed;
 
 /* Set by the handler when it observes a malformed delivery. async-signal-safe
- * stores to sig_atomic_t/int flags only. */
+ * stores to sig_atomic_t/int flags only.
+ */
 static volatile sig_atomic_t bad_si_code = 0;
 static volatile sig_atomic_t bad_si_addr = 0;
 static volatile sig_atomic_t unarmed_delivery = 0;
@@ -62,16 +65,19 @@ static void segv_handler(int sig, siginfo_t *info, void *uc)
 {
     (void) sig;
     (void) uc;
+
     /* A synchronous fault must report a fault si_code (SEGV_MAPERR for an
      * unmapped address), never SI_USER (0), which is what a stolen/cross-thread
-     * delivery produced. */
+     * delivery produced.
+     */
     if (info->si_code != SEGV_MAPERR && info->si_code != SEGV_ACCERR)
         bad_si_code = 1;
     if (info->si_addr != (void *) FAULT_ADDR)
         bad_si_addr = 1;
     if (!armed) {
         /* Delivered to a thread that is not currently faulting: the fault was
-         * misrouted. Cannot recover (no jmp target), so fail and exit. */
+         * misrouted. Cannot recover (no jmp target), so fail and exit.
+         */
         unarmed_delivery = 1;
         _exit(2);
     }
@@ -94,10 +100,13 @@ static void *fault_loop(void *arg)
 }
 
 /* Fork a child that faults under the disposition installed by `setup` and
- * return its wait status. Returns -1 on fork/waitpid failure, -2 if the child
- * had to be killed: a re-fault-forever regression spins the child on the
- * faulting PC without reaching a signal poll point, so no in-child alarm can
- * interrupt it -- the parent must bound the wait and kill. */
+ * return its wait status.
+ *
+ * Returns -1 on fork/waitpid failure, -2 if the child had to be killed: a
+ * re-fault-forever regression spins the child on the faulting PC without
+ * reaching a signal poll point, so no in-child alarm can interrupt it -- the
+ * parent must bound the wait and kill.
+ */
 #define CHILD_WAIT_MS 8000
 
 static int fault_child_status(void (*setup)(void))
@@ -126,7 +135,8 @@ static int fault_child_status(void (*setup)(void))
 }
 
 /* elfuse fork children report signal deaths as exit(128+signum); accept the
- * native WIFSIGNALED form too. */
+ * native WIFSIGNALED form too.
+ */
 static int died_by(int status, int sig)
 {
     if (WIFSIGNALED(status) && WTERMSIG(status) == sig)
@@ -144,8 +154,10 @@ static void blocked_handler(int sig, siginfo_t *info, void *uc)
     (void) sig;
     (void) info;
     (void) uc;
+
     /* Must never run: SIGSEGV was blocked when the fault hit, so Linux
-     * force_sig semantics reset to SIG_DFL and terminate instead. */
+     * force_sig semantics reset to SIG_DFL and terminate instead.
+     */
     _exit(3);
 }
 
@@ -167,8 +179,9 @@ int main(void)
 {
     printf("test-fault-signal-mt: multi-threaded SIGSEGV delivery\n\n");
 
-    /* Forced-fault disposition cases run first, in forked children, before
-     * this process installs its own SIGSEGV handler or spawns threads. */
+    /* Forced-fault disposition cases run first, in forked children, before this
+     * process installs its own SIGSEGV handler or spawns threads.
+     */
     TEST("SIG_IGN'd synchronous SIGSEGV terminates");
     int status = fault_child_status(setup_ign);
     if (status == -2)

--- a/tests/test-fchmodat-empty-path.c
+++ b/tests/test-fchmodat-empty-path.c
@@ -6,8 +6,8 @@
  *
  * fchmodat(fd, "", mode, AT_EMPTY_PATH) chmods fd itself instead of a name
  * beneath it. This is the only way to chmod an O_PATH descriptor -- plain
- * fchmod() rejects FD_PATH with EBADF, matching Linux -- and AT_FDCWD
- * resolves to the current directory rather than being an error.
+ * fchmod() rejects FD_PATH with EBADF, matching Linux -- and AT_FDCWD resolves
+ * to the current directory rather than being an error.
  *
  * The classic fchmodat(2) syscall predates any flags argument, so libc's
  * fchmodat() wrapper (glibc and musl both) rejects any flag other than
@@ -40,10 +40,10 @@ static int fchmodat2(int dirfd, const char *path, mode_t mode, int flags)
     return (int) syscall(SYS_fchmodat2, dirfd, path, (long) mode, (long) flags);
 }
 
-/* fchmodat2(2) is Linux 6.6+ and reached here via a raw syscall() with no
- * libc fallback. A host kernel that predates it (or any environment where
- * syscall 452 is simply unwired) returns ENOSYS; treat that as a skip
- * instead of failing the whole binary.
+/* fchmodat2(2) is Linux 6.6+ and reached here via a raw syscall() with no libc
+ * fallback. A host kernel that predates it (or any environment where syscall
+ * 452 is simply unwired) returns ENOSYS; treat that as a skip instead of
+ * failing the whole binary.
  */
 static int fchmodat2_supported(const char *probe_path)
 {
@@ -68,8 +68,8 @@ static int setup_fixtures(void)
     }
     close(fd);
 
-    /* The AT_FDCWD case below needs a writable cwd; the process's inherited
-     * cwd may not be (e.g. a read-only rootfs in a VM test image).
+    /* The AT_FDCWD case below needs a writable cwd; the process's inherited cwd
+     * may not be (e.g. a read-only rootfs in a VM test image).
      */
     snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/elfuse-fchmodat-empty-dir-%d",
              (int) getpid());

--- a/tests/test-fchownat-empty-path.c
+++ b/tests/test-fchownat-empty-path.c
@@ -41,8 +41,8 @@ static int setup_fixtures(void)
     }
     close(fd);
 
-    /* The AT_FDCWD case below needs a writable cwd; the process's inherited
-     * cwd may not be (e.g. a read-only rootfs in a VM test image).
+    /* The AT_FDCWD case below needs a writable cwd; the process's inherited cwd
+     * may not be (e.g. a read-only rootfs in a VM test image).
      */
     snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/elfuse-fchownat-empty-dir-%d",
              (int) getpid());

--- a/tests/test-fd-magiclink.c
+++ b/tests/test-fd-magiclink.c
@@ -255,6 +255,7 @@ static void check_intercepts_unchanged(void)
     TEST("open through magic link reopens");
     int reopened = open(magic("/proc/self/fd/", fd), O_RDONLY);
     char buf[16] = {0};
+
     /* Seek explicitly: elfuse serves this open by duplicating the descriptor,
      * so the result shares the original file offset rather than starting at 0
      * the way a fresh open on Linux would.

--- a/tests/test-flock.c
+++ b/tests/test-flock.c
@@ -96,10 +96,10 @@ int main(void)
                             gfl.l_type == F_WRLCK),
                 "F_GETLK returned an invalid l_type");
 
-    /* F_GETLK must report the *guest* PID of a conflicting lock, not
-     * elfuse's raw host PID -- guest code that treats l_pid as a real PID
-     * (e.g. a kill(pid, 0) liveness check) would otherwise resolve a foreign
-     * host process instead of the actual lock holder.
+    /* F_GETLK must report the *guest* PID of a conflicting lock, not elfuse's
+     * raw host PID -- guest code that treats l_pid as a real PID (e.g. a
+     * kill(pid, 0) liveness check) would otherwise resolve a foreign host
+     * process instead of the actual lock holder.
      */
     TEST("F_GETLK reports the guest PID of a conflicting child lock");
     int pfd[2];

--- a/tests/test-fork-ipc-protocol-host.c
+++ b/tests/test-fork-ipc-protocol-host.c
@@ -42,6 +42,7 @@ _Static_assert(offsetof(ipc_header_t, magic) == 0,
 _Static_assert(offsetof(ipc_header_t, ipa_bits) == sizeof(uint32_t),
                "ipa_bits must immediately follow magic; there is no version "
                "slot in the fork IPC header");
+
 /* Enforce the bool typing of has_shm / is_rosetta via _Generic so a silent
  * widening to uint8_t / uint32_t (which would still match sizeof(bool)) fails
  * the build instead of accidentally re-shaping the wire.
@@ -50,6 +51,7 @@ _Static_assert(_Generic(((ipc_header_t *) 0)->has_shm, bool: 1, default: 0),
                "has_shm must remain a bool field");
 _Static_assert(_Generic(((ipc_header_t *) 0)->is_rosetta, bool: 1, default: 0),
                "is_rosetta must remain a bool field");
+
 /* The wire is private to one build (FORK_IPC_PROTOCOL_MAGIC bumps on every
  * incompatible layout change), but parent and child still need to agree on the
  * width of the bool flags they exchange. Pin the assumption so a future

--- a/tests/test-fuse-alpine.sh
+++ b/tests/test-fuse-alpine.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-fuse-alpine.sh -- Validate guest FUSE inside the Alpine musl sysroot.
 #
 # Copyright 2026 elfuse contributors

--- a/tests/test-gdbstub.sh
+++ b/tests/test-gdbstub.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
+
 # test-gdbstub.sh - Validate LLDB <-> elfuse gdbstub interaction
 #
 # Copyright 2026 elfuse contributors
 # Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Starts elfuse with --gdb --gdb-stop-on-entry, drives LLDB in batch mode,
-# and validates register reads, memory reads, breakpoints, stepping, and
+# Starts elfuse with --gdb --gdb-stop-on-entry, drives LLDB in batch mode, and
+# validates register reads, memory reads, breakpoints, stepping, and
 # watchpoints.
 #
 # Usage: tests/test-gdbstub.sh [-e ELFUSE] [-v]
@@ -134,8 +135,8 @@ stop_elfuse()
     sleep 0.2
 }
 
-# Run LLDB in batch mode with the given commands.
-# Captures stdout+stderr into $LLDB_OUT.
+# Run LLDB in batch mode with the given commands. Captures stdout+stderr into
+# $LLDB_OUT.
 # Returns LLDB's exit code.
 run_lldb()
 {
@@ -325,8 +326,9 @@ run_lldb \
     -o "register read pc x0 x1 x2" \
     -o "process kill" \
     -o "quit"
-# After 3 steps from 0x400000: at 0x40000c
-# x0 should be 1 (stdout), x2 should be 6 (count)
+
+# After 3 steps from 0x400000: at 0x40000c x0 should be 1 (stdout), x2 should be
+# 6 (count)
 ok=0
 if echo "$LLDB_OUT" | grep -qi "0x.*40000c"; then
     ok=1
@@ -359,8 +361,9 @@ run_lldb \
     -o "register read x0 x1 x2" \
     -o "process kill" \
     -o "quit"
-# After 3 steps (past mov x0,#1 / adr x1,msg / mov x2,#6):
-# x0=1 (stdout), x2=6 (count), x1 = 0x400020 (msg addr)
+
+# After 3 steps (past mov x0,#1 / adr x1,msg / mov x2,#6): x0=1 (stdout), x2=6
+# (count), x1 = 0x400020 (msg addr)
 ok=0
 x0_ok=0
 x2_ok=0

--- a/tests/test-getdents-refcount.c
+++ b/tests/test-getdents-refcount.c
@@ -8,8 +8,8 @@
  * Companion to test-getdents64-overlong.c. That test drives sys_getdents64's
  * dirent-translation edge cases. This one pins a different invariant: a
  * directory fd's DIR* stream must survive a concurrent close()/dup2() while
- * sys_getdents64() is still mid-loop reading it (src/syscall/fs.c
- * dir_stream_t / dir_stream_acquire / dir_stream_release).
+ * sys_getdents64() is still mid-loop reading it (src/syscall/fs.c dir_stream_t
+ * / dir_stream_acquire / dir_stream_release).
  *
  * fd_table[fd].dir is a bare pointer for FD_DIR entries. Before this fix,
  * sys_getdents64() read it with no lock and no pin, then looped
@@ -18,17 +18,17 @@
  * from under the in-flight loop -- the exact same use-after-free class the
  * companion epoll fix (src/syscall/poll.c epoll_instance_acquire/_release)
  * addresses for FD_EPOLL. dir_stream_acquire()/_release() close the gap by
- * refcounting the wrapper instead of freeing it the instant the fd-table's
- * own reference goes away.
+ * refcounting the wrapper instead of freeing it the instant the fd-table's own
+ * reference goes away.
  *
- * This test hammers that window: a long-lived sibling spins raw getdents64()
- * on a directory fd the main thread keeps recreating, publishing, and
- * retiring -- once via close(), once via dup2() overwriting the slot (the
- * fd_alloc_at path, which also funnels through fd_cleanup_entry). Racing
- * close()/dup2() with getdents64() on the same fd is guest-undefined, so the
- * sibling's return value is not asserted; the contract under test is that
- * elfuse never faults or double-frees. Survival across all iterations with a
- * clean exit is the pass condition.
+ * This test hammers that window: a long-lived sibling spins raw getdents64() on
+ * a directory fd the main thread keeps recreating, publishing, and retiring --
+ * once via close(), once via dup2() overwriting the slot (the fd_alloc_at path,
+ * which also funnels through fd_cleanup_entry). Racing close()/dup2() with
+ * getdents64() on the same fd is guest-undefined, so the sibling's return value
+ * is not asserted; the contract under test is that elfuse never faults or
+ * double-frees. Survival across all iterations with a clean exit is the pass
+ * condition.
  *
  * Raw syscalls in the sibling (a CLONE_THREAD child has no libc TLS).
  *
@@ -78,10 +78,9 @@ static int make_stress_dir(void)
     return 0;
 }
 
-/* Spin raw getdents64() on whatever directory fd the main thread has
- * published. The fd may be closed (or reused) concurrently; a raw syscall
- * just returns an error, which is exactly the window the refcount must make
- * memory-safe.
+/* Spin raw getdents64() on whatever directory fd the main thread has published.
+ * The fd may be closed (or reused) concurrently; a raw syscall just returns an
+ * error, which is exactly the window the refcount must make memory-safe.
  */
 static int sibling_fn(void *arg)
 {
@@ -111,7 +110,8 @@ int main(void)
 
     long flags = 0x00000100 | 0x00000200 | 0x00000400 | 0x00000800 |
                  0x00010000 | 0x00200000; /* CLONE_VM|FS|FILES|SIGHAND|THREAD|
-                                             CHILD_CLEARTID */
+                                             CHILD_CLEARTID
+                                             */
     volatile uint32_t child_tid = 1;
     long ret = raw_syscall5(__NR_clone, flags,
                             (long) (sibling_stack + sizeof(sibling_stack)), 0,
@@ -141,8 +141,8 @@ int main(void)
 
         if (i % 2 == 0) {
             /* Retract, then close under the sibling's in-flight getdents64.
-             * Fires the close hook (fd_cleanup_entry -> dir_stream_release)
-             * on the stream the sibling is still reading.
+             * Fires the close hook (fd_cleanup_entry -> dir_stream_release) on
+             * the stream the sibling is still reading.
              */
             shared_fd = -1;
             close(fd);

--- a/tests/test-getdents64-overlong.c
+++ b/tests/test-getdents64-overlong.c
@@ -150,6 +150,7 @@ int main(int argc, char **argv)
     }
 
     TEST("listing has only the normal entry");
+
     /* The overlong file is present on disk but must be silently skipped, so the
      * visible-entry count is exactly 1.
      */

--- a/tests/test-guest-env-host.c
+++ b/tests/test-guest-env-host.c
@@ -33,7 +33,7 @@ void log_impl(int level, const char *file, int line, const char *fmt, ...)
     (void) fmt;
 }
 
-/* ---- the oracle -------------------------------------------------------- */
+/* the oracle */
 
 enum { MODEL_MAX = 32, MODEL_ENTRY_MAX = 256 };
 
@@ -44,8 +44,9 @@ typedef struct {
     bool refused; /* an override named nothing */
 } model_t;
 
-/* Split "KEY=VALUE" at the first '='. Returns false when @s is not one:
- * no '=' at all, or an empty name.
+/* Split "KEY=VALUE" at the first '='.
+ *
+ * Returns false when @s is not one: no '=' at all, or an empty name.
  */
 static bool model_split(const char *s, char *name, char *value)
 {
@@ -102,9 +103,9 @@ static const char *model_host_value(char *const *host_env, const char *name)
     return NULL;
 }
 
-/* Reference merge. Builds the environment as an insertion-ordered name list,
- * so position comes from when a name was first seen rather than from which
- * slot the implementation happened to reuse.
+/* Reference merge. Builds the environment as an insertion-ordered name list, so
+ * position comes from when a name was first seen rather than from which slot
+ * the implementation happened to reuse.
  */
 static void model_build(model_t *m,
                         char *const *host_env,
@@ -144,7 +145,7 @@ static void model_build(model_t *m,
     }
 }
 
-/* ---- structural invariants --------------------------------------------- */
+/* structural invariants */
 
 /* Hold @envp to what every returned vector owes regardless of the cell:
  * NULL-terminated at @n, every entry a well-formed "KEY=VALUE", no name twice.
@@ -184,13 +185,14 @@ static bool check_structure(char **envp, int n, const char *cell)
     return true;
 }
 
-/* ---- the product ------------------------------------------------------- */
+/* the product */
 
 /* One base per way a host vector can be awkward. */
 static char *base_plain[] = {(char *) "A=1", (char *) "B=2", (char *) "C=3",
                              NULL};
-/* The one base separating a name the launcher set to "" from one it never
- * set: the alphabet's bare "A" imports "A=" here instead of being skipped.
+
+/* The one base separating a name the launcher set to "" from one it never set:
+ * the alphabet's bare "A" imports "A=" here instead of being skipped.
  */
 static char *base_emptyval[] = {(char *) "A=", (char *) "B=2", NULL};
 static char *base_dup[] = {(char *) "A=first", (char *) "B=2",
@@ -215,9 +217,9 @@ static const struct {
     {"prefix", base_prefix},
 };
 
-/* One token per branch of the merge. The refused "=VAL" is in the product so
- * a rejection lands at every base and at either override position, not only
- * at the single base named_cells reaches.
+/* One token per branch of the merge. The refused "=VAL" is in the product so a
+ * rejection lands at every base and at either override position, not only at
+ * the single base named_cells reaches.
  */
 static const char *const alphabet[] = {
     "NEW=x",   "A=over",  "A=",          "A=a=b", "A",
@@ -299,7 +301,7 @@ static void run_cell(char *const *host_env,
     strv_free((const char **) envp, n);
 }
 
-/* ---- cells the product cannot spell ------------------------------------ */
+/* cells the product cannot spell */
 
 static void named_cells(void)
 {

--- a/tests/test-identity-override-host.c
+++ b/tests/test-identity-override-host.c
@@ -1,14 +1,14 @@
 /*
- * Host-side unit test for ELFUSE_FAKEROOT environment overrides and the
- * --user staging protocol.
+ * Host-side unit test for ELFUSE_FAKEROOT environment overrides and the --user
+ * staging protocol.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The staging cases are regression guards for the proc_set_initial_ids
- * contract in proc.h. No launcher performs two bring-ups in one host
- * process, so a regression shows up as the wrong uid/gid below rather than
- * as a launch failure.
+ * The staging cases are regression guards for the proc_set_initial_ids contract
+ * in proc.h. No launcher performs two bring-ups in one host process, so a
+ * regression shows up as the wrong uid/gid below rather than as a launch
+ * failure.
  */
 
 #include <stdio.h>
@@ -92,8 +92,8 @@ int main(void)
     assert(proc_get_gid() == GUEST_GID);
     assert(proc_fakeroot_enabled() == false);
 
-    /* Test 5: consume-once. A leftover would leak one launch's --user into
-     * the next launch of the same host process.
+    /* Test 5: consume-once. A leftover would leak one launch's --user into the
+     * next launch of the same host process.
      */
     proc_set_fakeroot_enabled(false);
     proc_set_initial_ids(1234, 5678);

--- a/tests/test-inotify.c
+++ b/tests/test-inotify.c
@@ -194,9 +194,11 @@ static void test_dir_create(void)
 }
 
 /* Drain events by reading (which drives elfuse's diff), retrying until a named
- * IN_CREATE for `want` shows up. Returns false if `unwant` (an event that must
- * never appear, e.g. from an unrelated directory) is seen first, or if `want`
- * never arrives within the retry budget. `unwant` may be NULL.
+ * IN_CREATE for `want` shows up.
+ *
+ * Returns false if `unwant` (an event that must never appear, e.g. from an
+ * unrelated directory) is seen first, or if `want` never arrives within the
+ * retry budget. `unwant` may be NULL.
  */
 static bool watched_child_seen(int fd, const char *want, const char *unwant)
 {
@@ -287,6 +289,7 @@ static void test_dir_rename_follows_inode(void)
         FAIL("mkdtemp");
         return;
     }
+
     /* Sized so the compiler can prove each snprintf fits (dir is a fixed-length
      * template; -Wformat-truncation reasons about declared buffer sizes).
      */

--- a/tests/test-kill-broadcast.c
+++ b/tests/test-kill-broadcast.c
@@ -41,8 +41,9 @@ static void usr1_handler(int sig)
     got_usr1 = 1;
 }
 
-/* Spin up to ~2 s waiting for a flag so slow HVC-forwarded delivery has time
- * to land without hanging the suite. */
+/* Spin up to ~2 s waiting for a flag so slow HVC-forwarded delivery has time to
+ * land without hanging the suite.
+ */
 static bool wait_flag(volatile sig_atomic_t *flag)
 {
     for (int i = 0; i < 2000 && !*flag; i++) {

--- a/tests/test-kill-pgroup.c
+++ b/tests/test-kill-pgroup.c
@@ -168,10 +168,10 @@ int main(void)
     int failed = 0;
     install();
 
-    /* 0: setpgid argument validation. The kernel defaults pgid==0 to pid
-     * before checking pgid < 0, so a negative pid with pgid==0 becomes a
-     * negative pgid and fails EINVAL, not ESRCH; ESRCH needs a valid pgid
-     * alongside the nonexistent pid.
+    /* 0: setpgid argument validation. The kernel defaults pgid==0 to pid before
+     * checking pgid < 0, so a negative pid with pgid==0 becomes a negative pgid
+     * and fails EINVAL, not ESRCH; ESRCH needs a valid pgid alongside the
+     * nonexistent pid.
      */
     if (setpgid(0, -5) != -1 || errno != EINVAL) {
         fprintf(stderr, "FAIL: setpgid(0,-5) should be EINVAL\n");

--- a/tests/test-large-io-boundary.c
+++ b/tests/test-large-io-boundary.c
@@ -171,6 +171,7 @@ static void test_large_read_from_split_block(void)
         ssize_t ret = read(fd, buf, IO_SIZE);
         ok = (ret == (ssize_t) IO_SIZE);
     }
+
     /* Verify the entire read buffer, including the 2MiB boundary crossing where
      * L3-to-L2 page table transitions happen.
      */

--- a/tests/test-launch-flags.sh
+++ b/tests/test-launch-flags.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-launch-flags.sh -- Pin the behavior of the guest launch flags
 #
 # Copyright 2026 elfuse contributors
@@ -7,20 +8,21 @@
 # Usage: tests/test-launch-flags.sh <elfuse-binary> <guest-elf>
 #            [<env-dump-guest> <cat-guest>]
 #
-# --user, --workdir, --env, and --clear-env are rejected before the first
-# guest instruction (--user before the VM exists, --workdir during bring-up),
-# so a launcher gets a diagnostic rather than a guest running as something
-# other than what was asked for. Given <env-dump-guest> the environment lanes
-# add only what tests/test-guest-env-host.c cannot reach: main() collecting
-# the --env tokens, build_linux_stack, and the /proc/self/environ sink.
+# --user, --workdir, --env, and --clear-env are rejected before the first guest
+# instruction (--user before the VM exists, --workdir during bring-up), so a
+# launcher gets a diagnostic rather than a guest running as something other than
+# what was asked for. Given <env-dump-guest> the environment lanes add only what
+# tests/test-guest-env-host.c cannot reach: main() collecting the --env tokens,
+# build_linux_stack, and the /proc/self/environ sink.
 
 set -euo pipefail
 
 ELFUSE="${1:?Usage: $0 <elfuse-binary> <guest-elf>}"
 GUEST="${2:?Usage: $0 <elfuse-binary> <guest-elf>}"
+
 # The environment observers are optional: a prebuilt guest-binary tree
-# (GUEST_TEST_BINARIES) predates test-env-dump, so those lanes skip rather
-# than fail when it is absent.
+# (GUEST_TEST_BINARIES) predates test-env-dump, so those lanes skip rather than
+# fail when it is absent.
 ENV_DUMP="${3:-}"
 ENV_CAT="${4:-}"
 
@@ -83,10 +85,11 @@ check reject "--env with an empty argument" "empty variable name" --env ""
 check accept "--fakeroot with an explicit root --user" '' --fakeroot --user 0:0
 check accept "--user UINT32_MAX" '' --user 4294967295
 
-# The containment refusal and its rationale live in elfuse_launch. mktemp
-# lands in /var/folders, outside is_sysroot_backed_temp_path()'s /tmp prefix,
-# so proc_resolve_sysroot_path's host fallback is reachable here.
+# The containment refusal and its rationale live in elfuse_launch. mktemp lands
+# in /var/folders, outside is_sysroot_backed_temp_path()'s /tmp prefix, so
+# proc_resolve_sysroot_path's host fallback is reachable here.
 scratch=$(mktemp -d)
+
 # create_private_dir() rejects a group or other bit on the /dev/shm backing
 # root, and that failure surfaces as a resolve error, not the refusal the last
 # check measures. The leaf itself never has to exist: path_translate_at() sets
@@ -103,8 +106,8 @@ check reject "--workdir absent in the sysroot, present on the host" \
 check accept "--workdir present in the sysroot" '' \
     --sysroot "$scratch/sysroot" --workdir /inroot
 
-# Pins elfuse_launch's "--sysroot /" carve-out: a bare separator must not
-# reject every workdir under it.
+# Pins elfuse_launch's "--sysroot /" carve-out: a bare separator must not reject
+# every workdir under it.
 check accept "--workdir under a root sysroot" '' --sysroot / --workdir /var/tmp
 
 # Refusal rationale in elfuse_launch; see dev_shm_resolve_path().
@@ -112,14 +115,14 @@ check reject "--workdir under /dev/shm" "not supported" \
     --workdir /dev/shm/launch-flags-wd
 
 # The environment the lanes below measure against. MARKER is set so an import
-# and a replacement have something to find; ABSENT is cleared in this process
-# so the "unset on the host" lane cannot be answered by an inherited value.
+# and a replacement have something to find; ABSENT is cleared in this process so
+# the "unset on the host" lane cannot be answered by an inherited value.
 export ELFUSE_TEST_MARKER=marker-value
 unset ELFUSE_TEST_ABSENT
 
 # guest_env <flags...> -- the guest's environ, one entry per line, in order.
-# stderr lands in a file rather than /dev/null so a lane that dies on launch
-# can report why, not just the exit code.
+# stderr lands in a file rather than /dev/null so a lane that dies on launch can
+# report why, not just the exit code.
 guest_env()
 {
     "$ELFUSE" "$@" "$ENV_DUMP" 2> "$scratch/guest-env-stderr"
@@ -150,9 +153,11 @@ env_exact()
 if [ -z "$ENV_DUMP" ] || [ ! -f "$ENV_DUMP" ]; then
     report_skip "environment lanes (no env-dump guest binary)"
 else
+
     # The `elfuse-oci run` spelling, and the only one that makes the guest's
     # environment a function of the flags alone.
     env_exact "--clear-env alone yields an empty environment" "" --clear-env
+
     # One vector through every branch of the merge at once.
     # tests/test-guest-env-host.c settles which answer each branch owes; this
     # lane adds that the answer survives build_linux_stack into the guest.
@@ -160,13 +165,14 @@ else
         "$(printf 'A=2\nB=\nC=b=c\nELFUSE_TEST_MARKER=marker-value')" \
         --clear-env --env A=1 --env B= --env C=b=c \
         --env ELFUSE_TEST_MARKER --env ELFUSE_TEST_ABSENT --env A=2
+
     # --clear-env selects the base wherever it appears, so a launcher that
     # appends it after the --env list gets the same environment.
     env_exact "--clear-env after --env selects the same base" "A=1" \
         --env A=1 --clear-env
 
-    # The only lane with a long override list, so it is the one that would
-    # catch main() sizing the override array short of the flags given.
+    # The only lane with a long override list, so it is the one that would catch
+    # main() sizing the override array short of the flags given.
     many_flags=()
     many_want=""
     for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
@@ -176,8 +182,8 @@ else
     env_exact "twelve --env entries all reach the guest" "$many_want" \
         --clear-env "${many_flags[@]}"
 
-    # Here-strings below, never pipes: under pipefail a `grep -q` exiting at
-    # its first match SIGPIPEs the writer. Every capture carries
+    # Here-strings below, never pipes: under pipefail a `grep -q` exiting at its
+    # first match SIGPIPEs the writer. Every capture carries
     # `|| status=$?` because set -e would abort on the very miss these lanes
     # exist to detect.
     status=0
@@ -239,13 +245,13 @@ want index $base_index)"
     fi
 
     # The procfs sink is held to the same flags and expected entries as the
-    # stack lanes above; it is not a direct comparison of one run's two
-    # sinks.
+    # stack lanes above; it is not a direct comparison of one run's two sinks.
     if [ -n "$ENV_CAT" ] && [ -f "$ENV_CAT" ]; then
-        # /proc/self/environ is NUL-separated and command substitution drops
-        # NUL bytes, so this one must translate inside the pipeline rather
-        # than through a variable. Safe against the SIGPIPE race above
-        # because tr reads to EOF and never exits early.
+
+        # /proc/self/environ is NUL-separated and command substitution drops NUL
+        # bytes, so this one must translate inside the pipeline rather than
+        # through a variable. Safe against the SIGPIPE race above because tr
+        # reads to EOF and never exits early.
         status=0
         procfs="$("$ELFUSE" --clear-env --env A=1 --env B=2 "$ENV_CAT" \
             /proc/self/environ 2> "$scratch/guest-env-stderr" \

--- a/tests/test-linkat-symlink-fallback.c
+++ b/tests/test-linkat-symlink-fallback.c
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Per linkat(2) on Darwin: without AT_SYMLINK_FOLLOW, hard-linking a symlink
- * itself (rather than its target) "may result in some file systems returning
- * an error" -- reproduced on Case-sensitive HFS+ as ENOTSUP, where the same
- * call against a regular file succeeds. Linux allows hard-linking a symlink
- * unconditionally. sys_linkat() falls back to symlinkat() with the same
- * target when the host linkat() fails with EPERM/ENOTSUP and the source is a
- * symlink, so the guest sees the Linux-compatible outcome regardless of the
- * host filesystem.
+ * itself (rather than its target) "may result in some file systems returning an
+ * error" -- reproduced on Case-sensitive HFS+ as ENOTSUP, where the same call
+ * against a regular file succeeds. Linux allows hard-linking a symlink
+ * unconditionally. sys_linkat() falls back to symlinkat() with the same target
+ * when the host linkat() fails with EPERM/ENOTSUP and the source is a symlink,
+ * so the guest sees the Linux-compatible outcome regardless of the host
+ * filesystem.
  *
  * The Makefile target only runs this under a --sysroot backed by a
  * Case-sensitive HFS+ disk image (created via hdiutil); it skips with exit 77

--- a/tests/test-lowbase-mem.c
+++ b/tests/test-lowbase-mem.c
@@ -46,6 +46,7 @@ static void test_binary_low_linked(void)
 {
     TEST("binary linked below ELF_DEFAULT_BASE");
     uintptr_t pc = (uintptr_t) &test_binary_low_linked;
+
     /* The legacy guard window is [0x100000, 0x400000); the test binary's .text
      * must land inside it for the regression to be meaningful.
      */
@@ -57,6 +58,7 @@ static void test_mprotect_own_data_page(void)
 {
     TEST("mprotect own .data page to PROT_READ");
     void *page = (void *) data_page;
+
     /* Drop the page to read-only, RELRO-style. Pre-fix this returned -EINVAL
      * because [SHIM_BASE, ELF_DEFAULT_BASE) was rejected outright.
      */
@@ -65,6 +67,7 @@ static void test_mprotect_own_data_page(void)
         FAIL("mprotect(PROT_READ) on low-linked .data page failed");
         return;
     }
+
     /* Restore RW immediately so any later code that touches the page (e.g.
      * printf's stdout buffer if the linker placed it nearby, or libc exit
      * cleanup) cannot fault. mprotect-restoring is itself the same code path;
@@ -78,6 +81,7 @@ static void test_mprotect_own_data_page(void)
 static void test_munmap_low_scratch_range(void)
 {
     TEST("munmap on scratch range below ELF_DEFAULT_BASE");
+
     /* 0x180000 sits in the legacy guard window [0x100000, 0x400000) but outside
      * the binary's loaded segments (which start at the link address >=
      * 0x200000). With the new high-IPA infra reserve, this range has no PT

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -1250,8 +1250,8 @@ run_suite()
 
     # Checked here rather than inside run_unit_tests so an empty build fails
     # this lane through the caller's accounting. Exiting from inside the lane
-    # would take the whole script down with it under MODE=all, skipping the
-    # qemu lane and the rosetta one, which does not read GUEST_TEST_BINARIES.
+    # would take the whole script down with it under MODE=all, skipping the qemu
+    # lane and the rosetta one, which does not read GUEST_TEST_BINARIES.
     if [ "${ALLOW_MISSING_BINARIES:-0}" != "1" ] \
         && ! require_unit_binaries "$GUEST_TEST_BINARIES"; then
         return 1

--- a/tests/test-mprotect-mt.c
+++ b/tests/test-mprotect-mt.c
@@ -504,6 +504,7 @@ static void test_rvae_2mib_straddle(void)
         FAIL("mmap");
         return;
     }
+
     /* Pick the first 2 MiB boundary AT LEAST 16 pages above the start so the
      * 32-page protect window straddles it (16 pages below + 16 above). If the
      * natural rounded-up boundary is too close to base, jump to the next one --
@@ -649,6 +650,7 @@ int main(void)
     test_rvae_boundary_sweep();
     test_rvae_2mib_straddle();
     test_rvae_icache_stress();
+
     /* Drive the RVAE1IS NUM encoding across its boundaries under contention: 17
      * pages -> NUM=8, 32 -> NUM=15 (mid), 64 -> NUM=31 (max).
      */

--- a/tests/test-mremap-fork-tracking.c
+++ b/tests/test-mremap-fork-tracking.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * These cases exercise elfuse's inherited-at-fork region bookkeeping, not a
- * portable Linux ABI contract. Do not add this binary to test-matrix.sh:
- * Linux can merge the adjacent file mappings below, and extends MAP_SHARED
- * mappings directly from the backing file rather than creating elfuse's
- * child-private tracking tail.
+ * portable Linux ABI contract. Do not add this binary to test-matrix.sh: Linux
+ * can merge the adjacent file mappings below, and extends MAP_SHARED mappings
+ * directly from the backing file rather than creating elfuse's child-private
+ * tracking tail.
  */
 
 #include <errno.h>
@@ -289,8 +289,9 @@ static void test_postfork_repeated_allocations_keep_lineage(void)
                 _exit(90);
 
             /* If child allocation reused the inherited source's vma_id,
-             * find_mremap_source would incorrectly accept the adjacent pair.
-             * A reseeded allocator keeps the logical lineages distinct. */
+             * find_mremap_source would incorrectly accept the adjacent pair. A
+             * reseeded allocator keeps the logical lineages distinct.
+             */
             errno = 0;
             void *same = mremap(first, 2 * span, 2 * span, 0);
             if (same != MAP_FAILED || errno != EFAULT)
@@ -386,8 +387,9 @@ static void test_misaligned_shared_mremap_writeback(void)
     }
 
     /* Deliberately place the source one host page into its reservation. This
-     * keeps the guest mapping page-aligned while making it non-2MiB-aligned,
-     * so the MAP_SHARED overlay/mremap path exercises a split HVF segment. */
+     * keeps the guest mapping page-aligned while making it non-2MiB-aligned, so
+     * the MAP_SHARED overlay/mremap path exercises a split HVF segment.
+     */
     size_t reservation_length = 2 * span + page;
     void *reservation = mmap(NULL, reservation_length, PROT_NONE,
                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -411,7 +413,8 @@ static void test_misaligned_shared_mremap_writeback(void)
     source[page + 7] = 'B';
 
     /* Block in-place growth so mremap must move the mapping and leave the
-     * destination on the snapshot-style shared-writeback path. */
+     * destination on the snapshot-style shared-writeback path.
+     */
     void *blocker = mmap(source + span, span, PROT_NONE,
                          MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
     if (blocker != source + span) {
@@ -462,10 +465,11 @@ static void test_misaligned_shared_mremap_writeback(void)
     close(fd);
 }
 
-/* Force the snapshot-style MAP_SHARED path by placing a guest-page mapping
- * one page into an otherwise unused reservation. Apple hosts use larger host
- * pages than the guest's 4 KiB pages, so this address cannot receive a live
- * file overlay. */
+/* Force the snapshot-style MAP_SHARED path by placing a guest-page mapping one
+ * page into an otherwise unused reservation. Apple hosts use larger host pages
+ * than the guest's 4 KiB pages, so this address cannot receive a live file
+ * overlay.
+ */
 static void *map_misaligned_shared_fixed(size_t length,
                                          int prot,
                                          int fd,
@@ -482,9 +486,10 @@ static void *map_misaligned_shared_fixed(size_t length,
 
     void *address = (char *) reservation + page;
     if (munmap(reservation, length + page) != 0) {
-        /* Keep ownership visible to the caller when the reservation cannot
-         * be released. Returning MAP_FAILED alone would make the live
-         * mapping indistinguishable from an allocation that never happened. */
+        /* Keep ownership visible to the caller when the reservation cannot be
+         * released. Returning MAP_FAILED alone would make the live mapping
+         * indistinguishable from an allocation that never happened.
+         */
         *reservation_out = reservation;
         return MAP_FAILED;
     }
@@ -829,9 +834,11 @@ static void test_file_backed_mremap_emfile_atomic(void)
         }
         if (errno != EMFILE || last_dup < 0)
             _exit(62);
+
         /* Keep one guest slot available for the /proc/self/maps proof below.
          * The close also releases one host descriptor; the file-backed filler
-         * loop consumes it again before finding the actual host/table limit. */
+         * loop consumes it again before finding the actual host/table limit.
+         */
         if (close(last_dup) != 0)
             _exit(69);
 
@@ -865,7 +872,8 @@ static void test_file_backed_mremap_emfile_atomic(void)
          * readable. Near the fixed tracker capacity, VMA count alone cannot
          * prove whether tracker pressure or host descriptors ended the filler
          * loop, so skip instead of attributing an ambiguous ENOMEM to the
-         * second mremap dup. */
+         * second mremap dup.
+         */
         int maps_count = 0;
         if (!count_maps_entries(&maps_count) || maps_count >= 4000)
             _exit(77);
@@ -890,7 +898,8 @@ static void test_file_backed_mremap_emfile_atomic(void)
 
         /* Exactly one host descriptor is free again. A fixed subrange move
          * consumes it for target tracking, then must fail atomically when the
-         * source-boundary snapshot cannot duplicate its backing fd. */
+         * source-boundary snapshot cannot duplicate its backing fd.
+         */
         errno = 0;
         char *fixed = mremap(fixed_probe + 2 * span, span, span,
                              MREMAP_MAYMOVE | MREMAP_FIXED, fixed_probe);
@@ -898,9 +907,10 @@ static void test_file_backed_mremap_emfile_atomic(void)
             fixed_probe[2 * span] != 'S')
             _exit(73);
 
-        /* Release guest dup slots and filler tracker descriptors, then retry.
-         * A failed split that published backing_fd=-1 would make this retry
-         * fail even though descriptor capacity is now available. */
+        /* Release guest dup slots and filler tracker descriptors, then retry. A
+         * failed split that published backing_fd=-1 would make this retry fail
+         * even though descriptor capacity is now available.
+         */
         for (int guest_fd = 0; guest_fd < 4096; guest_fd++) {
             if (guest_fd != fd)
                 (void) close(guest_fd);

--- a/tests/test-mremap-tail-emfile.c
+++ b/tests/test-mremap-tail-emfile.c
@@ -76,7 +76,8 @@ static void child_probe(int file_fd, unsigned char *base)
 
     /* Consume the host descriptor reserve with one-page file mappings separated
      * by holes. The attribution probe below rejects a region/address-capacity
-     * failure, so this loop cannot silently become a different regression. */
+     * failure, so this loop cannot silently become a different regression.
+     */
     const size_t filler_length = (size_t) FILL_LIMIT * 2 * PAGE_SIZE;
     void *reserved = mmap(NULL, filler_length, PROT_NONE,
                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -109,8 +110,8 @@ static void child_probe(int file_fd, unsigned char *base)
     /* Prove that the filler stopped on host descriptor pressure rather than
      * address-space or region-table capacity. Retry the same gap before
      * releasing anything: it must still fail with ENOMEM while the host table
-     * is exhausted. Then release two guest duplicate slots (a file-backed
-     * mmap may need one temporary and one tracked host fd) and map the gap
+     * is exhausted. Then release two guest duplicate slots (a file-backed mmap
+     * may need one temporary and one tracked host fd) and map the gap
      * successfully while leaving every existing region in place. If either
      * attribution step fails, the later ENOMEM assertions would be ambiguous.
      */
@@ -144,7 +145,8 @@ static void child_probe(int file_fd, unsigned char *base)
 
     /* Consume every descriptor released by the attribution probe and the
      * removed filler region. The following mremap/munmap calls must have no
-     * host descriptor available for their internal dup(). */
+     * host descriptor available for their internal dup().
+     */
     int probe_fds[3] = {-1, -1, -1};
     for (int i = 0; i < 3; i++) {
         probe_fds[i] = dup(file_fd);
@@ -153,7 +155,8 @@ static void child_probe(int file_fd, unsigned char *base)
     }
 
     /* Splitting either boundary of the child-private tail must fail before
-     * changing memory or PTEs when no descriptor is available. */
+     * changing memory or PTEs when no descriptor is available.
+     */
     errno = 0;
     result = mremap(base, SPAN + 2 * PAGE_SIZE, SPAN + PAGE_SIZE, 0);
     int remap_errno = errno;
@@ -283,7 +286,8 @@ static void test_full_table_munmap_without_overlay(void)
 
     /* The 32 KiB region and 16 KiB interior edge keep at least one aligned
      * host-page boundary inside the first/last VMA on both 4 KiB and 16 KiB
-     * hosts. The guest only exposes 4 KiB pages to this test. */
+     * hosts. The guest only exposes 4 KiB pages to this test.
+     */
     size_t region_length = 8 * PAGE_SIZE;
     size_t stride = region_length + PAGE_SIZE;
     size_t reservation_length = (size_t) FILL_LIMIT * stride + region_length;

--- a/tests/test-msync.c
+++ b/tests/test-msync.c
@@ -196,6 +196,7 @@ static void test_shm_name_visible_after_fork(void)
 
     char name[64];
     snprintf(name, sizeof(name), "/elfuse-msync-fork-%ld", (long) getpid());
+
     /* Best-effort cleanup of stale shm objects from a previous run that was
      * killed between create and the final unlink. macOS shm objects persist
      * across process death, so without this O_EXCL fails with EEXIST and the

--- a/tests/test-multi-vcpu.c
+++ b/tests/test-multi-vcpu.c
@@ -425,6 +425,7 @@ static void *vcpu_thread(void *arg)
     int markers_left = ctx->max_hvc5;
     for (;;) {
         vcpu_exit_t ex;
+
         /* Tell run_vcpu to return on every HVC #5 (max_hvc5=0) so the handler
          * can inspect X8 and decide whether to resume or stop.
          */

--- a/tests/test-netlink.c
+++ b/tests/test-netlink.c
@@ -201,8 +201,8 @@ int main(void)
 
     /* 7. readv(): a first entry far too small for the response. A receive that
      * stops at entry 0 cannot exceed READV_HEAD bytes. The entries are adjacent
-     * halves of one buffer, so the scattered bytes stay contiguous and parse
-     * as an ordinary message stream.
+     * halves of one buffer, so the scattered bytes stay contiguous and parse as
+     * an ordinary message stream.
      */
     req.nlh.nlmsg_seq = 4;
     sent = sendto(fd, &req, req.nlh.nlmsg_len, 0, (struct sockaddr *) &kernel,

--- a/tests/test-ofd-lock.c
+++ b/tests/test-ofd-lock.c
@@ -4,11 +4,11 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * OFD locks (Linux F_OFD_GETLK=36/F_OFD_SETLK=37/F_OFD_SETLKW=38) are owned
- * by the open file description rather than by a process, so Linux always
- * reports l_pid=-1 for a conflicting F_OFD_GETLK lock. Passing the host's
- * raw l_pid straight through leaks a host PID to the guest and breaks
- * software (e.g. SQLite) that checks for the OFD-lock -1 sentinel.
+ * OFD locks (Linux F_OFD_GETLK=36/F_OFD_SETLK=37/F_OFD_SETLKW=38) are owned by
+ * the open file description rather than by a process, so Linux always reports
+ * l_pid=-1 for a conflicting F_OFD_GETLK lock. Passing the host's raw l_pid
+ * straight through leaks a host PID to the guest and breaks software (e.g.
+ * SQLite) that checks for the OFD-lock -1 sentinel.
  */
 
 #include <errno.h>
@@ -54,9 +54,10 @@ int main(void)
         perror("open fd1");
         return 1;
     }
+
     /* A second open() yields a distinct open file description, so OFD locks
-     * taken on fd1 can conflict with a query made through fd2 even though
-     * both fds live in the same process.
+     * taken on fd1 can conflict with a query made through fd2 even though both
+     * fds live in the same process.
      */
     int fd2 = open(path, O_RDWR, 0644);
     if (fd2 < 0) {
@@ -79,8 +80,8 @@ int main(void)
     EXPECT_TRUE(gr == 0 && gfl.l_type == F_WRLCK,
                 "F_OFD_GETLK did not report the conflicting write lock");
 
-    /* This is the behavior issue #129 reports as broken: l_pid must be -1
-     * for an OFD lock conflict, never a real (host or guest) PID.
+    /* This is the behavior issue #129 reports as broken: l_pid must be -1 for
+     * an OFD lock conflict, never a real (host or guest) PID.
      */
     TEST("F_OFD_GETLK l_pid is -1 on conflict");
     EXPECT_EQ(gfl.l_pid, -1, "F_OFD_GETLK leaked a non -1 l_pid");

--- a/tests/test-oom-proc.c
+++ b/tests/test-oom-proc.c
@@ -5,19 +5,19 @@
  * Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
  * SPDX-License-Identifier: Apache-2.0
  *
- * elfuse backs /proc/self/oom_adj, oom_score_adj, and oom_score with a
- * per-open host temp file materialized at open() time, plus a separate
- * read-intercept path (proc_intercept_read) that serves live atomic state
- * to guest read/pread/readv so a write through a sibling fd is visible
- * without reopening. sendfile(2) and copy_file_range(2) do not go through
- * that read path -- they go through copy_fd_range's own, independently
- * wired proc_try_chunk_read_intercept call. These tests pin that second
- * wiring: open the source fd, mutate the value through a sibling fd, then
+ * elfuse backs /proc/self/oom_adj, oom_score_adj, and oom_score with a per-open
+ * host temp file materialized at open() time, plus a separate read-intercept
+ * path (proc_intercept_read) that serves live atomic state to guest
+ * read/pread/readv so a write through a sibling fd is visible without
+ * reopening. sendfile(2) and copy_file_range(2) do not go through that read
+ * path -- they go through copy_fd_range's own, independently wired
+ * proc_try_chunk_read_intercept call. These tests pin that second wiring: open
+ * the source fd, mutate the value through a sibling fd, then
  * sendfile/copy_file_range from the already-open fd and require the fresh
  * value, not the stale open-time snapshot.
  *
- * This is elfuse-internal plumbing with no Linux-kernel counterpart -- no
- * real program sendfile()s or copy_file_range()s out of procfs -- so unlike
+ * This is elfuse-internal plumbing with no Linux-kernel counterpart -- no real
+ * program sendfile()s or copy_file_range()s out of procfs -- so unlike
  * test-io-opt this suite is not run against the QEMU reference kernel; see
  * tests/test-matrix.sh.
  */
@@ -43,8 +43,8 @@ static void reset_oom_score_adj(void)
 
 /* Copy up to 32 bytes from in_fd to out_fd, returning the byte count and
  * reporting via *offsets_ok whether the syscall's offset bookkeeping advanced
- * to the expected 3 bytes. sendfile tracks one (source) offset;
- * copy_file_range tracks both a source and a destination offset.
+ * to the expected 3 bytes. sendfile tracks one (source) offset; copy_file_range
+ * tracks both a source and a destination offset.
  */
 typedef ssize_t (*oom_copy_fn)(int out_fd, int in_fd, int *offsets_ok);
 
@@ -66,9 +66,9 @@ static ssize_t copy_via_copy_file_range(int out_fd, int in_fd, int *offsets_ok)
 
 /* Open the synthetic oom_adj source, bump the value through a sibling
  * oom_score_adj fd, then `copy` 32 bytes from the already-open source into a
- * fresh temp file and require the updated "15\n" (3 bytes) instead of the
- * stale open-time snapshot. The copy method and its offset bookkeeping differ,
- * so the caller supplies them; everything else is shared.
+ * fresh temp file and require the updated "15\n" (3 bytes) instead of the stale
+ * open-time snapshot. The copy method and its offset bookkeeping differ, so the
+ * caller supplies them; everything else is shared.
  */
 static void run_oom_copy_test(const char *label,
                               const char *dst,

--- a/tests/test-osync-requeue.c
+++ b/tests/test-osync-requeue.c
@@ -38,6 +38,7 @@ static struct timespec t_wake;
 static void *waiter_fn(void *arg)
 {
     (void) arg;
+
     /* musl: do __wait(l,0,2,1); while (a_cas(l,0,2)); -- FUTEX_WAIT on barrier
      * expecting 2, retry while the word is still 2.
      */

--- a/tests/test-perf.sh
+++ b/tests/test-perf.sh
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
+
 # test-perf.sh -- Performance comparison: native vs elfuse for grep/wc/cat
 #
 # Copyright 2026 elfuse contributors
 # Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Measures wall-clock time for common coreutils operations, comparing
-# macOS native tools against the same tools running under elfuse. Overhead
-# comes from VM startup (~1-3ms) and per-syscall vmexits (~1-5us each).
-# Pure computation (regex matching etc.) runs at native speed.
+# Measures wall-clock time for common coreutils operations, comparing macOS
+# native tools against the same tools running under elfuse. Overhead comes from
+# VM startup (~1-3ms) and per-syscall vmexits (~1-5us each). Pure computation
+# (regex matching etc.) runs at native speed.
 #
-# Timing uses the epoch_us helper from tests/lib/bash-compat.sh, which
-# prefers $EPOCHREALTIME (bash 5.0+) and falls back to 'date +%s %N'
-# (macOS 14+/GNU coreutils) or python3 / perl so the script works on
-# stock macOS bash 3.2 too.
+# Timing uses the epoch_us helper from tests/lib/bash-compat.sh, which prefers
+# $EPOCHREALTIME (bash 5.0+) and falls back to 'date +%s %N' (macOS 14+/GNU
+# coreutils) or python3 / perl so the script works on stock macOS bash 3.2 too.
 #
 # Usage: tests/test-perf.sh <elfuse-binary> <tool-bin-dir>
 # Example: tests/test-perf.sh build/elfuse /path/to/tool/bin
 
 set -euo pipefail
-# pipefail in particular matters here: several benchmarks pipe an
-# elfuse-hosted producer (e.g. cat) into a native consumer (e.g. wc).
-# Without pipefail, a producer crash returns rc=0 from the pipeline,
-# so the elfuse-side failure was silently smoothed into a "fast" sample.
+
+# pipefail in particular matters here: several benchmarks pipe an elfuse-hosted
+# producer (e.g. cat) into a native consumer (e.g. wc). Without pipefail, a
+# producer crash returns rc=0 from the pipeline, so the elfuse-side failure was
+# silently smoothed into a "fast" sample.
 
 # shellcheck source=tests/lib/bash-compat.sh
 . "$(dirname "$0")/lib/bash-compat.sh"
@@ -44,13 +45,13 @@ PATTERN="syscall"
 
 PERF_FAILED=0
 
-# Collect $RUNS timing samples for a command, print median and stats.
-# Args: label command...
+# Collect $RUNS timing samples for a command, print median and stats. Args:
+# label command...
 # Earlier revisions swallowed every sample's exit status with '|| true',
-# which made a missing native binary, an elfuse crash, or a host SIP
-# block silently degrade into "median 0 ms PASS". Now any non-zero
-# sample aborts the timing for that label and flips PERF_FAILED so the
-# script exits non-zero after running every other benchmark.
+# which made a missing native binary, an elfuse crash, or a host SIP block
+# silently degrade into "median 0 ms PASS". Now any non-zero sample aborts the
+# timing for that label and flips PERF_FAILED so the script exits non-zero after
+# running every other benchmark.
 benchmark()
 {
     local label="$1"
@@ -122,9 +123,10 @@ trap 'rm -f "$TMPFILE"' EXIT
 for _ in $(seq 1 100); do cat "$SYSCALL_C" >> "$TMPFILE"; done
 TMPSIZE=$(wc -c < "$TMPFILE" | tr -d ' ')
 printf "  ${CYAN}(test file: %s bytes)${RESET}\n" "$TMPSIZE"
-# sh -c spawns a child shell that does not inherit the outer pipefail
-# from the script's 'set -o pipefail'. Run the pipeline under bash so
-# pipefail is available on systems whose /bin/sh is not bash-compatible.
+
+# sh -c spawns a child shell that does not inherit the outer pipefail from the
+# script's 'set -o pipefail'. Run the pipeline under bash so pipefail is
+# available on systems whose /bin/sh is not bash-compatible.
 benchmark "native cat|wc" bash -c "set -o pipefail; cat '$TMPFILE' | wc -l"
 benchmark "elfuse cat|wc" bash -c "set -o pipefail; '$ELFUSE' '$TOOL_BIN/cat' '$TMPFILE' | wc -l"
 echo

--- a/tests/test-proc-fidelity.c
+++ b/tests/test-proc-fidelity.c
@@ -115,6 +115,7 @@ static void test_proc_oom_score_adj_rejects_out_of_range(void)
         FAIL("open");
         return;
     }
+
     /* Linux validates the input domain on the writer side; the kernel returns
      * EINVAL for any value outside [-1000, 1000].
      */
@@ -149,6 +150,7 @@ static void test_proc_oom_adj_scaling(void)
         FAIL("open /proc/self/oom_adj");
         return;
     }
+
     /* Linux fs/proc/base.c oom_adj_write special-cases OOM_ADJUST_MAX so 15
      * maps directly to OOM_SCORE_ADJ_MAX (1000), not 15*1000/17 = 882.
      */
@@ -223,6 +225,7 @@ static void test_proc_oom_adj_same_fd_roundtrip(void)
 static void test_proc_oom_score_no_write(void)
 {
     TEST("/proc/self/oom_score writes are rejected");
+
     /* Linux: open succeeds (root bypasses the 0444 check, non-root sees EACCES
      * from the permission gate); writes always fail because there is no write
      * handler. The test focuses on the write side, which is uniform across
@@ -240,6 +243,7 @@ static void test_proc_oom_score_no_write(void)
         FAIL("read");
         return;
     }
+
     /* Stub returns 0; real Linux computes a small positive score, but for a
      * userspace bridge a constant zero is acceptable.
      */
@@ -249,6 +253,7 @@ static void test_proc_oom_score_no_write(void)
 static void test_proc_oom_score_write_fails(void)
 {
     TEST("/proc/self/oom_score write is rejected");
+
     /* The intended coverage is the proc node's write handler returning EIO.
      * That handler is only reached when open succeeds with write access. Only
      * root can open the 0444 file O_WRONLY; non-root sees EACCES at open and
@@ -271,6 +276,7 @@ static void test_proc_oom_score_write_fails(void)
     ssize_t w = write(fd, "0\n", 2);
     int saved = errno;
     close(fd);
+
     /* Linux's proc_reg_write returns -EIO when the proc node has no write op.
      * Older or stripped kernels may return other errno; the load-bearing
      * assertion is that the write fails, not the exact errno value.
@@ -443,6 +449,7 @@ static void test_proc_oom_zero_length_writev(void)
         FAIL("open");
         return;
     }
+
     /* Two empty iovecs: total length zero. Linux returns 0; the previous
      * implementation returned EINVAL via proc_parse_int_write.
      */
@@ -465,6 +472,7 @@ static void test_proc_oom_stat_size_zero(void)
         FAIL("stat");
         return;
     }
+
     /* A non-zero st_size would cap stat-sized read buffers, truncating
      * "-1000\n" (6 bytes) to whatever size was hardcoded.
      */
@@ -517,6 +525,7 @@ static void test_proc_fdinfo_eventfd_count(void)
         FAIL("read");
         return;
     }
+
     /* Linux fs/eventfd.c emits "eventfd-count: %16llx" with a single space
      * separator (not a tab, unlike pos:/flags:/mnt_id:). Pin the exact prefix
      * so a regression to a tab is caught. Decimal 42 is 0x2a.
@@ -553,6 +562,7 @@ static void test_proc_fdinfo_signalfd_mask(void)
         FAIL("read");
         return;
     }
+
     /* Linux fs/signalfd.c emits "sigmask:\t%016llx" with a tab separator
      * (verified against a real /proc/self/fdinfo dump on Linux 6.x). Pin the
      * exact prefix so a regression to a space is caught.
@@ -600,6 +610,7 @@ static void test_proc_fdinfo_timerfd_periodic_value(void)
 
     long long value_sec = -1, value_nsec = -1;
     long long interval_sec = -1, interval_nsec = -1;
+
     /* Linux fs/timerfd.c emits "it_value: (S, NS)" with a single space after
      * the colon (unlike pos:/flags: which use tabs).
      */
@@ -615,6 +626,7 @@ static void test_proc_fdinfo_timerfd_periodic_value(void)
 
     long long value_total_ns = value_sec * 1000000000LL + value_nsec;
     long long interval_total_ns = interval_sec * 1000000000LL + interval_nsec;
+
     /* it_interval is the static settime value and must round-trip; Linux's
      * timerfd_get_remaining() reports 0 once the timer has fired, while elfuse
      * computes time-until-next from the kqueue arm time. Both are non-negative
@@ -628,6 +640,7 @@ static void test_proc_fdinfo_timerfd_periodic_value(void)
 static void test_proc_fdinfo_timerfd_ticks_drains_kqueue(void)
 {
     TEST("/proc/self/fdinfo/<N> ticks reflects pending kqueue fires");
+
     /* Arm a periodic timer, wait for several fires, then read fdinfo WITHOUT
      * first reading the timerfd. The pre-fix snapshot exported a stale
      * expirations counter (the kqueue events had not been folded in), so ticks
@@ -674,6 +687,7 @@ static void test_proc_fdinfo_timerfd_ticks_drains_kqueue(void)
         FAIL("parse ticks");
         return;
     }
+
     /* At minimum one fire should be visible; on a slow host more would be
      * expected. Pre-fix elfuse would report 0 here.
      */
@@ -683,6 +697,7 @@ static void test_proc_fdinfo_timerfd_ticks_drains_kqueue(void)
 static void test_proc_fdinfo_dir_concurrent_safe(void)
 {
     TEST("/proc/self/fdinfo dir tolerates concurrent re-open");
+
     /* Open the directory twice and verify both enumerate independently. The
      * earlier shared-dir design could mutate one open's backing files while
      * another iterated. Both Linux and the per-open scratch fix should at
@@ -764,6 +779,7 @@ static int bind_listen_loopback_tcp(void)
 static void test_proc_net_tcp_sl_dense(void)
 {
     TEST("/proc/net/tcp sl column stays dense across mixed sockets");
+
     /* Interleave non-TCP sockets BEFORE the bound TCP listeners so the
      * proc_pidinfo iterator visits the rejected sockets first and the pre-fix
      * sparse-slot bug would assign nonzero sl to the first emitted row. Two TCP

--- a/tests/test-proc-smap.c
+++ b/tests/test-proc-smap.c
@@ -121,8 +121,9 @@ static bool parse_device_token(const char *token)
            parse_unsigned_token(minor, 16, &value);
 }
 
-/* Parse the address/perms/offset/dev/inode part of a smaps header. The rest
- * of the line is an optional pathname and is intentionally left opaque. */
+/* Parse the address/perms/offset/dev/inode part of a smaps header. The rest of
+ * the line is an optional pathname and is intentionally left opaque.
+ */
 static bool parse_header(const char *line, smaps_vma_t *vma)
 {
     const char *p = line;
@@ -184,10 +185,11 @@ static bool parse_header(const char *line, smaps_vma_t *vma)
     return true;
 }
 
-/* Parse a decimal field and optionally require a suffix after its number.
- * Both smaps field families share the same label/whitespace/overflow rules;
- * only the trailing unit differs ("kB" for the first group, none for the
- * remaining numeric fields). */
+/* Parse a decimal field and optionally require a suffix after its number. Both
+ * smaps field families share the same label/whitespace/overflow rules; only the
+ * trailing unit differs ("kB" for the first group, none for the remaining
+ * numeric fields).
+ */
 static bool parse_numeric_field(const char *line,
                                 const char *label,
                                 const char *suffix,
@@ -224,8 +226,10 @@ static bool parse_vmflags(const char *line, bool *writable)
     const char *p = line + label_len;
     if (*p && !isspace((unsigned char) *p))
         return false;
+
     /* Keep the provider's stable spelling for an empty flag set: the Linux
-     * field always has a separating space, even when no token follows. */
+     * field always has a separating space, even when no token follows.
+     */
     if (!*p)
         return false;
     bool has_wr = false;
@@ -241,8 +245,10 @@ static bool parse_vmflags(const char *line, bool *writable)
         if ((size_t) (p - start) == 2 && start[0] == 'w' && start[1] == 'r')
             has_wr = true;
     }
-    /* A synthetic PROT_NONE VMA has no provable access flags and therefore
-     * may legitimately emit an empty VmFlags field. */
+
+    /* A synthetic PROT_NONE VMA has no provable access flags and therefore may
+     * legitimately emit an empty VmFlags field.
+     */
     *writable = has_wr;
     return true;
 }
@@ -283,7 +289,8 @@ static bool parse_smaps(char *buf, size_t len, smaps_info_t *info)
         *next = '\0';
 
         /* smaps records are contiguous: a blank line is not a field and is
-         * rejected so malformed snapshots cannot hide an out-of-order VMA. */
+         * rejected so malformed snapshots cannot hide an out-of-order VMA.
+         */
         if (!*line) {
             goto fail;
         }
@@ -373,8 +380,9 @@ static void free_smaps(smaps_info_t *info)
 }
 
 /* Read, parse, and release one smaps snapshot. The parser owns only its VMA
- * array, so the transient file buffer can be cleaned up in this single place
- * on both success and failure. */
+ * array, so the transient file buffer can be cleaned up in this single place on
+ * both success and failure.
+ */
 static bool load_smaps(const char *path, smaps_info_t *info)
 {
     FILE *file = fopen(path, "r");
@@ -517,8 +525,9 @@ static int child_probe(uintptr_t target,
     uintptr_t stress_end = stress + stress_size;
 
 #ifdef MAP_FIXED_NOREPLACE
-    /* Keep the probe in a known gap so the synthetic smaps builder cannot
-     * merge it with the target's final rw page or the stress fixture. */
+    /* Keep the probe in a known gap so the synthetic smaps builder cannot merge
+     * it with the target's final rw page or the stress fixture.
+     */
     uintptr_t fixed_hint = 0x700000000000ULL;
     for (int attempt = 0; attempt < 32; attempt++) {
         void *candidate =
@@ -629,17 +638,20 @@ int main(void)
     }
     if (fixture_ok) {
         /* Start with a read-only page so an allocator placing this mapping
-         * immediately after target cannot merge target's final rw page into
-         * the stress range. Alternating permissions keeps every stress page
-         * as a distinct VMA while preserving the >256 completeness probe. */
+         * immediately after target cannot merge target's final rw page into the
+         * stress range. Alternating permissions keeps every stress page as a
+         * distinct VMA while preserving the >256 completeness probe.
+         */
         for (size_t i = 0; i < stress_pages; i += 2) {
             if (mprotect(stress + i * page_size, page_size, PROT_READ) < 0) {
                 fixture_ok = false;
                 break;
             }
         }
+
         /* Keep one page inaccessible so the parser and formatter exercise
-         * PROT_NONE coverage and the required empty VmFlags spelling. */
+         * PROT_NONE coverage and the required empty VmFlags spelling.
+         */
         if (fixture_ok &&
             mprotect(stress + 2 * page_size, page_size, PROT_NONE) < 0)
             fixture_ok = false;

--- a/tests/test-proc.c
+++ b/tests/test-proc.c
@@ -111,8 +111,8 @@ int main(void)
             FAIL("read failed");
     }
 
-    /* /proc/version and uname(2) describe one kernel, so the release the
-     * banner carries has to be the release uname reports.
+    /* /proc/version and uname(2) describe one kernel, so the release the banner
+     * carries has to be the release uname reports.
      */
     TEST("/proc/version matches uname");
     {
@@ -284,7 +284,8 @@ int main(void)
             FAIL("statfs /proc/self/exe failed");
         } else {
             /* /proc/self/exe points to the host binary file, which resides on a
-             * real filesystem, not procfs. */
+             * real filesystem, not procfs.
+             */
             EXPECT_TRUE(exe_st.f_type != 0x9fa0,
                         "statfs /proc/self/exe returned PROC_SUPER_MAGIC");
 

--- a/tests/test-process-lifecycle.c
+++ b/tests/test-process-lifecycle.c
@@ -587,6 +587,7 @@ static void test_signal_wait_status(void)
     int ready_ok = killed > 0 && read_all(ready[0], &byte, 1, true) >= 0;
     if (setup_ok)
         close(ready[0]);
+
     /* Let the child return from write(2) and enter EL0 compute code. This
      * specifically checks that the cross-process signal doorbell interrupts a
      * running vCPU whose valid Hypervisor.framework handle may be zero.
@@ -692,6 +693,7 @@ static void test_concurrent_wait_during_fork_admission(void)
                 break;
             usleep(1000);
         }
+
         /* Keep the waiter active briefly after the first report: a phantom
          * admission record would otherwise leave a second entry for this same
          * guest PID, producing a duplicate consuming wait.
@@ -1171,9 +1173,10 @@ static void test_pid1_retains_adopted_exit(void)
             report.adopted_ppid = wait_for_ppid(1, 3000);
             (void) write_all(result[1], &report, sizeof(report));
             close(result[1]);
+
             /* Keep exit_barrier[1] open until process teardown. EOF tells the
-             * observer that the leaf has finished, not merely that it sent
-             * the report above.
+             * observer that the leaf has finished, not merely that it sent the
+             * report above.
              */
             _exit(report.adopted_ppid == 1 ? 83 : 84);
         }

--- a/tests/test-process-vm.c
+++ b/tests/test-process-vm.c
@@ -163,10 +163,10 @@ static void test_error_paths(void)
  * behavior, not merely a strange result, which is why the copy helper uses
  * memmove per step.
  *
- * This does not try to catch that undefined behavior by its output. Measured
- * on this host, the forward copy it replaced produced correct leading bytes and
- * a result that simply differed from memmove, so nothing observable separates
- * the two reliably; the fix rests on the language rule, not on a reproducer.
+ * This does not try to catch that undefined behavior by its output. Measured on
+ * this host, the forward copy it replaced produced correct leading bytes and a
+ * result that simply differed from memmove, so nothing observable separates the
+ * two reliably; the fix rests on the language rule, not on a reproducer.
  *
  * What the case does pin is the part that is specified: the full count comes
  * back and nothing outside the destination is disturbed. The content of the
@@ -190,8 +190,9 @@ static void test_overlapping_self_copy(void)
         TEST("process_vm_readv overlapping self copy");
         EXPECT_EQ(raw_process_vm_readv(getpid(), &dst_iov, 1, &src_iov, 1, 0),
                   (long) span, "overlapping copy reported short");
-        /* head + delta, not head: the destination starts past the delta gap,
-         * so those bytes are before it too and a stray write there must fail.
+
+        /* head + delta, not head: the destination starts past the delta gap, so
+         * those bytes are before it too and a stray write there must fail.
          */
         EXPECT_TRUE(memcmp(buf, original, head + delta) == 0,
                     "overlapping copy wrote before the destination");

--- a/tests/test-proctitle-host.c
+++ b/tests/test-proctitle-host.c
@@ -38,6 +38,7 @@
 static void on_sigsegv(int sig)
 {
     (void) sig;
+
     /* Cannot rely on stdio inside an async signal handler, but a single _exit
      * with a recognizable code is sufficient: the run target prints a
      * meaningful failure when the child exits with 139.
@@ -61,6 +62,7 @@ int main(void)
     }
 
     size_t page = (size_t) pgsz;
+
     /* Layout: [page 0: writable argv] [page 1: PROT_NONE guard]
      *         [page 2: writable envp sentinel]
      * A reverted argv+envp walk that consults environ computes an avail

--- a/tests/test-proctitle-low-stack.sh
+++ b/tests/test-proctitle-low-stack.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-proctitle-low-stack.sh -- Regress Apple Silicon argv/env stack overwrite
 #
 # Copyright 2026 elfuse contributors
@@ -6,18 +7,17 @@
 #
 # Usage: tests/test-proctitle-low-stack.sh <elfuse-binary> <busybox-binary>
 #
-# The original failure (see git log for runtime/proctitle.c) was an argv
-# tail overshoot by Apple libc memset stp/DC ZVA ladders writing past the
-# explicit byte count when the destination touched the stack ceiling. The
-# fix walks only the contiguous argv block and stores byte-by-byte through
-# a volatile pointer.
+# The original failure (see git log for runtime/proctitle.c) was an argv tail
+# overshoot by Apple libc memset stp/DC ZVA ladders writing past the explicit
+# byte count when the destination touched the stack ceiling. The fix walks only
+# the contiguous argv block and stores byte-by-byte through a volatile pointer.
 #
 # This regression launches the standard busybox echo path under a host
-# RLIMIT_STACK far below every macOS default (8176 KiB on Apple Silicon,
-# 8192 KiB on Intel), and verifies the rewrite still terminates cleanly.
-# Earlier revisions of this script gated the cap behind a -gt comparison
-# that became a no-op on hosts whose default soft cap already met or
-# beat the gate value; the cap is now applied unconditionally.
+# RLIMIT_STACK far below every macOS default (8176 KiB on Apple Silicon, 8192
+# KiB on Intel), and verifies the rewrite still terminates cleanly. Earlier
+# revisions of this script gated the cap behind a -gt comparison that became a
+# no-op on hosts whose default soft cap already met or beat the gate value; the
+# cap is now applied unconditionally.
 
 set -euo pipefail
 
@@ -29,14 +29,14 @@ TEST_TIMEOUT="${TEST_TIMEOUT:-10}"
 # shellcheck source=tests/lib/test-runner.sh
 source "$SCRIPT_DIR/lib/test-runner.sh"
 
-# Override via env for local experiments. The default sits an order of
-# magnitude below every observed macOS shell default and well above the
-# floor where elfuse's own host runtime needs more stack than is provided
-# (empirically ~560 KiB on macOS 26 / Apple M-series).
+# Override via env for local experiments. The default sits an order of magnitude
+# below every observed macOS shell default and well above the floor where
+# elfuse's own host runtime needs more stack than is provided (empirically ~560
+# KiB on macOS 26 / Apple M-series).
 PROCTITLE_LOW_STACK_KIB="${PROCTITLE_LOW_STACK_KIB:-1024}"
 
-# Distinct exit codes from the wrapped child shell let the parent
-# distinguish "rlimit setup failed" from "elfuse crashed".
+# Distinct exit codes from the wrapped child shell let the parent distinguish
+# "rlimit setup failed" from "elfuse crashed".
 ULIMIT_SETUP_FAIL=98
 ULIMIT_VERIFY_FAIL=99
 

--- a/tests/test-readv-writev.c
+++ b/tests/test-readv-writev.c
@@ -286,10 +286,10 @@ static void test_pwritev2_append(void)
     EXPECT_TRUE(nr == 6 && !memcmp(buf, "baseXY", 6), "append data mismatch");
 }
 
-/* Test 8: zero iovcnt returns 0 without moving the append file offset.
- * Linux reference (verified under qemu-system-aarch64): import_iovec()
- * yields an empty iterator, do_iter_write returns 0 before the offset is
- * touched, so pwritev2(RWF_APPEND) with iovcnt == 0 is a complete no-op.
+/* Test 8: zero iovcnt returns 0 without moving the append file offset. Linux
+ * reference (verified under qemu-system-aarch64): import_iovec() yields an
+ * empty iterator, do_iter_write returns 0 before the offset is touched, so
+ * pwritev2(RWF_APPEND) with iovcnt == 0 is a complete no-op.
  */
 
 static void test_pwritev2_append_zero_iovcnt(void)
@@ -320,14 +320,14 @@ static void test_pwritev2_append_zero_iovcnt(void)
     EXPECT_TRUE(ret == 0 && pos == 1, "zero iovcnt not a no-op");
 }
 
-/* Test 8: zero-iovcnt validation ordering across all six vector entry
- * points. Linux reference (fs/read_write.c): a negative offset fails EINVAL
- * before the fd lookup (do_preadv/do_pwritev; -1 is a valid sentinel only
- * for preadv2/pwritev2), the positional variants fail non-seekable files
- * with ESPIPE (FMODE_PREAD/FMODE_PWRITE), wrong-direction and O_PATH fds
- * fail EBADF (FMODE_READ/FMODE_WRITE in do_iter_read/do_iter_write), and
- * RWF flags are never validated because do_iter_* return before
- * kiocb_set_rw_flags for an empty vector.
+/* Test 8: zero-iovcnt validation ordering across all six vector entry points.
+ * Linux reference (fs/read_write.c): a negative offset fails EINVAL before the
+ * fd lookup (do_preadv/do_pwritev; -1 is a valid sentinel only for
+ * preadv2/pwritev2), the positional variants fail non-seekable files with
+ * ESPIPE (FMODE_PREAD/FMODE_PWRITE), wrong-direction and O_PATH fds fail EBADF
+ * (FMODE_READ/FMODE_WRITE in do_iter_read/do_iter_write), and RWF flags are
+ * never validated because do_iter_* return before kiocb_set_rw_flags for an
+ * empty vector.
  */
 
 enum vec_op {

--- a/tests/test-rosetta-alpine.sh
+++ b/tests/test-rosetta-alpine.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-alpine.sh - Alpine-flavored x86_64 tests through Rosetta
 #
 # Copyright 2026 elfuse contributors
@@ -190,6 +191,7 @@ run_pipe()
     fi
     local out rc
     set +e
+
     # set -o pipefail inside the subshell so the captured $? reflects the first
     # non-zero stage exit, not just the last. Without this a producer that fails
     # after emitting matching text would silently pass.

--- a/tests/test-rosetta-audit.sh
+++ b/tests/test-rosetta-audit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-audit.sh - Rosetta thread/signal audit smoke
 #
 # Copyright 2026 elfuse contributors

--- a/tests/test-rosetta-cli.sh
+++ b/tests/test-rosetta-cli.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-cli.sh - Exercise x86_64/Rosetta CLI gating paths
 #
 # Copyright 2026 elfuse contributors
@@ -8,10 +9,10 @@ set -euo pipefail
 
 ELFUSE="${1:-build/elfuse}"
 
-# Shared report_pass / report_fail / report_skip + test-runner.sh
-# colors. The matrix runner reads only the Results: line emitted by
-# report_summary at the bottom; per-binary lines now match the aarch64
-# modes' [ OK ] / [ FAIL ] format.
+# Shared report_pass / report_fail / report_skip + test-runner.sh colors. The
+# matrix runner reads only the Results: line emitted by report_summary at the
+# bottom; per-binary lines now match the aarch64 modes' [ OK ] / [ FAIL ]
+# format.
 # shellcheck source=tests/lib/report.sh
 . "$(dirname "$0")/lib/report.sh"
 
@@ -85,8 +86,8 @@ run_expect_fail()
 }
 
 # Rosetta is on by default and architecture is auto-detected from the ELF
-# header; --no-rosetta opts out, and the rejection message points at the
-# right flag.
+# header; --no-rosetta opts out, and the rejection message points at the right
+# flag.
 run_expect_fail "rosetta-disabled-flag" \
     "x86_64 ELF rejected by --no-rosetta" \
     "$ELFUSE" --no-rosetta "$x64_elf"
@@ -100,12 +101,11 @@ run_expect_fail "rosetta-gdb" \
     "$ELFUSE" --gdb 4010 "$x64_elf"
 
 # With Rosetta installed, elfuse bootstrap now reaches the translator and
-# rosettad bridge. Depending on host/runtime state, the remaining gaps can
-# fail in rosettad's translation cache path, in Rosetta's high-VA allocator,
-# or with the translator's own VZ-environment complaint. On hosts without
-# Rosetta installed the failure surfaces earlier with an install hint.
-# Accept any of those Rosetta-specific signatures to avoid masking unrelated
-# elfuse failures.
+# rosettad bridge. Depending on host/runtime state, the remaining gaps can fail
+# in rosettad's translation cache path, in Rosetta's high-VA allocator, or with
+# the translator's own VZ-environment complaint. On hosts without Rosetta
+# installed the failure surfaces earlier with an install hint. Accept any of
+# those Rosetta-specific signatures to avoid masking unrelated elfuse failures.
 run_expect_fail "rosetta-default" \
     "requires the Rosetta Linux translator\\|translate produced empty/missing output\\|Translation failed, invalid path or invalid executable\\|VMAllocationTracker\\|Rosetta is only intended to run on Apple Silicon" \
     "$ELFUSE" "$x64_elf"

--- a/tests/test-rosetta-execfd.sh
+++ b/tests/test-rosetta-execfd.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
+
 # test-rosetta-execfd.sh - guest fd is preserved across a rosetta execve
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Regression for the hardcoded guest fd 3 in rosetta_finalize. The runner
-# used to install the x86_64 binary at guest fd 3, clobbering whatever the
-# guest had already opened there. apt hands gpgv a status pipe on fd 3
-# (gpgv --status-fd 3); the eviction broke signature verification with
-# "Good signature, but could not determine key fingerprint". rosetta_finalize
-# now takes the lowest free non-stdio slot and publishes it via AT_EXECFD, so a
-# guest fd opened before an x86_64 execve survives into the new image and
-# intentionally closed stdio fds stay closed.
+# Regression for the hardcoded guest fd 3 in rosetta_finalize. The runner used
+# to install the x86_64 binary at guest fd 3, clobbering whatever the guest had
+# already opened there. apt hands gpgv a status pipe on fd 3 (gpgv --status-fd
+# 3); the eviction broke signature verification with "Good signature, but could
+# not determine key fingerprint". rosetta_finalize now takes the lowest free
+# non-stdio slot and publishes it via AT_EXECFD, so a guest fd opened before an
+# x86_64 execve survives into the new image and intentionally closed stdio fds
+# stay closed.
 #
-# The probe: a shell opens fd 3 onto a marker file, then execs busybox to
-# cat /proc/self/fd/3. If the runner evicts fd 3, cat reads the busybox ELF
-# instead of the marker. Both processes are x86_64 statics, so the inner
-# exec goes through the rosetta exec re-bootstrap path.
+# The probe: a shell opens fd 3 onto a marker file, then execs busybox to cat
+# /proc/self/fd/3. If the runner evicts fd 3, cat reads the busybox ELF instead
+# of the marker. Both processes are x86_64 statics, so the inner exec goes
+# through the rosetta exec re-bootstrap path.
 #
 # Skips cleanly when Rosetta Linux is absent or the x86_64 fixture tree is
 # missing (run tests/fetch-fixtures.sh INCLUDE_X86_64=1 first).

--- a/tests/test-rosetta-failure-modes.sh
+++ b/tests/test-rosetta-failure-modes.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-#
+
 # CLI gating for x86_64-via-Rosetta
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Verifies that the three command-line gates around x86_64 guests
-# reject as designed. Treats the failure itself as the test: every
-# probe is expected to exit non-zero AND emit a recognisable error
-# fragment.
+# Verifies that the three command-line gates around x86_64 guests reject as
+# designed. Treats the failure itself as the test: every probe is expected to
+# exit non-zero AND emit a recognisable error fragment.
 #
 # Categories covered:
 #   1. --gdb on x86_64 ELF: rejected by main.c
@@ -16,12 +15,11 @@
 #   3. ELFUSE_NO_ROSETTA=1 with x86_64: same rejection via env
 #
 # The end-to-end dynamic-linker bring-up under Rosetta is covered by
-# tests/test-rosetta-glibc.sh (glibc-hello / glibc-hello-via-ldso),
-# and mid-process execve re-bootstrap is covered by
-# tests/test-rosetta-statics.sh (env-execve). Those tests carry the
-# same code-path scrutiny as the dynamic / execve probes that used to
-# live here, against the vendored fixture trees that are always
-# present, so this script no longer needs the x86_64-musl Alpine
+# tests/test-rosetta-glibc.sh (glibc-hello / glibc-hello-via-ldso), and
+# mid-process execve re-bootstrap is covered by tests/test-rosetta-statics.sh
+# (env-execve). Those tests carry the same code-path scrutiny as the dynamic /
+# execve probes that used to live here, against the vendored fixture trees that
+# are always present, so this script no longer needs the x86_64-musl Alpine
 # corpus and no longer self-stages it.
 #
 # Usage: tests/test-rosetta-failure-modes.sh [path/to/elfuse]
@@ -36,9 +34,9 @@ esac
 
 SHORTDIR=/tmp/elfuse-rfm
 
-# Shared report_pass / report_fail / report_skip + Results: summary
-# emitter. Matches the matrix runner's aarch64 per-binary format so
-# tests/test-matrix.sh elfuse-x86_64 output reads uniformly.
+# Shared report_pass / report_fail / report_skip + Results: summary emitter.
+# Matches the matrix runner's aarch64 per-binary format so tests/test-matrix.sh
+# elfuse-x86_64 output reads uniformly.
 # shellcheck source=tests/lib/report.sh
 . "$(dirname "$0")/lib/report.sh"
 
@@ -47,8 +45,8 @@ fail=0
 skip=0
 total=0
 
-# Expect a non-zero exit AND a stderr fragment match.
-# Args: <label> <stderr-grep-pattern> <command...>
+# Expect a non-zero exit AND a stderr fragment match. Args: <label>
+# <stderr-grep-pattern> <command...>
 probe_fail()
 {
     local label="$1" pattern="$2"
@@ -86,8 +84,8 @@ require_timeout
 mkdir -p "$SHORTDIR"
 trap 'rm -rf "$SHORTDIR"' EXIT
 
-# Synthesize a minimal x86_64 ELF (header-only, no segments worth loading).
-# This is enough to drive the CLI gates that key on e_machine = EM_X86_64.
+# Synthesize a minimal x86_64 ELF (header-only, no segments worth loading). This
+# is enough to drive the CLI gates that key on e_machine = EM_X86_64.
 # Self-contained: no external fixture tree needed.
 min_elf="${SHORTDIR}/min-x86_64.elf"
 python3 - "$min_elf" << 'PY'
@@ -112,9 +110,7 @@ probe_fail "gdb-x86_64" \
     "--gdb is not supported for x86_64 guests" \
     "$ELFUSE" --gdb 4242 "$min_elf"
 
-# ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
 
 report_summary "$total"
 

--- a/tests/test-rosetta-glibc.sh
+++ b/tests/test-rosetta-glibc.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-glibc.sh - glibc loader smoke through Rosetta
 #
 # Copyright 2026 elfuse contributors
@@ -59,9 +60,9 @@ if [ ! -x "$LD_SO" ] || [ ! -x "$HELLO" ] \
     stage_glibc_fixture
 fi
 
-# Run a probe binary under elfuse + sysroot, expect rc=0 and the
-# probe's "<label>-ok" success marker on stdout. Variant probes
-# (--list output check, ld.so chained loader, etc.) stay inline below.
+# Run a probe binary under elfuse + sysroot, expect rc=0 and the probe's
+# "<label>-ok" success marker on stdout. Variant probes (--list output check,
+# ld.so chained loader, etc.) stay inline below.
 probe_marker_ok()
 {
     local label="$1"
@@ -98,30 +99,27 @@ else
     printf '%s\n' "$list_out" >&2
 fi
 
-# Runtime dlopen of libm.so.6 -> dlsym sqrt -> sqrt(16.0) -> dlclose.
-# Exercises the runtime mmap-fresh-.so codepath, which is distinct from
-# the load-time PT_INTERP path the three probes above touch.
+# Runtime dlopen of libm.so.6 -> dlsym sqrt -> sqrt(16.0) -> dlclose. Exercises
+# the runtime mmap-fresh-.so codepath, which is distinct from the load-time
+# PT_INTERP path the three probes above touch.
 probe_marker_ok "glibc-dlopen" "glibc-dlopen-ok" "$DLOPEN_BIN"
 
-# Initial-exec TLS read/write through FS-register translation. The
-# binary touches a __thread int and a __thread pointer; a broken
-# FS-to-TPIDR_EL0 plumbing under Rosetta surfaces as a value mismatch
-# rather than a crash.
+# Initial-exec TLS read/write through FS-register translation. The binary
+# touches a __thread int and a __thread pointer; a broken FS-to-TPIDR_EL0
+# plumbing under Rosetta surfaces as a value mismatch rather than a crash.
 probe_marker_ok "glibc-tls" "glibc-tls-ok" "$TLS_BIN"
 
-# General-dynamic TLS via dlopen + __tls_get_addr. The companion
-# libgdtls.so is loaded at runtime, which forces the compiler-emitted
-# access sequence to call __tls_get_addr instead of using initial-exec
-# offsets. A broken Rosetta lowering of that path surfaces as a value
-# mismatch from the get/set accessors.
+# General-dynamic TLS via dlopen + __tls_get_addr. The companion libgdtls.so is
+# loaded at runtime, which forces the compiler-emitted access sequence to call
+# __tls_get_addr instead of using initial-exec offsets. A broken Rosetta
+# lowering of that path surfaces as a value mismatch from the get/set accessors.
 probe_marker_ok "glibc-gdtls" "glibc-gdtls-ok" "$GDTLS_BIN"
 
-# pthread per-thread TLS isolation. A worker thread reads + writes its
-# own __thread slot; the probe asserts the worker saw its initial
-# default (not the main thread's value) and that the main thread's
-# slot survives the worker's write. Exercises per-thread FS-register /
-# TPIDR_EL0 setup that the single-thread glibc-tls probe does not
-# touch.
+# pthread per-thread TLS isolation. A worker thread reads + writes its own
+# __thread slot; the probe asserts the worker saw its initial default (not the
+# main thread's value) and that the main thread's slot survives the worker's
+# write. Exercises per-thread FS-register / TPIDR_EL0 setup that the
+# single-thread glibc-tls probe does not touch.
 probe_marker_ok "glibc-pthread-tls" "glibc-pthread-tls-ok" "$PTHREAD_TLS_BIN"
 
 report_summary "$total"

--- a/tests/test-rosetta-jit.sh
+++ b/tests/test-rosetta-jit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-jit.sh - LuaJIT guest-JIT smoke through Rosetta
 #
 # Copyright 2026 elfuse contributors

--- a/tests/test-rosetta-madvise.sh
+++ b/tests/test-rosetta-madvise.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-madvise.sh - madvise(MADV_DONTNEED) on high-VA regions via
 # Rosetta
 #

--- a/tests/test-rosetta-mremap.sh
+++ b/tests/test-rosetta-mremap.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-mremap.sh - mremap() on high-VA source regions via Rosetta
 #
 # Copyright 2026 elfuse contributors

--- a/tests/test-rosetta-msync.sh
+++ b/tests/test-rosetta-msync.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-rosetta-msync.sh - msync(MS_SYNC/MS_ASYNC) on high-VA regions via Rosetta
 #
 # Copyright 2026 elfuse contributors

--- a/tests/test-rosetta-statics.sh
+++ b/tests/test-rosetta-statics.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
+
 # test-rosetta-statics.sh - Smoke test x86_64 statics under Rosetta
 #
 # Copyright 2026 elfuse contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Runs a curated set of static x86_64 binaries through elfuse and verifies
-# expected output. Aimed at fast-iteration regression coverage of the
-# rosetta runtime path (VZ ioctl gate, /proc/self/exe redirect, high-VA
-# mmap, kbuf alias). Distinct from test-matrix.sh elfuse-x86_64 which runs
-# the broader corpus.
+# expected output. Aimed at fast-iteration regression coverage of the rosetta
+# runtime path (VZ ioctl gate, /proc/self/exe redirect, high-VA mmap, kbuf
+# alias). Distinct from test-matrix.sh elfuse-x86_64 which runs the broader
+# corpus.
 #
 # Fixture source: the Alpine x86_64 staticbin tree assembled by
 # tests/fetch-fixtures.sh INCLUDE_X86_64=1. The tree contains busybox.static
 # plus a list of applet symlinks; both are statically-linked musl ELFs.
 #
 # Rosetta caps the binary-path field in its VZ_CAPS payload at 42 bytes
-# (ROSETTA_CAPS_BINARY_PATH_LEN). Keep these probes on the real checkout
-# path so they catch regressions in the runtime aliasing workaround rather
-# than masking them with a short-path staging tree.
+# (ROSETTA_CAPS_BINARY_PATH_LEN). Keep these probes on the real checkout path so
+# they catch regressions in the runtime aliasing workaround rather than masking
+# them with a short-path staging tree.
 #
 # Skips cleanly when:
 #   - Rosetta Linux is not installed on the host
@@ -40,9 +41,9 @@ ROSETTA_PATH="${MATRIX_ROSETTA_TRANSLATOR:-/Library/Apple/usr/libexec/oah/Rosett
 SHORTDIR=/tmp/elfuse-r
 STATICBIN=""
 
-# Shared report_pass / report_fail / report_skip + Results: summary
-# emitter. Matches the matrix runner's aarch64 per-binary format so
-# tests/test-matrix.sh elfuse-x86_64 output reads uniformly.
+# Shared report_pass / report_fail / report_skip + Results: summary emitter.
+# Matches the matrix runner's aarch64 per-binary format so tests/test-matrix.sh
+# elfuse-x86_64 output reads uniformly.
 # shellcheck source=tests/lib/report.sh
 . "$(dirname "$0")/lib/report.sh"
 
@@ -51,14 +52,14 @@ fail=0
 skip=0
 total=0
 
-# Run a binary, check exit code and (optionally) stdout regex.
-# Args: <label> <expected-stdout-regex|""> <expected-exit-code> <binary> [args...]
-# An empty regex skips the stdout check.
+# Run a binary, check exit code and (optionally) stdout regex. Args: <label>
+# <expected-stdout-regex|""> <expected-exit-code> <binary> [args...] An empty
+# regex skips the stdout check.
 #
-# Not named run_check: tests/lib/test-runner.sh, pulled in by report.sh
-# above, exports a run_check taking <tool> <pattern> and resolving the tool
-# through test_tool_path, which cannot serve the absolute binary paths and
-# expected exit codes used here.
+# Not named run_check: tests/lib/test-runner.sh, pulled in by report.sh above,
+# exports a run_check taking <tool> <pattern> and resolving the tool through
+# test_tool_path, which cannot serve the absolute binary paths and expected exit
+# codes used here.
 run_static_check()
 {
     local label="$1" expected_re="$2" expected_rc="$3"
@@ -110,10 +111,10 @@ staticbin_abs="$(cd "$STATICBIN_LONG" && pwd)"
 STATICBIN="$staticbin_abs"
 
 # Point HOME at the per-run tmp so the rosettad AOT cache lives at
-# $SHORTDIR/.cache/elfuse-rosettad and is empty on every invocation.
-# Without this, the cache from a previous run can satisfy rosetta via
-# the digest fast-path and silently bypass the /proc/self/fd/3 alias
-# that the long-path tests are meant to exercise.
+# $SHORTDIR/.cache/elfuse-rosettad and is empty on every invocation. Without
+# this, the cache from a previous run can satisfy rosetta via the digest
+# fast-path and silently bypass the /proc/self/fd/3 alias that the long-path
+# tests are meant to exercise.
 export HOME="$SHORTDIR"
 
 trap 'rm -rf "$SHORTDIR"' EXIT
@@ -122,21 +123,19 @@ printf 'elfuse:    %s\n' "$ELFUSE"
 printf 'fixtures:  %s\n' "$STATICBIN"
 printf 'rosetta:   %s\n\n' "$ROSETTA_PATH"
 
-# ---------------------------------------------------------------------------
 # busybox applets - statics validated to work end-to-end on M1.
-# ---------------------------------------------------------------------------
 
-# Simple stdout-producing applets. true/false return immediately; the
-# empty regex skips the stdout check.
+# Simple stdout-producing applets. true/false return immediately; the empty
+# regex skips the stdout check.
 run_static_check "echo" "^hello rosetta$" 0 "${STATICBIN}/echo" "hello rosetta"
 run_static_check "true" "" 0 "${STATICBIN}/true"
 run_static_check "false" "" 1 "${STATICBIN}/false"
 
-# env propagation: the host shell's environ reaches the rosetta guest's
-# printenv via execve auxiliary vector + ELF entry. env -i isolates the
-# environment so the probe variable is the only signal. The env wrapper
-# wraps the elfuse invocation; passing env -i as elfuse's argv[1] would
-# make elfuse try to load env as an ELF.
+# env propagation: the host shell's environ reaches the rosetta guest's printenv
+# via execve auxiliary vector + ELF entry. env -i isolates the environment so
+# the probe variable is the only signal. The env wrapper wraps the elfuse
+# invocation; passing env -i as elfuse's argv[1] would make elfuse try to load
+# env as an ELF.
 total=$((total + 1))
 set +e
 penv_out="$(env -i HOME=/ TZ=UTC ELFUSE_PROBE=elfuse-test \
@@ -149,8 +148,8 @@ else
     report_fail "printenv: rc=$penv_rc out=$(printf '%q' "$penv_out")"
 fi
 
-# Busybox expr returns 1 when the arithmetic result is zero (POSIX), and
-# 0 otherwise. expr-zero deliberately exercises the 0-result path.
+# Busybox expr returns 1 when the arithmetic result is zero (POSIX), and 0
+# otherwise. expr-zero deliberately exercises the 0-result path.
 run_static_check "expr-zero" "^0$" 1 "${STATICBIN}/expr" "1" "-" "1"
 run_static_check "expr-mul" "^42$" 0 "${STATICBIN}/expr" "6" "*" "7"
 
@@ -159,15 +158,15 @@ run_static_check "expr-mul" "^42$" 0 "${STATICBIN}/expr" "6" "*" "7"
 run_static_check "basename" "^rosetta$" 0 "${STATICBIN}/basename" "/some/path/rosetta"
 run_static_check "dirname" "^/a/b$" 0 "${STATICBIN}/dirname" "/a/b/c"
 
-# Filesystem read: stat the rosetta binary itself, prove that openat
-# against a real host path works.
+# Filesystem read: stat the rosetta binary itself, prove that openat against a
+# real host path works.
 run_static_check "stat-self" "regular file" 0 "${STATICBIN}/stat" "$ROSETTA_PATH"
 
 # Compute-heavy: factor a small number through libc / busybox arith.
 run_static_check "factor" "^60: 2 2 3 5$" 0 "${STATICBIN}/factor" "60"
 
-# seq writes one integer per line. Build the expected joined output and
-# match against the captured stdout via the helper.
+# seq writes one integer per line. Build the expected joined output and match
+# against the captured stdout via the helper.
 seq_out="$(printf '%s\n' 1 2 3 4 5)"
 out_seq="$("$TIMEOUT" 5 "$ELFUSE" "${STATICBIN}/seq" 1 5 2> /dev/null || true)"
 total=$((total + 1))
@@ -189,15 +188,16 @@ run_static_check "md5sum" "^[0-9a-f]{32}  " 0 \
 # Date + uname use clock_gettime and uname syscalls; their guest-side ABI
 # translation (translate_clockid, sys_uname) covers a different surface.
 run_static_check "uname-m" "^x86_64$" 0 "${STATICBIN}/uname" "-m"
+
 # Busybox 'arch' applet (separate dispatch from uname -m) confirms the
-# rosetta-translated guest reports its actual ISA via the dedicated
-# applet entry-point. Both forms must agree.
+# rosetta-translated guest reports its actual ISA via the dedicated applet
+# entry-point. Both forms must agree.
 run_static_check "arch" "^x86_64$" 0 "${STATICBIN}/busybox" "arch"
 run_static_check "busybox-arch-subcommand" "^x86_64$" 0 \
     "${STATICBIN}/busybox" "arch"
 
-# date: TZ propagates the same way as ELFUSE_PROBE above (wrap elfuse,
-# don't pass env to elfuse as argv[1]).
+# date: TZ propagates the same way as ELFUSE_PROBE above (wrap elfuse, don't
+# pass env to elfuse as argv[1]).
 total=$((total + 1))
 set +e
 date_out="$(env TZ=UTC "$ELFUSE" "${STATICBIN}/date" 2> /dev/null)"
@@ -213,14 +213,12 @@ fi
 run_static_check "id-u" "^0$|^[0-9]+$" 0 "${STATICBIN}/id" "-u"
 run_static_check "nproc" "^[1-9][0-9]*$" 0 "${STATICBIN}/nproc"
 
-# ---------------------------------------------------------------------------
 # Mid-process execve into x86_64 (rosetta re-bootstrap).
-# ---------------------------------------------------------------------------
 
-# env executes its argv[1] via execve. The post-reset rosetta re-bootstrap
-# path now handles x86_64 -> x86_64 mid-process execve, so the child
-# (env -> true) must exit 0. A timeout (rc=124) indicates a hang in the
-# re-bootstrap, distinct from a clean rejection.
+# env executes its argv[1] via execve. The post-reset rosetta re-bootstrap path
+# now handles x86_64 -> x86_64 mid-process execve, so the child (env -> true)
+# must exit 0. A timeout (rc=124) indicates a hang in the re-bootstrap, distinct
+# from a clean rejection.
 total=$((total + 1))
 set +e
 env_rc=$(
@@ -239,9 +237,9 @@ fi
 
 # Re-run the same execve with the rosettad AOT cache now warm for this digest.
 # The warm path returns from rosettad almost immediately, which historically
-# left stale TLB walk-cache entries alive across the exec page-table rebuild
-# and crashed the re-entry with an EL1 instruction abort (BAD_EXCEPTION
-# vec=0x200, exit 128). Guards the MMU-off _start re-entry in sys_execve.
+# left stale TLB walk-cache entries alive across the exec page-table rebuild and
+# crashed the re-entry with an EL1 instruction abort (BAD_EXCEPTION vec=0x200,
+# exit 128). Guards the MMU-off _start re-entry in sys_execve.
 total=$((total + 1))
 set +e
 env_warm_rc=$(
@@ -258,9 +256,7 @@ else
     report_fail "env-execve-warm: rc=$env_warm_rc (expected 0)"
 fi
 
-# ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
 
 report_summary "$total"
 

--- a/tests/test-setuid-exec.c
+++ b/tests/test-setuid-exec.c
@@ -1,4 +1,5 @@
-/* setuid-on-exec must grant an ID the guest can actually mean.
+/*
+ * setuid-on-exec must grant an ID the guest can actually mean.
  *
  * A sysroot's files are owned by whoever unpacked them on the host, and no host
  * IDs are mapped into the guest. Honouring setuid on such a file would leave
@@ -13,10 +14,10 @@
  * it pins is the other half: a virtual owner, foreign or root, never elevates.
  *
  * Note which owner does the work. The set-id path reads the *physical* stat,
- * and mkstemp already leaves the helper owned by the host user (501 or
- * whatever unpacked the tree), which is foreign to the guest either way. The
- * virtual chowns below stage the guest-visible half; the physical host owner
- * is what the exec actually sees and refuses to honour.
+ * and mkstemp already leaves the helper owned by the host user (501 or whatever
+ * unpacked the tree), which is foreign to the guest either way. The virtual
+ * chowns below stage the guest-visible half; the physical host owner is what
+ * the exec actually sees and refuses to honour.
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
@@ -140,6 +141,7 @@ static int stage_owner(unsigned owner)
     struct stat st;
     if (stat(helper_path, &st) != 0)
         return -1;
+
     /* exec reads ownership the same way stat does, so a stat that does not show
      * the chown means the two would disagree about what was staged.
      */
@@ -168,6 +170,7 @@ int main(int argc, char **argv)
         return child_main(argv[2]);
 
     int failures = 0;
+
     /* Checks that actually exercised an exec. Without this a run where every
      * interesting case skipped -- a privileged caller, say -- would print the
      * success line and exit 0 having proved nothing.
@@ -229,13 +232,13 @@ int main(int argc, char **argv)
      * The regression guard for that escalation.
      *
      * A guest stat cannot tell a recorded chown from one the host really
-     * performed -- the overlay is invisible from in here, and both report
-     * owner 0. That distinction matters, because when elfuse itself runs as
-     * host root the chown below is physical, and a physically root-owned
-     * setuid file is *supposed* to elevate. Resolve it from the outcome
-     * instead: elevation to 0 only happens when the physical owner is 0, which
-     * only a real chown can produce. Staying put and landing on root are both
-     * correct, one per staging; anything else is the bug.
+     * performed -- the overlay is invisible from in here, and both report owner
+     * 0. That distinction matters, because when elfuse itself runs as host root
+     * the chown below is physical, and a physically root-owned setuid file is
+     * *supposed* to elevate. Resolve it from the outcome instead: elevation to
+     * 0 only happens when the physical owner is 0, which only a real chown can
+     * produce. Staying put and landing on root are both correct, one per
+     * staging; anything else is the bug.
      */
     printf("test-setuid-exec: 3. virtual root owner does not elevate... ");
     {

--- a/tests/test-shebang-host.c
+++ b/tests/test-shebang-host.c
@@ -147,6 +147,7 @@ int main(void)
     }
     case9[510] = '\n';
     case9[511] = '\0';
+
     /* Since the interpreter is 508 characters, and our interp buffer is only
      * 256, it should return -ENOEXEC (buffer too small)
      */

--- a/tests/test-shim-identity-attention.c
+++ b/tests/test-shim-identity-attention.c
@@ -103,6 +103,7 @@ static int run_alarm_spin(const char *name, int use_realtime_vdso)
     }
 
     long delivered_ns = ns_diff((struct timespec *) &alarm_ts, &t_arm);
+
     /* The 100 ms timer should deliver within ~150 ms in practice; grant 300 ms
      * to absorb host scheduling jitter under load.
      */

--- a/tests/test-shim-urandom-smp.c
+++ b/tests/test-shim-urandom-smp.c
@@ -97,6 +97,7 @@ int main(void)
             failures++;
             continue;
         }
+
         /* Per-thread distribution sanity: each bucket should be roughly
          * NSAMPLES / 256 = 64 with stddev about 8. Flag any thread whose
          * distribution is wildly off.

--- a/tests/test-sigill.c
+++ b/tests/test-sigill.c
@@ -34,6 +34,7 @@ static void sigill_handler(int sig, siginfo_t *info, void *ucontext)
      * ucontext_t.uc_mcontext.__ss.__pc on aarch64 Linux is the faulting PC.
      */
     ucontext_t *uc = (ucontext_t *) ucontext;
+
     /* Linux aarch64: mcontext_t has regs[31], sp, pc, pstate. pc is at offset
      * regs[32] equivalent, but the layout varies. Use the struct field
      * directly.

--- a/tests/test-sigio.c
+++ b/tests/test-sigio.c
@@ -230,6 +230,7 @@ int main(void)
 
             sigio_count = 0;
             int dfd = dup(sv[0]);
+
             /* The original arming already covers readiness; closing sv[0]
              * leaves only the dup armed, proving the alias inherited O_ASYNC.
              */
@@ -281,6 +282,7 @@ int main(void)
             fcntl(sv[0], F_SETFL, fl & ~O_ASYNC);
 
             sigurg_count = 0;
+
             /* Urgent byte from the client; the server's OOB mark drives
              * EVFILT_EXCEPT/NOTE_OOB, which the watcher maps to SIGURG.
              */

--- a/tests/test-signalfd-hardening.c
+++ b/tests/test-signalfd-hardening.c
@@ -65,6 +65,7 @@ static void build_kernel_siginfo(int sig,
     memcpy(out + 4, &s32, 4); /* si_errno */
     s32 = code;
     memcpy(out + 8, &s32, 4);
+
     /* offset 12 is _pad0 (or part of _sifields alignment). Linux's _sifields
      * starts at offset 16 on aarch64; for SI_QUEUE the layout there is:
      *   si_pid (4) si_uid (4) si_value (8)
@@ -75,6 +76,7 @@ static void build_kernel_siginfo(int sig,
     memcpy(out + 20, &s32, 4);
     s32 = payload_int;
     memcpy(out + 24, &s32, 4);
+
     /* Kernel ignores the upper 4 bytes of si_value's int form, but writes the
      * pointer form into the full 8-byte slot at offset 24 for sigval_t. The
      * pointer goes into the low 8 bytes so signal_queue_rt() reads either
@@ -82,6 +84,7 @@ static void build_kernel_siginfo(int sig,
      */
     u64 = (uint64_t) (uintptr_t) payload_ptr;
     memcpy(out + 24, &u64, 8);
+
     /* If both int and ptr are set, ptr wins because it overlaps. Tests pick one
      * or the other.
      */

--- a/tests/test-sigsuspend.c
+++ b/tests/test-sigsuspend.c
@@ -32,6 +32,7 @@ int passes = 0, fails = 0;
 
 static volatile sig_atomic_t alarm_ran;
 static volatile sig_atomic_t usr1_ran;
+
 /* Delivery count while only the process-directed signal is in flight. The
  * per-thread wakeups sent afterwards must not be able to satisfy the
  * shared-signal assertion, so they are counted in a separate phase.
@@ -60,8 +61,8 @@ static double elapsed_since(const struct timespec *t0)
     return (t1.tv_sec - t0->tv_sec) + (t1.tv_nsec - t0->tv_nsec) / 1e9;
 }
 
-/* sigsuspend must not return before a signal arrives, must run the handler,
- * and must restore the mask it was called with.
+/* sigsuspend must not return before a signal arrives, must run the handler, and
+ * must restore the mask it was called with.
  */
 static void test_blocks_until_signal(void)
 {
@@ -105,8 +106,8 @@ static void test_blocks_until_signal(void)
     sigprocmask(SIG_SETMASK, &orig, NULL);
 }
 
-/* An ignored signal is discarded without reaching the guest, so it must not
- * end the wait. The alarm is the escape hatch that keeps this bounded.
+/* An ignored signal is discarded without reaching the guest, so it must not end
+ * the wait. The alarm is the escape hatch that keeps this bounded.
  */
 static void test_ignored_signal_does_not_wake(void)
 {
@@ -137,6 +138,7 @@ static void test_ignored_signal_does_not_wake(void)
 
 static pthread_barrier_t ready;
 static volatile sig_atomic_t mask_leaked;
+
 /* Incremented immediately before each worker calls sigsuspend(). The barrier
  * only gates the threads up to that point, so waiting on this instead of a
  * wall-clock sleep keeps the test honest on a loaded or cross-checked host.

--- a/tests/test-sigtimedwait.c
+++ b/tests/test-sigtimedwait.c
@@ -35,9 +35,7 @@ static int failures;
         }                                             \
     } while (0)
 
-/* ------------------------------------------------------------------ */
-/* Test 1: sigwait() consumes a pending SIGUSR1                        */
-/* ------------------------------------------------------------------ */
+/* Test 1: sigwait() consumes a pending SIGUSR1 */
 static void test_sigwait_basic(void)
 {
     printf("test-sigtimedwait: 1. sigwait basic... ");
@@ -59,9 +57,7 @@ static void test_sigwait_basic(void)
     printf("PASS\n");
 }
 
-/* ------------------------------------------------------------------ */
-/* Test 2: sigwaitinfo() populates siginfo_t                           */
-/* ------------------------------------------------------------------ */
+/* Test 2: sigwaitinfo() populates siginfo_t */
 static void test_sigwaitinfo_info(void)
 {
     printf("test-sigtimedwait: 2. sigwaitinfo populates siginfo... ");
@@ -84,9 +80,7 @@ static void test_sigwaitinfo_info(void)
     printf("PASS\n");
 }
 
-/* ------------------------------------------------------------------ */
-/* Test 3: sigtimedwait() poll-once (zero timeout) -> EAGAIN           */
-/* ------------------------------------------------------------------ */
+/* Test 3: sigtimedwait() poll-once (zero timeout) -> EAGAIN */
 static void test_sigtimedwait_poll_eagain(void)
 {
     printf("test-sigtimedwait: 3. zero timeout EAGAIN... ");
@@ -107,9 +101,7 @@ static void test_sigtimedwait_poll_eagain(void)
     printf("PASS\n");
 }
 
-/* ------------------------------------------------------------------ */
-/* Test 4: sigtimedwait() with short timeout -> EAGAIN after expiry    */
-/* ------------------------------------------------------------------ */
+/* Test 4: sigtimedwait() with short timeout -> EAGAIN after expiry */
 static void test_sigtimedwait_timeout(void)
 {
     printf("test-sigtimedwait: 4. short timeout EAGAIN... ");
@@ -130,9 +122,7 @@ static void test_sigtimedwait_timeout(void)
     printf("PASS\n");
 }
 
-/* ------------------------------------------------------------------ */
-/* Test 5: signal sent from another thread is consumed by sigwaitinfo  */
-/* ------------------------------------------------------------------ */
+/* Test 5: signal sent from another thread is consumed by sigwaitinfo */
 static pthread_t waiter_tid;
 
 static void *sender_fn(void *arg)
@@ -176,7 +166,7 @@ static void test_sigwaitinfo_thread(void)
     printf("PASS\n");
 }
 
-/* ------------------------------------------------------------------ */
+/* */
 
 int main(void)
 {

--- a/tests/test-static-bins.sh
+++ b/tests/test-static-bins.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
+
 # test-static-bins.sh -- Static binary smoke tests for elfuse
 #
 # Copyright 2026 elfuse contributors
 # Copyright 2025 Moritz Angermann, zw3rk pte. ltd.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Tests a variety of standalone static aarch64-linux-musl binaries through elfuse.
-# Exercises different runtime profiles: shell interpreters (bash, dash),
+# Tests a variety of standalone static aarch64-linux-musl binaries through
+# elfuse. Exercises different runtime profiles: shell interpreters (bash, dash),
 # scripting languages (lua, gawk), text tools (grep, sed, find), and
 # compute-heavy workloads (fibonacci, mandelbrot).
 #
@@ -20,8 +21,8 @@ ELFUSE="${1:?Usage: $0 <elfuse-binary> <static-bins-dir>}"
 BINDIR="${2:?Usage: $0 <elfuse-binary> <static-bins-dir>}"
 SYSROOT="${3:-}"
 
-# Source the shared runner so this script reuses the standard reporting
-# helpers and pass/fail accounting.
+# Source the shared runner so this script reuses the standard reporting helpers
+# and pass/fail accounting.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC2034  # Consumed by tests/lib/test-runner.sh.
 BIN=""
@@ -35,9 +36,9 @@ TEST_TIMEOUT="${TEST_TIMEOUT:-10}"
 # shellcheck source=tests/lib/test-runner.sh
 source "$SCRIPT_DIR/lib/test-runner.sh"
 
-# GNU 'timeout' is required to bound each guest invocation. On macOS it
-# ships via Homebrew coreutils. Fail loudly upfront instead of letting
-# every test report a cryptic "command not found, rc=127".
+# GNU 'timeout' is required to bound each guest invocation. On macOS it ships
+# via Homebrew coreutils. Fail loudly upfront instead of letting every test
+# report a cryptic "command not found, rc=127".
 if ! command -v timeout > /dev/null 2>&1; then
     printf "error: 'timeout' not on PATH (install Homebrew coreutils)\n" >&2
     exit 2
@@ -52,8 +53,8 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 # Resolve the binary under either the flat fixture directory or its bin/
-# subdirectory. Use -f rather than -x because guest ELFs are data files on
-# macOS and are launched through elfuse instead of directly by the host.
+# subdirectory. Use -f rather than -x because guest ELFs are data files on macOS
+# and are launched through elfuse instead of directly by the host.
 find_bin()
 {
     local name="$1"
@@ -203,8 +204,8 @@ srun_check "dash: functions" "$DASH_BIN" "result=15" -c 'sum() { total=0; for n 
 # Bash shell
 printf "\n${BLUE}── Bash shell ──${RESET}\n"
 
-# Keep the Bash coverage in a real script so array syntax, regexes, and
-# here-doc quoting are not obscured by nested shell escaping.
+# Keep the Bash coverage in a real script so array syntax, regexes, and here-doc
+# quoting are not obscured by nested shell escaping.
 cat > "$TMPDIR/bash-test.sh" << 'BASH_SCRIPT'
 echo "bash ${BASH_VERSION}"
 echo "sum=$((17 * 31))"

--- a/tests/test-string-builder-host.c
+++ b/tests/test-string-builder-host.c
@@ -187,8 +187,9 @@ static void test_formatted_errno_expansion(void)
     string_builder_t builder = {0};
     char expected[128];
 
-    /* `%m` is a GNU printf extension; use the host libc as the oracle so
-     * Darwin (which leaves it literal) remains a valid host-test platform. */
+    /* `%m` is a GNU printf extension; use the host libc as the oracle so Darwin
+     * (which leaves it literal) remains a valid host-test platform.
+     */
     errno = ENOENT;
     assert(snprintf(expected, sizeof(expected), "errno=%m") >= 0);
     errno = ENOENT;

--- a/tests/test-syscall-fidelity.c
+++ b/tests/test-syscall-fidelity.c
@@ -107,6 +107,7 @@ static void test_fchmodat2_symlink_nofollow(void)
         return;
     }
     close(fd);
+
     /* Derive the symlink name from the unique target so we never call mktemp,
      * which is racy and triggers a linker warning on glibc.
      */
@@ -491,6 +492,7 @@ static void test_openat2_resolve_no_symlinks_deep_path(void)
     TEST("openat2 RESOLVE_NO_SYMLINKS resolves a link-free deep path");
 
     char dir_template[] = "/tmp/elfuse-openat2-deep-XXXXXX";
+
     /* Where each component starts, so the teardown shortens the very path the
      * setup built instead of re-deriving its shape.
      */
@@ -676,6 +678,7 @@ static void test_openat2_resolve_no_xdev_allows_same_mount(void)
         PASS();
         return;
     }
+
     /* Acceptable if /etc/passwd doesn't exist on the host running the test, as
      * long as the error is not EXDEV.
      */
@@ -1342,9 +1345,9 @@ static void test_mmap_low_hint_exact(void)
     munmap(p, len);
 }
 
-/* A dirfd that is open but not a directory (and has no host-nameable path,
- * e.g. a pipe) must resolve a relative path with ENOTDIR, not EBADF: the fd
- * itself is valid, it just cannot anchor a lookup. Issue #133.
+/* A dirfd that is open but not a directory (and has no host-nameable path, e.g.
+ * a pipe) must resolve a relative path with ENOTDIR, not EBADF: the fd itself
+ * is valid, it just cannot anchor a lookup. Issue #133.
  */
 static void test_openat2_resolve_no_xdev_non_directory_dirfd_rejects_enotdir(
     void)

--- a/tests/test-syscall-smoke.c
+++ b/tests/test-syscall-smoke.c
@@ -243,6 +243,7 @@ static void test_at_path_ops(void)
         FAIL("mkdtemp");
         return;
     }
+
     /* Materialize cleanup paths up-front so that any early goto-out still
      * unlinks/rmdirs whatever the syscalls under test managed to create.
      */
@@ -291,6 +292,7 @@ out:
     if (subdir_path[0])
         rmdir(subdir_path);
     rmdir(dir_template);
+
     /* Body-side FAIL() already reported the specific step on failure; only
      * report PASS here. Adding a trailing else-FAIL would double-count.
      */
@@ -457,6 +459,7 @@ static void test_waitid(void)
         PASS();
         return;
     }
+
     /* waitid failed or returned the wrong siginfo; reap with waitpid so the
      * child does not linger as a zombie and skew later tests.
      */
@@ -544,6 +547,7 @@ static void test_stub_errnos(void)
     unsigned char vec = 0;
     errno = 0;
     long mr = syscall(SYS_mincore, mc, 4096, &vec);
+
     /* Mapped page: success with the residency LSB set. Unaligned addr: EINVAL.
      * A hole in the range: ENOMEM. Here the whole page is mapped.
      */

--- a/tests/test-sysfs-cpu.c
+++ b/tests/test-sysfs-cpu.c
@@ -217,9 +217,9 @@ int main(void)
                     "cpu root W_OK returned unexpected error");
     }
 
-    /* '..' in the suffix must not let the open/stat reach a real target.
-     * elfuse rejects traversal inside the synthetic tree with EACCES; Linux
-     * resolves the normalized sysfs path and reports ENOENT for this probe.
+    /* '..' in the suffix must not let the open/stat reach a real target. elfuse
+     * rejects traversal inside the synthetic tree with EACCES; Linux resolves
+     * the normalized sysfs path and reports ENOENT for this probe.
      */
     TEST("dotdot traversal in open does not resolve");
     {

--- a/tests/test-sysroot-absock-names.c
+++ b/tests/test-sysroot-absock-names.c
@@ -7,13 +7,13 @@
  * A pathname socket's address is a filesystem path, and it must resolve like
  * one: through the sysroot, with the same escape rules as open(2), so bind,
  * stat, connect, and unlink all agree on which file a name means. The address
- * read back through getsockname/getpeername must carry the guest's bytes,
- * never the sysroot prefix or a stored spelling.
+ * read back through getsockname/getpeername must carry the guest's bytes, never
+ * the sysroot prefix or a stored spelling.
  *
- * Linux contract pinned: unix(7). Binding to a pathname creates a socket
- * file at that path in the caller's namespace, colliding names are distinct
- * files, rebinding an in-use path is EADDRINUSE, and the full 108-byte
- * sun_path budget is the guest's.
+ * Linux contract pinned: unix(7). Binding to a pathname creates a socket file
+ * at that path in the caller's namespace, colliding names are distinct files,
+ * rebinding an in-use path is EADDRINUSE, and the full 108-byte sun_path budget
+ * is the guest's.
  *
  * Code under test: net_sockaddr_to_mac / net_sockaddr_from_mac in
  * src/syscall/net-absock.c and their call sites in src/syscall/net.c and
@@ -48,8 +48,8 @@ int passes = 0, fails = 0;
 
 #define DIR_S "/sockdir"
 
-/* Connect to @path, send @token, report what the peer heard through
- * @accepted on the listener side.
+/* Connect to @path, send @token, report what the peer heard through @accepted
+ * on the listener side.
  */
 static int connect_send(const char *path, char token)
 {
@@ -143,8 +143,8 @@ int main(void)
             close(fd2);
     }
 
-    /* Names differing only by case are distinct sockets, each reachable by
-     * its own spelling: one stored literally, one escaped.
+    /* Names differing only by case are distinct sockets, each reachable by its
+     * own spelling: one stored literally, one escaped.
      */
     TEST("case-colliding socket names coexist");
     {
@@ -176,14 +176,14 @@ int main(void)
     }
 
     /* recvmsg reports a datagram's source address, and the length it reports
-     * has to describe the bytes it wrote: the guest spelling, which is what
-     * the translation hands back. A host spelling is longer, so a guest
-     * sizing the path as msg_namelen - offsetof(sun_path) reads past the
-     * address into whatever its own buffer held. recvmsg used to report the
-     * macOS length while writing the translated address, which the other
-     * three readback paths (accept, getsockname and recvfrom) never did.
-     * Both sockets are bound, because an unbound sender has no address for
-     * the receiver to be told about.
+     * has to describe the bytes it wrote: the guest spelling, which is what the
+     * translation hands back. A host spelling is longer, so a guest sizing the
+     * path as msg_namelen - offsetof(sun_path) reads past the address into
+     * whatever its own buffer held. recvmsg used to report the macOS length
+     * while writing the translated address, which the other three readback
+     * paths (accept, getsockname and recvfrom) never did. Both sockets are
+     * bound, because an unbound sender has no address for the receiver to be
+     * told about.
      */
     TEST("recvmsg reports the guest address length");
     {
@@ -238,8 +238,8 @@ int main(void)
 
     /* A Linux-legal guest name whose translated host spelling overflows the
      * 104-byte macOS sun_path: the escape more than doubles a mixed-case
-     * component and the sysroot prefix comes on top, so this is the common
-     * case for deep socket paths, not a corner.
+     * component and the sysroot prefix comes on top, so this is the common case
+     * for deep socket paths, not a corner.
      */
     TEST("a name whose host spelling overflows macOS sun_path still binds");
     {
@@ -273,9 +273,9 @@ int main(void)
      * at_flags, so that rule cannot ride on an open flag here and is checked
      * outright. Following a guest-planted link reported ENOTSOCK for a host
      * file that exists and ENOENT for one that does not, which tells the guest
-     * whether any host path exists, including every path
-     * is_guest_system_path() keeps it from naming: connecting to /etc/passwd
-     * directly is ENOENT, and through the link it was not.
+     * whether any host path exists, including every path is_guest_system_path()
+     * keeps it from naming: connecting to /etc/passwd directly is ENOENT, and
+     * through the link it was not.
      */
     TEST("connect does not follow a shm symlink out of the backing dir");
     {
@@ -300,8 +300,8 @@ int main(void)
 
     /* The same rule for bind, which is the half that writes: a dangling link
      * binds the socket at its target, so following one plants a socket file
-     * anywhere the guest can name as a target. The recipe checks host-side
-     * that nothing landed there.
+     * anywhere the guest can name as a target. The recipe checks host-side that
+     * nothing landed there.
      */
     TEST("bind does not follow a shm symlink out of the backing dir");
     {
@@ -330,8 +330,8 @@ int main(void)
      * state handshake, so the child is a fresh elfuse process: it inherits the
      * namespace id but has not created that directory itself. Undoing the link
      * used to be conditional on having created it, so a guest that only
-     * inherited the socket read back the /tmp link path in place of the name
-     * it asked for, and could neither stat nor rebind what it was told.
+     * inherited the socket read back the /tmp link path in place of the name it
+     * asked for, and could neither stat nor rebind what it was told.
      */
     TEST("a forked child reads back the guest spelling, not the link");
     {

--- a/tests/test-sysroot-case-exact.c
+++ b/tests/test-sysroot-case-exact.c
@@ -89,8 +89,8 @@ int main(int argc, char **argv)
     EXPECT_ERRNO(rename("/data/MAKEfile", "/data/moved"), ENOENT,
                  "folded rename leaked");
 
-    /* O_CREAT with a wrong-case spelling must create a second, distinct
-     * entry (Linux semantics), not fold onto the existing one.
+    /* O_CREAT with a wrong-case spelling must create a second, distinct entry
+     * (Linux semantics), not fold onto the existing one.
      */
     TEST("wrong-case O_CREAT|O_EXCL succeeds");
     {

--- a/tests/test-sysroot-corpus.c
+++ b/tests/test-sysroot-corpus.c
@@ -4,29 +4,28 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * The recipe stages a small tree of on-disk spellings copied byte-for-byte
- * from tests/casefold-vectors.h (the frozen format), and this guest opens
- * every entry strictly by its guest name. That direction is what an existing
- * sysroot exercises after an elfuse upgrade: the disk holds spellings an
- * older build wrote, and the current build must keep reading them. The codec
- * unit test asserts the same table in-process; this asserts it end to end,
- * through staging the recipe cannot derive from the codec under test.
+ * The recipe stages a small tree of on-disk spellings copied byte-for-byte from
+ * tests/casefold-vectors.h (the frozen format), and this guest opens every
+ * entry strictly by its guest name. That direction is what an existing sysroot
+ * exercises after an elfuse upgrade: the disk holds spellings an older build
+ * wrote, and the current build must keep reading them. The codec unit test
+ * asserts the same table in-process; this asserts it end to end, through
+ * staging the recipe cannot derive from the codec under test.
  *
  * test-sysroot-name-staged is the neighbor with a different question: it pins
- * what escape-shaped and escape-resembling names mean when a host stages
- * them. Here every staged spelling is a well-formed escape from the frozen
- * table, and the assertion is that its guest name, and nothing else, reaches
- * it.
+ * what escape-shaped and escape-resembling names mean when a host stages them.
+ * Here every staged spelling is a well-formed escape from the frozen table, and
+ * the assertion is that its guest name, and nothing else, reaches it.
  *
  * Each staged file's content is its own guest name, so a resolve that lands
  * anywhere unexpected is caught by the first read. A regression shows up as
- * ENOENT on a guest name whose spelling is on disk (the decoder moved off
- * the frozen format), as an escape spelling leaking into a listing, or as
- * content that names a different file.
+ * ENOENT on a guest name whose spelling is on disk (the decoder moved off the
+ * frozen format), as an escape spelling leaking into a listing, or as content
+ * that names a different file.
  *
  * Run under --sysroot on a folding volume; the recipe probes and skips
- * elsewhere, since staged escapes only mean their guest names where the
- * escape is active.
+ * elsewhere, since staged escapes only mean their guest names where the escape
+ * is active.
  */
 
 #include <dirent.h>
@@ -46,8 +45,8 @@ int passes = 0, fails = 0;
 
 #define DIR_C "/corpus"
 
-/* The staged entry must answer to its guest name and carry it as content;
- * the trailing newline the recipe appends is not part of the assertion.
+/* The staged entry must answer to its guest name and carry it as content; the
+ * trailing newline the recipe appends is not part of the assertion.
  */
 static void check_reads_itself(const char *label, const char *guest)
 {

--- a/tests/test-sysroot-dotdot.c
+++ b/tests/test-sysroot-dotdot.c
@@ -6,10 +6,10 @@
  *
  * A guest resolves '..' against its own root, where Linux clamps it: "/.."
  * names "/" and can never reach the directory holding the guest tree
- * (path_resolution(7)). The sysroot resolvers prefix the sysroot onto the
- * guest path, so a '..' that climbs above the guest root has to be rewritten
- * or it walks out of the tree; every other '..' must survive verbatim, so the
- * host kernel keeps deciding whether the component it pops exists and is a
+ * (path_resolution(7)). The sysroot resolvers prefix the sysroot onto the guest
+ * path, so a '..' that climbs above the guest root has to be rewritten or it
+ * walks out of the tree; every other '..' must survive verbatim, so the host
+ * kernel keeps deciding whether the component it pops exists and is a
  * directory.
  *
  * Code under test: proc_resolve_sysroot_path_flags() and
@@ -19,8 +19,8 @@
  * clamp has a real file to escape to rather than an absent path that hides the
  * bug.
  *
- * A regression reports ELOOP for an ordinary "/.." path, or reaches
- * beside.txt. Run under --sysroot.
+ * A regression reports ELOOP for an ordinary "/.." path, or reaches beside.txt.
+ * Run under --sysroot.
  */
 
 #include <errno.h>
@@ -157,10 +157,10 @@ static void section_relative(void)
     close(root);
 }
 
-/* An interior '..' must reach the host verbatim: the resolvers clamp '..'
- * only at the guest root and spell interior ones through untouched, leaving
- * the pop to the kernel's own resolution. What is asserted here is that the
- * pop arrives, not how the kernel type-checks the component it pops.
+/* An interior '..' must reach the host verbatim: the resolvers clamp '..' only
+ * at the guest root and spell interior ones through untouched, leaving the pop
+ * to the kernel's own resolution. What is asserted here is that the pop
+ * arrives, not how the kernel type-checks the component it pops.
  */
 static void section_interior(void)
 {

--- a/tests/test-sysroot-exec-names.c
+++ b/tests/test-sysroot-exec-names.c
@@ -7,18 +7,18 @@
  * An executable under a case-protected directory exists on disk only under an
  * escaped spelling, and exec crosses that boundary twice: the path being
  * executed must be resolved like every other guest path, and the identity the
- * kernel then reports (/proc/self/exe, /proc/self/fd/N) must carry the
- * guest's bytes, never the stored spelling or the sysroot prefix.
+ * kernel then reports (/proc/self/exe, /proc/self/fd/N) must carry the guest's
+ * bytes, never the stored spelling or the sysroot prefix.
  *
  * Linux contract pinned: execveat(2) resolves pathname relative to dirfd with
- * the caller's namespace rules, and proc(5) says /proc/self/exe is a symlink
- * to the executed binary as pathnames name it, a path the process can hand
+ * the caller's namespace rules, and proc(5) says /proc/self/exe is a symlink to
+ * the executed binary as pathnames name it, a path the process can hand
  * straight back to execve.
  *
  * Code under test: sc_execveat in src/syscall/syscall.c, sys_execve in
  * src/syscall/exec.c, and proc_readlink_self_exe / proc_intercept_readlink in
- * src/runtime/procemu.c. A regression shows up as execveat reporting ENOENT
- * for a binary execve runs fine, or as /proc/self/exe naming an .ef= spelling,
+ * src/runtime/procemu.c. A regression shows up as execveat reporting ENOENT for
+ * a binary execve runs fine, or as /proc/self/exe naming an .ef= spelling,
  * which is how a self-re-exec (busybox applets, watchdogs) stops working.
  *
  * Run under --sysroot on a case-folding volume.
@@ -71,8 +71,8 @@ static int child_exe_is(const char *want, bool reexec)
         return EXIT_MISMATCH;
     }
     if (reexec) {
-        /* The reported identity must be live: hand it straight back to
-         * execve, as a self-re-exec does.
+        /* The reported identity must be live: hand it straight back to execve,
+         * as a self-re-exec does.
          */
         char *argv2[] = {buf, "--exe-is", (char *) want, NULL};
         execve("/proc/self/exe", argv2, NULL);

--- a/tests/test-sysroot-inotify-names.c
+++ b/tests/test-sysroot-inotify-names.c
@@ -5,28 +5,26 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * A guest name the volume cannot hold as itself is stored escaped, and the
- * inotify emulation reads directory snapshots straight off the volume, so
- * both halves of a watch cross the name boundary: the watched path must be
- * resolved like every other guest path, and the names carried inside
- * IN_CREATE/IN_DELETE events must be the guest's bytes, never the stored
- * spelling.
+ * inotify emulation reads directory snapshots straight off the volume, so both
+ * halves of a watch cross the name boundary: the watched path must be resolved
+ * like every other guest path, and the names carried inside IN_CREATE/IN_DELETE
+ * events must be the guest's bytes, never the stored spelling.
  *
- * Linux contract pinned: inotify(7). The name field of an event is the
- * filename within the watched directory, as the process would use it. A name
- * the process never wrote and cannot stat is not that.
+ * Linux contract pinned: inotify(7). The name field of an event is the filename
+ * within the watched directory, as the process would use it. A name the process
+ * never wrote and cannot stat is not that.
  *
  * Code under test: sys_inotify_add_watch and dir_snapshot_fd in
- * src/syscall/inotify.c, routing through src/syscall/path.c. A regression
- * shows up as inotify_add_watch reporting ENOENT for a directory the guest
- * can open, or as an event naming an .ef= spelling the guest cannot resolve,
- * which is how a file watcher (editors, build daemons) sees phantom files
- * appear.
+ * src/syscall/inotify.c, routing through src/syscall/path.c. A regression shows
+ * up as inotify_add_watch reporting ENOENT for a directory the guest can open,
+ * or as an event naming an .ef= spelling the guest cannot resolve, which is how
+ * a file watcher (editors, build daemons) sees phantom files appear.
  *
  * The emulation pumps its event queue when the descriptor is read, so events
- * are collected by polling a nonblocking fd with read(2), valid against a
- * real kernel too. A pass therefore does not prove poll(2) reports readiness
- * without an intervening read; that gap predates the name handling and is not
- * what this lane pins.
+ * are collected by polling a nonblocking fd with read(2), valid against a real
+ * kernel too. A pass therefore does not prove poll(2) reports readiness without
+ * an intervening read; that gap predates the name handling and is not what this
+ * lane pins.
  *
  * Run under --sysroot on a case-folding volume.
  */
@@ -50,8 +48,8 @@ int passes = 0, fails = 0;
 
 #define DIR_W "/watch"
 
-/* Collected event names, flattened; the emulation may batch or split reads,
- * so assertions are about membership rather than arrival order.
+/* Collected event names, flattened; the emulation may batch or split reads, so
+ * assertions are about membership rather than arrival order.
  */
 typedef struct {
     char names[16][NAME_MAX + 1];
@@ -59,11 +57,10 @@ typedef struct {
     int count;
 } events_t;
 
-/* Set as soon as any drained event carries a stored spelling, across the
- * whole run: leaking is a property of the stream, not of one lane. The one
- * exception is the watch on a directory outside the sysroot, where the
- * stored spelling is the correct name; the flag below suspends the check
- * for exactly that section.
+/* Set as soon as any drained event carries a stored spelling, across the whole
+ * run: leaking is a property of the stream, not of one lane. The one exception
+ * is the watch on a directory outside the sysroot, where the stored spelling is
+ * the correct name; the flag below suspends the check for exactly that section.
  */
 static bool escape_leaked;
 static bool stored_names_expected;
@@ -126,16 +123,16 @@ int main(int argc, char **argv)
     EXPECT_TRUE(fd >= 0, "inotify_init1");
 
     /* The watched path is a guest path: it exists in the sysroot and nowhere
-     * else, so a watch that bypasses translation opens the host's namespace
-     * and reports ENOENT for a directory the guest can chdir into.
+     * else, so a watch that bypasses translation opens the host's namespace and
+     * reports ENOENT for a directory the guest can chdir into.
      */
     TEST("a watch on an absolute sysroot directory can be added");
     wd = inotify_add_watch(fd, DIR_W, IN_CREATE | IN_DELETE);
     EXPECT_TRUE(wd >= 0, "inotify_add_watch");
 
-    /* The event name is the guest's spelling. On this volume the file below
-     * is stored escaped, so an undecoded snapshot diff would name .ef=...,
-     * bytes the guest never wrote and cannot stat.
+    /* The event name is the guest's spelling. On this volume the file below is
+     * stored escaped, so an undecoded snapshot diff would name .ef=..., bytes
+     * the guest never wrote and cannot stat.
      */
     TEST("IN_CREATE carries the guest name for an escaped file");
     snprintf(path, sizeof(path), "%s/MixedCase.txt", DIR_W);
@@ -162,9 +159,9 @@ int main(int argc, char **argv)
                     "expected IN_DELETE MixedCase.txt");
     }
 
-    /* Names differing only by case are distinct files, and their events must
-     * be distinct too: one stored literally, one escaped, both reported
-     * under the bytes the guest used.
+    /* Names differing only by case are distinct files, and their events must be
+     * distinct too: one stored literally, one escaped, both reported under the
+     * bytes the guest used.
      */
     TEST("a colliding pair produces two distinctly named events");
     memset(&ev, 0, sizeof(ev));
@@ -234,11 +231,11 @@ int main(int argc, char **argv)
 
     /* A watch is refused only for an object kqueue cannot observe: a FUSE node
      * or a synthetic /proc file, both of which elfuse answers itself with no
-     * host vnode behind them. /dev/shm is neither (the leaf is redirected to
-     * a real host file that kqueue watches like any other), so refusing it
-     * would deny a watch Linux grants on tmpfs. The same over-refusal reaches
-     * every path the open-intercept prefilter merely *might* claim: /etc/passwd
-     * with no sysroot copy, /sys/devices/system/cpu, and, because that filter
+     * host vnode behind them. /dev/shm is neither (the leaf is redirected to a
+     * real host file that kqueue watches like any other), so refusing it would
+     * deny a watch Linux grants on tmpfs. The same over-refusal reaches every
+     * path the open-intercept prefilter merely *might* claim: /etc/passwd with
+     * no sysroot copy, /sys/devices/system/cpu, and, because that filter
      * compares four bytes, any name beginning "/dev".
      */
     TEST("a watch on a /dev/shm leaf is granted, not refused");
@@ -258,13 +255,12 @@ int main(int argc, char **argv)
 
     /* The other half of that rule. A real shm leaf is watchable, but the guest
      * can also write a symlink into the backing directory, and following one
-     * leads wherever its target names. is_guest_system_path() keeps /etc out
-     * of reach precisely so a guest cannot address the host's copy, and a
-     * watch on it hands back that file's existence and every change to it.
-     * Every other consumer of a shm leaf already refuses to follow: stat
-     * reports the link itself and open reports ELOOP. Watching was the one
-     * that followed, so a guest could observe any host path it could name as
-     * a link target.
+     * leads wherever its target names. is_guest_system_path() keeps /etc out of
+     * reach precisely so a guest cannot address the host's copy, and a watch on
+     * it hands back that file's existence and every change to it. Every other
+     * consumer of a shm leaf already refuses to follow: stat reports the link
+     * itself and open reports ELOOP. Watching was the one that followed, so a
+     * guest could observe any host path it could name as a link target.
      */
     TEST("a watch does not follow a shm symlink out of the backing dir");
     {
@@ -286,10 +282,10 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Decoding is scoped the way listings are: a watch on a host directory
-     * the sysroot does not own carries entry names as stored, because those
-     * names are the host's and an escape-shaped literal there means itself.
-     * A decoding snapshot would name a file the guest cannot stat in that
+    /* Decoding is scoped the way listings are: a watch on a host directory the
+     * sysroot does not own carries entry names as stored, because those names
+     * are the host's and an escape-shaped literal there means itself. A
+     * decoding snapshot would name a file the guest cannot stat in that
      * directory, and would misreport a genuine literal ".ef=" file the guest
      * itself created there.
      */
@@ -332,8 +328,7 @@ int main(int argc, char **argv)
     }
 
     /* The catch-all: whatever arrived above, nothing may look like a stored
-     * spelling. This is what fails first when the snapshot diff stops
-     * decoding.
+     * spelling. This is what fails first when the snapshot diff stops decoding.
      */
     TEST("no event name was escape-shaped");
     EXPECT_TRUE(!escape_leaked, "an event leaked an .ef= spelling");

--- a/tests/test-sysroot-name-i18n.c
+++ b/tests/test-sysroot-name-i18n.c
@@ -13,14 +13,14 @@
  * volume considers equal, and each must stay two files to the guest.
  *
  * Scripts with no case and no normalization forms (Chinese, Thai, emoji) are
- * here too, because the rule escapes them as well and they have to survive
- * the round trip unchanged.
+ * here too, because the rule escapes them as well and they have to survive the
+ * round trip unchanged.
  *
  * Every name is created by the guest. On a folding sysroot the escape delivers
  * the Linux result for all of them. A case-sensitive APFS sysroot is different:
- * the volume still folds canonical normalization and refuses names that are
- * not well-formed UTF-8, and with case folding absent the escape is inactive,
- * so canonically-equal spellings alias (a write to one clobbers the other) and
+ * the volume still folds canonical normalization and refuses names that are not
+ * well-formed UTF-8, and with case folding absent the escape is inactive, so
+ * canonically-equal spellings alias (a write to one clobbers the other) and
  * ill-formed names fail with EILSEQ. That divergence is documented in
  * docs/filenames.md; run with argv[1] "csapfs" the test pins it exactly, so a
  * future change that closes the gap turns these expectations red and updates
@@ -142,9 +142,9 @@ static void check_pair(const char *label, const char *a, const char *b)
 
 /* A canonically-equal pair. On a folding sysroot this is check_pair; on
  * case-sensitive APFS the volume folds the two spellings together with the
- * escape off, so the documented divergence is pinned instead: the second
- * write lands in the first file, both spellings read it, and the listing
- * holds one entry under the first writer's spelling.
+ * escape off, so the documented divergence is pinned instead: the second write
+ * lands in the first file, both spellings read it, and the listing holds one
+ * entry under the first writer's spelling.
  */
 static void check_canonical_pair(const char *label,
                                  const char *a,
@@ -174,9 +174,9 @@ static void check_canonical_pair(const char *label,
     PASS();
 }
 
-/* A name that is not well-formed UTF-8. On a folding sysroot the escape
- * stores it; on case-sensitive APFS the volume refuses it and the guest sees
- * EILSEQ, which is the divergence to pin.
+/* A name that is not well-formed UTF-8. On a folding sysroot the escape stores
+ * it; on case-sensitive APFS the volume refuses it and the guest sees EILSEQ,
+ * which is the divergence to pin.
  */
 static void check_invalid_utf8(const char *label, const char *name)
 {
@@ -293,14 +293,14 @@ int main(int argc, char **argv)
                        "sur\xed\xa0\x80"
                        "rogate");
 
-    /* Everything created above must still be reachable, so the escapes have
-     * not collided with each other.
+    /* Everything created above must still be reachable, so the escapes have not
+     * collided with each other.
      */
     TEST("every name is still readable");
     {
         /* The ill-formed name exists only where the escape stored it; the
-         * caf\xc3\xa9 spellings read the same file on csapfs and different
-         * ones elsewhere, but both must resolve either way.
+         * caf\xc3\xa9 spellings read the same file on csapfs and different ones
+         * elsewhere, but both must resolve either way.
          */
         char got[64];
         EXPECT_TRUE(

--- a/tests/test-sysroot-name-length.c
+++ b/tests/test-sysroot-name-length.c
@@ -4,12 +4,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Linux allows a path component of 255 bytes, and a guest is entitled to all
- * of them, including for a name that has to be stored escaped, which is
- * longer on disk than the name it stands for. The volume underneath measures
- * its own limit in UTF-16 code units rather than bytes, which is what leaves
- * room for the escape; this asserts the guest-visible consequence, that no
- * length below the Linux maximum is refused and 256 bytes is.
+ * Linux allows a path component of 255 bytes, and a guest is entitled to all of
+ * them, including for a name that has to be stored escaped, which is longer on
+ * disk than the name it stands for. The volume underneath measures its own
+ * limit in UTF-16 code units rather than bytes, which is what leaves room for
+ * the escape; this asserts the guest-visible consequence, that no length below
+ * the Linux maximum is refused and 256 bytes is.
  *
  * The interesting lengths are the two tier boundaries the encoding has and the
  * Linux maximum. A guest must not be able to tell where a tier changes, so the
@@ -17,9 +17,9 @@
  *
  * Code under test: the two payload tiers in src/syscall/casefold.c and the
  * length accounting in src/syscall/casefold-walk.c. A regression shows up as
- * ENAMETOOLONG for a name Linux allows (most likely at whichever tier
- * boundary the encoding grew), or as a colliding pair at full length
- * collapsing into one file.
+ * ENAMETOOLONG for a name Linux allows (most likely at whichever tier boundary
+ * the encoding grew), or as a colliding pair at full length collapsing into one
+ * file.
  *
  * Run under --sysroot.
  */
@@ -89,8 +89,8 @@ static int create(const char *name, const char *text)
     return file_write(path, text);
 }
 
-/* One name of a given length: create it, read it back, and require a listing
- * to report the same bytes. @mixed picks whether it needs escaping.
+/* One name of a given length: create it, read it back, and require a listing to
+ * report the same bytes. @mixed picks whether it needs escaping.
  */
 static void check_length(size_t bytes, bool mixed)
 {
@@ -118,8 +118,8 @@ static void check_length(size_t bytes, bool mixed)
 }
 
 /* A colliding pair at a given length. Both members must exist as separate
- * files, which is the case a side-table-free mapping has to earn: the escape
- * is longer than the name, so this is where a length limit would bite.
+ * files, which is the case a side-table-free mapping has to earn: the escape is
+ * longer than the name, so this is where a length limit would bite.
  */
 static void check_pair(size_t bytes)
 {
@@ -204,8 +204,8 @@ int main(void)
     check_length(254, true);
     check_length(GUEST_NAME_MAX, true);
 
-    /* The same lengths through the second walker, which must not have a
-     * ceiling of its own.
+    /* The same lengths through the second walker, which must not have a ceiling
+     * of its own.
      */
     check_openat2(126);
     check_openat2(GUEST_NAME_MAX);

--- a/tests/test-sysroot-name-race.c
+++ b/tests/test-sysroot-name-race.c
@@ -7,8 +7,8 @@
  * Nothing serializes name creation in a sysroot, and the reason is that the
  * on-disk spelling of a guest name is a function of that name alone: two
  * processes creating names that the volume would fold together are writing
- * different entries, so they never contend. This asserts the consequence
- * rather than the mechanism.
+ * different entries, so they never contend. This asserts the consequence rather
+ * than the mechanism.
  *
  * fork(2) under elfuse spawns a separate host process, so the children below
  * really are separate processes sharing one sysroot with no shared state
@@ -75,8 +75,8 @@ static int content_is(const char *name, const char *want)
     return file_content_is(path, want);
 }
 
-/* Fork KIDS children and run @body in each, recording each child's exit code
- * in @code (-1 for a child that could not be forked or reaped, or that died
+/* Fork KIDS children and run @body in each, recording each child's exit code in
+ * @code (-1 for a child that could not be forked or reaped, or that died
  * abnormally). One fork/wait implementation for both rounds, so the reaping
  * bookkeeping cannot drift between them.
  */

--- a/tests/test-sysroot-name-relative.c
+++ b/tests/test-sysroot-name-relative.c
@@ -8,8 +8,8 @@
  * directory or to a directory descriptor. Both must reach the same file. That
  * is not automatic here, because a name whose spelling the volume cannot hold
  * is stored escaped, so the translation has to run whichever way the guest
- * spelled it, and for a relative name there is no leading component to key
- * on, only the descriptor it is resolved against.
+ * spelled it, and for a relative name there is no leading component to key on,
+ * only the descriptor it is resolved against.
  *
  * This matters well beyond a shell doing cd: fts, find, git and rsync walk
  * trees with openat(dirfd, name) throughout, and never build an absolute path
@@ -18,9 +18,9 @@
  * Code under test: src/syscall/casefold-walk.c reached from
  * src/syscall/path.c's path_translate_at, for the case where the guest path
  * does not begin with '/'. A regression shows up as the same guest name
- * resolving to two different files depending on how it was spelled, so a
- * create through one spelling is invisible through the other, and an O_EXCL
- * create of a name that already exists succeeds instead of reporting EEXIST.
+ * resolving to two different files depending on how it was spelled, so a create
+ * through one spelling is invisible through the other, and an O_EXCL create of
+ * a name that already exists succeeds instead of reporting EEXIST.
  *
  * Run under --sysroot.
  */
@@ -62,8 +62,8 @@ static void section_outside_sysroot(const char *host_dir)
 {
     char abs[PATH_MAX];
 
-    /* Visible, so a manual run without the recipe's host fixture reads as
-     * fewer tests run, not as the section passing.
+    /* Visible, so a manual run without the recipe's host fixture reads as fewer
+     * tests run, not as the section passing.
      */
     if (!host_dir || !host_dir[0]) {
         printf("  (outside-sysroot section skipped: no host dir given)\n");
@@ -126,8 +126,8 @@ static void section_openat2_no_symlinks(int dirfd)
      */
 
     /* RESOLVE_NO_XDEV is answered by a third walker, which probes each
-     * component to see whether a symlink moves the path onto another mount.
-     * It probes by name too, so it has the same requirement. Only detection
+     * component to see whether a symlink moves the path onto another mount. It
+     * probes by name too, so it has the same requirement. Only detection
      * matters here, not where the link points, so the target need not resolve.
      */
     TEST("openat2 RESOLVE_NO_XDEV sees a symlink under an escaped name");
@@ -157,10 +157,10 @@ static void section_openat2_no_symlinks(int dirfd)
     }
 
     /* The walker sees host spellings, and an escape is longer than the name it
-     * stands for: past the guest limit once the name passes 125 bytes. A
-     * walker sized to the guest limit refuses those components with
-     * ENAMETOOLONG for a file openat opens without complaint, which is the
-     * two-answers disagreement again, in a length rather than a spelling.
+     * stands for: past the guest limit once the name passes 125 bytes. A walker
+     * sized to the guest limit refuses those components with ENAMETOOLONG for a
+     * file openat opens without complaint, which is the two-answers
+     * disagreement again, in a length rather than a spelling.
      */
     TEST("openat2 RESOLVE_NO_SYMLINKS opens a 126-byte escaped name");
     {

--- a/tests/test-sysroot-name-soak.c
+++ b/tests/test-sysroot-name-soak.c
@@ -6,28 +6,28 @@
  *
  * test-sysroot-name-race aims ten processes at one narrow window; this is the
  * volume counterpart. Eight threads and two forked children hammer eight
- * directories with creates, renames, unlinks, stats, and listing scans over
- * one colliding set (four case spellings plus an NFC/NFD pair) for a
- * deadline given in seconds as argv[1]. Nothing serializes name creation (the
- * spelling is a function of the name alone), so this is the shape that would
- * surface a lost update or a decode landing on a sibling's entry.
+ * directories with creates, renames, unlinks, stats, and listing scans over one
+ * colliding set (four case spellings plus an NFC/NFD pair) for a deadline given
+ * in seconds as argv[1]. Nothing serializes name creation (the spelling is a
+ * function of the name alone), so this is the shape that would surface a lost
+ * update or a decode landing on a sibling's entry.
  *
- * Two invariants hold at every step, however the operations interleave:
- * every syscall returns success or the ENOENT/EEXIST that a concurrent
- * unlink or create legitimately produces, and every listing is a
- * duplicate-free subset of the colliding set: a duplicate means two disk
- * entries decoded to one guest name, an escape spelling means a decode was
- * skipped. After the deadline, workers join and a quiescent sweep checks
- * that whatever survived reads back a member's content and unlinks cleanly.
+ * Two invariants hold at every step, however the operations interleave: every
+ * syscall returns success or the ENOENT/EEXIST that a concurrent unlink or
+ * create legitimately produces, and every listing is a duplicate-free subset of
+ * the colliding set: a duplicate means two disk entries decoded to one guest
+ * name, an escape spelling means a decode was skipped. After the deadline,
+ * workers join and a quiescent sweep checks that whatever survived reads back a
+ * member's content and unlinks cleanly.
  *
  * A pass does not prove the absence of a race; it is evidence that sustained
- * churn lacks a reproducer today, and only a failure proves anything. Kept
- * out of `make check` for its runtime; run via test-sysroot-name-soak (or
+ * churn lacks a reproducer today, and only a failure proves anything. Kept out
+ * of `make check` for its runtime; run via test-sysroot-name-soak (or
  * check-soak) with --timeout 0.
  *
  * Code under test: the create/rename/unlink translation paths in
- * src/syscall/fs.c, the case-exact walk in src/syscall/casefold-walk.c, and
- * the dirent decode in src/syscall/path.c under contention.
+ * src/syscall/fs.c, the case-exact walk in src/syscall/casefold-walk.c, and the
+ * dirent decode in src/syscall/path.c under contention.
  */
 
 #include <dirent.h>
@@ -60,8 +60,8 @@ static const char *const names[] = {
 };
 #define N_NAMES (sizeof(names) / sizeof(names[0]))
 
-/* Monotonic seconds, so a wall-clock step during the run cannot stretch or
- * cut the soak (time(2) tracks CLOCK_REALTIME).
+/* Monotonic seconds, so a wall-clock step during the run cannot stretch or cut
+ * the soak (time(2) tracks CLOCK_REALTIME).
  */
 static time_t mono_now(void)
 {
@@ -112,9 +112,9 @@ static bool name_in_set(const char *n)
 }
 
 /* A listing must be a duplicate-free subset of the set at every instant:
- * entries come and go under churn, but two entries for one guest name mean
- * two disk spellings decoded onto it, and an escape prefix means one was
- * not decoded at all.
+ * entries come and go under churn, but two entries for one guest name mean two
+ * disk spellings decoded onto it, and an escape prefix means one was not
+ * decoded at all.
  */
 static void scan_listing(const char *dir)
 {
@@ -168,8 +168,9 @@ static void worker_loop(uint64_t seed)
                 soak_fail("create refused", path, name);
                 break;
             }
-            /* The content is the creating spelling, so any read landing on
-             * a sibling's file is visible to the quiescent sweep.
+
+            /* The content is the creating spelling, so any read landing on a
+             * sibling's file is visible to the quiescent sweep.
              */
             if (write(fd, name, strlen(name)) < 0)
                 soak_fail("write refused", path, name);
@@ -236,11 +237,9 @@ int main(int argc, char **argv)
     }
 
     /* Forked children first so they inherit no thread state; each is a full
-     * elfuse host process sharing the sysroot, which is the cross-process
-     * half of the churn.
-     */
-    /* Seeds are fixed so a failing interleaving can at least be retried
-     * with the same operation streams; distinct per worker so no two
+     * elfuse host process sharing the sysroot, which is the cross-process half
+     * of the churn. Seeds are fixed so a failing interleaving can at least be
+     * retried with the same operation streams; distinct per worker so no two
      * workers replay each other. The multiplier is the usual 64-bit
      * golden-ratio scatter constant.
      */
@@ -302,9 +301,9 @@ int main(int argc, char **argv)
                     continue;
                 }
                 got[n] = '\0';
+
                 /* Content is whichever member spelling last wrote the file;
-                 * anything else means a write landed through the wrong
-                 * entry.
+                 * anything else means a write landed through the wrong entry.
                  */
                 if (!name_in_set(got))
                     ok = false;

--- a/tests/test-sysroot-name-staged.c
+++ b/tests/test-sysroot-name-staged.c
@@ -8,12 +8,12 @@
  * the guest view has to be well defined for names elfuse itself would never
  * produce. Two questions matter.
  *
- * A name that is a well-formed escape means the name it decodes to, wherever
- * it came from, which is what makes the mapping a property of the name and
- * not of who wrote it. A name that merely resembles one means itself:
- * uppercase hex, an odd number of digits, a payload decoding to "/" or ".."
- * are all ordinary files, and the guest must be able to open them under the
- * bytes they are spelled with.
+ * A name that is a well-formed escape means the name it decodes to, wherever it
+ * came from, which is what makes the mapping a property of the name and not of
+ * who wrote it. A name that merely resembles one means itself: uppercase hex,
+ * an odd number of digits, a payload decoding to "/" or ".." are all ordinary
+ * files, and the guest must be able to open them under the bytes they are
+ * spelled with.
  *
  * Code under test: casefold_is_escaped and casefold_to_guest in
  * src/syscall/casefold.c, reached through the directory-entry and lookup paths
@@ -21,9 +21,9 @@
  * cannot open under any name, or as a name that resembles an escape being
  * decoded into something else.
  *
- * The recipe stages all of this host-side, because a guest cannot create a
- * name that elfuse would store under a different spelling. Run under
- * --sysroot; the fixtures are staged by the make recipe.
+ * The recipe stages all of this host-side, because a guest cannot create a name
+ * that elfuse would store under a different spelling. Run under --sysroot; the
+ * fixtures are staged by the make recipe.
  */
 
 #include <dirent.h>
@@ -198,8 +198,8 @@ int main(int argc, char **argv)
     expect_reachable("a different separator is not an escape", ".ef_464f4f",
                      "literal-legacy");
 
-    /* Both spellings of one name staged together. Only something outside
-     * elfuse can produce this, and the rule is that a lookup takes the literal
+    /* Both spellings of one name staged together. Only something outside elfuse
+     * can produce this, and the rule is that a lookup takes the literal
      * spelling: the escaped one is then unreachable under any guest name. The
      * listing reports the name twice, which is the visible cost of letting a
      * host tool write a tree elfuse also manages.

--- a/tests/test-sysroot-name-unique.c
+++ b/tests/test-sysroot-name-unique.c
@@ -7,16 +7,15 @@
  * On a case-folding sysroot a name whose spelling the volume cannot hold is
  * stored escaped, so a directory can end up holding a mixture of literal and
  * escaped entries. What must hold throughout is that each guest name is
- * reachable through exactly one of them: every spelling opens its own file,
- * a spelling that was never created reports ENOENT, and a listing reports each
+ * reachable through exactly one of them: every spelling opens its own file, a
+ * spelling that was never created reports ENOENT, and a listing reports each
  * name once and never leaks an on-disk spelling.
  *
  * The sequence below is adversarial on purpose. It creates the members of a
  * case-colliding set in an order that makes each one take a different kind of
- * slot, then deletes and recreates them so the literal slot changes hands
- * while the others stay put. No assertion here may depend on *which* spelling
- * won the literal slot: that follows arrival order and is not part of the
- * contract.
+ * slot, then deletes and recreates them so the literal slot changes hands while
+ * the others stay put. No assertion here may depend on *which* spelling won the
+ * literal slot: that follows arrival order and is not part of the contract.
  *
  * Code under test: the resolver in src/syscall/casefold-walk.c reached through
  * src/syscall/path.c, and the mutating handlers in src/syscall/fs.c that use
@@ -24,8 +23,8 @@
  * name surviving its own unlink, or a listing that disagrees with what can be
  * opened.
  *
- * Run under --sysroot. The host-side shape check in the make recipe asserts
- * the on-disk half.
+ * Run under --sysroot. The host-side shape check in the make recipe asserts the
+ * on-disk half.
  */
 
 #include <dirent.h>
@@ -124,8 +123,8 @@ int main(void)
     expect_absent("FOO absent before it is made", DIR_R "/FOO");
     expect_listing("listing holds Foo alone", "Foo");
 
-    /* The second member cannot take the same slot, so it is stored escaped,
-     * and the guest must not be able to tell.
+    /* The second member cannot take the same slot, so it is stored escaped, and
+     * the guest must not be able to tell.
      */
     TEST("create foo beside Foo");
     EXPECT_TRUE(file_write(DIR_R "/foo", "B") == 0, "create foo");
@@ -193,8 +192,8 @@ int main(void)
     }
     expect_listing("listing after link", "FOO,fOO,foo");
 
-    /* Taking the set apart one at a time: each removal leaves the rest
-     * readable under their own names.
+    /* Taking the set apart one at a time: each removal leaves the rest readable
+     * under their own names.
      */
     TEST("unlink fOO");
     EXPECT_TRUE(unlink(DIR_R "/fOO") == 0, "unlink fOO");

--- a/tests/test-sysroot-openat2-walk.c
+++ b/tests/test-sysroot-openat2-walk.c
@@ -4,24 +4,24 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * macOS has no equivalent of RESOLVE_NO_SYMLINKS, so elfuse answers the flag
- * by walking the path itself and reporting ELOOP at the first symlink
- * component. Linux bounds that resolution by the number of links followed,
- * never by the number of components walked (path_resolution(7)), so a
- * link-free path resolves however deep it runs. The walk sees the host
- * spelling, which carries the sysroot's own directories in front of the guest
- * path, and those are not the guest's to account for either. A dirfd-relative
- * path is walked from the descriptor instead, where Linux clamps '..' at the
- * guest root (path_resolution(7)); the walk must stop climbing there rather
- * than continue onto the host directories above the sysroot.
+ * macOS has no equivalent of RESOLVE_NO_SYMLINKS, so elfuse answers the flag by
+ * walking the path itself and reporting ELOOP at the first symlink component.
+ * Linux bounds that resolution by the number of links followed, never by the
+ * number of components walked (path_resolution(7)), so a link-free path
+ * resolves however deep it runs. The walk sees the host spelling, which carries
+ * the sysroot's own directories in front of the guest path, and those are not
+ * the guest's to account for either. A dirfd-relative path is walked from the
+ * descriptor instead, where Linux clamps '..' at the guest root
+ * (path_resolution(7)); the walk must stop climbing there rather than continue
+ * onto the host directories above the sysroot.
  *
  * Code under test: sys_path_has_symlink() in src/syscall/path.c, both the
- * absolute arm and the dirfd-relative arm. A regression reports ELOOP or
- * ENOENT for a link-free path Linux resolves: a deep chain through the
- * absolute arm, or an escaping '..' whose relative walk leaves the sysroot
- * and meets the host's own symlinks (macOS /tmp). The chains are staged by
- * the recipe rather than by the guest so their names reach the disk
- * literally, keeping the walk the only thing under test.
+ * absolute arm and the dirfd-relative arm. A regression reports ELOOP or ENOENT
+ * for a link-free path Linux resolves: a deep chain through the absolute arm,
+ * or an escaping '..' whose relative walk leaves the sysroot and meets the
+ * host's own symlinks (macOS /tmp). The chains are staged by the recipe rather
+ * than by the guest so their names reach the disk literally, keeping the walk
+ * the only thing under test.
  */
 
 #include <errno.h>
@@ -36,9 +36,9 @@
 
 int passes = 0, fails = 0;
 
-/* The deep chain runs past WALK_MAXSYMLINKS; the shallow one stays under it
- * on its own but crosses it once the sysroot's host directories are counted
- * too, which is the shape only a sysroot can show.
+/* The deep chain runs past WALK_MAXSYMLINKS; the shallow one stays under it on
+ * its own but crosses it once the sysroot's host directories are counted too,
+ * which is the shape only a sysroot can show.
  */
 #define DEEP_COMPONENTS (WALK_MAXSYMLINKS + 4)
 #define SHALLOW_COMPONENTS (WALK_MAXSYMLINKS - 2)
@@ -57,8 +57,8 @@ static int open_no_symlinks(const char *path)
     return openat2_no_symlinks(AT_FDCWD, path);
 }
 
-/* Spell the chain the recipe staged: "/<root>" then @components levels of
- * "d". */
+/* Spell the chain the recipe staged: "/<root>" then @components levels of "d".
+ */
 static void chain_path(char *out,
                        size_t outsz,
                        const char *root,
@@ -97,10 +97,9 @@ static void expect_dirfd_resolves(const char *label,
 }
 
 /* The walk from a descriptor must clamp '..' where the guest root sits, not
- * where the sysroot's host parent does. An unclamped walk climbs onto the
- * host, where the next named component resolves against the host's own tree
- * (macOS /tmp is a symlink), so a path the guest resolves comes back ELOOP or
- * ENOENT.
+ * where the sysroot's host parent does. An unclamped walk climbs onto the host,
+ * where the next named component resolves against the host's own tree (macOS
+ * /tmp is a symlink), so a path the guest resolves comes back ELOOP or ENOENT.
  */
 static void section_relative(void)
 {
@@ -121,8 +120,8 @@ static void section_relative(void)
     expect_dirfd_resolves("the clamp seeds from the descriptor's own depth",
                           tmp, "../../tmp/leaf");
 
-    /* The counterweight: a clamped '..' must not blind the walk to the
-     * symlink sitting where it lands.
+    /* The counterweight: a clamped '..' must not blind the walk to the symlink
+     * sitting where it lands.
      */
     TEST("a symlink is still ELOOP through a clamped \"..\"");
     EXPECT_ERRNO(openat2_no_symlinks(root, "../link/leaf"), ELOOP,
@@ -144,16 +143,15 @@ int main(void)
     expect_resolves("a chain under the budget resolves behind the sysroot",
                     "shallow", SHALLOW_COMPONENTS);
 
-    /* The counterweight: with no budget left in the walk, the flag still has
-     * to reject the thing it exists to reject.
+    /* The counterweight: with no budget left in the walk, the flag still has to
+     * reject the thing it exists to reject.
      */
     TEST("a symlink component is still ELOOP");
     EXPECT_ERRNO(open_no_symlinks("/link/leaf"), ELOOP,
                  "a symlink component must be rejected");
 
-    /* Guards the byte-for-byte copy of interior '..': a resolver that
-     * collapsed it would spell this path /real/leaf and hide the link from
-     * the walk.
+    /* Guards the byte-for-byte copy of interior '..': a resolver that collapsed
+     * it would spell this path /real/leaf and hide the link from the walk.
      */
     TEST("an interior .. keeps the symlink before it visible");
     EXPECT_ERRNO(open_no_symlinks("/link/../real/leaf"), ELOOP,

--- a/tests/test-sysroot-outside-names.c
+++ b/tests/test-sysroot-outside-names.c
@@ -5,31 +5,31 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * The escape encoding is scoped to the sysroot: only there did elfuse choose
- * the stored spelling, so only there may a listing decode one. A host
- * directory reached through the fallback holds names elfuse never wrote. A
- * file named ".ef=464f4f" in such a directory is a file named ".ef=464f4f"
- * and nothing else; decoding it would report a name the directory does not
- * contain and that no open() can resolve, while hiding the entry's real name
- * behind it. Lookups already treat these directories literally, so a decoding
- * listing also disagrees with the resolver about what the directory holds.
+ * the stored spelling, so only there may a listing decode one. A host directory
+ * reached through the fallback holds names elfuse never wrote. A file named
+ * ".ef=464f4f" in such a directory is a file named ".ef=464f4f" and nothing
+ * else; decoding it would report a name the directory does not contain and that
+ * no open() can resolve, while hiding the entry's real name behind it. Lookups
+ * already treat these directories literally, so a decoding listing also
+ * disagrees with the resolver about what the directory holds.
  *
- * Code under test: path_translate_dirent_name and its per-directory scoping
- * in src/syscall/path.c, reached from the getdents64 loop in
- * src/syscall/fs.c via the host fallback in proc_resolve_sysroot_path_flags.
- * A regression shows up as ls of a host directory inventing a name no open()
- * resolves, and as two real entries collapsing into one listed name.
+ * Code under test: path_translate_dirent_name and its per-directory scoping in
+ * src/syscall/path.c, reached from the getdents64 loop in src/syscall/fs.c via
+ * the host fallback in proc_resolve_sysroot_path_flags. A regression shows up
+ * as ls of a host directory inventing a name no open() resolves, and as two
+ * real entries collapsing into one listed name.
  *
  * argv[1] is a host directory staged by the make recipe, outside the sysroot
  * the recipe also creates. Run under --sysroot on a case-folding volume; the
- * recipe asserts host-side that the control file the guest creates inside
- * the sysroot was stored escaped, so a pass on a byte-exact volume cannot be
+ * recipe asserts host-side that the control file the guest creates inside the
+ * sysroot was stored escaped, so a pass on a byte-exact volume cannot be
  * vacuous.
  *
- * argv[2] = "nosysroot" runs the same assertions with no sysroot configured
- * at all, where nothing decodes anywhere: the other half of the scoping
- * contract, reached through path_dirent_dir_holds_escapes, which refuses
- * every directory once there is no sysroot to snapshot. The in-sysroot
- * control is skipped, there being no sysroot to hold it.
+ * argv[2] = "nosysroot" runs the same assertions with no sysroot configured at
+ * all, where nothing decodes anywhere: the other half of the scoping contract,
+ * reached through path_dirent_dir_holds_escapes, which refuses every directory
+ * once there is no sysroot to snapshot. The in-sysroot control is skipped,
+ * there being no sysroot to hold it.
  */
 
 #include <dirent.h>
@@ -61,6 +61,7 @@ int main(int argc, char **argv)
     }
 
     bool with_sysroot = !(argc > 2 && !strcmp(argv[2], "nosysroot"));
+
     /* Both legs run the same assertions, so the summary has to say which one
      * reported them.
      */
@@ -92,10 +93,10 @@ int main(int argc, char **argv)
     snprintf(path, sizeof(path), "%s/%s", argv[1], DECODES_TO);
     EXPECT_ERRNO(open(path, O_RDONLY), ENOENT, "should not exist");
 
-    /* Creates outside the sysroot are literal too, so after this the
-     * directory really holds both spellings. A decoding listing folds them
-     * into two entries named DECODES_TO: the file just written plus the
-     * decode of the staged escape, with the escape's own bytes gone.
+    /* Creates outside the sysroot are literal too, so after this the directory
+     * really holds both spellings. A decoding listing folds them into two
+     * entries named DECODES_TO: the file just written plus the decode of the
+     * staged escape, with the escape's own bytes gone.
      */
     TEST("a created literal name does not collapse with the escape");
     fd = open(path, O_CREAT | O_WRONLY, 0644);
@@ -109,9 +110,9 @@ int main(int argc, char **argv)
         unlink(path);
     }
 
-    /* Host-side control for the recipe: stored escaped only if the volume
-     * folds and the sysroot scope still decodes, proving the assertions
-     * above did not pass merely because nothing was escaping anywhere.
+    /* Host-side control for the recipe: stored escaped only if the volume folds
+     * and the sysroot scope still decodes, proving the assertions above did not
+     * pass merely because nothing was escaping anywhere.
      */
     if (with_sysroot) {
         TEST("a control name inside the sysroot still escapes");

--- a/tests/test-sysroot-path-matrix.c
+++ b/tests/test-sysroot-path-matrix.c
@@ -7,25 +7,25 @@
  * Every escaped bug in the path layer sat in one cell of a cross product the
  * hand-written tests visited selectively: a final symlink through a dirfd, a
  * long-tier name through the openat2 walker, a create below an intermediate
- * link. This test enumerates the product programmatically (addressing mode
- * x operation x path shape x name class), so a cell exists because the loop
+ * link. This test enumerates the product programmatically (addressing mode x
+ * operation x path shape x name class), so a cell exists because the loop
  * reached it, not because someone thought of it.
  *
  * Linux contract pinned: path_resolution(7) makes no distinction between an
  * absolute path, a cwd-relative one, and an openat(2) dirfd-relative one that
  * name the same file: same result, same errno, same object. The oracle is
- * exactly that agreement: each cell runs one operation through all three
- * modes and requires identical (rc, errno), the same (st_dev, st_ino) for
- * lookups, and for creates that the canonical absolute spelling sees what
- * was made. Agreement is the invariant every escaped dirfd bug violated, so
- * a divergence names its cell in the failure message.
+ * exactly that agreement: each cell runs one operation through all three modes
+ * and requires identical (rc, errno), the same (st_dev, st_ino) for lookups,
+ * and for creates that the canonical absolute spelling sees what was made.
+ * Agreement is the invariant every escaped dirfd bug violated, so a divergence
+ * names its cell in the failure message.
  *
  * Code under test: path_translate_at and its relative/dirfd legs in
  * src/syscall/path.c, over the resolvers in src/syscall/proc-state.c and the
  * walk in src/syscall/casefold-walk.c. A regression shows up as one mode
- * diverging: a create landing beside a link instead of through it, a
- * lookup succeeding where a sibling mode reports ENOENT, or an errno class
- * changing with the spelling of the same file.
+ * diverging: a create landing beside a link instead of through it, a lookup
+ * succeeding where a sibling mode reports ENOENT, or an errno class changing
+ * with the spelling of the same file.
  *
  * Deliberately not here: the sysroot mounted at "/" (read-only root;
  * test-sysroot-root), concurrency (test-sysroot-name-race), and name-length
@@ -65,8 +65,8 @@ enum { MODE_ABS, MODE_CWD, MODE_DIRFD, MODE_COUNT };
 static const char *const mode_name[MODE_COUNT] = {"absolute", "cwd-relative",
                                                   "dirfd"};
 
-/* The dirfd every MODE_DIRFD operation is measured from; opened on ROOT once
- * in main. MODE_CWD relies on main having chdir'd to ROOT.
+/* The dirfd every MODE_DIRFD operation is measured from; opened on ROOT once in
+ * main. MODE_CWD relies on main having chdir'd to ROOT.
  */
 static int root_fd = -1;
 
@@ -82,8 +82,8 @@ static const char *spell(int mode, const char *rel, char *out, size_t outsz)
 
 typedef int (*cell_op_t)(int mode, const char *rel, cell_result_t *res);
 
-/* Fill @res from a stat-like probe of @rel in @mode; @nofollow picks the
- * lstat flavor. Identity is recorded so lookups can assert one object.
+/* Fill @res from a stat-like probe of @rel in @mode; @nofollow picks the lstat
+ * flavor. Identity is recorded so lookups can assert one object.
  */
 static int probe_stat(int mode,
                       const char *rel,
@@ -173,8 +173,8 @@ static int op_openat2_nosym(int mode, const char *rel, cell_result_t *res)
 }
 
 /* Create @rel, record the outcome, verify through the canonical absolute
- * spelling that exactly this mode's create is visible, then remove it the
- * same canonical way so the next mode starts from the same directory.
+ * spelling that exactly this mode's create is visible, then remove it the same
+ * canonical way so the next mode starts from the same directory.
  */
 static int op_create(int mode, const char *rel, cell_result_t *res)
 {
@@ -195,6 +195,7 @@ static int op_create(int mode, const char *rel, cell_result_t *res)
     res->has_id = false;
     if (fd >= 0) {
         close(fd);
+
         /* The canonical spelling must see what this mode made: a create that
          * "succeeded" somewhere else is the failure this matrix exists for.
          */
@@ -329,9 +330,9 @@ static const op_t ops[] = {
 };
 
 /* Path shapes: a prefix the leaf is planted under. sublink is a symlink to
- * Sub.Dir, so the third shape crosses an intermediate link; the fourth
- * carries a '..' component, which the resolvers collapse lexically, so every
- * addressing mode must keep agreeing about where the leaf lives.
+ * Sub.Dir, so the third shape crosses an intermediate link; the fourth carries
+ * a '..' component, which the resolvers collapse lexically, so every addressing
+ * mode must keep agreeing about where the leaf lives.
  */
 static const char *const shapes[] = {"", "Sub.Dir/", "sublink/",
                                      "Sub.Dir/../Sub.Dir/"};
@@ -376,10 +377,11 @@ static void run_cell(const op_t *op, const char *shape, const char *leaf)
     for (int m = 1; m < MODE_COUNT; m++) {
         if (r[m].rc != r[0].rc || r[m].err != r[0].err)
             agree = false;
+
         /* Identity must match for lookups only: a mutating cell makes (and
-         * removes) a fresh object per mode, so its inodes legitimately
-         * differ; placement is already folded into rc via the canonical
-         * probe inside the op.
+         * removes) a fresh object per mode, so its inodes legitimately differ;
+         * placement is already folded into rc via the canonical probe inside
+         * the op.
          */
         if (!op->creates && r[m].has_id && r[0].has_id &&
             (r[m].dev != r[0].dev || r[m].ino != r[0].ino))
@@ -446,8 +448,8 @@ int main(void)
                 char rel[PATH_MAX];
 
                 if (ops[o].creates) {
-                    /* Mutating cells use a fresh leaf beside the fixture so
-                     * the lookup fixtures stay untouched.
+                    /* Mutating cells use a fresh leaf beside the fixture so the
+                     * lookup fixtures stay untouched.
                      */
                     char fresh[PATH_MAX];
                     snprintf(fresh, sizeof(fresh), "New.%s", leaves[l]);
@@ -473,8 +475,8 @@ int main(void)
     run_cell(&ops[1], "", "final-link");
     run_cell(&ops[2], "", "final-link");
 
-    /* Trailing separator asserts directoriness; a regular file owes ENOTDIR
-     * in every mode alike (path_resolution(7)).
+    /* Trailing separator asserts directoriness; a regular file owes ENOTDIR in
+     * every mode alike (path_resolution(7)).
      */
     run_cell(&ops[0], "", "plain-name/");
     run_cell(&ops[0], "", "Mixed.Name/");

--- a/tests/test-sysroot-pathmax.c
+++ b/tests/test-sysroot-pathmax.c
@@ -7,25 +7,24 @@
  * Linux allows a path of 4096 bytes; macOS stops at 1024 (PATH_MAX,
  * sys/syslimits.h), and an escaped component roughly doubles on disk, so a
  * guest path the kernel it emulates would accept can exceed what the host
- * kernel will take. The documented policy (docs/filenames.md, "Whole paths")
- * is that such a path reports ENAMETOOLONG and is never truncated, because a
+ * kernel will take. The documented policy (docs/filenames.md, "Whole paths") is
+ * that such a path reports ENAMETOOLONG and is never truncated, because a
  * truncated path names a different file. This pins the guest-visible
  * consequences of that policy at the boundary.
  *
- * Two lanes: literal components (host length ~ guest length + sysroot
- * prefix, so the ceiling is crossed on any volume) and escaped components
- * (guest path well under 1024; only the escape expansion crosses, so this
- * lane exercises the case-exact walk specifically). Both assert the same
- * contract: every level either works fully (create, stat, list back)
- * or fails with exactly ENAMETOOLONG, monotonically once the ceiling is
- * crossed, with no level truncating into a sibling that a listing would
- * expose.
+ * Two lanes: literal components (host length ~ guest length + sysroot prefix,
+ * so the ceiling is crossed on any volume) and escaped components (guest path
+ * well under 1024; only the escape expansion crosses, so this lane exercises
+ * the case-exact walk specifically). Both assert the same contract: every level
+ * either works fully (create, stat, list back) or fails with exactly
+ * ENAMETOOLONG, monotonically once the ceiling is crossed, with no level
+ * truncating into a sibling that a listing would expose.
  *
- * Code under test: the accumulated-path checks in
- * src/syscall/casefold-walk.c and the translation exits in
- * src/syscall/path.c. A regression shows up as a create succeeding past the
- * ceiling under a spelling other than its own (truncation), as a wrong
- * errno, or as a success-after-failure flip while descending.
+ * Code under test: the accumulated-path checks in src/syscall/casefold-walk.c
+ * and the translation exits in src/syscall/path.c. A regression shows up as a
+ * create succeeding past the ceiling under a spelling other than its own
+ * (truncation), as a wrong errno, or as a success-after-failure flip while
+ * descending.
  *
  * On a byte-exact volume the escaped lane stores names literally and stays
  * short of the ceiling; its probes then assert plain success, so the test
@@ -70,17 +69,19 @@ static void step_name(char *out, size_t outsz, int depth, bool escaped)
     out[escaped ? ESC_STEP_LEN : STEP_LEN] = '\0';
 }
 
-/* The recipe probes the volume host-side and passes "fold" or "exact": a
- * guest cannot tell the volume kinds apart (hiding that difference is what
- * the escape is for), but whether the escaped lane must cross the ceiling
- * depends on it, and an expectation that accepts both outcomes on a folding
- * volume would let the interesting lane pass vacuously.
+/* The recipe probes the volume host-side and passes "fold" or "exact": a guest
+ * cannot tell the volume kinds apart (hiding that difference is what the escape
+ * is for), but whether the escaped lane must cross the ceiling depends on it,
+ * and an expectation that accepts both outcomes on a folding volume would let
+ * the interesting lane pass vacuously.
  */
 static bool volume_folds;
 
 /* Descend one level at a time under @root, requiring each mkdir to either
- * succeed completely or fail with ENAMETOOLONG, and never to succeed again
- * once a level has failed. Returns the deepest path that succeeded in @path.
+ * succeed completely or fail with ENAMETOOLONG, and never to succeed again once
+ * a level has failed.
+ *
+ * Returns the deepest path that succeeded in @path.
  */
 static void descend(const char *root, bool escaped)
 {
@@ -116,6 +117,7 @@ static void descend(const char *root, bool escaped)
             return;
         }
         hit_ceiling = true;
+
         /* The failed level must not exist under any spelling: a truncated
          * create would leave an entry the parent listing exposes.
          */
@@ -128,8 +130,8 @@ static void descend(const char *root, bool escaped)
     if (escaped && !hit_ceiling) {
         /* A byte-exact volume stores the escaped lane literally, and
          * ESC_MAX_DEPTH * (ESC_STEP_LEN + 1) stays under 1024 there; not
-         * crossing is the correct outcome on such a volume, and the only
-         * legal one on a folding volume is crossing.
+         * crossing is the correct outcome on such a volume, and the only legal
+         * one on a folding volume is crossing.
          */
         struct stat st;
         if (volume_folds)
@@ -148,8 +150,8 @@ static void descend(const char *root, bool escaped)
                  : "literal deepest level lists exactly one child");
     {
         /* The deepest surviving directory holds at most the single child the
-         * next (failed) level would have created, which is none. Any entry
-         * here is a truncated spelling of a deeper create.
+         * next (failed) level would have created, which is none. Any entry here
+         * is a truncated spelling of a deeper create.
          */
         DIR *d = opendir(deepest);
         struct dirent *de;
@@ -180,6 +182,7 @@ static void descend(const char *root, bool escaped)
         snprintf(file, sizeof(file), "%s", deepest);
         step_name(name, sizeof(name), depth_limit, escaped);
         snprintf(file + len, sizeof(file) - len, "/%s", name);
+
         /* Fill the remaining guest budget so the host spelling is over the
          * ceiling whichever lane this is.
          */
@@ -193,9 +196,9 @@ static void descend(const char *root, bool escaped)
             close(fd);
             FAIL("open(O_CREAT) succeeded on a path past the ceiling");
         } else if (errno == ENAMETOOLONG || errno == ENOENT) {
-            /* ENOENT is legal when an intermediate level is the one past
-             * the ceiling on a byte-exact volume: the parent chain stops
-             * existing before the name gets too long.
+            /* ENOENT is legal when an intermediate level is the one past the
+             * ceiling on a byte-exact volume: the parent chain stops existing
+             * before the name gets too long.
              */
             PASS();
         } else {

--- a/tests/test-sysroot-root.c
+++ b/tests/test-sysroot-root.c
@@ -11,11 +11,11 @@
  * root reports ELOOP, a diagnosis about symlinks for a path containing none.
  *
  * Code under test: proc_resolve_sysroot_create_path and
- * proc_resolve_sysroot_path_flags in src/syscall/proc-state.c: the parent
- * split off the walk's recorded offsets, and the all-slash guard the
- * containment check needs. A regression shows up as ELOOP where the host's
- * own answer should come through, which sends a caller looking for a link
- * loop that does not exist.
+ * proc_resolve_sysroot_path_flags in src/syscall/proc-state.c: the parent split
+ * off the walk's recorded offsets, and the all-slash guard the containment
+ * check needs. A regression shows up as ELOOP where the host's own answer
+ * should come through, which sends a caller looking for a link loop that does
+ * not exist.
  *
  * Nothing here writes: the macOS root is read-only, and what is asserted is
  * that the guest is told so rather than being told something untrue. Run under
@@ -65,8 +65,8 @@ int main(void)
      * containment check splits a parent off the resolved path, and with the
      * one-character prefix that parent is the root itself; treating the shape
      * as impossible reported ELOOP for lstat("/"), which no Linux kernel can
-     * produce: "/" is a directory, and nofollow only changes the answer for
-     * a symlink.
+     * produce: "/" is a directory, and nofollow only changes the answer for a
+     * symlink.
      */
     TEST("the root itself resolves without following");
     EXPECT_TRUE(lstat("/", &st) == 0 && S_ISDIR(st.st_mode), "lstat /");

--- a/tests/test-sysroot-symlink-escape.c
+++ b/tests/test-sysroot-symlink-escape.c
@@ -6,13 +6,13 @@
  *
  * proc_resolve_sysroot_path_flags() only runs its sysroot-prefix + realpath()
  * containment check on absolute guest paths, since it has no dirfd context to
- * rebuild a host location from a relative one. That left openat(dirfd, name)
- * to the host kernel's own resolution, unconfined to dirfd's subtree: a
- * symlink reachable through a sysroot-contained dirfd with a relative target
- * holding enough ".." components could walk straight out of the sysroot with
- * no check at all. path_translate_at() now reconstructs the absolute guest
- * path from the dirfd's guest base path and re-validates it through the same
- * resolver the absolute-path surface uses.
+ * rebuild a host location from a relative one. That left openat(dirfd, name) to
+ * the host kernel's own resolution, unconfined to dirfd's subtree: a symlink
+ * reachable through a sysroot-contained dirfd with a relative target holding
+ * enough ".." components could walk straight out of the sysroot with no check
+ * at all. path_translate_at() now reconstructs the absolute guest path from the
+ * dirfd's guest base path and re-validates it through the same resolver the
+ * absolute-path surface uses.
  *
  * The Makefile target stages an absolute-target symlink and a relative-target
  * (deep "..") symlink under $sysroot/d1, both pointing at a host file outside

--- a/tests/test-sysroot-symlink-target.c
+++ b/tests/test-sysroot-symlink-target.c
@@ -4,23 +4,22 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * A relative symlink target stores the bytes the guest gave it, and
- * readlink(2) hands them back. On a folding sysroot that puts the target and
- * the disk out of step, because a name the volume cannot hold as itself is
- * stored escaped; handing the stored bytes to the host kernel then looks for
- * a name that is not there. An absolute target cannot even be stored
- * verbatim: anything following the link natively resolves it from the host
- * root rather than the sysroot, so creation rewrites it to a target relative
- * to the link's own directory (sys_symlinkat in src/syscall/fs.c). readlink
- * reports that rewritten spelling, the one visible divergence, because
- * nothing on disk tells a rewritten target from a relative one the guest
- * wrote.
+ * A relative symlink target stores the bytes the guest gave it, and readlink(2)
+ * hands them back. On a folding sysroot that puts the target and the disk out
+ * of step, because a name the volume cannot hold as itself is stored escaped;
+ * handing the stored bytes to the host kernel then looks for a name that is not
+ * there. An absolute target cannot even be stored verbatim: anything following
+ * the link natively resolves it from the host root rather than the sysroot, so
+ * creation rewrites it to a target relative to the link's own directory
+ * (sys_symlinkat in src/syscall/fs.c). readlink reports that rewritten
+ * spelling, the one visible divergence, because nothing on disk tells a
+ * rewritten target from a relative one the guest wrote.
  *
  * Following therefore happens in the guest's namespace: the target is resolved
  * as a guest path, through the same sysroot-or-host dispatch every other guest
  * path takes. An absolute target consequently behaves exactly like the same
- * absolute path typed by the guest: inside the sysroot when it is there, on
- * the host when it is not and the path is not a guest system directory.
+ * absolute path typed by the guest: inside the sysroot when it is there, on the
+ * host when it is not and the path is not a guest system directory.
  *
  * Code under test: the symlink handling in src/syscall/casefold-walk.c and the
  * splice in src/syscall/proc-state.c. A regression shows up as ENOENT for a
@@ -152,11 +151,11 @@ int main(void)
         EXPECT_TRUE(chdir("/") == 0, "restore cwd");
     }
 
-    /* readlink reports the disk. A relative target is stored verbatim, so
-     * the guest's own bytes come back; an absolute one was rewritten at
-     * symlink() time to the sysroot-relative spelling (see the header), and
-     * that spelling is what comes back. The link here sits one directory
-     * below the guest root, so the rewrite is ".." plus the absolute target.
+    /* readlink reports the disk. A relative target is stored verbatim, so the
+     * guest's own bytes come back; an absolute one was rewritten at symlink()
+     * time to the sysroot-relative spelling (see the header), and that spelling
+     * is what comes back. The link here sits one directory below the guest
+     * root, so the rewrite is ".." plus the absolute target.
      */
     TEST("readlink returns a relative target verbatim");
     at(path, sizeof(path), "rel-escaped");
@@ -222,9 +221,9 @@ int main(void)
         "content through an over-climbing target");
 
     /* Regression guards for the link budget, green at introduction: exactly
-     * MAXSYMLINKS (40) links resolve and the 41st reports ELOOP, matching
-     * Linux (path_resolution(7)). An off-by-one in either direction flips
-     * exactly one of the pair.
+     * MAXSYMLINKS (40) links resolve and the 41st reports ELOOP, matching Linux
+     * (path_resolution(7)). An off-by-one in either direction flips exactly one
+     * of the pair.
      */
     TEST("a 40-link chain resolves");
     {
@@ -272,8 +271,8 @@ int main(void)
                     readlink(path, buf, sizeof(buf) - 1) > 0,
                 "the link itself exists");
 
-    /* Operations that do not follow must keep working on the link, since a
-     * fix that resolved targets everywhere would break removing a dangling one.
+    /* Operations that do not follow must keep working on the link, since a fix
+     * that resolved targets everywhere would break removing a dangling one.
      */
     TEST("unlink removes the link, not its target");
     at(path, sizeof(path), "rel-escaped");
@@ -282,8 +281,8 @@ int main(void)
     EXPECT_TRUE(reads("Target.One", "escaped") == 0, "target still there");
 
     /* Creating below an intermediate link has to follow it too, and the create
-     * resolver is separate code from the lookup one, the same split that let
-     * a wrong-case create escape once already. The new file must appear in the
+     * resolver is separate code from the lookup one, the same split that let a
+     * wrong-case create escape once already. The new file must appear in the
      * directory the link names, not beside the link.
      */
     TEST("a create below an intermediate link follows it");
@@ -387,14 +386,14 @@ int main(void)
         if (f >= 0)
             close(f);
 
-        /* Creates through the descriptor must cross the link too. Create is
-         * a separate resolver from lookup, and the descriptor-relative walk
-         * is a separate entry point from the absolute one; the absolute
+        /* Creates through the descriptor must cross the link too. Create is a
+         * separate resolver from lookup, and the descriptor-relative walk is a
+         * separate entry point from the absolute one; the absolute
          * create-below-a-link cases above pass while this one regresses
-         * whenever the two entry points map the create flag differently:
-         * the create then aims at the host-literal path instead of landing
-         * inside the sysroot, per openat(2)'s dirfd rule and
-         * path_resolution(7)'s follow rule for intermediate components.
+         * whenever the two entry points map the create flag differently: the
+         * create then aims at the host-literal path instead of landing inside
+         * the sysroot, per openat(2)'s dirfd rule and path_resolution(7)'s
+         * follow rule for intermediate components.
          */
         TEST("a dirfd-relative create below an intermediate link");
         f = -1;

--- a/tests/test-tgkill-directed.c
+++ b/tests/test-tgkill-directed.c
@@ -55,6 +55,7 @@ static void *blocking_worker(void *arg)
     (void) arg;
     worker_tid = (int) raw_gettid();
     worker_ready = 1;
+
     /* Block in read() on an empty pipe. A thread-directed signal must land here
      * and interrupt this read with EINTR; a byte written by the parent is the
      * fallback that unblocks the worker if the signal was misdelivered.
@@ -150,6 +151,7 @@ static void *counting_worker(void *arg)
     sigset_t block;
     sigemptyset(&block);
     sigaddset(&block, SIGUSR2);
+
     /* Per-thread block so the pending signal stays queued on this thread until
      * it unblocks -- no thread can consume another's instance.
      */

--- a/tests/test-thread-churn.c
+++ b/tests/test-thread-churn.c
@@ -5,16 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * elfuse keeps one thread-table slot per guest thread (MAX_THREADS = 64).
- * Creating well over 64 threads across the test's lifetime forces later
- * clones to reuse slots whose previous occupant already exited on its own,
- * which is the only path that reaps the terminated worker's host pthread
- * (issue #157: stale joinable handles leaked on slot reuse).
+ * Creating well over 64 threads across the test's lifetime forces later clones
+ * to reuse slots whose previous occupant already exited on its own, which is
+ * the only path that reaps the terminated worker's host pthread (issue #157:
+ * stale joinable handles leaked on slot reuse).
  *
- * The sequential phase is the sharpest probe: each worker is the last one
- * alive when it exits, so its wind-down runs the last-worker wakeup that
- * takes the thread-table lock AFTER the slot is released. The next clone
- * joins that same pthread at slot-reuse time; joining under the table lock
- * would deadlock here deterministically.
+ * The sequential phase is the sharpest probe: each worker is the last one alive
+ * when it exits, so its wind-down runs the last-worker wakeup that takes the
+ * thread-table lock AFTER the slot is released. The next clone joins that same
+ * pthread at slot-reuse time; joining under the table lock would deadlock here
+ * deterministically.
  */
 
 #include <pthread.h>
@@ -35,8 +35,8 @@ static void *churn_fn(void *arg)
     return NULL;
 }
 
-/* Phase 1: sequential create+join, one live worker at a time. Every round
- * past the table size reuses the slot freed by the previous round.
+/* Phase 1: sequential create+join, one live worker at a time. Every round past
+ * the table size reuses the slot freed by the previous round.
  */
 static void test_sequential_churn(void)
 {

--- a/tests/test-times.c
+++ b/tests/test-times.c
@@ -4,9 +4,9 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * Tests: return-value tick clock, self utime/stime accounting, waited-for
- * child cutime/cstime accounting (counted once, not on stop/WNOWAIT
- * snapshots), NULL buffer, EFAULT on a bad pointer.
+ * Tests: return-value tick clock, self utime/stime accounting, waited-for child
+ * cutime/cstime accounting (counted once, not on stop/WNOWAIT snapshots), NULL
+ * buffer, EFAULT on a bad pointer.
  */
 
 #include <fcntl.h>
@@ -39,8 +39,8 @@ static void burn_cpu_ms(long ms)
 }
 
 /* Like burn_cpu_ms, but spends the time in real open/write/close syscalls
- * rather than pure computation, so the host accounts some of it as system
- * time (ru_stime) rather than all user time.
+ * rather than pure computation, so the host accounts some of it as system time
+ * (ru_stime) rather than all user time.
  */
 static void burn_syscalls_ms(long ms)
 {
@@ -157,9 +157,9 @@ int main(void)
                 } else if (after.tms_cutime <= before.tms_cutime) {
                     FAIL("cutime did not grow individually");
                 } else {
-                    /* A regression that always reports cstime==0 must not
-                     * pass here: this child's loop is real host syscalls, not
-                     * pure computation, so cstime alone must also grow.
+                    /* A regression that always reports cstime==0 must not pass
+                     * here: this child's loop is real host syscalls, not pure
+                     * computation, so cstime alone must also grow.
                      */
                     EXPECT_TRUE(after.tms_cstime > before.tms_cstime,
                                 "cstime did not grow individually");

--- a/tests/test-usage-synopsis.sh
+++ b/tests/test-usage-synopsis.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # test-usage-synopsis.sh -- Pin the usage synopsis renderings against drift
 #
 # Copyright 2026 elfuse contributors
@@ -9,10 +10,10 @@
 # main() prints its usage synopsis at three sites: the --help block, the
 # unknown-option error, and the missing-elf-path error. They were once three
 # hand-maintained string literals and had drifted; the missing-elf-path copy
-# predated the GDB stub and never learned [--gdb PORT] [--gdb-stop-on-entry],
-# so the most common error path advertised an incomplete flag set. All three
-# now expand ELFUSE_USAGE_BODY, which --help renders wrapped and the error
-# paths render flat.
+# predated the GDB stub and never learned [--gdb PORT] [--gdb-stop-on-entry], so
+# the most common error path advertised an incomplete flag set. All three now
+# expand ELFUSE_USAGE_BODY, which --help renders wrapped and the error paths
+# render flat.
 #
 # Rather than sample the flag list, which is what let the old copies drift
 # unnoticed, this compares the renderings against each other: a flag reaching
@@ -34,22 +35,23 @@ set -euo pipefail
 
 ELFUSE="${1:?Usage: $0 <elfuse-binary>}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# Labels here are sentences rather than tool names, so widen the column past
-# the library default before report.sh reads it.
+
+# Labels here are sentences rather than tool names, so widen the column past the
+# library default before report.sh reads it.
 TEST_LABEL_WIDTH="${TEST_LABEL_WIDTH:-50}"
 # shellcheck source=tests/lib/report.sh
 . "$SCRIPT_DIR/lib/report.sh"
 
-# report_pass / report_skip in tests/lib/report.sh increment these; only
-# fail is read directly, by the exit status at the bottom.
+# report_pass / report_skip in tests/lib/report.sh increment these; only fail is
+# read directly, by the exit status at the bottom.
 # shellcheck disable=SC2034
 pass=0
 fail=0
 # shellcheck disable=SC2034
 skip=0
 
-# Compare one rendering against another and report through the shared
-# emitter, so this suite lines up with the rest of make check's output.
+# Compare one rendering against another and report through the shared emitter,
+# so this suite lines up with the rest of make check's output.
 check()
 {
     local label="$1" want="$2" got="$3"
@@ -65,9 +67,9 @@ check()
 # The synopsis block runs from the "usage:" line to the first blank line.
 help_block="$("$ELFUSE" --help | awk '/^usage: /{f=1} f{if (!NF) exit; print}')"
 
-# Collapsing runs of whitespace undoes the wrap without assuming how many
-# lines it takes or where the breaks fall, so re-grouping the flags is not a
-# failure while dropping or renaming one is.
+# Collapsing runs of whitespace undoes the wrap without assuming how many lines
+# it takes or where the breaks fall, so re-grouping the flags is not a failure
+# while dropping or renaming one is.
 help_flat="$(printf '%s\n' "$help_block" | tr '\n' ' ' | tr -s ' ')"
 help_flat="${help_flat% }"
 
@@ -95,20 +97,20 @@ check "missing-elf-path error is a single line" "1" \
 check "unknown-option error is a single line" "1" \
     "$(printf '%s\n' "$bad_flag_err" | grep -c .)"
 
-# 80 columns is the width every --help reader is assumed to have; a longer
-# line wraps at an arbitrary column and defeats the alignment below.
+# 80 columns is the width every --help reader is assumed to have; a longer line
+# wraps at an arbitrary column and defeats the alignment below.
 over80="$(printf '%s\n' "$help_block" | awk 'length($0) > 80' | wc -l | tr -d ' ')"
 check "every --help synopsis line fits 80 columns" "0" "$over80"
 
-# Continuation lines are indented to the column after "usage: elfuse ", so
-# the flags form one block under the first line's.
+# Continuation lines are indented to the column after "usage: elfuse ", so the
+# flags form one block under the first line's.
 indent="$(printf '%s' 'usage: elfuse ' | wc -c | tr -d ' ')"
 misaligned="$(printf '%s\n' "$help_block" | awk -v n="$indent" \
     'NR > 1 && substr($0, 1, n) != sprintf("%*s", n, "")' | wc -l | tr -d ' ')"
 check "continuation lines align under the flags" "0" "$misaligned"
 
-# More than one line proves the wrap is real; a single-line --help synopsis
-# is the regression that made the flags unscannable on an 80-column terminal.
+# More than one line proves the wrap is real; a single-line --help synopsis is
+# the regression that made the flags unscannable on an 80-column terminal.
 lines="$(printf '%s\n' "$help_block" | grep -c .)"
 check "--help wraps the synopsis over several lines" "yes" \
     "$([ "$lines" -gt 1 ] && echo yes || echo "no ($lines line)")"

--- a/tests/test-util.h
+++ b/tests/test-util.h
@@ -55,7 +55,8 @@ static inline ssize_t read_file_nul(const char *path, char *buf, size_t bufsz)
 }
 
 /* Read a file whose size is not available from st_size (for example a proc
- * file) until EOF, growing the buffer and appending a NUL terminator. */
+ * file) until EOF, growing the buffer and appending a NUL terminator.
+ */
 static inline ssize_t read_file_dynamic_nul(const char *path,
                                             char **buf_out,
                                             size_t *len_out)
@@ -252,8 +253,8 @@ static inline int dir_entry_count(const char *dir)
 }
 
 /* Membership only; an unopenable @dir reads as absent, so a negative-only
- * assertion must pair with a positive one or use dir_count_name, whose -1
- * keeps "cannot read" distinct from "not present".
+ * assertion must pair with a positive one or use dir_count_name, whose -1 keeps
+ * "cannot read" distinct from "not present".
  */
 static inline bool dir_contains(const char *dir, const char *name)
 {
@@ -293,11 +294,12 @@ static inline int dir_count_name(const char *dir, const char *name)
 }
 
 /* Bind a pathname AF_UNIX socket of @type at @path, listening with @backlog
- * when it is positive. Returns the descriptor, or -1 with the socket closed
- * and no socket file created by this call left behind.
- * An over-long @path is truncated into sun_path exactly as the lanes did by
- * hand; the bind then addresses the truncated name, which the caller's own
- * assertions catch.
+ * when it is positive.
+ *
+ * Returns the descriptor, or -1 with the socket closed and no socket file
+ * created by this call left behind. An over-long @path is truncated into
+ * sun_path exactly as the lanes did by hand; the bind then addresses the
+ * truncated name, which the caller's own assertions catch.
  */
 static inline int unix_bind(const char *path, int type, int backlog)
 {
@@ -314,10 +316,10 @@ static inline int unix_bind(const char *path, int type, int backlog)
         return -1;
     }
     if (backlog > 0 && listen(fd, backlog) != 0) {
-        /* bind created the file, so a rerun would get EADDRINUSE from it.
-         * Only this branch unlinks: on a bind failure the file is not this
-         * call's, and removing it would break whoever owns it. sun_path,
-         * not @path, because the file carries the truncated name.
+        /* bind created the file, so a rerun would get EADDRINUSE from it. Only
+         * this branch unlinks: on a bind failure the file is not this call's,
+         * and removing it would break whoever owns it. sun_path, not @path,
+         * because the file carries the truncated name.
          */
         unlink(sa.sun_path);
         close(fd);

--- a/tests/test-wakeup-pipe-host.c
+++ b/tests/test-wakeup-pipe-host.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * A reader thread runs wakeup_pipe_signal() and wakeup_pipe_read_fd() across
- * the main thread's wakeup_pipe_init(), the pairing ThreadSanitizer reported
- * on wakeup_pipe_wr under test-fork-exec. Only a -fsanitize=thread build has a
+ * the main thread's wakeup_pipe_init(), the pairing ThreadSanitizer reported on
+ * wakeup_pipe_wr under test-fork-exec. Only a -fsanitize=thread build has a
  * race detector; elsewhere this checks init, idempotency, and drain.
  */
 

--- a/tests/test-x11.c
+++ b/tests/test-x11.c
@@ -588,6 +588,7 @@ int main(void)
     TEST("DISPLAY parse '/path/sock:0'");
     {
         display_info_t d;
+
         /* Path does not exist on disk, so parse_display falls back to the full
          * string as socket_path
          */

--- a/tests/x86_64-glibc-pthread-tls.c
+++ b/tests/x86_64-glibc-pthread-tls.c
@@ -34,7 +34,8 @@ static void emit(int fd, const char *s)
 struct worker_result {
     uint64_t initial;     /* per_thread_value as the worker first sees it */
     uint64_t after_write; /* per_thread_value after the worker writes its
-                           * own marker */
+                           * own marker
+                           */
 };
 
 static void *worker(void *arg)
@@ -79,6 +80,7 @@ int main(void)
         emit(STDERR_FILENO, "worker-write-readback-wrong");
         return 5;
     }
+
     /* Main's slot must still hold the value we wrote before pthread _create,
      * untouched by the worker's write.
      */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a tracked contributing guide and enforces comment width with `commentflow` across Make and CI. Previously comments were hand-wrapped and ungated; now `make indent` reflows comments before `clang-format`, CI separates formatter findings from analyzer outages, and there are no runtime behavior changes.

- `CONTRIBUTING.md`: single source of truth for C style, formatter ownership, gates, and commit‑message rules. `README.md` links to it; the `elfuse-*` skills defer to it for anything it now covers.
- Comment width gate: `make indent` calls `.ci/check-commentflow.sh --write` ahead of `clang-format`; `make check-format` and the Lint workflow call the same script. The script is bash 3.2–compatible, owns the reflow, is the only place that probes for `commentflow`, and no longer supports `--list`. Exit codes: 0 clean, 1 files would change, 2 the check could not run (including missing tool or empty selection); outages print guidance. The Lint workflow rechecks when `.clang-format`, the gate script, the workflow, or covered files change, and covers C/H, assembly, and shell.
- Tree-wide reflow: comments reflowed only; host objects and the shim rebuild byte‑identical (line‑number immediates aside); proof targets still pass.
- `cppcheck` gate: runs in parallel, uses a 300s hang guard, logs its version, and adopts the same 0/1/2 exit convention to separate findings from outages; a prior suppression was removed by guarding the loop; missing‑analyzer exits report as outages.
- Style stragglers: bring headers to `#pragma once`, drop unnecessary casts, prefer `sizeof(*ptr)` allocations, and add cheap null guards where needed; compiled output remains unchanged.

**Migration for contributors**
- Install `commentflow` and run `make indent` before committing; CI fails on comment reflow (exit 1) and flags a missing tool as an outage (exit 2) with guidance.
- Use `CONTRIBUTING.md` for review expectations and gate scope; `make check-format` is broader than CI and must not add new warnings on touched scripts.

<sup>Written for commit 2c7d879dec69a4a0b66c843c3014f4b1a0b87aea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

