### PR TITLE
Honor CBAUD/CIBAUD in TCGETS, TCGETS2 and TCSETS

### DIFF
--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -776,11 +776,14 @@ static uint32_t mac_oflag_to_linux(tcflag_t mf)
 #define LINUX_CLOCAL 0x0800
 
 /* LINUX_CBAUD 0x0000100f and LINUX_CBAUDEX 0x00001000 encode baud in c_cflag;
- * macOS uses dedicated speed fields, so termios translation ignores CBAUD on
- * translation. TCGETS2/TCSETS2 use BOTHER to signal numeric c_ispeed/c_ospeed.
+ * macOS uses dedicated speed fields, so the c_cflag translation tables skip
+ * CBAUD and the TCGETS/TCSETS arms convert it with the helpers below.
+ * TCGETS2/TCSETS2 use BOTHER to signal numeric c_ispeed/c_ospeed.
  */
 #define LINUX_CBAUD 0x100f
 #define LINUX_BOTHER 0x1000
+/* CIBAUD is CBAUD shifted by IBSHIFT (asm-generic/termbits.h). */
+#define LINUX_IBSHIFT 16
 
 /* Decode a Linux CBAUD field value to a numeric baud rate.
  * Returns the numeric rate, or 0 for B0 / unknown. Standard rates B0-B38400 are
@@ -806,6 +809,68 @@ static speed_t linux_cbaud_to_speed(uint32_t cbaud)
     return 0;
 }
 
+/* Encode a numeric baud rate as a Linux CBAUD field value (the inverse of
+ * linux_cbaud_to_speed).
+ *
+ * Returns the B* index for the standard rates, or BOTHER for a rate Linux has
+ * no symbolic name for, so cfgetospeed() in the guest sees the same constant it
+ * passed to cfsetospeed().
+ */
+static uint32_t speed_to_linux_cbaud(speed_t speed)
+{
+    for (uint32_t i = 0; i < 16; i++) {
+        if (linux_cbaud_to_speed(i) == speed)
+            return i;
+        if (i && linux_cbaud_to_speed(LINUX_BOTHER | i) == speed)
+            return LINUX_BOTHER | i;
+    }
+    return LINUX_BOTHER;
+}
+
+/* Encode the host line rates into the CBAUD and CIBAUD fields of a Linux
+ * c_cflag, the way tty_termios_encode_baud_rate() does: CBAUD always carries
+ * the output rate; CIBAUD is set only when the input rate differs, and is left
+ * at B0 ("same as output") otherwise.
+ */
+static uint32_t linux_cflag_speed_bits(const struct termios *t)
+{
+    speed_t ospeed = cfgetospeed(t), ispeed = cfgetispeed(t);
+    uint32_t bits = speed_to_linux_cbaud(ospeed);
+    if (ispeed != ospeed)
+        bits |= speed_to_linux_cbaud(ispeed) << LINUX_IBSHIFT;
+    return bits;
+}
+
+/* Apply the CBAUD/CIBAUD fields of a plain (non-termios2) Linux c_cflag to a
+ * host termios, following drivers/tty/tty_baudrate.c: the output rate is the
+ * CBAUD table entry; the input rate is CIBAUD's, or the output rate when CIBAUD
+ * is B0. Two values carry no rate and leave the host speed untouched: B0 in
+ * CBAUD, which on Linux means "drop DTR/RTS" (not emulated), and a bare BOTHER,
+ * which the kernel resolves from the tty's current c_ospeed/c_ispeed because
+ * the plain struct has no speed fields -- so a tcgetattr/tcsetattr round trip
+ * on a port set to 74880 through termios2 must not collapse the line to B0.
+ */
+static int apply_linux_cflag_speeds(struct termios *t, uint32_t c_cflag)
+{
+    uint32_t cbaud = c_cflag & LINUX_CBAUD;
+    uint32_t cibaud = (c_cflag >> LINUX_IBSHIFT) & LINUX_CBAUD;
+    speed_t orate = linux_cbaud_to_speed(cbaud);
+
+    /* Both B0 and a bare BOTHER decode to 0, but they must part ways in the
+     * CIBAUD-empty fallback: BOTHER resolves the input rate from the tty's
+     * current output rate (tty_termios_baud_rate reads c_ospeed), while B0
+     * carries no rate at all and must leave a split input rate alone.
+     */
+    speed_t irate = cibaud == 0
+                        ? (cbaud == LINUX_BOTHER ? cfgetospeed(t) : orate)
+                        : linux_cbaud_to_speed(cibaud);
+    if (orate && cfsetospeed(t, orate) < 0)
+        return -1;
+    if (irate && cfsetispeed(t, irate) < 0)
+        return -1;
+    return 0;
+}
+
 /* CSIZE: Linux CS5=0x00, CS6=0x10, CS7=0x20, CS8=0x30
  *        macOS CS5=0x00, CS6=0x100, CS7=0x200, CS8=0x300
  */
