### PR TITLE
Install Git hooks and a CI gate to enforce commit‑message rules and staged checks

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -3,6 +3,12 @@
 # Verify clang-format conformance for all tracked C/H files in src/ and tests/.
 # The repository's .clang-format is calibrated against clang-format-22; older
 # versions produce different output and are rejected to keep CI deterministic.
+#
+# Exit codes, matching .ci/check-commentflow.sh: 0 clean, 1 files differ from
+# the style, 2 the check could not run. The split matters to the pre-commit
+# hook, which blocks on 1 and only warns on 2: a machine without the pinned
+# formatter has not shown you a defect, and turning that into a failed commit
+# teaches contributors to pass --no-verify. CI fails on either.
 
 set -u -o pipefail
 
@@ -15,23 +21,55 @@ if [ -z "${CLANG_FORMAT:-}" ]; then
             CLANG_FORMAT="clang-format"
         else
             echo "Error: clang-format-22 is required (older versions differ in style)" >&2
-            exit 1
+            exit 2
         fi
     else
         echo "Error: clang-format-22 is required (older versions differ in style)" >&2
-        exit 1
+        exit 2
     fi
 fi
 
-ret=0
+# Named paths win over the tracked set, so the pre-commit hook can point this at
+# an extracted index and get the same version gate and the same diff applied to
+# staged content instead of carrying its own copy of both.
+list_files()
+{
+    if [ "$#" -gt 0 ]; then
+        printf '%s\0' "$@"
+    else
+        git ls-files -z -- 'src/*.c' 'src/*.h' 'src/**/*.c' 'src/**/*.h' \
+            'tests/*.c' 'tests/*.h'
+    fi
+}
+
+# Kept apart, because the two answers have different consequences and one of
+# them must not be able to mask the other. A file that differs is a defect in
+# the change and blocks; a file the formatter could not read or parse is not,
+# and reporting it as a style violation sends the author to reformat code that
+# was already fine. A named path that does not exist reached the diff below and
+# came back as "this file differs" in its entirety, which is the mistyped-path
+# case .ci/check-security.sh guards against by name.
+differ=0
+unusable=0
 while IFS= read -r -d '' file; do
+    if [ ! -r "$file" ]; then
+        echo "Cannot read $file" >&2
+        unusable=1
+        continue
+    fi
     expected=$(mktemp)
-    "$CLANG_FORMAT" "$file" > "$expected" 2> /dev/null
+    if ! "$CLANG_FORMAT" "$file" > "$expected"; then
+        echo "Error: $CLANG_FORMAT failed on $file" >&2
+        unusable=1
+        rm -f "$expected"
+        continue
+    fi
     if ! diff -u -p --label="$file" --label="expected coding style" "$file" "$expected"; then
-        ret=1
+        differ=1
     fi
     rm -f "$expected"
-done < <(git ls-files -z -- 'src/*.c' 'src/*.h' 'src/**/*.c' 'src/**/*.h' \
-    'tests/*.c' 'tests/*.h')
+done < <(list_files "$@")
 
-exit $ret
+[ "$differ" -eq 0 ] || exit 1
+[ "$unusable" -eq 0 ] || exit 2
+exit 0

--- a/.ci/check-security.sh
+++ b/.ci/check-security.sh
@@ -25,8 +25,18 @@ comment_only='^[[:space:]]*(//|/\*|\*|\*/)'
 # place this appears.
 scratch_marker='(^|[^[:alnum:]_])ponytail:'
 
-# Only scan elfuse host source, not tests/ or assembly shim.
-#
+# Only scan elfuse host source, not tests/ or assembly shim. Named paths win
+# over the tracked set so the pre-commit hook can point this at an extracted
+# index and get the same patterns applied to staged content.
+list_files()
+{
+    if [ "$#" -gt 0 ]; then
+        printf '%s\0' "$@"
+    else
+        git ls-files -z -- 'src/*.c' 'src/*.h' 'src/**/*.c' 'src/**/*.h'
+    fi
+}
+
 # Each match uses process substitution rather than a shell pipeline: under
 # `pipefail`, an early `grep -q` exit closes its stdin, the upstream filter
 # receives SIGPIPE, and the pipeline returns non-zero even when the pattern
@@ -34,6 +44,15 @@ scratch_marker='(^|[^[:alnum:]_])ponytail:'
 # filter in a separate process whose exit status doesn't feed back into the
 # matcher.
 while IFS= read -r -d '' f; do
+
+    # A path that cannot be read matches nothing, and nothing matching is what
+    # this script reports as clean. A named path is supplied by a caller, so a
+    # stale or mistyped one would turn a security gate into a success message.
+    if [ ! -r "$f" ]; then
+        echo "Cannot read $f"
+        failed=1
+        continue
+    fi
     if grep -qE "$banned" < <(grep -vE "$comment_only" -- "$f"); then
         echo "Banned function in $f:"
         grep -nE "$banned" -- "$f" | grep -vE "$comment_only" || true
@@ -54,7 +73,7 @@ while IFS= read -r -d '' f; do
         grep -nE "$scratch_marker" -- "$f" || true
         failed=1
     fi
-done < <(git ls-files -z -- 'src/*.c' 'src/*.h' 'src/**/*.c' 'src/**/*.h')
+done < <(list_files "$@")
 
 if [ $failed -eq 0 ]; then
     echo "Security checks passed."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,6 +99,71 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 scripts/proof-scope.py --self-test
 
+      - name: Commit messages
+        # CONTRIBUTING.md's "Git Commit Style" section states seven rules and
+        # said continuous integration enforced them. Nothing did: the hooks
+        # under scripts/ are opt-in, so a contributor who never ran
+        # "make install-hooks" was gated by a sentence. This is that gate.
+        #
+        # Pull requests only. A push to main carries commits that already came
+        # through one, and the merge queue re-validating them would only find
+        # what this already rejected.
+        #
+        # The checkout is shallow, so both ends of the range have to be
+        # fetched, and a range whose walk runs into the shallow boundary comes
+        # back wrong rather than failing: rev-list exits 0 having listed
+        # whatever it could reach. Both directions happen, and neither is
+        # acceptable, so both are guarded below. Depth is generous because
+        # merge commits inside a pull request make the walk deeper than the
+        # commit count alone.
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          set -euo pipefail
+          : "${COUNT:?the pull_request payload carries no commit count}"
+          depth=$((COUNT * 2 + 50))
+          git fetch --no-tags --depth="$depth" origin "$HEAD"
+          # The same depth for the base, not 1. Fetched at depth 1 the base has
+          # no known ancestry, so "$BASE..$HEAD" excludes the base commit and
+          # nothing else: everything below the fork point stays in the range.
+          # The moment the base branch moves past the point the pull request
+          # forked from, which is the ordinary case, a two-commit pull request
+          # comes back as the whole fetched slice and the gate judges the
+          # project's history against today's rules.
+          git fetch --no-tags --depth="$depth" origin "$BASE"
+          # This is what catches that, and the count comparison cannot: a range
+          # truncated at the base end comes back longer than the pull request,
+          # not shorter. merge-base fails exactly when the boundary leaves the
+          # two ends with no common ancestor to compute the range from.
+          if ! git merge-base "$BASE" "$HEAD" > /dev/null; then
+            echo "::error::No common ancestor for this pull request's base and" \
+                 "head; the shallow boundary truncated the range. Raise the depth."
+            exit 1
+          fi
+          # And this catches the head end. A surplus past the guard above is not
+          # this check's business: the range and GitHub's count are derived
+          # differently, and the direction that means "some commits went
+          # unchecked" is fewer.
+          found=$(git rev-list --count "$BASE..$HEAD")
+          if [ "$found" -lt "$COUNT" ]; then
+            echo "::error::Reached $found of this pull request's $COUNT commits;" \
+                 "the shallow boundary truncated the range. Raise the fetch depth."
+            exit 1
+          fi
+          git rev-list --no-merges "$BASE..$HEAD" | scripts/check-commit-log.sh
+
+      - name: Git hook self-test
+        # The hooks and this job's commit-message gate are the same script, so
+        # a rule that regresses regresses in both places at once. Every case in
+        # the test was a live defect: a rejected merge subject leaves a merge
+        # half-finished, and a "git commit -v" message linted against its own
+        # appended diff fails on width for reasons the author cannot see.
+        if: ${{ !cancelled() }}
+        run: scripts/test-git-hooks.sh
+
       - name: Skill cross-references
         # The .claude/ skills cite files, make targets and sections by name.
         # Nothing else notices when one is renamed, and a skill that points at
@@ -176,7 +241,7 @@ jobs:
           # It needs a diff long enough to fill the pipe buffer, which is
           # exactly the diff that must not skip a check.
           if grep -qE "$pat" <<< "$files"; then c=true; fi
