### PR TITLE
Stop ppoll calling a live descriptor invalid

### DIFF
--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -96,6 +96,86 @@ static inline void host_fd_refs_close(host_fd_ref_t *refs, uint32_t n)
         host_fd_ref_close(&refs[i]);
 }
 
+/* A guest's events reach the host untranslated, and the two spellings of a
+ * writable descriptor do not share a value: Linux POLLWRNORM is 0x100, which
+ * macOS spells POLLWRBAND, while macOS POLLWRNORM is POLLOUT itself. Testing
+ * the pair answers a guest that asks with either. Linux's default mask stops
+ * there, so Linux POLLWRBAND (0x200) is deliberately absent.
+ */
+#define POLL_WRITE_EVENTS (POLLOUT | POLLWRBAND)
+
+/* Evaluate the entries host poll() refused. macOS poll() answers POLLNVAL for
+ * any descriptor it will not put on a kqueue: /dev/null, /dev/zero,
+ * /dev/random, /dev/urandom, directories, and kqueue descriptors themselves.
+ * Linux polls all of them, the character devices and directories through the
+ * default always-ready mask and an epoll descriptor through its own readiness.
+ * macOS select() accepts every one of them, so the caller drops them from the
+ * poll() set and routes them here.
+ *
+ * A host descriptor at or above FD_SETSIZE has no bit in an fd_set and reports
+ * the requested events ready, which matches Linux for everything except an
+ * epoll descriptor with nothing pending.
+ *
+ * Returns how many entries are ready.
+ */
+static uint32_t poll_eval_unpollable(const struct pollfd *host_fds,
+                                     const host_fd_ref_t *refs,
+                                     const bool *unpollable,
+                                     short *revents,
+                                     uint32_t nfds)
+{
+    fd_set read_set, write_set, except_set;
+    FD_ZERO(&read_set);
+    FD_ZERO(&write_set);
+    FD_ZERO(&except_set);
+
+    int max_fd = -1;
+    for (uint32_t i = 0; i < nfds; i++) {
+        revents[i] = 0;
+        if (!unpollable[i] || !RANGE_CHECK(refs[i].fd, 0, FD_SETSIZE))
+            continue;
+        int fd = refs[i].fd;
+        short events = host_fds[i].events;
+        if (events & (POLLIN | POLLRDNORM))
+            FD_SET(fd, &read_set);
+        if (events & POLL_WRITE_EVENTS)
+            FD_SET(fd, &write_set);
+        if (events & POLLPRI)
+            FD_SET(fd, &except_set);
+        if (fd > max_fd)
+            max_fd = fd;
+    }
+
+    struct timeval zero = {0, 0};
+    bool selected = max_fd < 0 || select(max_fd + 1, &read_set, &write_set,
+                                         &except_set, &zero) >= 0;
+
+    uint32_t ready = 0;
+    for (uint32_t i = 0; i < nfds; i++) {
+        if (!unpollable[i])
+            continue;
+        int fd = refs[i].fd;
+        short events = host_fds[i].events;
+        short got = 0;
+        if (!RANGE_CHECK(fd, 0, FD_SETSIZE)) {
+            got = (short) (events & (POLLIN | POLLRDNORM | POLL_WRITE_EVENTS));
+        } else if (selected) {
+            int mask = 0;
+            if (FD_ISSET(fd, &read_set))
+                mask |= events & (POLLIN | POLLRDNORM);
+            if (FD_ISSET(fd, &write_set))
+                mask |= events & POLL_WRITE_EVENTS;
+            if (FD_ISSET(fd, &except_set))
+                mask |= POLLPRI;
+            got = (short) mask;
+        }
+        revents[i] = got;
+        if (got)
+            ready++;
+    }
+    return ready;
+}
+
 int64_t sys_ppoll(guest_t *g,
                   uint64_t fds_gva,
                   uint32_t nfds,
@@ -125,6 +205,14 @@ int64_t sys_ppoll(guest_t *g,
      */
     uint64_t guest_gen[256] = {0};
     uint32_t invalid_count = 0;
+
+    /* Entries host poll() refuses with POLLNVAL even though their reference
+     * resolved. See poll_eval_unpollable().
+     */
+    bool unpollable[256] = {false};
+    short unpollable_revents[256] = {0};
+    uint32_t unpollable_count = 0;
+    bool unpollable_checked = false;
     for (uint32_t i = 0; i < nfds; i++) {
         host_refs[i] = (host_fd_ref_t) {.fd = -1, .owned = false};
         int guest_fd = guest_fds[i].fd;
@@ -247,10 +335,34 @@ int64_t sys_ppoll(guest_t *g,
         poll_timeout_ms > 0 ? poll_now_ms() + poll_timeout_ms : -1;
 
     int ret;
+    uint32_t unpollable_ready = 0;
 ppoll_retry:
     do {
-        int slice = poll_timeout_ms == 0 ? 0 : poll_slice_ms(deadline_ms);
+        if (unpollable_count > 0)
+            unpollable_ready = poll_eval_unpollable(
+                host_fds, host_refs, unpollable, unpollable_revents, nfds);
+
+        int slice = (poll_timeout_ms == 0 || unpollable_ready > 0)
+                        ? 0
+                        : poll_slice_ms(deadline_ms);
         ret = poll(host_fds, nfds + added_wakeup, slice);
+
+        /* Take the descriptors macOS refuses out of the set once and evaluate
+         * them through select() from here on. A refused entry makes poll()
+         * return at once, so this costs no wait.
+         */
+        if (ret > 0 && !unpollable_checked) {
+            unpollable_checked = true;
+            for (uint32_t i = 0; i < nfds; i++) {
+                if (need_pollnval[i] || !(host_fds[i].revents & POLLNVAL))
+                    continue;
+                unpollable[i] = true;
+                host_fds[i].fd = -1;
+                unpollable_count++;
+            }
+            if (unpollable_count > 0)
+                goto ppoll_retry;
+        }
 
         /* Check for process/thread interrupts after waking. */
         if (thread_stop_requested() || futex_interrupt_consume() ||
@@ -277,7 +389,7 @@ ppoll_retry:
             if (hup_pending)
                 break;
         }
-    } while (ret == 0 && poll_timeout_ms != 0 &&
+    } while (ret == 0 && unpollable_ready == 0 && poll_timeout_ms != 0 &&
              (deadline_ms < 0 || poll_slice_ms(deadline_ms) > 0));
 
     /* POSIX poll() ignores entries with fd < 0 and resets revents to 0, so
@@ -289,6 +401,13 @@ ppoll_retry:
             if (need_pollnval[i])
                 host_fds[i].revents = POLLNVAL;
         ret += (int) invalid_count;
+    }
+
+    if (ret >= 0 && unpollable_count > 0) {
+        for (uint32_t i = 0; i < nfds; i++)
+            if (unpollable[i])
+                host_fds[i].revents = unpollable_revents[i];
+        ret += (int) unpollable_ready;
     }
 
     /* A pty master whose guest-side slaves have all closed is hung up, but the

--- a/tests/test-poll.c
+++ b/tests/test-poll.c
@@ -48,6 +48,14 @@ static void *restart_read_sender(void *arg)
     return NULL;
 }
 
+static int ppoll_past_eintr(struct pollfd *fds, nfds_t n, struct timespec *ts)
+{
+    int r = ppoll(fds, n, ts, NULL);
+    if (r < 0 && errno == EINTR)
+        r = ppoll(fds, n, ts, NULL);
+    return r;
+}
+
 static int fork_exit_after_us(useconds_t usec)
 {
     int pid = fork();
@@ -402,6 +410,152 @@ int main(void)
                      */
         else
             FAIL("setpgid unexpected result");
+    }
+
+    /* ppoll on descriptors macOS poll() refuses. Linux polls character devices
+     * and directories through the default always-ready mask, and an epoll
+     * descriptor through its own readiness.
+     */
+    TEST("ppoll always-ready devices");
+    {
+        static const char *const paths[] = {"/dev/null", "/dev/zero",
+                                            "/dev/urandom", "/"};
+        struct pollfd pfd[4];
+        int opened = 0;
+        for (unsigned i = 0; i < sizeof(paths) / sizeof(paths[0]); i++) {
+            int fd = open(paths[i], O_RDONLY);
+            if (fd < 0)
+                continue;
+            pfd[opened].fd = fd;
+            pfd[opened].events = POLLIN | POLLOUT;
+            pfd[opened].revents = 0;
+            opened++;
+        }
+        struct timespec ts = {0, 0};
+        int r = ppoll_past_eintr(pfd, (nfds_t) opened, &ts);
+        int bad = 0;
+        for (int i = 0; i < opened; i++) {
+            if ((pfd[i].revents & POLLNVAL) || !(pfd[i].revents & POLLIN) ||
+                !(pfd[i].revents & POLLOUT))
+                bad++;
+            close(pfd[i].fd);
+        }
+        if (opened == 4 && r == opened && bad == 0)
+            PASS();
+        else
+            FAIL("device or directory reported unpollable");
+    }
+
+    TEST("ppoll on an epoll fd");
+    {
+        int ep = epoll_create1(0);
+        int pfds[2];
+        if (ep < 0 || pipe(pfds) != 0) {
+            FAIL("epoll_create1 or pipe failed");
+        } else {
+            struct epoll_event ev = {.events = EPOLLIN, .data.fd = pfds[0]};
+            epoll_ctl(ep, EPOLL_CTL_ADD, pfds[0], &ev);
+
+            struct pollfd probe = {.fd = ep, .events = POLLIN, .revents = 0};
+            struct timespec ts = {0, 0};
+            ppoll_past_eintr(&probe, 1, &ts);
+            int idle_ok = probe.revents == 0;
+
+            (void) !write(pfds[1], "x", 1);
+            probe.revents = 0;
+            int r = ppoll_past_eintr(&probe, 1, &ts);
+            int ready_ok = r == 1 && (probe.revents & POLLIN);
+
+            if (idle_ok && ready_ok)
+                PASS();
+            else
+                FAIL("epoll fd readiness misreported");
+            close(ep);
+            close(pfds[0]);
+            close(pfds[1]);
+        }
+    }
+
+    TEST("ppoll keeps POLLNVAL for closed fd");
+    {
+        int live = open("/dev/null", O_RDONLY);
+        int fd = open("/dev/null", O_RDONLY);
+        close(fd);
+        struct pollfd pfd[2];
+        pfd[0].fd = fd;
+        pfd[0].events = POLLIN;
+        pfd[0].revents = 0;
+        pfd[1].fd = live;
+        pfd[1].events = POLLIN;
+        pfd[1].revents = 0;
+        struct timespec ts = {0, 0};
+        int r = ppoll_past_eintr(pfd, 2, &ts);
+        if (r == 2 && (pfd[0].revents & POLLNVAL) &&
+            (pfd[1].revents & POLLIN) && !(pfd[1].revents & POLLNVAL))
+            PASS();
+        else
+            FAIL("closed fd lost its POLLNVAL");
+        close(live);
+    }
+
+    /* An unpollable entry that is not ready must not turn a blocking wait into
+     * a spin, and must not stop a pollable entry from waking the call.
+     */
+    TEST("ppoll waits alongside an epoll fd");
+    {
+        int ep = epoll_create1(0);
+        int pfds[2];
+        if (ep < 0 || pipe(pfds) != 0) {
+            FAIL("epoll_create1 or pipe failed");
+        } else {
+            struct pollfd pfd[2];
+            pfd[0].fd = ep;
+            pfd[0].events = POLLIN;
+            pfd[0].revents = 0;
+            pfd[1].fd = pfds[0];
+            pfd[1].events = POLLIN;
+            pfd[1].revents = 0;
+
+            struct timespec start, end;
+            clock_gettime(CLOCK_MONOTONIC, &start);
+            struct timespec ts = {0, 150 * 1000 * 1000};
+            int r = ppoll_past_eintr(pfd, 2, &ts);
+            clock_gettime(CLOCK_MONOTONIC, &end);
+            long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 +
+                              (end.tv_nsec - start.tv_nsec) / 1000000;
+            int waited = r == 0 && elapsed_ms >= 100;
+
+            (void) !write(pfds[1], "x", 1);
+            pfd[0].revents = 0;
+            pfd[1].revents = 0;
+            r = ppoll_past_eintr(pfd, 2, &ts);
+            int woke =
+                r == 1 && (pfd[1].revents & POLLIN) && pfd[0].revents == 0;
+
+            if (waited && woke)
+                PASS();
+            else
+                FAIL("blocking wait with an epoll fd misbehaved");
+            close(ep);
+            close(pfds[0]);
+            close(pfds[1]);
+        }
+    }
+
+    /* Linux POLLWRNORM is the bit macOS spells POLLWRBAND, and the guest's
+     * events reach the host untranslated.
+     */
+    TEST("ppoll honors POLLWRNORM");
+    {
+        int fd = open("/dev/null", O_RDWR);
+        struct pollfd pfd = {.fd = fd, .events = POLLWRNORM, .revents = 0};
+        struct timespec ts = {0, 0};
+        int r = ppoll_past_eintr(&pfd, 1, &ts);
+        if (r == 1 && (pfd.revents & POLLWRNORM) && !(pfd.revents & POLLNVAL))
+            PASS();
+        else
+            FAIL("POLLWRNORM on /dev/null not reported ready");
+        close(fd);
     }
 
     SUMMARY("test-poll");


### PR DESCRIPTION
`ppoll` tells the guest a descriptor is invalid when macOS `poll()` will not put it on a kqueue: `/dev/null`, `/dev/zero`, `/dev/urandom`, directory descriptors and epoll descriptors are all open and, on Linux, ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops ppoll on macOS from reporting POLLNVAL for live descriptors, matching Linux readiness for devices, directories, and epoll fds. Old: we propagated host poll()’s POLLNVAL; New: detect host-refused entries once and compute their readiness via select(), keeping POLLNVAL only for invalid fds.

- Detect POLLNVAL-only entries once, drop them from the poll set, and re-evaluate via select() (zero timeout) each loop; a refused entry causes a single immediate restart, and calls without them make no extra syscalls.
- Return readiness for always-ready devices and directories; epoll fds report idle vs ready correctly; do not interfere with other pollable entries; honor timeouts and wakeups; do not spin.
- Preserve POLLNVAL for closed/invalid guest fds; other error paths unchanged.
- Treat write readiness as POLLOUT|POLLWRBAND so guest POLLWRNORM is honored; for fds ≥ FD_SETSIZE, return requested readiness bits to mirror Linux.
- Tests cover devices/directories readiness, epoll idle/ready, closed fd retaining POLLNVAL, blocking wait alongside an epoll fd, and POLLWRNORM on /dev/null.

<sup>Written for commit f0c25bfa779441024df58c7cae86c6fa459f890a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