@@ -817,7 +882,9 @@ static const termios_field_pair_t csize_map[] = {
 };
 
 /* CBAUD and CBAUDEX are absent on purpose: the baud rate travels in the
- * c_ispeed and c_ospeed fields, not in c_cflag.
+ * c_ispeed and c_ospeed fields, not in c_cflag. The TCGETS/TCSETS arms in
+ * sys_ioctl encode and decode the CBAUD field separately, since plain termios
+ * has no speed fields for a guest libc to consult.
  */
 static const termios_flag_pair_t cflag_map[] = {
     {LINUX_CSTOPB, CSTOPB}, {LINUX_CREAD, CREAD}, {LINUX_PARENB, PARENB},
@@ -2276,7 +2343,12 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         linux_termios_t lt = {0};
         lt.c_iflag = mac_iflag_to_linux(t.c_iflag);
         lt.c_oflag = mac_oflag_to_linux(t.c_oflag);
-        lt.c_cflag = mac_cflag_to_linux(t.c_cflag);
+
+        /* Plain termios has no speed fields: cfgetospeed()/cfgetispeed() in the
+         * guest decode CBAUD/CIBAUD out of c_cflag, so encode the host rates
+         * back into it.
+         */
+        lt.c_cflag = mac_cflag_to_linux(t.c_cflag) | linux_cflag_speed_bits(&t);
         lt.c_lflag = mac_lflag_to_linux(t.c_lflag);
         termios_copy_cc_to_linux(lt.c_cc, t.c_cc);
         if (guest_write_small(g, arg, &lt, sizeof(lt)) < 0) {
@@ -2305,6 +2377,16 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         t.c_cflag = linux_cflag_to_mac(lt.c_cflag);
         t.c_lflag = linux_lflag_to_mac(lt.c_lflag);
         termios_copy_cc_to_mac(t.c_cc, lt.c_cc);
+
+        /* musl and glibc <= 2.41 store the rate in CBAUD (and CIBAUD for a
+         * split input rate) and issue plain TCSETS; glibc 2.42+ always uses
+         * TCSETS2. Dropping the field here would leave a USB-serial port at
+         * whatever speed the host last had.
+         */
+        if (apply_linux_cflag_speeds(&t, lt.c_cflag) < 0) {
+            host_fd_ref_close(&host_ref);
+            return linux_errno();
+        }
         int action = termios_action_for(request);
         if (tcsetattr(host_fd, action, &t) < 0) {
             host_fd_ref_close(&host_ref);
@@ -2315,9 +2397,11 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
     }
 
     case LINUX_TCGETS2: {
-        /* termios2 variant: same as TCGETS but with c_ispeed/c_ospeed. Set
-         * BOTHER in c_cflag so the guest uses the numeric speed fields rather
-         * than decoding CBAUD (which mac_cflag_to_linux drops).
+        /* termios2 variant: same as TCGETS plus numeric c_ispeed/c_ospeed. The
+         * kernel hands back the same c_cflag for both requests (the B* index
+         * when the rate has one, BOTHER otherwise), so encode it the same way
+         * rather than forcing BOTHER; the numeric fields are always filled, as
+         * the kernel does.
          */
         struct termios t;
         if (tcgetattr(host_fd, &t) < 0) {
@@ -2327,7 +2411,8 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         linux_termios2_t lt2 = {0};
         lt2.c_iflag = mac_iflag_to_linux(t.c_iflag);
         lt2.c_oflag = mac_oflag_to_linux(t.c_oflag);
-        lt2.c_cflag = mac_cflag_to_linux(t.c_cflag) | LINUX_BOTHER;
+        lt2.c_cflag =
+            mac_cflag_to_linux(t.c_cflag) | linux_cflag_speed_bits(&t);
         lt2.c_lflag = mac_lflag_to_linux(t.c_lflag);
         termios_copy_cc_to_linux(lt2.c_cc, t.c_cc);
         lt2.c_ispeed = (uint32_t) cfgetispeed(&t);
@@ -2362,22 +2447,31 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         t.c_lflag = linux_lflag_to_mac(lt2.c_lflag);
         termios_copy_cc_to_mac(t.c_cc, lt2.c_cc);
 
-        /* Resolve baud rate: BOTHER means use numeric c_ispeed/c_ospeed;
-         * otherwise decode the standard CBAUD index to a numeric rate.
+        /* Resolve the rates the way tty_termios_baud_rate() and
+         * tty_termios_input_baud_rate() do: the output rate is CBAUD's table
+         * entry, or the numeric c_ospeed for BOTHER; the input rate is CIBAUD's
+         * -- B0 meaning "same as output", BOTHER meaning the numeric c_ispeed.
+         * The TCGETS2 arm above reports a split host rate as CBAUD+CIBAUD
+         * indexes, so an unchanged tcgetattr/tcsetattr pair from a termios2
+         * libc must decode CIBAUD or it would collapse the input rate to the
+         * output rate. B0 output (drop DTR/RTS on Linux, not emulated) leaves
+         * the host speed untouched, as in the plain TCSETS arm.
          */
         uint32_t cbaud = lt2.c_cflag & LINUX_CBAUD;
-        speed_t ispeed, ospeed;
-        if (cbaud == LINUX_BOTHER) {
-            ispeed = (speed_t) lt2.c_ispeed;
-            ospeed = (speed_t) lt2.c_ospeed;
-        } else {
-            speed_t rate = linux_cbaud_to_speed(cbaud);
-            ispeed = rate;
-            ospeed = rate;
-        }
-        if (cfsetispeed(&t, ispeed) < 0 || cfsetospeed(&t, ospeed) < 0) {
-            host_fd_ref_close(&host_ref);
-            return linux_errno();
+        uint32_t cibaud = (lt2.c_cflag >> LINUX_IBSHIFT) & LINUX_CBAUD;
+        speed_t ospeed = cbaud == LINUX_BOTHER ? (speed_t) lt2.c_ospeed
+                                               : linux_cbaud_to_speed(cbaud);
+        if (ospeed != 0) {
+            speed_t ispeed = cibaud == 0 ? ospeed
+                             : cibaud == LINUX_BOTHER
+                                 ? (speed_t) lt2.c_ispeed
+                                 : linux_cbaud_to_speed(cibaud);
+            if (ispeed == 0)
+                ispeed = ospeed;
+            if (cfsetispeed(&t, ispeed) < 0 || cfsetospeed(&t, ospeed) < 0) {
+                host_fd_ref_close(&host_ref);
+                return linux_errno();
+            }
         }
         int action = termios_action_for(request);
         if (tcsetattr(host_fd, action, &t) < 0) {

--- a/tests/test-pty.c
+++ b/tests/test-pty.c
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -72,6 +73,14 @@
 #ifndef AT_EMPTY_PATH
 #define AT_EMPTY_PATH 0x1000
 #endif
+
+/* termios2 is only reachable through asm/termbits.h, which clashes with
+ * termios.h; spell the asm-generic values (shared by aarch64 and x86_64).
+ */
+#define TEST_TCGETS2 0x802c542a
+#define TEST_TCSETS2 0x402c542b
+#define TEST_CBAUD 0x100f
+#define TEST_BOTHER 0x1000
 #ifndef SYS_statx
 #define SYS_statx 291
 #endif
@@ -1378,6 +1387,182 @@ int main(void)
         }
         if (fm >= 0)
             close(fm);
+    }
+
+    /* Serial line control on a slave. The guest libc's tcsetattr() encodes the
+     * rate in CBAUD and issues plain TCSETS (glibc's cfsetspeed, musl always),
+     * so a translation that only reads the termios2 speed fields silently
+     * leaves the host line at its old rate and tcgetattr() reports B0 forever.
+     */
+    {
+        int sm = open("/dev/ptmx", O_RDWR | O_NOCTTY);
+        unsigned int sn = 0;
+        int sunlock = 0;
+        if (sm >= 0 && ioctl(sm, TIOCGPTN, &sn) == 0 &&
+            ioctl(sm, TIOCSPTLCK, &sunlock) == 0) {
+            char spath[64];
+            snprintf(spath, sizeof(spath), "/dev/pts/%u", sn);
+            int sl = open(spath, O_RDWR | O_NOCTTY);
+            struct termios stio;
+            int sget = sl >= 0 ? tcgetattr(sl, &stio) : -1;
+
+            TEST("tcsetattr(B115200) round-trips through tcgetattr");
+            int sset = -1;
+            struct termios sback;
+            memset(&sback, 0, sizeof(sback));
+            if (sget == 0) {
+                cfsetispeed(&stio, B115200);
+                cfsetospeed(&stio, B115200);
+                sset = tcsetattr(sl, TCSANOW, &stio);
+                if (sset == 0)
+                    sget = tcgetattr(sl, &sback);
+            }
+            EXPECT_TRUE(sset == 0 && sget == 0 &&
+                            cfgetospeed(&sback) == B115200 &&
+                            cfgetispeed(&sback) == B115200,
+                        "CBAUD dropped on TCSETS or not reported by TCGETS");
+
+            /* A plain tcgetattr/tcsetattr pair must not touch the line: a
+             * BOTHER-only CBAUD (what TCGETS reports for a nonstandard host
+             * rate) resolves to the current speed on Linux, not to B0.
+             */
+            TEST("tcsetattr with an unchanged termios keeps the rate");
+            int skeep = sget == 0 ? tcsetattr(sl, TCSANOW, &sback) : -1;
+            struct termios sagain;
+            memset(&sagain, 0, sizeof(sagain));
+            int sget2 = skeep == 0 ? tcgetattr(sl, &sagain) : -1;
+            EXPECT_TRUE(
+                skeep == 0 && sget2 == 0 && cfgetospeed(&sagain) == B115200,
+                "unchanged tcsetattr disturbed the line rate");
+
+            /* Set a rate Linux has no B* constant for through termios2 (the
+             * path pyserial takes for custom baud rates), then do the plain
+             * pair: TCGETS can only report BOTHER for it, and TCSETS must
+             * resolve that to the current 74880, not cfsetospeed(B0).
+             */
+            TEST("a nonstandard rate survives a plain tcgetattr/tcsetattr");
+            struct {
+                uint32_t c_iflag, c_oflag, c_cflag, c_lflag;
+                uint8_t c_line;
+                uint8_t c_cc[19];
+                uint32_t c_ispeed, c_ospeed;
+            } st2;
+            memset(&st2, 0, sizeof(st2));
+            int s2get = sl >= 0 ? ioctl(sl, TEST_TCGETS2, &st2) : -1;
+            int s2set = -1;
+            if (s2get == 0) {
+                st2.c_cflag = (st2.c_cflag & ~TEST_CBAUD) | TEST_BOTHER;
+                st2.c_ispeed = st2.c_ospeed = 74880;
+                s2set = ioctl(sl, TEST_TCSETS2, &st2);
+            }
+            struct termios splain;
+            memset(&splain, 0, sizeof(splain));
+            int s2pair = s2set == 0 && tcgetattr(sl, &splain) == 0
+                             ? tcsetattr(sl, TCSANOW, &splain)
+                             : -1;
+            memset(&st2, 0, sizeof(st2));
+            int s2after = s2pair == 0 ? ioctl(sl, TEST_TCGETS2, &st2) : -1;
+            EXPECT_TRUE(
+                s2after == 0 && st2.c_ospeed == 74880 && st2.c_ispeed == 74880,
+                "plain TCSETS with a BOTHER-only CBAUD changed the "
+                "rate");
+
+            /* A split rate travels in CIBAUD on a plain TCSETS (musl's
+             * cfsetispeed writes it; glibc <= 2.41 does not) and the kernel
+             * reports CIBAUD back only when the rates differ
+             * (tty_termios_encode_baud_rate), so a raw round trip must see both
+             * fields and a re-unified rate must clear CIBAUD again.
+             */
+            TEST("split input rate round-trips through CIBAUD");
+            struct termios ssplit;
+            int ssget = sl >= 0 ? tcgetattr(sl, &ssplit) : -1;
+            int ssset = -1, ssback = -1;
+            struct termios ssaw;
+            memset(&ssaw, 0, sizeof(ssaw));
+            if (ssget == 0) {
+                ssplit.c_cflag &= ~(TEST_CBAUD | (TEST_CBAUD << 16));
+                ssplit.c_cflag |= B115200 | (B9600 << 16);
+                ssset = ioctl(sl, TCSETS, &ssplit);
+                if (ssset == 0)
+                    ssback = ioctl(sl, TCGETS, &ssaw);
+            }
+            EXPECT_TRUE(ssset == 0 && ssback == 0 &&
+                            (ssaw.c_cflag & TEST_CBAUD) == B115200 &&
+                            ((ssaw.c_cflag >> 16) & TEST_CBAUD) == B9600,
+                        "CIBAUD not applied by TCSETS or not reported by "
+                        "TCGETS");
+
+            /* B0 in both CBAUD and CIBAUD carries no rate: a guest that
+             * hand-rolled a termios with the baud bits zeroed must not disturb
+             * the split host rate through the CIBAUD-empty fallback (B0 and
+             * bare BOTHER both decode to 0 but only BOTHER resolves from the
+             * current output rate).
+             */
+            TEST("CBAUD=B0 leaves a split rate untouched");
+            struct termios sb0;
+            int sb0get = sl >= 0 ? tcgetattr(sl, &sb0) : -1;
+            int sb0set = -1, sb0chk = -1;
+            if (sb0get == 0) {
+                struct termios sraw = sb0;
+                sraw.c_cflag &= ~(TEST_CBAUD | (TEST_CBAUD << 16));
+                sb0set = ioctl(sl, TCSETS, &sraw);
+                memset(&st2, 0, sizeof(st2));
+                sb0chk = sb0set == 0 ? ioctl(sl, TEST_TCGETS2, &st2) : -1;
+            }
+            EXPECT_TRUE(
+                sb0chk == 0 && st2.c_ispeed == 9600 && st2.c_ospeed == 115200,
+                "B0 fallback collapsed the split rate");
+
+            /* The same split rate must survive an unchanged tcgetattr/tcsetattr
+             * pair through the termios2 requests (what glibc 2.42 issues):
+             * TCGETS2 reports CBAUD+CIBAUD indexes, and TCSETS2 must decode
+             * CIBAUD instead of collapsing the input rate to the output rate.
+             */
+            TEST("split rate survives an unchanged TCGETS2/TCSETS2 pair");
+            memset(&st2, 0, sizeof(st2));
+            int sp2get = ioctl(sl, TEST_TCGETS2, &st2);
+            int sp2ok = sp2get == 0 && (st2.c_cflag & TEST_CBAUD) == B115200 &&
+                        ((st2.c_cflag >> 16) & TEST_CBAUD) == B9600 &&
+                        st2.c_ispeed == 9600 && st2.c_ospeed == 115200;
+            int sp2set = sp2ok ? ioctl(sl, TEST_TCSETS2, &st2) : -1;
+            memset(&st2, 0, sizeof(st2));
+            int sp2after = sp2set == 0 ? ioctl(sl, TEST_TCGETS2, &st2) : -1;
+            EXPECT_TRUE(
+                sp2after == 0 && st2.c_ispeed == 9600 && st2.c_ospeed == 115200,
+                "unchanged TCSETS2 collapsed a split rate");
+
+            int ssuni = -1;
+            if (ssback == 0) {
+                ssaw.c_cflag &= ~(TEST_CBAUD << 16);
+                ssuni = ioctl(sl, TCSETS, &ssaw) == 0 ? ioctl(sl, TCGETS, &ssaw)
+                                                      : -1;
+            }
+            EXPECT_TRUE(ssuni == 0 &&
+                            ((ssaw.c_cflag >> 16) & TEST_CBAUD) == 0 &&
+                            (ssaw.c_cflag & TEST_CBAUD) == B115200,
+                        "CIBAUD B0 did not re-unify the input rate");
+
+            /* TCGETS and TCGETS2 come from the same kernel c_cflag, so their
+             * CBAUD fields must be identical, and a standard rate must show as
+             * the B* index (not BOTHER) in both.
+             */
+            TEST("TCGETS2 reports the same CBAUD as TCGETS");
+            struct termios sagree;
+            memset(&sagree, 0, sizeof(sagree));
+            memset(&st2, 0, sizeof(st2));
+            EXPECT_TRUE(ioctl(sl, TCGETS, &sagree) == 0 &&
+                            ioctl(sl, TEST_TCGETS2, &st2) == 0 &&
+                            (st2.c_cflag & TEST_CBAUD) ==
+                                (sagree.c_cflag & TEST_CBAUD) &&
+                            (st2.c_cflag & TEST_CBAUD) == B115200 &&
+                            st2.c_ospeed == 115200,
+                        "TCGETS2 c_cflag disagrees with TCGETS");
+
+            if (sl >= 0)
+                close(sl);
+        }
+        if (sm >= 0)
+            close(sm);
     }
 
     SUMMARY("test-pty");


### PR DESCRIPTION
> [!NOTE]
> Piece 1 of #310, sent separately per the discussion there.

## Summary

Plain `TCSETS` dropped the baud rate and `TCGETS` reported B0. `TCGETS`/`TCGETS2`/`TCSETS` now encode and decode `CBAUD`/`CIBAUD` like the Linux tty core, so `tcsetattr(B115200)` from a musl or glibc <= 2.41 guest reaches the host line and `cfgetospeed()` round-trips.

> [!IMPORTANT]
> What to look at:
> 1. `apply_linux_cflag_speeds()`: the two values that must **not** touch the host speed: `B0` in `CBAUD` and a bare `BOTHER`. The kernel resolves `BOTHER` on a plain `TCSETS` from the tty's *current* `c_ospeed` (`drivers/tty/tty_ioctl.c` `set_termios` starts from `tty->termios`; `drivers/tty/tty_baudrate.c` `tty_termios_baud_rate`). An earlier draft decoded it to 0 and collapsed a 74880-baud line to B0 on the next `tcgetattr`/`tcsetattr` pair (see evidence).
> 2. `linux_cflag_speed_bits()`: `CIBAUD` is set only when input != output, and `TCGETS2` now uses the same encoding instead of always `BOTHER`, matching `tty_termios_encode_baud_rate()`.
> 3. `TCSETS2` decodes `CIBAUD` symmetrically (B0 = same as output, `BOTHER` = numeric `c_ispeed`, else table): since `TCGETS2` now reports a split rate as `CBAUD`+`CIBAUD` indexes rather than the old blanket `BOTHER`, an unchanged `tcgetattr`/`tcsetattr` pair from glibc 2.42 would otherwise collapse the input rate to the output rate (found in self-review on the staging fork, jotpalch/elfuse#1).

## Problem

| | observed |
|---|---|
| `src/syscall/io.c` TCSETS arm (`io.c:2289-2316` at bffd6bd) | never calls `cfsetispeed`/`cfsetospeed`; only the TCSETS2 arm did |
| `TCGETS` | never encodes the host rate into `CBAUD`, so `cfgetospeed()` == 0 |
| who is affected | musl (always) and glibc <= 2.41 issue plain `TCSETS` with the rate in `CBAUD`; glibc 2.42+ switched to `TCGETS2`/`TCSETS2` unconditionally (`sysdeps/unix/sysv/linux/tcsetattr.c`, `kernel-features.h` `__ASSUME_TERMIOS2`) |
| why it stayed hidden | on a host pty the rate is meaningless; it becomes visible the moment a guest opens a real serial port, which the `/dev` passthrough already allows (`/dev/cu.usbmodem*`) |

## Change

- `io.c`: `linux_cflag_speed_bits()` (host termios -> `CBAUD`/`CIBAUD` bits) and `apply_linux_cflag_speeds()` (Linux `c_cflag` -> `cfsetospeed`/`cfsetispeed`), used by the `TCGETS`, `TCGETS2` and `TCSETS/TCSETSW/TCSETSF` arms. `LINUX_IBSHIFT` added next to `LINUX_CBAUD`.
- `tests/test-pty.c`: slave-side block (5 checks): B115200 round trip; unchanged termios keeps the rate; 74880 set via raw `TCSETS2` survives a plain `tcgetattr`/`tcsetattr` pair; split rate through `CIBAUD` and re-unification; `TCGETS`/`TCGETS2` agree.

Kernel references (Linux v7.2): `include/uapi/asm-generic/termbits.h` (`CBAUD` 0x100f, `BOTHER` 0x1000, `CIBAUD` = `CBAUD << 16`, `B115200` 0x1002), `drivers/tty/tty_baudrate.c` (`tty_termios_baud_rate`, `tty_termios_input_baud_rate`, `tty_termios_encode_baud_rate`), `drivers/tty/tty_ioctl.c` (`set_termios`, `get_termios`). x86_64 (Rosetta) guests share the `asm-generic` layout.

## Evidence

Harness: open a macOS pty pair, preset the host side to 9600, hand the slave to a static aarch64 guest that does `tcsetattr(B115200)` and reads it back.

<details><summary>glibc 2.41 guest, before (bffd6bd) vs after</summary>

before:
```
== 3. baud rate round-trip (TCSETS/TCSETS2 depending on libc) ==
  tcsetattr(B115200) = 0
  cfgetospeed -> 0 (want 4098)
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Inappropriate ioctl for device bits=0x0
  TIOCMBIS(DTR|RTS)= -1Inappropriate ioctl for device
  TIOCMBIC(DTR|RTS)= -1Inappropriate ioctl for device
  tcflush/TCFLSH  = -1Inappropriate ioctl for device
  tcdrain/TCSBRK  = -1Inappropriate ioctl for device
  TIOCOUTQ        = -1Inappropriate ioctl for device outq=-1
  TIOCEXCL        = -1Inappropriate ioctl for device
host-side speed after guest tcsetattr(B115200): ispeed=9600 ospeed=9600
```
after:
```
== 3. baud rate round-trip (TCSETS/TCSETS2 depending on libc) ==
  tcsetattr(B115200) = 0
  cfgetospeed -> 4098 (want 4098)
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Inappropriate ioctl for device bits=0x0
  TIOCMBIS(DTR|RTS)= -1Inappropriate ioctl for device
  TIOCMBIC(DTR|RTS)= -1Inappropriate ioctl for device
  tcflush/TCFLSH  = 0
  tcdrain/TCSBRK  = 0
  TIOCOUTQ        = 0 outq=0
  TIOCEXCL        = 0
host-side speed after guest tcsetattr(B115200): ispeed=115200 ospeed=115200
```
</details>

<details><summary>musl 1.2.5 guest, after</summary>

```
== 3. baud rate round-trip (TCSETS/TCSETS2 depending on libc) ==
  tcsetattr(B115200) = 0
  cfgetospeed -> 4098 (want 4098)
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Not a tty bits=0x0
  TIOCMBIS(DTR|RTS)= -1Not a tty
  TIOCMBIC(DTR|RTS)= -1Not a tty
  tcflush/TCFLSH  = 0
  tcdrain/TCSBRK  = 0
  TIOCOUTQ        = 0 outq=0
  TIOCEXCL        = 0
host-side speed after guest tcsetattr(B115200): ispeed=115200 ospeed=115200
```
</details>

<details><summary>74880 (BOTHER) regression: draft vs final</summary>

draft (decoded bare BOTHER to 0):
```
host pty slave = /dev/ttys002, host speed preset to ispeed=74880 ospeed=74880
  guest tcgetattr: cfgetospeed=4096 (BOTHER=0x1000) c_cflag&CBAUD=0x1000
  guest tcsetattr(unchanged speed) = 0 
  TCFLSH(TCIFLUSH=0)   = 0 
  TCFLSH(3 invalid)    = -1 Invalid argument (want EINVAL)
  TCXONC(TCOON=1)      = 0 
  TCXONC(4 invalid)    = -1 Invalid argument (want EINVAL)
  TCSBRKP(0)           = 0 
  TIOCNXCL             = 0 
host-side speed after guest round-trip: ispeed=0 ospeed=0 (want 74880)
```
final:
```
host pty slave = /dev/ttys002, host speed preset to ispeed=74880 ospeed=74880
  guest tcgetattr: cfgetospeed=4096 (BOTHER=0x1000) c_cflag&CBAUD=0x1000
  guest tcsetattr(unchanged speed) = 0 
  TCFLSH(TCIFLUSH=0)   = 0 
  TCFLSH(3 invalid)    = -1 Invalid argument (want EINVAL)
  TCXONC(TCOON=1)      = 0 
  TCXONC(4 invalid)    = -1 Invalid argument (want EINVAL)
  TCSBRKP(0)           = 0 
  TIOCNXCL             = 0 
host-side speed after guest round-trip: ispeed=74880 ospeed=74880 (want 74880)
```
</details>

<details><summary>native macOS build of the same program, same pty (control)</summary>

```
== 3. baud rate round-trip (TCSETS/TCSETS2 depending on libc) ==
  tcsetattr(B115200) = 0
  cfgetospeed -> 115200 (want 115200)
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Inappropriate ioctl for device bits=0x0
  TIOCMBIS(DTR|RTS)= -1Inappropriate ioctl for device
  TIOCMBIC(DTR|RTS)= -1Inappropriate ioctl for device
  tcflush/TCFLSH  = 0
  tcdrain/TCSBRK  = 0
  TIOCOUTQ        = 0 outq=0
  TIOCEXCL        = 0
host pty /dev/ttys002
host-side speed after native tcsetattr: 115200 115200
```
</details>

<details><summary>real hardware: ESP32-S3 USB-Serial/JTAG (/dev/cu.usbmodem101), before vs after</summary>

before:
```
== 2. open(/dev/cu.usbmodem101) ==
  open = 3 ok
== 3. baud rate round-trip (TCSETS/TCSETS2 depending on libc) ==
  tcsetattr(B115200) = 0
  cfgetospeed -> 0 (want 4098)
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Inappropriate ioctl for device bits=0x0
  TIOCMBIS(DTR|RTS)= -1Inappropriate ioctl for device
  TIOCMBIC(DTR|RTS)= -1Inappropriate ioctl for device
  tcflush/TCFLSH  = -1Inappropriate ioctl for device
  tcdrain/TCSBRK  = -1Inappropriate ioctl for device
  TIOCOUTQ        = -1Inappropriate ioctl for device outq=-1
  TIOCEXCL        = -1Inappropriate ioctl for device
```
after (this PR + piece 2):
```
== 2. open(/dev/cu.usbmodem101) ==
  open = 3 ok
== 3. baud rate round-trip (TCSETS/TCSETS2 depending on libc) ==
  tcsetattr(B115200) = 0
  cfgetospeed -> 4098 (want 4098)
== 4. line / modem-control ioctls ==
  TIOCMGET        = 0 bits=0x6
  TIOCMBIS(DTR|RTS)= 0
  TIOCMBIC(DTR|RTS)= 0
  tcflush/TCFLSH  = 0
  tcdrain/TCSBRK  = 0
  TIOCOUTQ        = 0 outq=0
  TIOCEXCL        = 0
```
</details>

## Tests

- `build/elfuse build/test-pty`: 63 passed, 0 failed (includes the split-rate TCGETS2/TCSETS2 regression test)
- `make check BAREMETAL_CROSS=aarch64-elf- LINUX_TOOLCHAIN=/opt/homebrew/opt/aarch64-unknown-linux-gnu -j8`: rc=0, `All 77 tests passed` (fixture-dependent musl/dyn-glibc cases skipped as on a stock checkout)
- `clang-format --dry-run -Werror` clean

## Not in this PR

- The line/modem ioctls (`TCFLSH`, `TCSBRK`, `TIOCM*`, ...) -> piece 2 (stacked PR).
- `B0` hang-up (drop DTR/RTS) is not emulated; documented in the comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor CBAUD/CIBAUD in TCGETS, TCGETS2, and TCSETS so baud rates round-trip correctly. Previously TCSETS ignored baud bits and TCGETS reported B0; now standard, custom (BOTHER), and split input rates are preserved.

- TCGETS/TCGETS2: encode host ospeed/ispeed into CBAUD and CIBAUD like the Linux tty core; TCGETS2 no longer forces BOTHER and still fills numeric speeds.
- TCSETS/TCSETS2: apply CBAUD/CIBAUD; CIBAUD B0 means “same as output”; B0 in CBAUD and a bare BOTHER leave the host speed unchanged; Linux’s B0 hang-up is not emulated.
- Tests: cover B115200 round-trip via plain TCSETS, preserving a BOTHER-only rate (74880) across tcgetattr/tcsetattr, split-rate round-trip and re-unification, and TCGETS vs TCGETS2 agreement.

<sup>Written for commit 3a6c8804163854c308f493a74546471ff52bafba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

