### PR TITLE
Give the fd reference helpers an errno return

### DIFF
--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -260,8 +260,9 @@ static int64_t stat_at_path(guest_t *g,
             }
         }
     } else {
-        if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+        if (ref_err < 0)
+            return ref_err;
 
         int intercepted = PROC_NOT_INTERCEPTED;
         if (path_might_use_stat_intercept(tx.intercept_path)) {
@@ -319,9 +320,10 @@ int64_t sys_fstat(guest_t *g, int fd, uint64_t stat_gva)
     }
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0) {
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0) {
         log_debug("fstat(%d): invalid guest fd", fd);
-        return -LINUX_EBADF;
+        return ref_err;
     }
     if (fstat(host_ref.fd, &mac_st) < 0) {
         log_debug("fstat(%d->%d): host fstat failed errno=%d", fd, host_ref.fd,
@@ -577,8 +579,9 @@ int64_t sys_fstatfs(guest_t *g, int fd, uint64_t buf_gva)
     }
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     struct statfs mac_st;
     if (fstatfs(host_ref.fd, &mac_st) < 0) {

--- a/src/syscall/fs-xattr.c
+++ b/src/syscall/fs-xattr.c
@@ -221,8 +221,9 @@ int64_t sys_fgetxattr(guest_t *g,
                       uint64_t size)
 {
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     char name[LINUX_XATTR_NAME_MAX + 1];
     if (guest_read_str(g, name_gva, name, sizeof(name)) < 0) {
@@ -302,8 +303,9 @@ int64_t sys_fsetxattr(guest_t *g,
 int64_t sys_flistxattr(guest_t *g, int fd, uint64_t list_gva, uint64_t size)
 {
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     if (size == 0) {
         ssize_t ret = flistxattr(host_ref.fd, NULL, 0, 0);

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -722,8 +722,9 @@ int64_t sys_openat_path(guest_t *g,
     }
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     int host_fd =
         open_nonblocking_writer(dir_ref.fd, tx.host_path, flags, mode);
@@ -1475,8 +1476,9 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
             return shadow_fl;
 
         host_fd_ref_t host_ref;
-        if (host_fd_ref_open(fd, &host_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+        if (ref_err < 0)
+            return ref_err;
         int mac_fl = fcntl(host_ref.fd, F_GETFL);
         host_fd_ref_close(&host_ref);
         if (mac_fl < 0)
@@ -1577,8 +1579,9 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
             return -LINUX_EINVAL;
 
         host_fd_ref_t host_ref;
-        if (host_fd_ref_open(fd, &host_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+        if (ref_err < 0)
+            return ref_err;
 
         /* An owned fd keeps O_NONBLOCK on the host whatever the guest asks; the
          * request is recorded in the shadow below and the transfer paths read
@@ -1632,8 +1635,9 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
     case 6:   /* F_SETLK */
     case 7: { /* F_SETLKW */
         host_fd_ref_t host_ref;
-        if (host_fd_ref_open(fd, &host_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+        if (ref_err < 0)
+            return ref_err;
         int mac_cmd = (cmd == 5) ? F_GETLK : (cmd == 6) ? F_SETLK : F_SETLKW;
         int64_t rc = fcntl_flock_wait(g, &host_ref, arg, mac_cmd, cmd == 5,
                                       false, cmd == 7);
@@ -1645,8 +1649,9 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
     case 37:   /* F_OFD_SETLK */
     case 38: { /* F_OFD_SETLKW */
         host_fd_ref_t host_ref;
-        if (host_fd_ref_open(fd, &host_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+        if (ref_err < 0)
+            return ref_err;
         int mac_cmd = (cmd == 36)   ? F_OFD_GETLK
                       : (cmd == 37) ? F_OFD_SETLK
                                     : F_OFD_SETLKW;
@@ -1762,8 +1767,9 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
         return fd_table[fd].seals;
     case LINUX_F_ADD_SEALS: {
         host_fd_ref_t host_ref;
-        if (host_fd_ref_open(fd, &host_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+        if (ref_err < 0)
+            return ref_err;
         int cur = fd_table[fd].seals;
         /* Cannot add seals if F_SEAL_SEAL is already set */
         if (cur & LINUX_F_SEAL_SEAL) {
@@ -2059,8 +2065,9 @@ int64_t sys_fchdir(int fd)
         return fuse_rc;
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     char proc_virt[64];
     const char *proc_virtual = proc_virtual_dir_path(
@@ -2217,8 +2224,9 @@ int64_t sys_readlinkat(guest_t *g,
         return -LINUX_ENOSYS;
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* Apply sysroot redirect for absolute paths */
     ssize_t len = readlinkat(path_translation_dirfd(&tx, &dir_ref),
@@ -2253,8 +2261,9 @@ int64_t sys_unlinkat(guest_t *g, int dirfd, uint64_t path_gva, int flags)
         return rc;
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* path_translate_at rewrites /dev/shm/<name> to the absolute backing path,
      * so shm_unlink works; path_translation_dirfd drops the guest dirfd there.
@@ -2296,8 +2305,9 @@ int64_t sys_mkdirat(guest_t *g, int dirfd, uint64_t path_gva, int mode)
         return rc;
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     if (mkdirat(path_translation_dirfd(&tx, &dir_ref), tx.host_path,
                 (mode_t) mode) < 0) {
@@ -2348,11 +2358,13 @@ int64_t sys_renameat2(guest_t *g,
         return -LINUX_ENOSYS;
 
     host_fd_ref_t olddir_ref, newdir_ref;
-    if (host_dirfd_ref_open(olddirfd, &olddir_ref) < 0)
-        return -LINUX_EBADF;
-    if (host_dirfd_ref_open(newdirfd, &newdir_ref) < 0) {
+    int64_t ref_err = host_dirfd_ref_open(olddirfd, &olddir_ref);
+    if (ref_err < 0)
+        return ref_err;
+    ref_err = host_dirfd_ref_open(newdirfd, &newdir_ref);
+    if (ref_err < 0) {
         host_fd_ref_close(&olddir_ref);
-        return -LINUX_EBADF;
+        return ref_err;
     }
     host_fd_t old_host_dirfd = path_translation_dirfd(&old_tx, &olddir_ref);
     host_fd_t new_host_dirfd = path_translation_dirfd(&new_tx, &newdir_ref);
@@ -2451,8 +2463,9 @@ int64_t sys_mknodat(guest_t *g, int dirfd, uint64_t path_gva, int mode, int dev)
         return rc;
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* FIFO via mkfifoat and regular files via openat are supported; device
      * nodes need root
@@ -2608,8 +2621,9 @@ int64_t sys_symlinkat(guest_t *g,
         return rc;
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* An absolute target is stored verbatim, but the host kernel resolves it
      * against the real host root -- not --sysroot -- whenever anything follows
@@ -2675,11 +2689,13 @@ int64_t sys_linkat(guest_t *g,
         return -LINUX_ENOSYS;
 
     host_fd_ref_t olddir_ref, newdir_ref;
-    if (host_dirfd_ref_open(olddirfd, &olddir_ref) < 0)
-        return -LINUX_EBADF;
-    if (host_dirfd_ref_open(newdirfd, &newdir_ref) < 0) {
+    int64_t ref_err = host_dirfd_ref_open(olddirfd, &olddir_ref);
+    if (ref_err < 0)
+        return ref_err;
+    ref_err = host_dirfd_ref_open(newdirfd, &newdir_ref);
+    if (ref_err < 0) {
         host_fd_ref_close(&olddir_ref);
-        return -LINUX_EBADF;
+        return ref_err;
     }
     host_fd_t old_host_dirfd = path_translation_dirfd(&old_tx, &olddir_ref);
     host_fd_t new_host_dirfd = path_translation_dirfd(&new_tx, &newdir_ref);
@@ -2787,8 +2803,9 @@ int64_t sys_faccessat(guest_t *g,
     }
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* Check intercepted stat paths first since macOS has no /proc filesystem
      * and the sysfs CPU tree is synthetic. Access must reflect the synthetic
@@ -2832,8 +2849,9 @@ int64_t sys_ftruncate(int fd, int64_t length)
         return -LINUX_EPERM;
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     if (seals & (LINUX_F_SEAL_SHRINK | LINUX_F_SEAL_GROW)) {
         struct stat st;
@@ -2904,8 +2922,9 @@ int64_t sys_fchmod(int fd, uint32_t mode)
     if (fd_snapshot(fd, &snap) && snap.type == FD_PATH)
         return -LINUX_EBADF;
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
     if (fchmod(host_ref.fd, mode) < 0) {
         host_fd_ref_close(&host_ref);
         return linux_errno();
@@ -2957,8 +2976,9 @@ int64_t sys_fchmodat(guest_t *g,
             return -LINUX_EPERM;
 
         host_fd_ref_t ref;
-        if (host_dirfd_ref_open(dirfd, &ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_dirfd_ref_open(dirfd, &ref);
+        if (ref_err < 0)
+            return ref_err;
         if (fchmod(ref.fd, mode) < 0) {
             host_fd_ref_close(&ref);
             return linux_errno();
@@ -3004,8 +3024,9 @@ int64_t sys_fchmodat(guest_t *g,
         return 0;
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     int mac_flags = path_translation_at_flags(&tx, translate_at_flags(flags));
     if (fchmodat(path_translation_dirfd(&tx, &dir_ref), tx.host_path, mode,
@@ -3130,8 +3151,9 @@ int64_t sys_fchownat(guest_t *g,
             return -LINUX_EPERM;
 
         host_fd_ref_t ref;
-        if (host_dirfd_ref_open(dirfd, &ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_dirfd_ref_open(dirfd, &ref);
+        if (ref_err < 0)
+            return ref_err;
 
         int host_rc = fchown(ref.fd, owner, group);
         int saved_errno = errno;
@@ -3194,8 +3216,9 @@ int64_t sys_fchownat(guest_t *g,
     }
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     int mac_flags = path_translation_at_flags(&tx, translate_at_flags(flags));
     host_fd_t host_dirfd = path_translation_dirfd(&tx, &dir_ref);
@@ -3236,8 +3259,9 @@ int64_t sys_fchown(int fd, uint32_t owner, uint32_t group)
     if (fd_snapshot(fd, &snap) && snap.type == FD_PATH)
         return -LINUX_EBADF;
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     int host_rc = fchown(host_ref.fd, owner, group);
     int saved_errno = errno;
@@ -3287,8 +3311,9 @@ int64_t sys_utimensat(guest_t *g,
         return -LINUX_EINVAL;
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* If path is NULL (path_gva == 0), operate on the dirfd itself */
     const char *path_arg = NULL;

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -804,7 +804,13 @@ typedef struct {
 
 static inline fd_block_state_t fd_block_state_of(const fd_entry_t *e);
 
-static inline int host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
+/* Returns 0, or a negative Linux errno the caller propagates unchanged. A slot
+ * that is closed or out of range is -LINUX_EBADF; an open slot the pin could
+ * not be allocated for is -LINUX_ENOMEM, so a caller can tell a bad descriptor
+ * from a host that is out of memory. O_PATH entries are accepted here; the
+ * calls that Linux rejects on one use host_fd_ref_open_io() instead.
+ */
+static inline int64_t host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
 {
     ref->fd = -1;
     ref->lifetime = NULL;
@@ -812,7 +818,7 @@ static inline int host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
     if (thread_is_single_active()) {
         int host_fd = fd_to_host(guest_fd);
         if (host_fd < 0)
-            return -1;
+            return -LINUX_EBADF;
         ref->fd = host_fd;
         return 0;
     }
@@ -820,7 +826,7 @@ static inline int host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
     fd_entry_t snap;
     int host_fd = fd_host_ref_acquire(guest_fd, &snap, &ref->lifetime);
     if (host_fd < 0)
-        return -1;
+        return linux_errno();
     ref->fd = host_fd;
     return 0;
 }
@@ -830,9 +836,9 @@ static inline int host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
  * With one active thread there is no mutator and the two relaxed reads are
  * already consistent; with siblings alive both come from one fd_lock window.
  */
-static inline int host_fd_ref_open_state(guest_fd_t guest_fd,
-                                         host_fd_ref_t *ref,
-                                         fd_block_state_t *st_out)
+static inline int64_t host_fd_ref_open_state(guest_fd_t guest_fd,
+                                             host_fd_ref_t *ref,
+                                             fd_block_state_t *st_out)
 {
     ref->fd = -1;
     ref->lifetime = NULL;
@@ -846,7 +852,7 @@ static inline int host_fd_ref_open_state(guest_fd_t guest_fd,
     if (thread_is_single_active()) {
         int host_fd = fd_to_host(guest_fd);
         if (host_fd < 0)
-            return -1;
+            return -LINUX_EBADF;
         *st_out = fd_block_state(guest_fd);
         ref->fd = host_fd;
         return 0;
@@ -855,7 +861,7 @@ static inline int host_fd_ref_open_state(guest_fd_t guest_fd,
     fd_entry_t snap;
     int host_fd = fd_host_ref_acquire(guest_fd, &snap, &ref->lifetime);
     if (host_fd < 0)
-        return -1;
+        return linux_errno();
     *st_out = fd_block_state_of(&snap);
     ref->fd = host_fd;
     return 0;
@@ -876,7 +882,7 @@ static inline void host_fd_ref_close(host_fd_ref_t *ref)
 }
 
 /* Open a dirfd reference, treating LINUX_AT_FDCWD as AT_FDCWD. */
-static inline int host_dirfd_ref_open(guest_fd_t dirfd, host_fd_ref_t *ref)
+static inline int64_t host_dirfd_ref_open(guest_fd_t dirfd, host_fd_ref_t *ref)
 {
     if (dirfd == LINUX_AT_FDCWD) {
         ref->fd = AT_FDCWD;

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -1322,8 +1322,9 @@ static int64_t host_fd_ref_open_checked(int guest_fd,
                                         fd_block_state_t *st_out)
 {
     fd_block_state_t st;
-    if (host_fd_ref_open_state(guest_fd, ref, &st) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open_state(guest_fd, ref, &st);
+    if (ref_err < 0)
+        return ref_err;
 
     if (st.type == FD_PATH || (st.seals & LINUX_F_SEAL_WRITE)) {
         int64_t err = (st.type == FD_PATH) ? -LINUX_EBADF : -LINUX_EPERM;
@@ -1886,8 +1887,9 @@ static int64_t vec_zero_iovcnt(int fd, bool op_is_write, bool positional)
         return 0;
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     int64_t ret = 0;
     if (positional && lseek(host_ref.fd, 0, SEEK_CUR) < 0 && errno == ESPIPE)

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -1079,10 +1079,11 @@ static int64_t sys_mmap_high_va(guest_t *g,
             }
             close_host_backing_fd = true;
         } else {
-            if (host_fd_ref_open(fd, &backing_ref) < 0) {
+            int64_t ref_err = host_fd_ref_open(fd, &backing_ref);
+            if (ref_err < 0) {
                 if (replaced_remove_fd >= 0)
                     close(replaced_remove_fd);
-                return -LINUX_EBADF;
+                return ref_err;
             }
             host_backing_fd = backing_ref.fd;
         }
@@ -2869,9 +2870,10 @@ int64_t sys_mmap(guest_t *g,
         }
 
         if (!is_anon) {
-            if (host_fd_ref_open(fd, &fresh.backing_ref) < 0) {
+            int64_t ref_err = host_fd_ref_open(fd, &fresh.backing_ref);
+            if (ref_err < 0) {
                 mmap_fresh_dispose(&fresh);
-                return -LINUX_EBADF;
+                return ref_err;
             }
             host_backing_fd = fresh.backing_ref.fd;
         }
@@ -3095,9 +3097,10 @@ int64_t sys_mmap(guest_t *g,
          * Closes on every failure path within the non-fixed branch.
          */
         if (!is_anon) {
-            if (host_fd_ref_open(fd, &fresh.backing_ref) < 0) {
+            int64_t ref_err = host_fd_ref_open(fd, &fresh.backing_ref);
+            if (ref_err < 0) {
                 mmap_fresh_dispose(&fresh);
-                return -LINUX_EBADF;
+                return ref_err;
             }
             host_backing_fd = fresh.backing_ref.fd;
         }

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -149,8 +149,9 @@ int64_t sys_sendmsg(guest_t *g, int fd, uint64_t msg_gva, int linux_flags)
 
     host_fd_ref_t host_ref;
     fd_block_state_t sock_st;
-    if (host_fd_ref_open_state(fd, &host_ref, &sock_st) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &sock_st);
+    if (ref_err < 0)
+        return ref_err;
 
     linux_msghdr_t lmsg;
     if (guest_read_small(g, msg_gva, &lmsg, sizeof(lmsg)) < 0) {
@@ -468,8 +469,9 @@ int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
 
     host_fd_ref_t host_ref;
     fd_block_state_t sock_st;
-    if (host_fd_ref_open_state(fd, &host_ref, &sock_st) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &sock_st);
+    if (ref_err < 0)
+        return ref_err;
 
     linux_msghdr_t lmsg;
     if (guest_read_small(g, msg_gva, &lmsg, sizeof(lmsg)) < 0) {
@@ -1061,8 +1063,9 @@ int64_t sys_sendmmsg(guest_t *g,
         host_fd_ref_t host_ref;
 
         fd_block_state_t sock_st;
-        if (host_fd_ref_open_state(fd, &host_ref, &sock_st) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &sock_st);
+        if (ref_err < 0)
+            return ref_err;
         if (guest_read_small(g, msg_gva, &lmsg, sizeof(lmsg)) < 0) {
             host_fd_ref_close(&host_ref);
             return -LINUX_EFAULT;
@@ -1160,8 +1163,9 @@ int64_t sys_recvmmsg(guest_t *g,
         host_fd_ref_t host_ref;
 
         fd_block_state_t sock_st;
-        if (host_fd_ref_open_state(fd, &host_ref, &sock_st) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &sock_st);
+        if (ref_err < 0)
+            return ref_err;
         if (guest_read_small(g, msg_gva, &lmsg, sizeof(lmsg)) < 0) {
             host_fd_ref_close(&host_ref);
             return -LINUX_EFAULT;
@@ -1285,8 +1289,9 @@ int64_t sys_recvmmsg(guest_t *g,
         linux_timespec_t ts;
         if (guest_read_small(g, timeout_gva, &ts, sizeof(ts)) == 0) {
             host_fd_ref_t host_ref;
-            if (host_fd_ref_open(fd, &host_ref) < 0)
-                return -LINUX_EBADF;
+            int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+            if (ref_err < 0)
+                return ref_err;
             if (ts.tv_sec < 0 || !RANGE_CHECK(ts.tv_nsec, 0, 1000000000LL)) {
                 host_fd_ref_close(&host_ref);
                 return -LINUX_EINVAL;

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -527,8 +527,9 @@ int64_t sys_bind(guest_t *g, int fd, uint64_t addr_gva, uint32_t addrlen)
         return netlink_bind(fd, g, addr_gva, addrlen);
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     uint8_t linux_sa[128];
     if (addrlen > sizeof(linux_sa)) {
@@ -583,8 +584,9 @@ int64_t sys_bind(guest_t *g, int fd, uint64_t addr_gva, uint32_t addrlen)
 int64_t sys_listen(int fd, int backlog)
 {
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     if (listen(host_ref.fd, backlog) < 0) {
         host_fd_ref_close(&host_ref);
@@ -613,8 +615,9 @@ static int64_t do_accept(guest_t *g,
     fd_block_state_t sock_st = {.type = FD_CLOSED};
 
     if (thread_is_single_active()) {
-        if (host_fd_ref_open_state(fd, &host_ref, &sock_st) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &sock_st);
+        if (ref_err < 0)
+            return ref_err;
         listener_type = fd_table[fd].type;
         listener_generation = fd_table[fd].generation;
         if (listener_type == FD_SOCKET)
@@ -748,8 +751,9 @@ int64_t sys_connect(guest_t *g, int fd, uint64_t addr_gva, uint32_t addrlen)
 {
     host_fd_ref_t host_ref;
     fd_block_state_t sock_st;
-    if (host_fd_ref_open_state(fd, &host_ref, &sock_st) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &sock_st);
+    if (ref_err < 0)
+        return ref_err;
 
     uint8_t linux_sa[128];
     if (addrlen > sizeof(linux_sa)) {
@@ -940,8 +944,9 @@ int64_t sys_getsockname(guest_t *g,
         return netlink_getsockname(fd, g, addr_gva, addrlen_gva);
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     struct sockaddr_storage mac_sa;
     socklen_t mac_len = sizeof(mac_sa);
@@ -996,8 +1001,9 @@ int64_t sys_getpeername(guest_t *g,
                         uint64_t addrlen_gva)
 {
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     struct sockaddr_storage mac_sa;
     socklen_t mac_len = sizeof(mac_sa);
@@ -1031,8 +1037,9 @@ int64_t sys_sendto(guest_t *g,
 
     host_fd_ref_t host_ref;
     fd_block_state_t send_st;
-    if (host_fd_ref_open_state(fd, &host_ref, &send_st) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &send_st);
+    if (ref_err < 0)
+        return ref_err;
 
     uint64_t avail = 0;
     void *buf =
@@ -1164,8 +1171,9 @@ int64_t sys_recvfrom(guest_t *g,
 
     host_fd_ref_t host_ref;
     fd_block_state_t recv_st;
-    if (host_fd_ref_open_state(fd, &host_ref, &recv_st) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open_state(fd, &host_ref, &recv_st);
+    if (ref_err < 0)
+        return ref_err;
 
     uint64_t avail = 0;
     void *buf =
@@ -1481,8 +1489,9 @@ int64_t sys_setsockopt(guest_t *g,
     }
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     int mac_level = level, mac_optname = optname;
 
@@ -1647,8 +1656,9 @@ int64_t sys_getsockopt(guest_t *g,
     }
 
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     int mac_level = level, mac_optname = optname;
     int small_int_opt = socket_opt_uses_small_int(level, optname);
@@ -1771,8 +1781,9 @@ getsockopt_translated:
 int64_t sys_shutdown(int fd, int how)
 {
     host_fd_ref_t host_ref;
-    if (host_fd_ref_open(fd, &host_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* Shutdown constants are identical on Linux and macOS */
     if (shutdown(host_ref.fd, how) < 0) {

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -560,8 +560,9 @@ int path_translate_at(guest_fd_t dirfd,
         host_fd_ref_t ref;
         casefold_verdict_t verdict;
 
-        if (host_dirfd_ref_open(dirfd, &ref) < 0) {
-            errno = EBADF;
+        int64_t ref_err = host_dirfd_ref_open(dirfd, &ref);
+        if (ref_err < 0) {
+            errno = (ref_err == -LINUX_ENOMEM) ? ENOMEM : EBADF;
             return -1;
         }
         verdict = casefold_resolve_at(ref.fd, "", tx->guest_path, follow_final,
@@ -815,8 +816,9 @@ int sys_path_has_symlink(guest_fd_t dirfd, const char *path)
             clamp = true;
         }
 
-        if (host_dirfd_ref_open(dirfd, &dir_ref) < 0) {
-            errno = EBADF;
+        int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+        if (ref_err < 0) {
+            errno = (ref_err == -LINUX_ENOMEM) ? ENOMEM : EBADF;
             return -1;
         }
         if (dir_ref.fd == AT_FDCWD) {
@@ -1241,8 +1243,9 @@ static int path_openat2_dirfd_host_path(guest_fd_t dirfd,
     }
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0) {
-        errno = EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0) {
+        errno = (ref_err == -LINUX_ENOMEM) ? ENOMEM : EBADF;
         return -1;
     }
     int rc = fcntl(dir_ref.fd, F_GETPATH, out);
@@ -1562,8 +1565,9 @@ static int dirfd_symlink_chain_reaches_absolute_target(guest_fd_t dirfd,
                                                        const char *path)
 {
     host_fd_ref_t ref;
-    if (host_dirfd_ref_open(dirfd, &ref) < 0) {
-        errno = EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &ref);
+    if (ref_err < 0) {
+        errno = (ref_err == -LINUX_ENOMEM) ? ENOMEM : EBADF;
         return -1;
     }
 
@@ -1842,8 +1846,9 @@ static int open_guest_walk_root_fd(guest_fd_t dirfd,
     }
 
     host_fd_ref_t dir_ref;
-    if (host_dirfd_ref_open(dirfd, &dir_ref) < 0) {
-        errno = EBADF;
+    int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+    if (ref_err < 0) {
+        errno = (ref_err == -LINUX_ENOMEM) ? ENOMEM : EBADF;
         return -1;
     }
 

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -225,8 +225,19 @@ int64_t sys_ppoll(guest_t *g,
         int guest_fd = guest_fds[i].fd;
         int host_fd = -1;
         if (guest_fd >= 0) {
-            if (host_fd_ref_open_io_gen(guest_fd, &host_refs[i],
-                                        &guest_gen[i]) < 0) {
+            int64_t rc =
+                host_fd_ref_open_io_gen(guest_fd, &host_refs[i], &guest_gen[i]);
+            if (rc == -LINUX_ENOMEM) {
+                /* The pin could not be allocated. POLLNVAL here would name a
+                 * descriptor that is still open, and the usual reaction to
+                 * POLLNVAL is to close it, so a guest under memory pressure
+                 * would tear down its own working fds. Fail the whole wait with
+                 * the errno Linux uses when it cannot build the tables for one.
+                 */
+                host_fd_refs_close(host_refs, i);
+                return -LINUX_ENOMEM;
+            }
+            if (rc < 0) {
                 need_pollnval[i] = true;
                 invalid_count++;
             } else {
@@ -710,7 +721,10 @@ int64_t sys_pselect6(guest_t *g,
                 }
                 int i = (int) fd_index;
                 host_fd_ref_t ref = HOST_FD_REF_INIT;
-                if (host_fd_ref_open_io(i, &ref) < 0)
+                int64_t rc = host_fd_ref_open_io(i, &ref);
+                if (rc == -LINUX_ENOMEM)
+                    goto pselect_nomem;
+                if (rc < 0)
                     goto pselect_badf;
                 int host_fd = ref.fd;
                 reqs[req_count].host_fd = host_fd;
@@ -971,6 +985,9 @@ pselect_inval:
     goto pselect_cleanup;
 pselect_badf:
     err = -LINUX_EBADF;
+    goto pselect_cleanup;
+pselect_nomem:
+    err = -LINUX_ENOMEM;
 pselect_cleanup:
     for (int i = 0; i < req_count; i++)
         host_fd_ref_close(&reqs[i].ref);
@@ -1355,8 +1372,9 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         return -LINUX_EINVAL;
 
     host_fd_ref_t epoll_ref;
-    if (host_fd_ref_open(epfd, &epoll_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(epfd, &epoll_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     /* Pin the instance so a concurrent close(epfd) cannot free it under us. */
     epoll_instance_t *inst = epoll_instance_acquire(epfd);
@@ -1637,8 +1655,9 @@ int64_t sys_epoll_pwait(guest_t *g,
                         uint64_t sigmask_gva)
 {
     host_fd_ref_t epoll_ref;
-    if (host_fd_ref_open(epfd, &epoll_ref) < 0)
-        return -LINUX_EBADF;
+    int64_t ref_err = host_fd_ref_open(epfd, &epoll_ref);
+    if (ref_err < 0)
+        return ref_err;
 
     if (maxevents <= 0) {
         host_fd_ref_close(&epoll_ref);

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -1594,8 +1594,13 @@ static int64_t sc_flock(guest_t *g,
     (void) verbose;
     host_fd_ref_t host_ref;
     int64_t err = host_fd_ref_open_io((int) x0, &host_ref);
-    if (err < 0)
-        return err;
+    if (err < 0) {
+        /* ENOMEM is not in flock(2)'s errno set. Linux answers a lock it has no
+         * room to record with ENOLCK, so spell the shortage the way a guest
+         * checking flock's documented values can read it.
+         */
+        return err == -LINUX_ENOMEM ? -LINUX_ENOLCK : err;
+    }
 
     /* A blocking flock parks the vCPU thread where no teardown wake reaches it,
      * so poll LOCK_NB instead. An explicit LOCK_NB, and LOCK_UN which never

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -2213,8 +2213,9 @@ static int64_t sc_execveat(guest_t *g,
         /* path_gva is already x1, use directly */
     } else if (flags & LINUX_AT_EMPTY_PATH) {
         host_fd_ref_t dir_ref;
-        if (host_fd_ref_open(dirfd, &dir_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_fd_ref_open(dirfd, &dir_ref);
+        if (ref_err < 0)
+            return ref_err;
         if (fcntl(dir_ref.fd, F_GETPATH, resolved) < 0) {
             host_fd_ref_close(&dir_ref);
             return -LINUX_ENOENT;
@@ -2239,8 +2240,9 @@ static int64_t sc_execveat(guest_t *g,
         if (tx.fuse_path || tx.proc_resolved != 0)
             return -LINUX_ENOSYS;
         host_fd_ref_t dir_ref;
-        if (host_dirfd_ref_open(dirfd, &dir_ref) < 0)
-            return -LINUX_EBADF;
+        int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
+        if (ref_err < 0)
+            return ref_err;
 
         /* O_CLOEXEC: the descriptor is closed a few lines below, but a
          * concurrent execve on another vCPU thread inside that window would


### PR DESCRIPTION
## Summary

#324 split "this slot is not open" from "the pin could not be allocated" in `fd_host_ref_acquire`, and taught `host_fd_ref_open_io_state` to report the difference. Its commit message names what it left behind:

> The rest of the tree still collapses the two through `host_fd_ref_open`, which cannot express the difference without changing its return type at 55 call sites.

This is that change. `host_fd_ref_open`, `host_fd_ref_open_state` and `host_dirfd_ref_open` return `int64_t` — 0 or a negative Linux errno — and the call sites propagate it instead of spelling `-LINUX_EBADF` themselves. A closed or out-of-range slot is still `-LINUX_EBADF`; the allocation failure is `-LINUX_ENOMEM`.

The count matches: 55 `return -LINUX_EBADF`, 5 `errno = EBADF`, and 4 `return -1` inside the helpers.

## What it changes for a guest

`ppoll` and `pselect6` are the two callers that could not express the shortage at all. `ppoll` marked the entry `POLLNVAL` and kept going, which names a descriptor the guest still holds as invalid, and the usual reaction to `POLLNVAL` is to close it. `pselect6` failed the whole call with `EBADF`. Both answer with `ENOMEM` now, which is what Linux returns when it cannot build the tables for a wait. `ppoll` releases the references it took for the entries ahead of the failure before returning.

The three `path.c` callers set `errno` from the helper's return rather than overwriting it with `EBADF`.

`flock` is remapped separately in the second commit: `flock(2)` does not document `ENOMEM`, and Linux spells a lock it has no room to record as `ENOLCK`. The other `_io` callers — `read`, `ioctl`, `splice`, `copy_file_range`, `fsync` — either document `ENOMEM` or have no better value, and a resource failure is closer to the truth there than the `EBADF` they used to give.

## What this does not prove

There is no test. I want to be straight about why rather than have it come up in review.

After #324 the only path to `ENOMEM` is `malloc` returning NULL for an `fd_lifetime_t` in `fd_host_ref_acquire`. A guest program has no lever on the host allocator, so no test under `tests/` can drive it. Before #324 it was reachable — the per-call `dup()` failed with `EMFILE` once the host table filled, which `ulimit -n` can force — and `tests/test-poll-fd-exhaustion.c` on this branch did exactly that. Pinning removed the `dup`, and with it both the failure and the way to reach it: that test now passes against an unmodified `main`. I dropped it rather than leave an assertion in the tree that can no longer fail.

Forcing the allocator would mean interposing `malloc` for the host-side unit binaries, which this tree has no machinery for. That felt like a larger and separate proposal than the return-type change, so I left it out; happy to add it if you would rather this land with a lane behind it.

So: no observable behaviour change today, and nothing here guards against a regression. What it buys is that the distinction `fd_host_ref_acquire` already makes survives the boundary, and that the next caller that can fail for a reason other than a bad descriptor does not have to change 63 sites first.

## Checks

`make check` (38 lanes, 0 failed), `make check-format` (49 scripts), all six `.ci/*.sh`, `make lint` — rc=0, with no new clang-tidy warning on a touched line.

## History

This branch previously argued that `ppoll`/`pselect6` exhausted the host descriptor table by duplicating. #324 removed the duplication, so that argument no longer holds and the tests built on it no longer fail on `main`. The branch is rebased and rewritten to the scope above. The `fuse.c` collapse from the earlier review is already fixed upstream at `fuse.c:2418`; the `flock` errno and the settle sleep are addressed here (the sleep lived in a test that is gone).
