### PR TITLE
Translate the serial line and modem-control ioctls

### DIFF
--- a/scripts/check-eintr-contract.py
+++ b/scripts/check-eintr-contract.py
@@ -89,6 +89,12 @@ INVENTORY = {
         "forbids",
         "The timeout is spent in 1 ms chunks before this reports EINTR.",
     ),
+    "syscall/io.c::tty_drain_interruptible": (
+        "forbids",
+        "The kernel returns a plain -EINTR from the TCSBRK/TCSBRKP/TIOCSBRK "
+        "drain (tty_io.c, no ERESTARTSYS), and part of the output has already "
+        "drained, so a restart would wait the interval again.",
+    ),
     "syscall/fuse.c::fuse_request_locked": (
         "forbids",
         "FUSE_INTERRUPT is on the wire and the request is detached, so a "

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -338,6 +338,61 @@ static int64_t io_check_access(int host_fd, short events)
     return 0;
 }
 
+/* Interruptible output drain, mirroring tty_wait_until_sent(): the Linux kernel
+ * waits for pending output before TCSBRK, TCSBRKP and TIOCSBRK, and a pending
+ * signal aborts the wait with a plain -EINTR that reaches the guest without a
+ * restart (tty_io.c "Factor out some common prep work" block). macOS tcdrain()
+ * would park the vCPU thread beyond the reach of guest signals -- a serial port
+ * stalled by flow control would hang the guest unkillably -- so poll TIOCOUTQ
+ * in short slices with the same interruption checks as
+ * io_wait_fd_or_interrupted(). Fds without an output-queue count (macOS returns
+ * ENOTTY for non-ttys; ptys do implement TIOCOUTQ) fall back to a single
+ * tcdrain(), which returns immediately for those.
+ */
+static int64_t tty_drain_interruptible(int host_fd)
+{
+    int wake_fd = wakeup_pipe_read_fd();
+    struct pollfd fds[1] = {
+        {.fd = wake_fd, .events = POLLIN},
+    };
+
+    for (;;) {
+        int outq = 0;
+        if (ioctl(host_fd, TIOCOUTQ, &outq) < 0)
+            return tcdrain(host_fd) < 0 ? linux_errno() : 0;
+        if (outq == 0)
+            return 0;
+
+        signal_check_timer_real();
+        bool leader_only = thread_stop_is_leader_work_only();
+        bool interrupted = (!leader_only && thread_stop_requested()) ||
+                           (!leader_only && futex_interrupt_consume()) ||
+                           signal_pending_interruption(NULL);
+        if (!interrupted) {
+            int ret = poll(fds, 1, leader_only ? 0 : 20);
+            if (ret < 0 && errno != EINTR)
+                return linux_errno();
+
+            /* Consume the wakeup byte like io_wait_fd_or_interrupted() does:
+             * the interruption conditions it announces are re-checked at the
+             * top of every iteration, and a byte left in the pipe would turn
+             * each subsequent poll into an immediate return and this loop into
+             * a busy spin for as long as output stays queued.
+             */
+            if (ret > 0 && wake_fd >= 0 && (fds[0].revents & POLLIN))
+                wakeup_pipe_drain();
+            interrupted = leader_only;
+        }
+        if (interrupted) {
+            /* Linux returns a plain -EINTR here (not ERESTARTSYS), and part of
+             * the interval has already drained: no restart.
+             */
+            syscall_restart_forbid();
+            return -LINUX_EINTR;
+        }
+    }
+}
+
 void urandom_fd_reset_cache(int guest_fd)
 {
     if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))
@@ -2480,6 +2535,186 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         }
         host_fd_ref_close(&host_ref);
         return 0;
