### PR TITLE
Widen the EINTR gate to waits it could not see

### DIFF
--- a/scripts/check-eintr-contract.py
+++ b/scripts/check-eintr-contract.py
@@ -170,10 +170,34 @@ INVENTORY = {
         "syscall_is_restarted(), so the retry waits the same connection out "
         "instead of starting a second one.",
     ),
+    "syscall/net.c::connect_or_interrupted": (
+        "restartable",
+        "Flips the socket nonblocking, forwards connect_nonblock_wait, and "
+        "restores the guest's flags. It consumes nothing of its own; the SYN "
+        "the wait below it already sent is sys_connect's problem, not this "
+        "one's.",
+    ),
+    "syscall/net.c::sys_connect": (
+        "restartable",
+        "The one caller whose restart needs a precondition rather than a ban: "
+        "the SYN is out, so it treats EALREADY as in-flight always and EISCONN "
+        "as in-flight only under syscall_is_restarted(), and the retry waits "
+        "the same connection out instead of opening a second one.",
+    ),
     "syscall/net.c::sys_sendto": (
         "restartable",
         "POLLOUT wait, then send. An interrupted wait has sent nothing, and a "
         "send that moved bytes returns the count.",
+    ),
+    "syscall/net.c::do_accept": (
+        "restartable",
+        "The readiness wait precedes accept, so an interrupted wait has not "
+        "removed a connection from the listen queue.",
+    ),
+    "syscall/net.c::sys_recvfrom": (
+        "restartable",
+        "The first wait precedes recvfrom, and later interrupted waits return "
+        "the accumulated count instead of EINTR.",
     ),
     "syscall/net-msg.c::sys_sendmsg": (
         "restartable",
@@ -185,6 +209,64 @@ INVENTORY = {
         "Interrupting message i reports i as the count when i > 0, so the "
         "restart never re-sends a delivered message; only an interrupt before "
         "the first send reaches the guest as EINTR.",
+    ),
+    "syscall/net-msg.c::sys_recvmsg": (
+        "restartable",
+        "The first wait precedes recvmsg, and later interrupted waits return "
+        "the accumulated count instead of EINTR.",
+    ),
+    "syscall/net-msg.c::sys_recvmmsg": (
+        "forbids",
+        "The finite initial poll consumes part of the guest's relative timeout, "
+        "so every exit past it refuses the restart that would start the timeout "
+        "over. The vlen==1 fast path runs only when no timeout was supplied and "
+        "never reaches the poll, so its EINTR stays restartable.",
+    ),
+    "syscall/fs.c::fcntl_flock_wait": (
+        "restartable",
+        "The nonblocking flock probe changes nothing before the backoff waits.",
+    ),
+    "syscall/io.c::sys_read": (
+        "restartable",
+        "io_xfer returns EINTR only before it has transferred a byte.",
+    ),
+    "syscall/io.c::sys_readv": (
+        "restartable",
+        "io_xfer returns EINTR only before it has transferred a byte.",
+    ),
+    "syscall/io.c::sys_write": (
+        "restartable",
+        "io_xfer returns EINTR only before it has transferred a byte.",
+    ),
+    "syscall/io.c::sys_writev": (
+        "restartable",
+        "io_xfer returns EINTR only before it has transferred a byte.",
+    ),
+    "syscall/io.c::sys_splice": (
+        "restartable",
+        "Adds no hazard of its own: the input-side io_xfer reports before the "
+        "first byte, and the one exit that has consumed something -- a chunk "
+        "read but not written -- is forbidden by splice_drain_chunk, which is "
+        "the only frame that knows how much never left.",
+    ),
+    "syscall/io.c::sys_vmsplice": (
+        "restartable",
+        "A partial transfer returns its count; EINTR reaches the guest only "
+        "before the first byte.",
+    ),
+    "syscall/proc.c::proc_wait_autoreap_children": (
+        "forbids",
+        "The loop can reap an exited child before its backoff reports EINTR, "
+        "so re-execution would observe different process state.",
+    ),
+    "syscall/syscall.c::sc_flock": (
+        "restartable",
+        "The nonblocking flock probe changes nothing before the backoff waits.",
+    ),
+    "syscall/sysvipc.c::sys_semop": (
+        "restartable",
+        "A failed IPC_NOWAIT probe applies none of the semaphore operations "
+        "before the backoff waits.",
     ),
     "syscall/netlink.c::nl_wait_readable_locked": (
         "restartable",
@@ -273,10 +355,35 @@ FORBID_MARKER = "syscall_restart_forbid()"
 # one of these as reporting EINTR, so the classification survives the cleanup
 # that hides the constant.
 #
-# A name belongs here when it can return -LINUX_EINTR to its caller. Callers of
-# a helper listed here are still free to be 'restartable': the entry states the
+# Listed by hand. Membership is a property of the code, that this helper hands
+# EINTR to its caller, and no spelling rule tracks it: connect_or_interrupted
+# and net_recv_zero_payload_gate sit on opposite sides of any suffix convention
+# and both report EINTR upward. Deriving the list from INVENTORY would also make
+# deleting an entry shrink the regex, which is the gate getting weaker at the
+# moment it should be complaining.
+#
+# A caller of a helper is still free to be 'restartable': the entry states the
 # decision, it does not presume one.
-EINTR_HELPERS = ("io_wait_fd_or_interrupted",)
+EINTR_HELPERS = (
+    "io_wait_fd_or_interrupted",
+    "net_wait_or_interrupted",
+    "net_recv_zero_payload_gate",
+    "connect_nonblock_wait",
+    "connect_or_interrupted",
+    "io_retry_backoff",
+    "io_xfer",
+)
+
+# Both directions the pair can drift. A helper missing from INVENTORY is one the
+# gate demands a classification of without carrying one itself; an empty tuple
+# builds the regex '\b()\s*\(', which matches every call in the tree and buries
+# the real answer under a thousand unclassified functions.
+assert EINTR_HELPERS, "EINTR_HELPERS must not be empty"
+for _helper in EINTR_HELPERS:
+    assert any(
+        key.endswith("::" + _helper) for key in INVENTORY
+    ), f"EINTR helper {_helper} is not classified in INVENTORY"
+
 HELPER_RE = re.compile(r"\b(" + "|".join(EINTR_HELPERS) + r")\s*\(")
 
 FUNC_START_RE = re.compile(r"^(\w[\w \t\*]*?)\b(\w+)\s*\([^;]*$")

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -1304,6 +1304,16 @@ int64_t sys_recvmmsg(guest_t *g,
             int timeout_ms = timespec_to_poll_ms(ts.tv_sec, ts.tv_nsec);
             struct pollfd pfd = {.fd = host_ref.fd, .events = POLLIN};
             int pr = poll(&pfd, 1, timeout_ms);
+
+            /* However that poll ended, it spent part of a relative timeout the
+             * guest supplied, and the per-message loop below carries no bound
+             * of its own. Every EINTR exit past this point therefore belongs to
+             * a call whose deadline a restart would begin again from zero,
+             * including the one that matters most: a poll that reported
+             * readable, a sibling that took the datagram, and an interrupted
+             * wait inside the first sys_recvmsg.
+             */
+            syscall_restart_forbid();
             host_fd_ref_close(&host_ref);
             if (pr == 0)
                 return -LINUX_EAGAIN;

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -2240,8 +2240,10 @@ static int64_t proc_wait_autoreap_children(int pid, int options)
             return 0;
 
         int64_t wait_rc = io_retry_backoff(&backoff);
-        if (wait_rc < 0)
+        if (wait_rc < 0) {
+            syscall_restart_forbid();
             return wait_rc;
+        }
     }
 }
 


### PR DESCRIPTION
The gate classifies a function when it names EINTR, calls syscall_restart_forbid, or calls a name in its wait-helper list. That list held one name. Everything reaching a wait through io_xfer, io_retry_backoff or net_wait_or_interrupted therefore decided the restart question outside the gate's view: the receive half of the socket layer, the read and write path, flock, semop and splice among them.

Deriving the list from a naming convention was tried first and does not hold. The tree disagrees with any suffix rule in both directions. connect_or_interrupted carries the suffix, while
net_recv_zero_payload_gate and io_xfer do not and report EINTR upward all the same. Derivation also means deleting an inventory entry shrinks the regex, which is the gate going quiet at the moment it should complain. The list is spelled out instead, under two assertions: it may not be empty, since the empty alternation matches every call in the tree and buries the answer under a thousand unclassified functions, and every name in it has to carry a classification of its own.

sys_recvmmsg forbade the restart only when its own poll returned EINTR, which is the single case where the timeout had not been spent. The case that matters is the other one: a poll that reports readable after most of the interval, a sibling that takes the datagram, and an interrupted wait inside the first sys_recvmsg reaching the guest as EINTR with nothing received. The restart re-runs the call with the full timeout. The forbid is unconditional now, so every exit past the poll inherits it.

proc_wait_autoreap_children forbids as well, because its loop can reap an exited child before the backoff reports EINTR. Whether that is a consumption the restart cannot recover is arguable in the other direction: the rescan skips entries it has already marked inactive and reaches the same ECHILD, which is what POSIX gives a waiter under SA_NOCLDWAIT once the children are gone. Recorded here as the conservative reading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the EINTR gate to cover waits reached via common helpers and tightened restart semantics where timeouts or state can be consumed. Previously the gate only saw direct EINTR mentions or a single wait helper; now it enumerates helpers explicitly and asserts coverage. Behavior changes: sys_recvmmsg used to forbid restart only when its poll returned EINTR; it now forbids restart for every exit after the poll to avoid resetting a relative timeout. proc_wait_autoreap_children now forbids restart on interrupted waits to avoid observing different process state.

**Reviewer notes**
- scripts/check-eintr-contract.py: enumerates EINTR helpers (e.g., io_xfer, io_retry_backoff, net_wait_or_interrupted, connect_nonblock_wait, connect_or_interrupted, net_recv_zero_payload_gate) and asserts the list is non-empty and every helper is classified; HELPER_RE is built from this list.
- Adds restartability classifications for key paths: recvmsg/recvmmsg, accept/connect, read/write/readv/writev, flock, semop, splice/vmsplice, and proc waiters.
- sys_recvmmsg: unconditional syscall_restart_forbid() after poll ensures a restart cannot restart the relative timeout; the vlen==1 fast path (no timeout) is unchanged.
- proc_wait_autoreap_children: calls syscall_restart_forbid() when io_retry_backoff returns an error, preventing re-execution after a child may have been reaped.

<sup>Written for commit 74c44020711d401e36562ff82bde6291ab9e69ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