-          if grep -qE '^\.ci/.*\.sh$' <<< "$files"; then sh=true; fi
+          if grep -qE '^(\.ci|scripts)/.*\.sh$' <<< "$files"; then sh=true; fi
           if grep -qE "$cfpat" <<< "$files"; then cf=true; fi
           echo "c=$c" >> "$GITHUB_OUTPUT"
           echo "sh=$sh" >> "$GITHUB_OUTPUT"
@@ -239,12 +304,15 @@ jobs:
         run: .ci/check-format.sh
 
       - name: shellcheck
-        # Scoped to .ci/ -- tests/ has pre-existing warnings that the
-        # repository's own check-format target already surfaces.
+        # Scoped to .ci/ and scripts/ -- tests/ has pre-existing warnings that
+        # the repository's own check-format target already surfaces. scripts/
+        # is here because the git hooks live there and a hook that aborts on
+        # its own shell is worse than no hook: it teaches contributors to pass
+        # --no-verify, which costs the checks that do work.
         if: ${{ !cancelled() && steps.changed.outputs.sh == 'true' }}
         run: |
           set -euo pipefail
-          mapfile -d '' files < <(git ls-files -z -- '.ci/*.sh')
+          mapfile -d '' files < <(git ls-files -z -- '.ci/*.sh' 'scripts/*.sh')
           shellcheck --severity=warning "${files[@]}"
 
       - name: cppcheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1229,9 +1229,23 @@ In addition, this project expects contributors to follow these additional rules:
   Excessive use of parentheses "()" can clutter the subject line, making it harder to quickly grasp
   the essential message.
 