+    }
+
+    case LINUX_TCSBRK: {
+        /* Linux overloads TCSBRK: its kernel always waits for pending output
+         * first, then sends a break only for arg 0; a nonzero arg is how glibc
+         * and musl implement tcdrain(3) (they issue TCSBRK with 1). macOS has
+         * no ioctl form of either, so route to the POSIX wrappers in that
+         * order.
+         */
+        int64_t rc = tty_drain_interruptible(host_fd);
+        if (rc == 0 && arg == 0 && tcsendbreak(host_fd, 0) < 0)
+            rc = linux_errno();
+        host_fd_ref_close(&host_ref);
+        return rc;
+    }
+
+    case LINUX_TCSBRKP: {
+        /* POSIX form of tcsendbreak: arg is the duration in deciseconds (0
+         * means 250 ms). The Linux kernel drains pending output before both
+         * TCSBRK and TCSBRKP; macOS tcsendbreak() does not, and ignores the
+         * duration (fixed ~0.4 s), which is close enough for a break.
+         */
+        int64_t rc = tty_drain_interruptible(host_fd);
+        if (rc == 0 && tcsendbreak(host_fd, (int) arg) < 0)
+            rc = linux_errno();
+        host_fd_ref_close(&host_ref);
+        return rc;
+    }
+
+    case LINUX_TIOCSBRK:
+    case LINUX_TIOCCBRK: {
+        /* BSD-style break on/off (pyserial's break_condition). Same request
+         * semantics on macOS; a pty answers ENOTTY on both systems. The Linux
+         * kernel drains pending output before TIOCSBRK (but not TIOCCBRK), same
+         * as TCSBRK.
+         */
+        int64_t rc = 0;
+        if (request == LINUX_TIOCSBRK)
+            rc = tty_drain_interruptible(host_fd);
+        if (rc == 0 &&
+            ioctl(host_fd, request == LINUX_TIOCSBRK ? TIOCSBRK : TIOCCBRK) < 0)
+            rc = linux_errno();
+        host_fd_ref_close(&host_ref);
+        return rc;
+    }
+
+    case LINUX_TCFLSH: {
+        /* tcflush(3): arg is the queue selector. Linux numbers TCIFLUSH,
+         * TCOFLUSH, TCIOFLUSH 0..2 (asm-generic/termbits-common.h); macOS
+         * numbers them 1..3 (sys/termios.h), hence the explicit map.
+         */
+        int queue;
+        switch (arg) {
+        case 0:
+            queue = TCIFLUSH;
+            break;
+        case 1:
+            queue = TCOFLUSH;
+            break;
+        case 2:
+            queue = TCIOFLUSH;
+            break;
+        default:
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EINVAL;
+        }
+        int rc = tcflush(host_fd, queue);
+        host_fd_ref_close(&host_ref);
+        return rc < 0 ? linux_errno() : 0;
+    }
+
+    case LINUX_TCXONC: {
+        /* tcflow(3): arg is the action. Linux numbers TCOOFF, TCOON, TCIOFF,
+         * TCION 0..3 (asm-generic/termbits-common.h); macOS numbers them 1..4
+         * (sys/termios.h), hence the explicit map.
+         */
+        int action;
+        switch (arg) {
+        case 0:
+            action = TCOOFF;
+            break;
+        case 1:
+            action = TCOON;
+            break;
+        case 2:
+            action = TCIOFF;
+            break;
+        case 3:
+            action = TCION;
+            break;
+        default:
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EINVAL;
+        }
+        int rc = tcflow(host_fd, action);
+        host_fd_ref_close(&host_ref);
+        return rc < 0 ? linux_errno() : 0;
+    }
+
+    case LINUX_TIOCOUTQ: {
+        /* Bytes still queued for output; pyserial's out_waiting and the esptool
+         * reset sequence poll this.
+         */
+        int pending = 0;
+        if (ioctl(host_fd, TIOCOUTQ, &pending) < 0) {
+            host_fd_ref_close(&host_ref);
+            return linux_errno();
+        }
+        int32_t val = (int32_t) pending;
+        if (guest_write_small(g, arg, &val, sizeof(val)) < 0) {
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EFAULT;
+        }
+        host_fd_ref_close(&host_ref);
+        return 0;
+    }
+
+    case LINUX_TIOCEXCL:
+    case LINUX_TIOCNXCL: {
+        /* Exclusive-use flag on the tty; no argument. */
+        int rc =
+            ioctl(host_fd, request == LINUX_TIOCEXCL ? TIOCEXCL : TIOCNXCL);
+        host_fd_ref_close(&host_ref);
+        return rc < 0 ? linux_errno() : 0;
+    }
+
+    case LINUX_TIOCMGET: {
+        /* Modem control lines. TIOCM_* bit values are identical on Linux and
+         * macOS (see linux-wire.h), so the int needs no translation. Only real
+         * serial drivers implement these on Darwin; a pty answers ENOTTY.
+         */
+        int bits = 0;
+        if (ioctl(host_fd, TIOCMGET, &bits) < 0) {
+            host_fd_ref_close(&host_ref);
+            return linux_errno();
+        }
+        int32_t val = (int32_t) bits;
+        if (guest_write_small(g, arg, &val, sizeof(val)) < 0) {
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EFAULT;
+        }
+        host_fd_ref_close(&host_ref);
+        return 0;
+    }
+
+    case LINUX_TIOCMSET:
+    case LINUX_TIOCMBIS:
+    case LINUX_TIOCMBIC: {
+        /* The Linux kernel masks the set/clear words to the output lines
+         * (DTR|RTS|OUT1|OUT2|LOOP, tty_io.c tty_tiocmset) before they reach
+         * the driver, so read-only status bits (CTS/DSR/CAR/RNG) in the guest's
+         * word are silently dropped. Darwin has no OUT1/OUT2/LOOP, so the
+         * settable intersection is DTR|RTS. TIOCMSET on Linux means "set = val
+         * & mask, clear = ~val & mask" -- bits outside the mask are left alone
+         * -- whereas Darwin's TIOCMSET overwrites the whole word, so emulate
+         * the Linux semantics with a TIOCMBIS/TIOCMBIC pair. The first host
+         * call is issued even when its masked word is empty so a fd whose
+         * driver lacks modem control still reports ENOTTY, as Linux does before
+         * looking at the value.
+         */
+        int32_t val = 0;
+        if (guest_read_small(g, arg, &val, sizeof(val)) < 0) {
+            host_fd_ref_close(&host_ref);
+            return -LINUX_EFAULT;
+        }
+        const int settable = TIOCM_DTR | TIOCM_RTS;
+        int rc;
+        if (request == LINUX_TIOCMSET) {
+            int bis = (int) val & settable;
+            int bic = ~(int) val & settable;
+            rc = ioctl(host_fd, TIOCMBIS, &bis);
+            if (rc == 0 && bic != 0)
+                rc = ioctl(host_fd, TIOCMBIC, &bic);
+        } else {
+            int bits = (int) val & settable;
+            rc = ioctl(host_fd, request == LINUX_TIOCMBIS ? TIOCMBIS : TIOCMBIC,
+                       &bits);
+        }
+        host_fd_ref_close(&host_ref);
+        return rc < 0 ? linux_errno() : 0;
     }
 
     case LINUX_TIOCGPGRP: {

--- a/src/syscall/linux-wire.h
+++ b/src/syscall/linux-wire.h
@@ -137,6 +137,29 @@ typedef struct {
 #define LINUX_FIOASYNC 0x5452   /* set/clear O_ASYNC (arg: int *) */
 #define LINUX_TIOCNOTTY 0x5422  /* -> macOS TIOCNOTTY (same semantics) */
 #define LINUX_TIOCGSID 0x5429   /* -> macOS TIOCGSID (same semantics) */
+
+/* Serial line control. Linux encodes the argument in the ioctl arg word itself;
+ * macOS has no ioctl form and exposes tcsendbreak/tcdrain/tcflush/tcflow.
+ */
+#define LINUX_TCSBRK 0x5409   /* arg 0: tcsendbreak; nonzero: tcdrain (glibc) */
+#define LINUX_TCXONC 0x540A   /* arg 0..3 -> tcflow TCOOFF/TCOON/TCIOFF/TCION */
+#define LINUX_TCFLSH 0x540B   /* arg 0..2 -> tcflush TCI/TCO/TCIOFLUSH */
+#define LINUX_TIOCEXCL 0x540C /* -> macOS TIOCEXCL (same semantics) */
+#define LINUX_TIOCNXCL 0x540D /* -> macOS TIOCNXCL (same semantics) */
+#define LINUX_TIOCOUTQ 0x5411 /* -> macOS TIOCOUTQ (int *) */
+#define LINUX_TCSBRKP 0x5425  /* POSIX tcsendbreak; arg is duration */
+#define LINUX_TIOCSBRK 0x5427 /* -> macOS TIOCSBRK (break on) */
+#define LINUX_TIOCCBRK 0x5428 /* -> macOS TIOCCBRK (break off) */
+
+/* Modem control lines. TIOCM_* bit values (LE=0x001 DTR=0x002 RTS=0x004
+ * ST=0x008 SR=0x010 CTS=0x020 CAR=0x040 RNG=0x080 DSR=0x100) are identical on
+ * Linux (asm-generic/termios.h) and macOS (sys/ttycom.h), so the int travels
+ * as-is.
+ */
+#define LINUX_TIOCMGET 0x5415 /* -> macOS TIOCMGET (int *) */
+#define LINUX_TIOCMBIS 0x5416 /* -> macOS TIOCMBIS (int *) */
+#define LINUX_TIOCMBIC 0x5417 /* -> macOS TIOCMBIC (int *) */
+#define LINUX_TIOCMSET 0x5418 /* -> macOS TIOCMSET (int *) */
 /* termios2 variant (adds c_ispeed/c_ospeed) */
 #define LINUX_TCGETS2 0x802c542a
 #define LINUX_TCSETS2 0x402c542b  /* termios2 set (TCSANOW) */

--- a/tests/test-pty.c
+++ b/tests/test-pty.c
@@ -1393,6 +1393,9 @@ int main(void)
      * rate in CBAUD and issues plain TCSETS (glibc's cfsetspeed, musl always),
      * so a translation that only reads the termios2 speed fields silently
      * leaves the host line at its old rate and tcgetattr() reports B0 forever.
+     * tcflush/tcdrain/TIOCOUTQ/TIOCEXCL are the calls pyserial and esptool make
+     * on every open; they used to fall through to ENOTTY. TIOCMGET is ENOTTY on
+     * a Linux pty too (no tiocmget op), so only its errno is pinned here.
      */
     {
         int sm = open("/dev/ptmx", O_RDWR | O_NOCTTY);
@@ -1557,6 +1560,41 @@ int main(void)
                             (st2.c_cflag & TEST_CBAUD) == B115200 &&
                             st2.c_ospeed == 115200,
                         "TCGETS2 c_cflag disagrees with TCGETS");
+
+            TEST("tcflush/tcdrain/tcflow on the slave");
+            EXPECT_TRUE(sl >= 0 && tcflush(sl, TCIOFLUSH) == 0 &&
+                            tcdrain(sl) == 0 && tcflow(sl, TCOON) == 0,
+                        "TCFLSH/TCSBRK/TCXONC not translated");
+
+            TEST("TCFLSH rejects an out-of-range selector");
+            EXPECT_ERRNO(sl >= 0 ? ioctl(sl, TCFLSH, 3) : -1, EINVAL,
+                         "TCFLSH(3)");
+
+            TEST("TIOCOUTQ on the slave");
+            int soutq = -1;
+            EXPECT_TRUE(
+                sl >= 0 && ioctl(sl, TIOCOUTQ, &soutq) == 0 && soutq == 0,
+                "TIOCOUTQ not translated");
+
+            TEST("TIOCEXCL/TIOCNXCL on the slave");
+            EXPECT_TRUE(
+                sl >= 0 && ioctl(sl, TIOCEXCL) == 0 && ioctl(sl, TIOCNXCL) == 0,
+                "TIOCEXCL/TIOCNXCL not translated");
+
+            TEST("TIOCMGET on a pty is ENOTTY");
+            int sbits = 0;
+            EXPECT_ERRNO(sl >= 0 ? ioctl(sl, TIOCMGET, &sbits) : -1, ENOTTY,
+                         "TIOCMGET");
+
+            /* The set family masks the guest word to the output lines before
+             * the host call, but a pty must still answer ENOTTY even when the
+             * masked word is empty: Linux rejects on the missing driver op
+             * before looking at the value.
+             */
+            TEST("TIOCMBIS with only status bits is still ENOTTY on a pty");
+            sbits = TIOCM_CTS | TIOCM_DSR;
+            EXPECT_ERRNO(sl >= 0 ? ioctl(sl, TIOCMBIS, &sbits) : -1, ENOTTY,
+                         "TIOCMBIS");
 
             if (sl >= 0)
                 close(sl);


### PR DESCRIPTION
> [!NOTE]
> Piece 2 of #310, on top of the CBAUD/CIBAUD work merged in #312.

## Summary

Thirteen serial line-control and modem-control ioctls fell through to `ENOTTY`. They now route to the Darwin equivalents, so pyserial/esptool/picocom-style tools (and any program calling `tcflush()` on its tty) work on a passthrough serial port.

> [!IMPORTANT]
> What to look at:
> 1. The drain before `TCSBRK`/`TCSBRKP`/`TIOCSBRK` is interruptible: the kernel's `tty_wait_until_sent` aborts on a pending signal with a plain `-EINTR` (no restart), so the arms poll `TIOCOUTQ` in short slices with the `io_wait_fd_or_interrupted()` interruption checks instead of parking the vCPU thread in macOS `tcdrain()`, which guest signals cannot reach; a flow-control-stalled port would otherwise hang the guest unkillably. Only `TCSBRK` arg 0 actually breaks (arg != 0 is glibc/musl `tcdrain()`), and `TIOCCBRK` does not drain, matching the kernel's prep block.
> 2. `TCFLSH`/`TCXONC` selectors are renumbered explicitly: Linux 0-based (`asm-generic/termbits-common.h`), Darwin 1-based (`sys/termios.h`). Out-of-range -> `EINVAL`, as the kernel.
> 3. The `TIOCM` set family masks the guest word to the settable lines the way `tty_tiocmset()` does (Linux mask `DTR|RTS|OUT1|OUT2|LOOP`; Darwin has no OUT1/OUT2/LOOP, so the intersection is `DTR|RTS`), dropping read-only status bits silently as Linux does. `TIOCMSET` is emulated with a `TIOCMBIS`/`TIOCMBIC` pair because Linux only touches masked bits while Darwin's `TIOCMSET` overwrites the whole word. Bit values themselves are identical on both. A pty answers `ENOTTY` on both systems, and the driver check precedes the value (a status-bits-only `TIOCMBIS` is still `ENOTTY` on a pty).
> 4. Every new arm closes `host_ref` on all paths.

## Problem

`sys_ioctl` default arm (`io.c:2573` at bffd6bd) returns `ENOTTY` for: `TCSBRK` `TCSBRKP` `TCFLSH` `TCXONC` `TIOCOUTQ` `TIOCEXCL` `TIOCNXCL` `TIOCSBRK` `TIOCCBRK` `TIOCMGET` `TIOCMSET` `TIOCMBIS` `TIOCMBIC`.

Who hits it (from source): pyserial `open()` -> `_reset_input_buffer()` -> `termios.tcflush` (`serialposix.py:344,677`, fatal); `setDTR`/`setRTS` -> `TIOCMBIS`/`TIOCMBIC` (`:706-715`); `out_waiting` -> `TIOCOUTQ` (`:755`); `break_condition` -> `TIOCSBRK`/`TIOCCBRK` (`:300-301`); esptool reset sequences -> `TIOCMSET`/`TIOCMGET` (`esptool/reset.py:22-25`); glibc/musl `tcdrain()` -> `TCSBRK 1`; Python `termios.tcflush` on the controlling tty fails today for any guest.

## Change

- `linux-wire.h`: `LINUX_TCSBRK/TCXONC/TCFLSH/TIOCEXCL/TIOCNXCL/TIOCOUTQ/TCSBRKP/TIOCSBRK/TIOCCBRK/TIOCMGET/TIOCMBIS/TIOCMBIC/TIOCMSET`, values from `asm-generic/ioctls.h` (same on aarch64 and x86_64).
- `io.c` `sys_ioctl`: arms routing to `tcdrain`/`tcsendbreak`/`tcflush`/`tcflow` and host `ioctl(TIOCOUTQ|TIOCEXCL|TIOCNXCL|TIOCSBRK|TIOCCBRK|TIOCM*)`.
- `tests/test-pty.c`: `tcflush`/`tcdrain`/`tcflow` on the slave; `TCFLSH(3)` -> `EINVAL`; `TIOCOUTQ`; `TIOCEXCL`/`TIOCNXCL`; `TIOCMGET` on a pty is `ENOTTY`.

## Evidence

<details><summary>macOS pty, glibc 2.41 guest: before vs after</summary>

before:
```
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Inappropriate ioctl for device bits=0x0
  TIOCMBIS(DTR|RTS)= -1Inappropriate ioctl for device
  TIOCMBIC(DTR|RTS)= -1Inappropriate ioctl for device
  tcflush/TCFLSH  = -1Inappropriate ioctl for device
  tcdrain/TCSBRK  = -1Inappropriate ioctl for device
  TIOCOUTQ        = -1Inappropriate ioctl for device outq=-1
  TIOCEXCL        = -1Inappropriate ioctl for device
host-side speed after guest tcsetattr(B115200): ispeed=9600 ospeed=9600
```
after:
```
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Inappropriate ioctl for device bits=0x0
  TIOCMBIS(DTR|RTS)= -1Inappropriate ioctl for device
  TIOCMBIC(DTR|RTS)= -1Inappropriate ioctl for device
  tcflush/TCFLSH  = 0
  tcdrain/TCSBRK  = 0
  TIOCOUTQ        = 0 outq=0
  TIOCEXCL        = 0
host-side speed after guest tcsetattr(B115200): ispeed=115200 ospeed=115200
```
</details>

<details><summary>real hardware: ESP32-S3 (/dev/cu.usbmodem101), reproducer before vs after</summary>

before:
```
== 4. line / modem-control ioctls ==
  TIOCMGET        = -1Inappropriate ioctl for device bits=0x0
  TIOCMBIS(DTR|RTS)= -1Inappropriate ioctl for device
  TIOCMBIC(DTR|RTS)= -1Inappropriate ioctl for device
  tcflush/TCFLSH  = -1Inappropriate ioctl for device
  tcdrain/TCSBRK  = -1Inappropriate ioctl for device
  TIOCOUTQ        = -1Inappropriate ioctl for device outq=-1
  TIOCEXCL        = -1Inappropriate ioctl for device
```
after:
```
== 4. line / modem-control ioctls ==
  TIOCMGET        = 0 bits=0x6
  TIOCMBIS(DTR|RTS)= 0
  TIOCMBIC(DTR|RTS)= 0
  tcflush/TCFLSH  = 0
  tcdrain/TCSBRK  = 0
  TIOCOUTQ        = 0 outq=0
  TIOCEXCL        = 0
```
</details>

<details><summary>Linux esptool 5.3.1 (python:3.12-slim arm64 sysroot) on the ESP32-S3: before vs after</summary>

before (dies inside `Serial.open()`):
```
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/esptool/loader.py", line 443, in __init__
    self._port.open()
  File "/usr/local/lib/python3.12/site-packages/serial/serialposix.py", line 344, in open
    self._reset_input_buffer()
  File "/usr/local/lib/python3.12/site-packages/serial/serialposix.py", line 677, in _reset_input_buffer
    termios.tcflush(self.fd, termios.TCIFLUSH)
termios.error: (25, 'Inappropriate ioctl for device')
```
after (`--before usb-reset`; see note):
```
00:15:50 WARN  src/core/sysroot.c:409: sysroot /private/tmp/claude-501/-Users-chenweicheng-claude-project/287bec26-be2d-4f79-81dd-14d93c69f673/scratchpad/sysroot-esptool is case-insensitive; workloads with colliding guest names such as Linux kernel trees may fail. Use --create-sysroot to run inside a case-sensitive APFS sparsebundle.
esptool v5.3.1
Serial port /dev/cu.usbmodem101:
Connecting...
Detecting chip type... ESP32-S3
Connected to ESP32-S3 on /dev/cu.usbmodem101:
Chip type:          ESP32-S3 (QFN56) (revision v0.1)
Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz, Embedded PSRAM 8MB (AP_3v3)
Crystal frequency:  40MHz
MAC:                34:85:18:42:6c:98
Uploading stub flasher...
Running stub flasher...
Stub flasher running.
Flash Memory Information:
=========================
Manufacturer: c8
Device: 4017
Detected flash size: 8MB
Flash type set in eFuse: quad (4 data lines)
Flash voltage set by eFuse: 3.3V
Hard resetting via RTS pin...
```
`--before usb-reset` is needed because esptool picks its reset strategy from the port's VID/PID, which pyserial on Linux reads from `/sys/class/tty/<name>/device/...` (`serial/tools/list_ports_linux.py:30-53`); that sysfs view is piece 3 in #310, not this PR.
</details>

## Tests

- `build/elfuse build/test-pty`: 70 passed, 0 failed (on top of #312, rebased onto current main)
- `make check ...`: rc=0, `All 77 tests passed`
- `clang-format --dry-run -Werror` clean

## Not in this PR

- `TIOCGSERIAL`/`TIOCSSERIAL` stay `ENOTTY` (no Darwin equivalent; pyserial only uses them in the opt-in `set_low_latency_mode()`).
- `TCSBRKP` duration is approximated: Darwin `tcsendbreak()` ignores the duration (fixed ~0.4 s) vs Linux `arg*100` ms.
- Device-node aliases (`/dev/ttyUSB*`, `/dev/ttyACM*`) and the `/sys/class/tty` walk -> piece 3 in #310.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate Linux serial line-control and modem-control ioctls to Darwin so passthrough ttys work with pyserial/esptool/picocom and any program calling tcflush()/tcdrain(). Previously these ioctls returned ENOTTY; now they route to tcdrain/tcsendbreak/tcflush/tcflow and `TIOC*` equivalents with Linux-matching behavior where it affects semantics.

- Drain semantics before TCSBRK/TCSBRKP/TIOCSBRK match Linux: poll `TIOCOUTQ` in short slices and return plain -EINTR (no restart), avoiding vCPU hangs in macOS tcdrain(); documented in `scripts/check-eintr-contract.py`. Only TCSBRK arg 0 sends break; nonzero drains.
- Selector mapping: `TCFLSH` (0..2 -> `TCIFLUSH`/`TCOFLUSH`/`TCIOFLUSH`) and `TCXONC` (0..3 -> `TCOOFF`/`TCOON`/`TCIOFF`/`TCION`) are renumbered to Darwin’s 1-based values; out-of-range -> EINVAL. `TCSBRKP` duration is accepted but approximated by Darwin.
- Modem control: `TIOCMGET`/`TIOCMBIS`/`TIOCMBIC` forwarded; `TIOCMSET` emulated with BIS/BIC so only masked bits change. Mask to DTR|RTS (Darwin lacks OUT1/OUT2/LOOP). Bit values are identical; guest 32-bit ints preserved. ptys continue to return ENOTTY.
- `TIOCOUTQ` and `TIOCEXCL`/`TIOCNXCL` forwarded. New request numbers added in `src/syscall/linux-wire.h`. Tests in `tests/test-pty.c` cover flush/drain/flow, selector validation, `TIOCOUTQ`, exclusivity, and pty ENOTTY.

<sup>Written for commit 79d3e0a080ccebf5229e3a784dd206c909301645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