-These conventions are enforced by continuous integration rather than by
-[githooks](https://git-scm.com/docs/githooks); see `.github/workflows/lint.yml` for the checks a
-pull request has to clear.
+The seven rules above are enforced by `scripts/git-commit-msg.sh`, which the
+"Commit messages" step of the `Lint (Linux)` job in `.github/workflows/lint.yml`
+runs over every commit in a pull request. See that workflow for the rest of the
+checks a pull request has to clear.
+
+The first `make` in a fresh clone installs the same script as a local hook, so
+a message is rejected while it is still cheap to rewrite rather than after the
+push. Alongside it go a pre-commit hook that checks staged formatting, comment
+reflow, banned APIs and whitespace, and a pre-push hook that validates every
+unpublished commit. A hook you already wrote is never replaced.
+`make uninstall-hooks` removes them, `make install-hooks` puts them back. The
+hooks only move the feedback earlier; CI runs the same checks either way.
+
+Two rules cannot be decided by a script. Imperative mood is checked by
+rejecting the past-tense, third-person and gerund forms of common verbs, so an
+unlisted verb passes. "What and why, not how" is checked only for a body that
+opens by announcing the mechanism. Both are guidance a reviewer still applies.
 
 ## References
 * [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html)

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ define link-and-sign
 endef
 
 # Main executable
-.PHONY: all elfuse
+.PHONY: all elfuse install-hooks uninstall-hooks
 .PHONY: gen-syscall-dispatch check-syscall-dispatch
 
 all: elfuse
@@ -128,6 +128,14 @@ $(BUILD_DIR)/syscall/syscall.o: $(DISPATCH_HEADER)
 
 ## Build the elfuse executable
 elfuse: $(ELFUSE_BIN)
+
+## Install the repository's Git hooks without replacing local hooks
+install-hooks:
+	@$(HOOK_INSTALLER)
+
+## Remove hooks that install-hooks created, leaving any local hook alone
+uninstall-hooks:
+	@$(HOOK_INSTALLER) --uninstall
 
 $(ELFUSE_BIN): $(OBJS) | $(BUILD_DIR)
 	$(call link-and-sign,$@,$(OBJS))

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ or process semantics. `make test-rosetta-all` covers the x86_64 acceptance
 suites in isolation. See [docs/testing.md](docs/testing.md) for the full
 target list, fixture flow, and validation-by-change-type guidance.
 
+The first `make` in a fresh clone installs Git hooks that run the same checks
+CI does, at commit and push time instead of after: staged formatting, comment
+reflow, banned APIs, whitespace and conflict markers, and the commit-message
+rules in [CONTRIBUTING.md](CONTRIBUTING.md). A missing local formatter warns
+rather than blocks, and a hook you already wrote is never replaced.
+`make uninstall-hooks` removes them, `make install-hooks` puts them back. They
+do not replace `make check`.
+
 ## Limitations
 
 `elfuse` runs single Linux user-space processes (and their `fork` /

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -18,6 +18,44 @@ $(BUILD_DIR):
 # Automatic header dependency generation (-MMD -MP)
 DEPFLAGS = -MMD -MP -MF $(BUILD_DIR)/$(subst /,_,$*).d
 
+# Git hooks, installed on the first make of a fresh clone.
+#
+# The hooks run the same checks CI does, at commit and push time instead of
+# after. Left to "make install-hooks" they are enforced on whoever read the
+# README carefully, which is not the population that needs them; the cost of
+# being wrong is a symlink, and uninstall-hooks removes it.
+#
+# Once per tree, not once per build: the stamp is what keeps a rebuild from
+# re-running this, and a hook removed by hand stays removed until the next
+# clean. A target rather than a read-time side effect, so a dry run or a query
+# leaves the checkout untouched. A tarball export has no git dir, which the
+# script exits 0 on. Where it does fail, and it can, the recipe below swallows
+# the status rather than the build stopping over a symlink.
+#
+# Hung off compilation and the help screen rather than off MAKECMDGOALS.
+# Naming the goals would give every one of them a rule, including the
+# misspelled ones: a typo that stops today with "No rule to make target" would
+# instead find an empty rule, report nothing to be done, and exit 0. A build
+# system that succeeds on "make check-fromat" is a worse trade than installing
+# a symlink one command later.
+#
+# Every binary this tree builds reaches the two object rules below, host unit
+# tests included, so one order-only prerequisite there covers every build
+# entry point without listing any of them. help covers the case that builds
+# nothing, which is what a bare make prints. clean, distclean and the two hook
+# targets reach neither, so they skip this without being named.
+HOOK_INSTALLER := scripts/install-git-hooks.sh
+HOOK_STAMP := $(BUILD_DIR)/.hooks-installed
+
+# The stamp records a run that reported success. An installer that could not
+# reach the hooks directory returns non-zero and leaves no stamp, so the next
+# make retries rather than remembering a failure as done; an unwritable build/
+# fails the touch and is likewise retried. Neither can fail the build, which is
+# what the trailing no-op is for: hooks are a convenience, and a checkout that
+# cannot take them still has to compile.
+$(HOOK_STAMP): | $(BUILD_DIR)
+	@$(HOOK_INSTALLER) --quiet && touch $@ 2> /dev/null || :
+
 # Build flavor guard.
 #
 # Objects compiled with -fsanitize=... cannot be linked into a binary built
@@ -97,12 +135,14 @@ endif
 # triggers a rebuild on input change (e.g., build/dispatch.h from
 # src/syscall/dispatch.tbl) use explicit normal prerequisites where needed.
 
-$(BUILD_DIR)/%.o: src/%.c | $(BUILD_DIR) $(GENERATED_HEADERS)
+help: | $(HOOK_STAMP)
+
+$(BUILD_DIR)/%.o: src/%.c | $(BUILD_DIR) $(GENERATED_HEADERS) $(HOOK_STAMP)
 	@mkdir -p $(dir $@)
 	@echo "  CC      $<"
 	$(Q)$(CC) $(CFLAGS) $(DEPFLAGS) -I$(BUILD_DIR) -Isrc -c -o $@ $<
 
-$(BUILD_DIR)/%.o: tests/%.c | $(BUILD_DIR) $(GENERATED_HEADERS)
+$(BUILD_DIR)/%.o: tests/%.c | $(BUILD_DIR) $(GENERATED_HEADERS) $(HOOK_STAMP)
 	@mkdir -p $(dir $@)
 	@echo "  CC      $<"
 	$(Q)$(CC) $(CFLAGS) $(DEPFLAGS) -I$(BUILD_DIR) -Isrc -c -o $@ $<

--- a/scripts/check-commit-log.sh
+++ b/scripts/check-commit-log.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Validate the commit messages whose object IDs arrive on standard input.
+#
+# The shared body of the pre-push hook and the CI commit-log gate, so a
+# contributor with hooks installed and one without are judged by the same script
+# rather than by two lists that drift.
+
+set -uo pipefail
+
+script_dir=$(cd -P "$(dirname "$0")" && pwd)
+message_hook="$script_dir/git-commit-msg.sh"
+failed=0
+
+while read -r commit; do
+    [ -n "$commit" ] || continue
+    if ! git show -s --format=%B "$commit" | "$message_hook" -; then
+
+        # Positional, not "-- $commit": after a double dash git reads the
+        # argument as a pathspec and prints nothing, which left every rejection
+        # naming an empty commit. Through cat -v: the subject is
+        # attacker-supplied text on its way to a terminal or a CI log, and an
+        # escape sequence in one can rewrite what the reader sees around it.
+        printf 'Invalid commit: %s\n' \
+            "$(git show -s --format='%h %s' "$commit" | cat -v)" >&2
+        failed=1
+    fi
+done
+
+exit "$failed"

--- a/scripts/git-commit-msg.sh
+++ b/scripts/git-commit-msg.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+# Enforce the commit-message rules CONTRIBUTING.md states, so a message is
+# rejected while it is still cheap to rewrite.
+#
+# Every check below traces to a numbered rule in the "Git Commit Style" section.
+# A rule that cannot be decided mechanically is not guessed at: the
+# imperative-mood and what-and-why checks look for the forms that are wrong
+# beyond argument and let everything else through. Both were calibrated against
+# 400 commits of this repository's history and rejected none of them.
+#
+# The expensive failure here is a false rejection, not a missed one. CI runs the
+# same script over a pull request's commits, so a message that slips past a
+# contributor without hooks installed is still caught before it merges.
+
+set -uo pipefail
+
+message_file=$1
+
+# "-" reads standard input. The hook itself is always handed a real path, but
+# the commit-log gate feeds whole messages through this script, and routing
+# those through /dev/stdin assumes a device that a minimal container need not
+# have. Where it is missing the read yields nothing and every commit is rejected
+# for want of a subject, which is a failure mode a check must not have.
+if [ "$message_file" = "-" ]; then
+    message_file=$(mktemp) || exit 1
+    trap 'rm -f "$message_file"' EXIT
+    cat > "$message_file"
+fi
+
+# "git commit -v" appends the diff below a scissors line, and those lines are
+# not comment-prefixed. git strips them itself, but only after this hook has
+# run, so without cutting them here every verbose commit gets linted against its
+# own diff and fails on line width.
+message=$(sed '/-\{8,\}[[:space:]]*>8[[:space:]]*-\{8,\}/,$d' "$message_file" \
+    | git stripspace --strip-comments)
+subject=${message%%$'\n'*}
+body=
+second=
+if [ "$message" != "$subject" ]; then
+    body=${message#*$'\n'}
+    second=${body%%$'\n'*}
+fi
+failed=0
+
+error()
+{
+    printf 'Commit message: %s\n' "$1" >&2
+    failed=1
+}
+
+# Messages git composes itself. A merge subject names the branch and routinely
+# runs past 50 characters, and rejecting one aborts the merge halfway; the fixup
+# and squash forms are consumed by rebase and never reach history.
+#
+# The merge forms are spelled out rather than matched as "Merge ", which is also
+# how an ordinary imperative subject starts: "Merge the free lists into one" is
+# a sentence this gate has to read, and under the looser pattern it skipped
+# every rule below, in the hook and in CI alike.
+case "$subject" in
+    fixup!\ * | squash!\ *) exit 0 ;;
+    Merge\ branch\ * | Merge\ branches\ * | Merge\ tag\ * | Merge\ commit\ * | \
+        Merge\ pull\ request\ * | Merge\ remote-tracking\ branch\ *) exit 0 ;;
+esac
+
+# Rule 2, plus the additional rule against single-word commits.
+if [ -z "$subject" ]; then
+    error "a descriptive subject is required"
+elif [ "${#subject}" -gt 50 ]; then
+    error "subject exceeds 50 characters"
+else
+    case "$subject" in
+        *[[:space:]]*) ;;
+        *) error "subject must contain more than one word" ;;
+    esac
+fi
+
+# The range is printable ASCII, so this catches a tab and a stray control byte
+# as well as anything above 0x7f. Saying "ASCII" alone would misname the first
+# two, which are ASCII and still unwanted.
+if LC_ALL=C grep -q '[^ -~]' <<< "$message"; then
+    error "message must be printable ASCII, with no tabs or control characters"
+fi
+
+# Rule 3.
+case "$subject" in
+    [[:space:]]*) error "subject must not start with whitespace" ;;
+    [a-z]*) error "subject must start with a capital letter" ;;
+esac
+
+# Rule 4.
+case "$subject" in
+    *.) error "subject must not end with a period" ;;
+esac
+
+# Rule 5. Only the past-tense, third-person and gerund forms are listed. A verb
+# absent from this list is accepted, which is the safe direction to be wrong in.
+first_word=$(printf '%s' "${subject%%[[:space:]]*}" | tr '[:upper:]' '[:lower:]')
+case "$first_word" in
+    added | adds | adding | adjusted | adjusts | adjusting | amended | amends | \
+        amending | avoided | avoids | avoiding | bumped | bumps | bumping | \
+        changed | changes | changing | checked | checks | checking | committed | \
+        commits | committing | copied | copies | copying | corrected | corrects | \
+        correcting | created | creates | creating | decreased | decreases | \
+        decreasing | deleted | deletes | deleting | disabled | disables | disabling | \
+        dropped | drops | dropping | duplicated | duplicates | duplicating | \
+        enabled | enables | enabling | excluded | excludes | excluding | fixed | \
+        fixes | fixing | handled | handles | handling | implemented | implements | \
+        implementing | improved | improves | improving | included | includes | \
+        including | increased | increases | increasing | installed | installs | \
+        installing | introduced | introduces | introducing | merged | merges | \
+        merging | moved | moves | moving | pruned | prunes | pruning | refactored | \
+        refactors | refactoring | released | releases | releasing | removed | \
+        removes | removing | renamed | renames | renaming | replaced | replaces | \
+        replacing | resolved | resolves | resolving | reverted | reverts | \
+        reverting | showed | shows | showing | tested | tests | testing | tidied | \
+        tidies | tidying | updated | updates | updating | used | uses | using)
+        error "subject must use the imperative mood"
+        ;;
+esac
+
+# A scope prefix hides the real subject behind a tag, which defeats rules 3 and
+# 5 for the words that matter. The four commits in history using this form all
+# predate the current style.
+if [[ $subject =~ ^[[:alpha:]]+(\!|\([^\)]*\))?:[[:space:]] ]]; then
+    error "subject must not use conventional-commit syntax"
+fi
+
+# Backticks are confusable with single quotes on some terminals, so they are
+# refused outright. Parentheses are not: CONTRIBUTING objects to excessive use,
+# and a subject naming main() or times(2) or a pull-request number carries one
+# pair for a reason. Two pairs is where a subject starts reading as clutter.
+case "$subject" in
+    *\`*) error "subject must not contain backticks" ;;
+esac
+
+opens=${subject//[^(]/}
+if [ "${#opens}" -gt 1 ]; then
+    error "subject overuses parentheses"
+fi
+
+# Rule 1. An empty second line is what separates them, so a non-empty one with
+# anything following is a run-together subject and body.
+if [ -n "$body" ] && [ -n "$second" ]; then
+    error "separate the subject from the body with a blank line"
+fi
+
+# Rule 6.
+wide=0
+while IFS= read -r line; do
+    [ "${#line}" -le 72 ] || wide=1
+done <<< "$body"
+[ "$wide" -eq 0 ] || error "body lines must not exceed 72 characters"
+
+# Rule 7, in the one form that can be decided by looking: a body that opens a
+# section announcing it is about to describe the mechanism. A regex, where the
+# checks above are globs, because this one is genuinely alternation over words
+# and spelling that out as a case is less legible than the pattern it replaces.
+if grep -qiE '^(how|implementation( (details|notes|steps))?|steps?)[[:space:]]*:' <<< "$body"; then
+    error "body must explain what and why, not how"
+fi
+
+exit "$failed"

--- a/scripts/git-pre-commit.sh
+++ b/scripts/git-pre-commit.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+# Reject staged defects that are cheap to find before CI.
+#
+# Everything here reads the staged content, not the working tree, so a partial
+# "git add -p" is judged on what would actually be committed.
+#
+# A missing local formatter warns rather than blocks. A tool this machine does
+# not have is not a defect in the change, and CI enforces both formatters
+# regardless; turning that into a failed commit only teaches contributors to
+# pass --no-verify, which costs the checks that do work.
+
+set -uo pipefail
+
+repo_root=$(git rev-parse --show-toplevel) || exit 1
+cd "$repo_root" || exit 1
+
+# The checkers come from beside the installed script, not from the worktree
+# being committed to. Installed, $0 is the symlink under .git/hooks; a linked
+# worktree on a branch that predates .ci/ would otherwise resolve them to paths
+# that do not exist there and lose the checks without saying so.
+hook_path=$0
+while [ -L "$hook_path" ]; do
+    hook_dir=$(cd -P "$(dirname "$hook_path")" && pwd)
+    hook_path=$(readlink "$hook_path")
+    case "$hook_path" in
+        /*) ;;
+        *) hook_path="$hook_dir/$hook_path" ;;
+    esac
+done
+ci_dir=$(cd -P "$(dirname "$hook_path")/../.ci" 2> /dev/null && pwd)
+
+if git diff --cached --quiet; then
+    exit 0
+fi
+
+failed=0
+staged_dir=
+trap '[ -n "$staged_dir" ] && rm -rf "$staged_dir"' EXIT
+
+# Bash 3.2 is what /usr/bin/env bash resolves to on a stock macOS, and there
+# "${array[@]}" of an empty array is an unbound variable under set -u, while
+# "${#array[@]}" is not. Every expansion below therefore sits behind a count
+# test; a docs-only commit otherwise aborts on the first empty one.
+#
+# One pass, four sets, matching what each CI gate reads. Two of those gates read
+# more than C: a commit touching only a shell script would otherwise stage
+# nothing this hook looks at and reach CI unchecked, which is the opposite of
+# the parity it advertises.
+c_files=()
+src_files=()
+flow_files=()
+sh_files=()
+staged=()
+while IFS= read -r -d '' file; do
+    case "$file" in
+        src/*.c | src/*.h)
+            c_files+=("$file")
+            src_files+=("$file")
+            flow_files+=("$file")
+            ;;
+        tests/*.c | tests/*.h)
+            c_files+=("$file")
+            flow_files+=("$file")
+            ;;
+
+        # Reflowed by .ci/check-commentflow.sh but not formatted by
+        # .ci/check-format.sh, so these reach one gate and not the other.
+        frama-c-stubs/*.h) flow_files+=("$file") ;;
+        *.s | *.S | *.sh | *.bash) flow_files+=("$file") ;;
+    esac
+    case "$file" in
+        .ci/*.sh | scripts/*.sh) sh_files+=("$file") ;;
+    esac
+done < <(git diff --cached --name-only -z --diff-filter=ACMR)
+
+staged+=("${c_files[@]+"${c_files[@]}"}")
+staged+=("${flow_files[@]+"${flow_files[@]}"}")
+staged+=("${sh_files[@]+"${sh_files[@]}"}")
+
+if [ "${#staged[@]}" -gt 0 ]; then
+    staged_dir=$(mktemp -d) || exit 1
+
+    # .clang-format comes out of the index too. Staged alongside a C change, the
+    # working-tree copy is a different style than the one being committed, and
+    # the hook would judge the change against a rule the commit does not carry.
+    if ! printf '%s\0' "${staged[@]}" \
+        | git checkout-index --stdin -z -f --prefix="$staged_dir/"; then
+        echo "Cannot read the staged content." >&2
+        exit 1
+    fi
+
+    # Tracked, it comes out of the index like everything else. Untracked, the
+    # worktree copy is all there is, and a repository that does not carry one at
+    # all is not an error here: clang-format falls back to its own default and
+    # CI is the authority either way.
+    if git ls-files --error-unmatch .clang-format > /dev/null 2>&1; then
+        printf '%s\0' .clang-format \
+            | git checkout-index --stdin -z -f --prefix="$staged_dir/"
+    elif [ -e .clang-format ]; then
+        cp .clang-format "$staged_dir/"
+    fi
+
+    # The version gate, the patterns and the diff all live in .ci/, and this
+    # runs them there rather than carrying a second copy that drifts. Each is
+    # given the extracted index so it sees staged content, from a working
+    # directory that keeps its diagnostics naming src/foo.c and not a temp path.
+    #
+    # Both checkers separate "these files are wrong" from "this check could not
+    # run", so which clang-format counts stays check-format.sh's answer alone.
+    # Asking again here is the duplication being removed, and asking only
+    # whether some clang-format exists gets the version case wrong: an unpinned
+    # one on PATH would block every C commit over a formatter the author does
+    # not have rather than over anything they wrote. Absent .ci, both checks
+    # below are unreachable. Say so: skipping quietly and then printing that the
+    # staged checks passed is the failure mode this hook exists to prevent, and
+    # it is the one an author cannot see.
+    if [ -z "$ci_dir" ] && [ "${#c_files[@]}" -gt 0 ]; then
+        echo "note: no .ci beside $hook_path; format and API checks skipped." >&2
+    fi
+
+    if [ "${#c_files[@]}" -gt 0 ] && [ -n "$ci_dir" ]; then
+        status=0
+        (cd "$staged_dir" && "$ci_dir/check-format.sh" "${c_files[@]}") \
+            || status=$?
+        if [ "$status" -eq 1 ]; then
+            failed=1
+        elif [ "$status" -ne 0 ]; then
+            echo "note: format check skipped, commit not blocked; CI runs it." >&2
+        fi
+    fi
+
+    if [ "${#src_files[@]}" -gt 0 ] && [ -n "$ci_dir" ]; then
+        if ! (cd "$staged_dir" \
+            && "$ci_dir/check-security.sh" "${src_files[@]}"); then
+            failed=1
+        fi
+    fi
+
+    if [ "${#sh_files[@]}" -gt 0 ]; then
+        if ! command -v shellcheck > /dev/null 2>&1; then
+            echo "note: shellcheck not found, skipping shell check." >&2
+        elif ! (cd "$staged_dir" \
+            && shellcheck --severity=warning "${sh_files[@]}"); then
+            failed=1
+        fi
+    fi
+
+    # Exit 1 is "these files would change"; anything else is the tool failing to
+    # read them, which .ci/check-commentflow.sh is careful never to report as a
+    # style violation. Same discipline here: a parse error that reads as bad
+    # style sends the author to reformat code that was already fine.
+    commentflow=${COMMENTFLOW:-commentflow}
+    if [ "${#flow_files[@]}" -eq 0 ]; then
+        :
+    elif ! command -v "$commentflow" > /dev/null 2>&1; then
+        echo "note: commentflow not found, skipping comment reflow check." >&2
+    else
+        status=0
+        "$commentflow" --check "${flow_files[@]/#/$staged_dir/}" || status=$?
+        if [ "$status" -eq 1 ]; then
+            echo "Staged comments need reflowing; run 'make indent'." >&2
+            failed=1
+        elif [ "$status" -ne 0 ]; then
+            echo "note: $commentflow exited $status (I/O or parse error)." >&2
+        fi
+    fi
+fi
+
+# Covers trailing whitespace, space-before-tab, and leftover conflict markers,
+# each reported as file:line. A hand-rolled conflict-marker grep only repeats
+# this, and repeating it through a pipe into "grep -q" under pipefail makes it
+# fail open: grep exits at the first match, git takes SIGPIPE, the pipeline
+# reports 141, and the caller reads that as "clean" on exactly the large diffs
+# worth checking.
+if ! git diff --cached --check; then
+    failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+    exit 1
+fi
+
+echo "Staged checks passed. Commit-message rules run next; use the body for what and why."

--- a/scripts/git-pre-push.sh
+++ b/scripts/git-pre-push.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Validate every non-merge commit that a push would introduce.
+#
+# The last chance before a pull request exists. A rewrite is still free here;
+# after the push it costs a force-push and whatever review was already based on
+# the old hashes.
+
+set -uo pipefail
+
+remote=${1:-}
+
+# Installed hooks are symlinks, so $0 names the link under .git/hooks and
+# "dirname $0" gives that directory rather than the checkout the link points
+# into. Walk the chain to find the checker beside the real script instead of
+# under whichever worktree happens to be pushing.
+#
+# Unbounded on purpose. A cycle would spin here forever, but the chain has
+# already been resolved once by whatever exec'd this script: a cyclic or
+# overlong $0 fails with ELOOP before the first line runs, so this loop only
+# ever walks a chain the kernel already walked to the end.
+hook_path=$0
+while [ -L "$hook_path" ]; do
+    hook_dir=$(cd -P "$(dirname "$hook_path")" && pwd)
+    hook_path=$(readlink "$hook_path")
+    case "$hook_path" in
+        /*) ;;
+        *) hook_path="$hook_dir/$hook_path" ;;
+    esac
+done
+hook_dir=$(cd -P "$(dirname "$hook_path")" && pwd)
+check_script="$hook_dir/check-commit-log.sh"
+zero_oid=0000000000000000000000000000000000000000
+failed=0
+
+# For a branch the remote has never seen there is no remote_sha to diff from, so
+# the boundary is "everything not already published". Scope that to the remote
+# being pushed to when it has refs to scope by: a commit sitting only in some
+# other remote's namespace has not been published to this one, and excluding it
+# would let a malformed message through.
+#
+# A remote with no tracking refs at all is the exception, and it has to be. A
+# freshly added fork, or a push straight at a URL, excludes nothing, so the walk
+# reaches the root commit and every message in the project's history is judged
+# against today's rules. That produces hundreds of rejections for commits the
+# author never wrote, and the only way out of it is --no-verify, which costs
+# every other check too. Falling back to all remotes there means a commit
+# already published somewhere is not this push's problem. CI checks the pull
+# request either way.
+published="--remotes"
+if [ -n "$remote" ] && [ -n "$(git for-each-ref --count=1 \
+    --format='%(refname)' "refs/remotes/$remote/")" ]; then
+    published="--remotes=$remote"
+fi
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    [ -n "${local_ref:-}" ] || continue
+    [ "$local_sha" != "$zero_oid" ] || continue
+    git cat-file -e "${local_sha}^{commit}" 2> /dev/null || continue
+
+    if [ "$remote_sha" = "$zero_oid" ]; then
+        if ! commits=$(git rev-list --no-merges "$local_sha" --not "$published"); then
+            echo "Push rejected: cannot list commits for $local_ref -> $remote_ref." >&2
+            failed=1
+            continue
+        fi
+    else
+        if ! commits=$(git rev-list --no-merges "${remote_sha}..${local_sha}"); then
+            echo "Push rejected: cannot list commits for $local_ref -> $remote_ref." >&2
+            failed=1
+            continue
+        fi
+    fi
+
+    if [ -n "$commits" ]; then
+        if ! printf '%s\n' "$commits" | "$check_script"; then
+            echo "Push rejected for $local_ref -> $remote_ref." >&2
+            failed=1
+        fi
+    fi
+done
+
+exit "$failed"

--- a/scripts/git-prepare-commit-msg.sh
+++ b/scripts/git-prepare-commit-msg.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Put the rules in the editor buffer, where they are read, rather than leaving
+# them to be discovered by rejection.
+
+set -uo pipefail
+
+message_file=$1
+source=${2:-}
+
+# A message that already exists came from -m, a template, a merge, a squash or
+# an amend. Appending to any of those edits someone else's text.
+case "$source" in
+    message | template | merge | squash | commit) exit 0 ;;
+esac
+
+# git strips comment lines using core.commentChar, not "#". Writing the wrong
+# one leaves this guidance in the message, where it becomes the subject and is
+# then rejected for starting with punctuation. "auto" asks git to pick a
+# character the message does not already use, which is only knowable once the
+# message exists, so treat it as the default it picks for an empty buffer.
+comment_char=$(git config --get core.commentChar) || comment_char='#'
+case "$comment_char" in
+    '' | auto) comment_char='#' ;;
+esac
+
+# "git commit -v" has already appended the diff below a scissors line by the
+# time this runs. Everything from there down is git's, so it must not count as a
+# message the author wrote, and the guidance has to go above it or git discards
+# the two together. Read against the whole file the diff looked like an existing
+# message and the rules were never offered to anyone committing with -v, which
+# is the population that reads the buffer.
+scissors='-\{8,\}[[:space:]]*>8[[:space:]]*-\{8,\}'
+cut=$(grep -n -- "$scissors" "$message_file" | sed -n '1s/:.*//p')
+
+if grep -qE "^[^[:space:]$comment_char]" \
+    < <(sed "/$scissors/,\$d" "$message_file"); then
+    exit 0
+fi
+
+# Exit 0 rather than 1 wherever this cannot proceed: the buffer is a
+# convenience, and a hook that aborts the commit over its own scratch file has
+# cost the author more than it ever offered them.
+rules=$(mktemp) || exit 0
+trap 'rm -f "$rules"' EXIT
+
+{
+    printf '\n%s Commit rules, from CONTRIBUTING.md:\n' "$comment_char"
+    printf '%s  1. Separate the subject from the body with a blank line\n' "$comment_char"
+    printf '%s  2. Limit the subject line to 50 characters\n' "$comment_char"
+    printf '%s  3. Capitalize the subject line\n' "$comment_char"
+    printf '%s  4. Do not end the subject line with a period\n' "$comment_char"
+    printf '%s  5. Use the imperative mood in the subject line\n' "$comment_char"
+    printf '%s  6. Wrap the body at 72 characters\n' "$comment_char"
+    printf '%s  7. Use the body to explain what and why, not how\n' "$comment_char"
+    printf '%s\n%s ASCII only. No backticks in the subject.\n' "$comment_char" "$comment_char"
+    printf '%s\n%s Staged files:\n' "$comment_char" "$comment_char"
+    git diff --cached --name-only | sed "s/^/$comment_char - /"
+} > "$rules"
+
+if [ -z "$cut" ]; then
+    cat "$rules" >> "$message_file"
+else
+    spliced=$(mktemp) || exit 0
+    {
+        head -n "$((cut - 1))" "$message_file"
+        cat "$rules"
+        tail -n "+$cut" "$message_file"
+    } > "$spliced" && cat "$spliced" > "$message_file"
+    rm -f "$spliced"
+fi

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# Link the repository's Git hooks into the hooks directory, or unlink them.
+#
+# Symlinks, so a hook edited on a branch takes effect without reinstalling. They
+# point into the main worktree when it has the hook: hooks live in the shared
+# git dir and apply to every worktree. A newer linked worktree supplies a hook
+# that the main worktree does not have yet.
+#
+# A hook that is already there is never replaced. It belongs to whoever put it
+# there, and silently overwriting it is how a tool loses the right to be run
+# automatically.
+
+set -uo pipefail
+
+mode=install
+quiet=0
+for arg in "$@"; do
+    case "$arg" in
+        --uninstall) mode=uninstall ;;
+        --quiet) quiet=1 ;;
+        *)
+            echo "usage: ${0##*/} [--uninstall] [--quiet]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# A tarball export has no git dir and nothing to install into. Not an error: the
+# build has no business failing over a convenience.
+git rev-parse --git-dir > /dev/null 2>&1 || exit 0
+
+root=$(git worktree list --porcelain | sed -n '1s/^worktree //p')
+hooks=$(git rev-parse --path-format=absolute --git-path hooks)
+[ -n "$root" ] && [ -n "$hooks" ] || exit 0
+script_dir=$(cd -P "$(dirname "$0")" && pwd)
+
+# say <tag> <text>
+say()
+{
+    [ "$quiet" -eq 1 ] || printf '  %-7s %s\n' "$1" "$2"
+}
+
+# "git rev-parse --git-path hooks" answers with core.hooksPath when that is set,
+# which is where git will actually look. Worth saying only when that lands
+# somewhere other than this repository's own hooks directory, since it is
+# frequently a directory shared with other repositories. Pointing it at the
+# default is not news, and neither is repeating it on a build that changed
+# nothing, so the quiet path holds it until something is actually installed.
+default_hooks="$(git rev-parse --path-format=absolute --git-common-dir)/hooks"
+hooks_moved=0
+if [ "$hooks" != "$default_hooks" ]; then
+    hooks_moved=1
+fi
+
+installed=0
+failed=0
+
+if [ "$mode" = uninstall ]; then
+
+    # Enumerate what is installed, not what scripts/ holds today: a branch that
+    # deletes a hook script would otherwise strand its link, because the name is
+    # only known from the script that is now gone. A link counts as ours when it
+    # points at the matching git-<name>.sh inside the scripts directory of some
+    # worktree of this repository, which leaves a hand-written hook, a regular
+    # file, and a link into anywhere else alone.
+    for target in "$hooks"/*; do
+        [ -L "$target" ] || continue
+        name=${target##*/}
+        link=$(readlink "$target")
+        while IFS= read -r wt; do
+            [ -n "$wt" ] || continue
+            if [ "$link" = "$wt/scripts/git-$name.sh" ]; then
+                rm -f "$target"
+                say RM "$name"
+                break
+            fi
+        done <<EOF
+$(git worktree list --porcelain | sed -n 's/^worktree //p')
+EOF
+    done
+    exit 0
+fi
+
+for hook in "$script_dir"/git-*.sh; do
+    [ -e "$hook" ] || continue
+    name=${hook##*/git-}
+    name=${name%.sh}
+    target="$hooks/$name"
+    source="$root/scripts/${hook##*/}"
+    [ -e "$source" ] || source=$hook
+
+    mkdir -p "$hooks" || { failed=1; continue; }
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        say KEEP "$target"
+    elif ln -s "$source" "$target" 2> /dev/null; then
+        say HOOK "$name"
+        installed=$((installed + 1))
+    else
+
+        # Not silent: the caller stamps this run as done only when it reports
+        # success, so a hooks directory that was briefly unavailable is retried
+        # rather than remembered as installed.
+        echo "install-git-hooks: cannot link $target" >&2
+        failed=1
+    fi
+done
+
+# The quiet path is the one make runs on its own, and it stays silent unless it
+# actually did something. A line per already-linked hook on every build is how
+# output stops being read.
+if [ "$quiet" -eq 0 ] || [ "$installed" -gt 0 ]; then
+    if [ "$hooks_moved" -eq 1 ]; then
+        printf '  NOTE    core.hooksPath sends hooks to %s\n' "$hooks"
+    fi
+fi
+
+if [ "$quiet" -eq 1 ] && [ "$installed" -gt 0 ]; then
+    printf "  HOOKS   installed %d git hook(s); make uninstall-hooks removes them\n" \
+        "$installed"
+fi
+
+exit "$failed"

--- a/scripts/test-git-hooks.sh
+++ b/scripts/test-git-hooks.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+
+# Exercise the commit-message rules against messages that must pass and must
+# fail. Every case below is a regression that was live at some point: a hook
+# that rejects a merge aborts the merge halfway, and one that lints the diff
+# "git commit -v" appends rejects a message that is fine.
+#
+# Runs the hook under /bin/bash as well when that shell is older than 4.4,
+# because a stock macOS resolves "/usr/bin/env bash" there and empty arrays
+# under set -u behave differently.
+#
+# Messages go in through "-", the same door the pre-push hook and the CI
+# commit-log gate use, and not through /dev/stdin. That path exists precisely
+# because a minimal container need not carry that device, so a test written
+# against it exercises the branch nothing else takes and breaks where the branch
+# it skipped was written to work.
+
+set -uo pipefail
+
+script_dir=$(cd -P "$(dirname "$0")" && pwd)
+hook="$script_dir/git-commit-msg.sh"
+failures=0
+checks=0
+
+# expect_ok <name> <message>
+expect_ok()
+{
+    checks=$((checks + 1))
+    local out
+    if ! out=$(printf '%s' "$2" | "$hook" - 2>&1); then
+        printf 'FAIL (rejected, should pass): %s\n      %s\n' "$1" "$out" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# expect_fail <name> <message> <expected diagnostic substring>
+expect_fail()
+{
+    checks=$((checks + 1))
+    local out
+    if out=$(printf '%s' "$2" | "$hook" - 2>&1); then
+        printf 'FAIL (accepted, should reject): %s\n' "$1" >&2
+        failures=$((failures + 1))
+    elif [ "${out#*"$3"}" = "$out" ]; then
+        printf 'FAIL (wrong reason): %s\n      wanted %s, got %s\n' "$1" "$3" "$out" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+expect_ok 'plain subject' 'Add a syscall'
+expect_ok 'subject and body' 'Add a syscall
+
+Explain the problem this solves.
+'
+expect_ok 'exactly 50 characters' 'Reject a syscall that outlives its own page tables'
+expect_ok 'one parenthesized group' 'Route main() error paths through one label'
+expect_ok 'pull-request reference' 'Implement times syscall (#199)'
+expect_ok 'verb absent from the mood list' 'Wire the epoll wakeup pipe'
+
+# git composes these itself; rejecting a merge subject aborts the merge.
+expect_ok 'merge subject over 50' 'Merge pull request #311 from sysprog21/contributing'
+expect_ok 'revert subject' 'Revert "Gate comment width in make and CI"
+
+This reverts commit 047b59c.
+'
+expect_ok 'fixup subject' 'fixup! Add a syscall'
+
+# "Merge " also starts an ordinary imperative subject, so the exemption names
+# the forms git writes rather than the word they share.
+expect_fail 'hand-written merge subject' 'Merge the free lists into one.' \
+    'end with a period'
+
+# "git commit -v" puts the diff below a scissors line, uncommented. Linting it
+# fails on width, on ASCII, and on whatever else the diff happens to contain.
+expect_ok 'verbose commit diff is ignored' 'Add a syscall
+
+Short body.
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+diff --git a/src/big.c b/src/big.c
++an added line considerably wider than seventy two characters, as diffs are
+'
+
+# The subject, second line and body are split with parameter expansion rather
+# than three sed calls, so the shapes that expansion gets wrong are worth
+# pinning: no trailing newline, no body at all, and a blank line that is the
+# whole body.
+expect_ok 'no trailing newline' 'Add a syscall'
+expect_ok 'trailing blank line only' 'Add a syscall
+
+'
+expect_ok 'body line exactly 72' 'Add a syscall
+
+123456789012345678901234567890123456789012345678901234567890123456789012
+'
+expect_fail 'tab inside the subject' 'Add	a	syscall' 'printable ASCII'
+
+expect_fail 'empty' '' 'descriptive subject'
+expect_fail 'body line 73' 'Add a syscall
+
+1234567890123456789012345678901234567890123456789012345678901234567890123
+' 'exceed 72'
+expect_fail 'single word' 'Fix' 'more than one word'
+expect_fail '51 characters' 'Reject a syscall that outlives its own page tables!' 'exceeds 50'
+expect_fail 'lowercase start' 'add a syscall' 'capital letter'
+expect_fail 'trailing period' 'Add a syscall.' 'end with a period'
+expect_fail 'past tense' 'Added a syscall' 'imperative mood'
+expect_fail 'gerund' 'Adding a syscall' 'imperative mood'
+expect_fail 'conventional commit' 'fs: skip procfs symlinks' 'conventional-commit'
+# The backticks below are the input under test, not a substitution.
+# shellcheck disable=SC2016
+expect_fail 'backtick' 'Add `sys_mmap` handling' 'backticks'
+expect_fail 'excessive parentheses' 'Add mmap(2) and mprotect(2) here' 'overuses parentheses'
+expect_fail 'non-ASCII' 'Add a syscall and an em dash '$'—''here' 'printable ASCII'
+expect_fail 'no blank line' 'Add a syscall
+Body on the second line.
+' 'blank line'
+expect_fail 'body over 72' 'Add a syscall
+
+This body line is quite deliberately wider than the seventy-two column limit.
+' 'exceed 72'
+expect_fail 'body describes how' 'Add a syscall
+
+How: it calls into the dispatch table.
+' 'what and why'
+
+# The pre-commit hook must survive a commit that stages no C at all. What breaks
+# is an unguarded empty-array expansion under set -u, which only bash 3.2
+# rejects, and only a stock macOS still resolves "/usr/bin/env bash" to one. On
+# a Linux runner both names below are the same bash 5 binary, so running them
+# both is a duplicate rather than the coverage it resembles. Dedupe by resolved
+# path: one pass reported honestly beats two that are the same pass counted
+# twice.
+seen_shells=
+for shell in /bin/bash bash; do
+    resolved=$(command -v "$shell" 2> /dev/null) || continue
+    resolved=$(cd -P "$(dirname "$resolved")" 2> /dev/null && printf '%s/%s' "$(pwd)" "${resolved##*/}")
+    case " $seen_shells " in
+        *" $resolved "*) continue ;;
+    esac
+    seen_shells="$seen_shells $resolved"
+    checks=$((checks + 1))
+    tmp=$(mktemp -d) || exit 1
+    if ! (
+        cd "$tmp" || exit 1
+        git init -q . && git config user.email t@t && git config user.name T
+        cp "$script_dir/../.clang-format" . 2> /dev/null
+        echo doc > README.md
+        git add README.md
+        "$shell" "$script_dir/git-pre-commit.sh" > /dev/null
+    ); then
+        printf 'FAIL: pre-commit on a docs-only change under %s (%s)\n' \
+            "$shell" "$("$shell" --version | head -1)" >&2
+        failures=$((failures + 1))
+    fi
+    rm -rf "$tmp"
+done
+
+# Pushing a branch to a remote that has no tracking refs yet, which is what a
+# freshly added fork looks like. The boundary "everything not already published"
+# excludes nothing there, so the walk reaches the root commit: the hook must not
+# judge a history it was handed rather than one the author wrote.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q --bare origin.git
+    git init -q --bare fork.git
+    git init -q work && cd work || exit 1
+    git config user.email t@t && git config user.name T
+    git remote add origin ../origin.git
+    git remote add fork ../fork.git
+    cp -R "$script_dir/../scripts" .
+
+    # Published history the author did not write, and would not be able to fix.
+    git commit -q --allow-empty -m "Added a thing badly." --no-verify
+    git push -q origin HEAD:refs/heads/main
+    git fetch -q origin
+
+    # One clean commit of their own, pushed to a fork that has seen nothing.
+    git commit -q --allow-empty -m "Add a clean thing" --no-verify
+    ./scripts/install-git-hooks.sh --quiet
+    git push -q fork HEAD:refs/heads/topic
+) > /dev/null 2>&1; then
+    echo 'FAIL: pushing to a fresh remote judges history the author did not write' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# A force-push can advertise a remote tip the local repository has never
+# fetched. Reject the push instead of treating a failed revision walk as an
+# empty range.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q --bare remote.git
+    git init -q work && cd work || exit 1
+    git config user.email t@t && git config user.name T
+    git remote add origin ../remote.git
+    cp -R "$script_dir/../scripts" . && cp "$script_dir/../.clang-format" .
+    ./scripts/install-git-hooks.sh --quiet
+
+    git commit -q --allow-empty -m "Add base"
+    git push -q origin HEAD:refs/heads/main
+    git branch stale
+    git clone -q ../remote.git writer && cd writer || exit 1
+    git config user.email t@t && git config user.name T
+    git checkout -q -b main origin/main
+
+    # The setup has to succeed, or the force-push below is rejected for its
+    # message and this check passes without the unavailable tip ever existing.
+    git commit -q --allow-empty -m "Add remote change" || exit 1
+    git push -q origin HEAD:refs/heads/main || exit 1
+
+    # "$tmp", not "..": the clone above put writer inside work, so a single
+    # level up is still work and every "git -C work" below would fail with
+    # "cannot change to work". Negated, that failure reads as the push having
+    # been rejected, and the check passes without the hook running at all.
+    cd "$tmp" && git -C work checkout -q stale
+    git -C work commit -q --allow-empty -m "Added an invalid message" --no-verify
+    ! git -C work push -q --force origin HEAD:refs/heads/main
+) > /dev/null 2>&1; then
+    echo 'FAIL: force-push with an unavailable remote tip bypasses pre-push' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# An unpinned clang-format on PATH must not block a commit. The hook delegates
+# the version gate to .ci/check-format.sh, so the two answers it can get back,
+# "this file is wrong" and "I could not run", have to stay distinguishable; a
+# hook that conflates them rejects a correctly formatted file over a formatter
+# the author happens to have.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+
+    # An isolated PATH, not a prefix. A runner with the pinned formatter in
+    # /usr/bin has check-format.sh select that one before ever reaching the
+    # fake, and the case under test never runs. Everything else the hook needs
+    # is linked in; only clang-format is withheld.
+    mkdir -p fakebin
+    for dir in /usr/bin /bin /usr/local/bin /opt/homebrew/bin; do
+        [ -d "$dir" ] || continue
+        for tool in "$dir"/*; do
+            case "${tool##*/}" in
+                clang-format*) continue ;;
+            esac
+            [ -x "$tool" ] || continue
+            ln -sf "$tool" "fakebin/${tool##*/}" 2> /dev/null
+        done
+    done
+    printf '#!/bin/sh\necho "clang-format version 18.1.0"\n' > fakebin/clang-format
+    chmod +x fakebin/clang-format
+
+    git init -q . && git config user.email t@t && git config user.name T
+    mkdir -p src .ci scripts
+    cp "$script_dir/../.ci/check-format.sh" "$script_dir/../.ci/check-security.sh" .ci/
+    cp "$script_dir/git-pre-commit.sh" scripts/
+    cp "$script_dir/../.clang-format" .
+    printf 'int main(void)\n{\n    return 0;\n}\n' > src/ok.c
+    git add src/ok.c
+    # The isolation is the whole fixture, so assert it rather than assume it.
+    ! PATH="$tmp/fakebin" command -v clang-format-22 > /dev/null 2>&1 || exit 1
+    PATH="$tmp/fakebin" bash scripts/git-pre-commit.sh
+) > /dev/null 2>&1; then
+    echo 'FAIL: an unpinned clang-format blocks the commit' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# Through the installed symlinks, not by calling the scripts where they live.
+# The two shapes differ: installed, $0 is the link under .git/hooks, so a hook
+# resolving a sibling script from "dirname $0" looks in the wrong directory and
+# only fails once someone actually commits. Direct invocation never sees it.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q --bare remote.git
+    git init -q work && cd work || exit 1
+    git config user.email t@t && git config user.name T
+    git remote add origin ../remote.git
+    cp -R "$script_dir/../scripts" . && cp "$script_dir/../.clang-format" .
+    ./scripts/install-git-hooks.sh --quiet
+
+    echo doc > README.md && git add README.md
+    # Rejected by commit-msg, so nothing lands.
+    git commit -q -m "Added a doc." > /dev/null 2>&1 && exit 1
+    git commit -q -m "Add a doc" > /dev/null 2>&1 || exit 1
+
+    # Pre-push has to find check-commit-log.sh from the installed symlink.
+    git commit -q --allow-empty -m "Add another doc" > /dev/null 2>&1 || exit 1
+    git push -q origin HEAD:refs/heads/probe > /dev/null 2>&1 || exit 1
+) > /dev/null 2>&1; then
+    echo 'FAIL: hooks do not work through the installed symlinks' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# Hooks installed from the primary worktree run when an older linked worktree
+# lacks the checker. The link must resolve the helper beside its own source.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q --bare remote.git
+    git init -q primary && cd primary || exit 1
+    git config user.email t@t && git config user.name T
+    echo base > README.md && git add README.md
+    git commit -q -m "Add base"
+    git branch old
+    cp -R "$script_dir/../scripts" . && cp "$script_dir/../.clang-format" .
+    ./scripts/install-git-hooks.sh --quiet
+    git worktree add -q ../linked old
+    cd ../linked || exit 1
+    git remote add origin ../remote.git
+
+    echo doc > linked.md && git add linked.md
+    git commit -q -m "Add linked doc" > /dev/null 2>&1 || exit 1
+
+    # A clean push succeeds whether or not a hook ran, so the assertion is the
+    # rejection: this commit reaches the remote only if pre-push failed to
+    # resolve check-commit-log.sh beside the script the symlink points at.
+    git commit -q --allow-empty -m "Added a bad subject" --no-verify
+    ! git push -q origin HEAD:refs/heads/old > /dev/null 2>&1 || exit 1
+    git reset -q --hard HEAD~1
+    git push -q origin HEAD:refs/heads/old > /dev/null 2>&1 || exit 1
+) > /dev/null 2>&1; then
+    echo 'FAIL: pre-push cannot use the primary worktree checker' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# git strips comments with core.commentChar, not with "#". Written with the
+# wrong one, the guidance survives into the message and becomes the subject.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q . && git config user.email t@t && git config user.name T
+    git config core.commentChar ";"
+    : > msg
+    "$script_dir/git-prepare-commit-msg.sh" msg
+    [ -z "$(git stripspace --strip-comments < msg)" ] || exit 1
+) > /dev/null 2>&1; then
+    echo 'FAIL: the message template ignores core.commentChar' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# "git commit -v" has appended the diff by the time prepare-commit-msg runs. The
+# rules still have to reach the buffer, and above the scissors line, since git
+# drops everything below it along with the diff.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q . && git config user.email t@t && git config user.name T
+    {
+        printf '\n# Please enter the commit message.\n'
+        printf '# ------------------------ >8 ------------------------\n'
+        printf 'diff --git a/a b/a\n+a line the message must not be judged on\n'
+    } > msg
+    "$script_dir/git-prepare-commit-msg.sh" msg
+    grep -q 'Commit rules' msg || exit 1
+    [ "$(grep -n 'Commit rules' msg | sed -n '1s/:.*//p')" \
+        -lt "$(grep -n '>8' msg | sed -n '1s/:.*//p')" ] || exit 1
+) > /dev/null 2>&1; then
+    echo 'FAIL: the rules never reach a "git commit -v" buffer' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# The format gate separates "this file is wrong" from "I could not read it", or
+# the pre-commit hook blocks a commit over a path it failed to extract.
+checks=$((checks + 1))
+status=0
+"$script_dir/../.ci/check-format.sh" no-such-file.c > /dev/null 2>&1 || status=$?
+if [ "$status" -ne 2 ]; then
+    printf 'FAIL: the format check reports %d, not 2, on a path it cannot read\n' \
+        "$status" >&2
+    failures=$((failures + 1))
+fi
+
+# A staged shell script reaches the same gates CI runs it through. Before, an
+# all-shell commit staged nothing the hook looked at.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    command -v shellcheck > /dev/null 2>&1 || exit 0
+    git init -q . && git config user.email t@t && git config user.name T
+    mkdir -p scripts .ci
+    cp "$script_dir/git-pre-commit.sh" scripts/
+    cp "$script_dir/../.ci/check-format.sh" "$script_dir/../.ci/check-security.sh" .ci/
+    printf '#!/bin/sh\nunused_variable=2\n' > scripts/thing.sh
+    git add scripts/thing.sh
+    ! bash scripts/git-pre-commit.sh > /dev/null 2>&1 || exit 1
+) > /dev/null 2>&1; then
+    echo 'FAIL: a staged shell script bypasses the pre-commit checks' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# A path with a space in it, and a hook whose script a branch later removes. The
+# first truncated the worktree path; the second stranded the link, because the
+# name was only ever read from the script that had gone.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    mkdir -p "$tmp/with space" && cd "$tmp/with space" || exit 1
+    git init -q repo && cd repo || exit 1
+    git config user.email t@t && git config user.name T
+    mkdir scripts && cp "$script_dir"/git-*.sh "$script_dir/install-git-hooks.sh" scripts/
+    ./scripts/install-git-hooks.sh --quiet
+    hooks=$(git rev-parse --path-format=absolute --git-path hooks)
+
+    # pwd -P: mktemp hands back a /var path that resolves to /private/var on
+    # macOS, and the installer records the resolved one.
+    here=$(pwd -P)
+    [ "$(readlink "$hooks/pre-push")" = "$here/scripts/git-pre-push.sh" ] || exit 1
+
+    # Installing from a linked worktree is where the primary path has to survive
+    # intact. With it truncated at the space the link still lands somewhere
+    # plausible, because the missing source falls back to the invoking worktree,
+    # so only this arrangement tells the two apart.
+    git commit -q --allow-empty -m "Add base" --no-verify
+    git worktree add -q ../linked -b linked
+    cp -R scripts "../linked/scripts"
+
+    # Uninstall first, or the install below reports KEEP for links the primary
+    # already made and the assertion passes without the linked path deciding
+    # anything.
+    ./scripts/install-git-hooks.sh --uninstall > /dev/null
+    (cd ../linked && ./scripts/install-git-hooks.sh --quiet)
+    [ "$(readlink "$hooks/pre-push")" = "$here/scripts/git-pre-push.sh" ] || exit 1
+    ./scripts/install-git-hooks.sh --uninstall > /dev/null
+    rm -rf ../linked
+    git worktree prune
+    ./scripts/install-git-hooks.sh --quiet
+
+    rm scripts/git-prepare-commit-msg.sh
+    ./scripts/install-git-hooks.sh --uninstall > /dev/null
+    for left in "$hooks"/commit-msg "$hooks"/pre-commit "$hooks"/pre-push \
+        "$hooks"/prepare-commit-msg; do
+        [ ! -e "$left" ] && [ ! -L "$left" ] || exit 1
+    done
+) > /dev/null 2>&1; then
+    echo 'FAIL: install or uninstall mishandles spaces or a removed script' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+# A security gate that cannot read what it was asked to scan must not report
+# that the scan was clean.
+checks=$((checks + 1))
+if "$script_dir/../.ci/check-security.sh" no-such-file.c > /dev/null 2>&1; then
+    echo 'FAIL: the security check passes on a path it cannot read' >&2
+    failures=$((failures + 1))
+fi
+
+# A hook that cannot reach the .ci checkers must say so. Skipping them quietly
+# and then reporting that the staged checks passed is the one failure this hook
+# exists to prevent, and the author has no way to see it.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q . && git config user.email t@t && git config user.name T
+    mkdir -p scripts src
+    cp "$script_dir/git-pre-commit.sh" scripts/
+    cp "$script_dir/../.clang-format" .
+    printf '#include <string.h>\nvoid f(char *d, const char *s)\n{\n    strcpy(d, s);\n}\n' \
+        > src/bad.c
+    git add src/bad.c
+
+    # Captured, not piped into "grep -q": under pipefail an early grep exit
+    # leaves the hook writing into a closed pipe, and the 141 that comes back
+    # would fail this check on the run where the note was actually printed.
+    out=$(bash scripts/git-pre-commit.sh 2>&1)
+    case "$out" in
+        *"format and API checks skipped"*) ;;
+        *) exit 1 ;;
+    esac
+) > /dev/null 2>&1; then
+    echo 'FAIL: unreachable .ci checkers are skipped without a word' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
+if [ "$failures" -ne 0 ]; then
+    printf '%d of %d hook checks failed.\n' "$failures" "$checks" >&2
+    exit 1
+fi
+
+printf 'All %d hook checks passed.\n' "$checks"

--- a/scripts/test-git-hooks.sh
+++ b/scripts/test-git-hooks.sh
@@ -333,6 +333,47 @@ if ! (
 fi
 rm -rf "$tmp"
 
+# A linked worktree can carry these scripts before the primary worktree does.
+# Its installation still has to enumerate its own scripts and run pre-push.
+checks=$((checks + 1))
+tmp=$(mktemp -d) || exit 1
+if ! (
+    cd "$tmp" || exit 1
+    git init -q --bare remote.git
+    git init -q primary && cd primary || exit 1
+    git config user.email t@t && git config user.name T
+    echo base > README.md && git add README.md
+    git commit -q -m "Add base"
+    git branch old
+    git worktree add -q ../linked
+    cd ../linked || exit 1
+    git remote add origin ../remote.git
+    cp -R "$script_dir/../scripts" . && mkdir mk
+    cp "$script_dir/../mk/common.mk" mk/
+
+    make -sn -f mk/common.mk BUILD_DIR=build build/.hooks-installed > /dev/null
+    [ ! -e build/.hooks-installed ] || exit 1
+    [ ! -e "$(git rev-parse --git-path hooks)/pre-push" ] || exit 1
+    ! make -sq -f mk/common.mk BUILD_DIR=build build/.hooks-installed
+    [ ! -e build/.hooks-installed ] || exit 1
+    [ ! -e "$(git rev-parse --git-path hooks)/pre-push" ] || exit 1
+    make -s -f mk/common.mk BUILD_DIR=build build/.hooks-installed
+    [ -e build/.hooks-installed ] || exit 1
+    [ -L "$(git rev-parse --git-path hooks)/commit-msg" ] || exit 1
+
+    # The stamp only says the target ran. What has to be true is that the hooks
+    # it linked are live in this worktree, and a commit that must be refused is
+    # the only thing that shows it.
+    echo doc > linked.md && git add linked.md
+    ! git commit -q -m "Added a bad subject" > /dev/null 2>&1 || exit 1
+    git commit -q -m "Add linked doc" > /dev/null 2>&1 || exit 1
+    git push -q origin HEAD:refs/heads/linked > /dev/null 2>&1 || exit 1
+) > /dev/null 2>&1; then
+    echo 'FAIL: hooks do not install from a linked worktree' >&2
+    failures=$((failures + 1))
+fi
+rm -rf "$tmp"
+
 # git strips comments with core.commentChar, not with "#". Written with the
 # wrong one, the guidance survives into the message and becomes the subject.
 checks=$((checks + 1))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Install Git hooks and a CI gate to enforce commit‑message rules and staged checks. Previously rules were documented but unenforced and hooks were opt‑in; now hooks auto‑install on first build, validate locally, and CI checks every PR commit with a shallow‑safe range.

- .ci checkers take explicit paths; `.ci/check-format.sh` returns 1 for style diffs and 2 when the pinned formatter is unavailable; `.ci/check-security.sh` also accepts named paths and fails on unreadable inputs. The pre-commit hook runs these against the extracted index.
- New hooks in `scripts/`: `git-commit-msg.sh` (rules), `git-pre-commit.sh` (format, comment reflow, banned APIs, whitespace, shellcheck), `git-pre-push.sh` (validates new non‑merge commits), `check-commit-log.sh` (shared), `git-prepare-commit-msg.sh` (injects rules; respects scissors and core.commentChar), `install-git-hooks.sh` (link/unlink without overwriting), and `test-git-hooks.sh` (self‑tests).
- CI lint workflow: adds a “Commit messages” job that guards shallow fetch depth and runs `scripts/check-commit-log.sh`; runs hook self‑tests; extends shellcheck to `scripts/`.

**Rollout and developer impact**
- Hooks install on the first `make` via symlinks; existing hooks are never replaced. Remove with `make uninstall-hooks`; reinstall with `make install-hooks`.
- Missing local tools only warn in pre-commit (unpinned/absent `clang-format`, missing `commentflow`, missing `shellcheck`); CI enforces the same checks.
- Commit‑message rules exempt merge/fixup/squash and ignore verbose diffs; bodies >72 chars and non‑ASCII/tab characters are rejected. Imperative mood and “what/why, not how” are best‑effort and still reviewer‑judged.
- CI commit checks run only on pull requests; do not reduce the fetch depth below what the workflow computes. No contributor migration required.

<sup>Written for commit 40a1bd14521f298acaef85c34337a7c8fab1ec8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

