### PR TITLE
Pin host file descriptors instead of duplicating them for multi-threaded fd syscalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,13 @@ $(BUILD_DIR)/test-eventfd-semaphore-contended: \
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
 
+# test-fd-pin-lock keeps a sibling thread live so the fd syscalls under test
+# take the multi-threaded pin path rather than the single-active fast path.
+$(BUILD_DIR)/test-fd-pin-lock: \
+		tests/test-fd-pin-lock.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
+
 # test-socket-accept-contended parks two threads on one listener.
 $(BUILD_DIR)/test-socket-accept-contended: \
 		tests/test-socket-accept-contended.c | $(BUILD_DIR)

--- a/frama-c-stubs/Hypervisor/Hypervisor.h
+++ b/frama-c-stubs/Hypervisor/Hypervisor.h
@@ -120,14 +120,34 @@ typedef struct {
 hv_return_t hv_vcpu_destroy(hv_vcpu_t vcpu);
 hv_return_t hv_vcpu_run(hv_vcpu_t vcpu);
 hv_return_t hv_vcpus_exit(hv_vcpu_t *vcpus, unsigned int vcpu_count);
+
+/* Contracts on the register accessors, not just declarations. Without an
+ * assigns clause WP must assume the call writes anywhere, which defeats the
+ * assigns clause of every caller it appears in. The frame is what the API
+ * documents: the call fills the out-parameter and touches nothing else the
+ * caller can name. HVF's vCPU state is not in the C memory model, so there is
+ * nothing else to state.
+ */
+/*@
+  requires \valid(value);
+  assigns *value;
+ */
 hv_return_t hv_vcpu_get_reg(hv_vcpu_t vcpu, hv_reg_t reg, uint64_t *value);
 hv_return_t hv_vcpu_set_reg(hv_vcpu_t vcpu, hv_reg_t reg, uint64_t value);
+/*@
+  requires \valid(value);
+  assigns *value;
+ */
 hv_return_t hv_vcpu_get_sys_reg(hv_vcpu_t vcpu,
                                 hv_sys_reg_t reg,
                                 uint64_t *value);
 hv_return_t hv_vcpu_set_sys_reg(hv_vcpu_t vcpu,
                                 hv_sys_reg_t reg,
                                 uint64_t value);
+/*@
+  requires \valid(value);
+  assigns *value;
+ */
 hv_return_t hv_vcpu_get_simd_fp_reg(hv_vcpu_t vcpu,
                                     hv_simd_fp_reg_t reg,
                                     hv_simd_fp_uchar16_t *value);

--- a/frama-c-stubs/mach/arm/thread_status.h
+++ b/frama-c-stubs/mach/arm/thread_status.h
@@ -1,0 +1,25 @@
+/*
+ * Mach arm64 thread-state stub for Frama-C
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * macOS supplies this header; Frama-C's modeled libc does not, and its absence
+ * is the only thing that stopped src/syscall/signal.c from parsing. Only the
+ * one name signal.c reaches for is declared: arm_thread_state64_set_pc_fptr,
+ * which on a real arm64e host signs the pointer before storing it and on arm64
+ * is a plain assignment. The proof does not depend on which, because no proved
+ * function touches thread state; this exists so the file parses at all.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifndef __arm_thread_state64_stub_defined
+#define __arm_thread_state64_stub_defined
+
+#define arm_thread_state64_set_pc_fptr(ts, fptr) \
+    ((void) ((ts).__pc = (uint64_t) (uintptr_t) (void *) (fptr)))
+
+#endif

--- a/frama-c-stubs/sys/ucontext.h
+++ b/frama-c-stubs/sys/ucontext.h
@@ -1,0 +1,57 @@
+/*
+ * Darwin ucontext stub for Frama-C
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * macOS supplies this header; Frama-C's modeled libc does not. src/syscall/
+ * signal.c reaches into a host ucontext in exactly one place, the SIGBUS
+ * recovery handler, which redirects the interrupted context's PC. Only the
+ * shape that reaches it needs declaring: uc_mcontext is a pointer to a machine
+ * context whose __ss member carries the arm64 thread state.
+ *
+ * The Linux sigcontext the guest sees is elfuse's own type in
+ * syscall/linux-wire.h and has nothing to do with this one. Both appear in
+ * signal.c; do not conflate them when reading it.
+ */
+
+#pragma once
+
+#ifndef __darwin_ucontext_stub_defined
+#define __darwin_ucontext_stub_defined
+
+#include <stdint.h>
+
+struct __darwin_arm_thread_state64 {
+    uint64_t __x[29];
+    uint64_t __fp;
+    uint64_t __lr;
+    uint64_t __sp;
+    uint64_t __pc;
+    uint32_t __cpsr;
+    uint32_t __pad;
+};
+
+/* __es first, as on the real SDK, so __ss sits at its true offset of 16. No
+ * proof reasons about the offset today and nothing here is compiled for real,
+ * but a stub that silently disagrees with the header it stands in for is the
+ * kind that answers a future question wrongly.
+ */
+struct __darwin_arm_exception_state64 {
+    uint64_t __far;
+    uint32_t __esr;
+    uint32_t __exception;
+};
+
+struct __darwin_mcontext64 {
+    struct __darwin_arm_exception_state64 __es;
+    struct __darwin_arm_thread_state64 __ss;
+};
+
+typedef struct __darwin_ucontext {
+    int uc_onstack;
+    unsigned int uc_sigmask;
+    struct __darwin_mcontext64 *uc_mcontext;
+} ucontext_t;
+
+#endif

--- a/mk/verify.mk
+++ b/mk/verify.mk
@@ -256,12 +256,29 @@ VERIFY_NETLINKWALK_UNPROVED := the reply builders, the socket I/O, and whether \
 their callers honor these preconditions stay test-covered
 
 VERIFY_SIGFRAME_SRC  := src/proved/sigframe.h
-VERIFY_SIGFRAME_FCTS := sigframe_base
-VERIFY_SIGFRAME_MIN_GOALS ?= 15
+VERIFY_SIGFRAME_FCTS := sigframe_base sigframe_fpsimd_vreg_offset
+VERIFY_SIGFRAME_MIN_GOALS ?= 20
 VERIFY_SIGFRAME_MODEL := typed
 VERIFY_SIGFRAME_SCAN := src/proved/sigframe.h
-VERIFY_SIGFRAME_CLAIM := for ANY interrupted stack pointer and frame size
-VERIFY_SIGFRAME_UNPROVED := the frame field layout is not covered at all yet
+VERIFY_SIGFRAME_CLAIM := for ANY interrupted stack pointer and frame size, \
+and ANY vector register index
+VERIFY_SIGFRAME_UNPROVED := the 32-store FPSIMD loop that consumes the offset \
+stays test-covered, and so do the magic and size values
+
+# A whole-function proof of build_sigcontext_reserved in src/syscall/signal.c
+# was tried and is not here. It reaches 67 of 71 with the Bytes model, and the
+# four that stay open are Z3 timeouts on the store loop's frame condition, not
+# counterexamples: they survive a 180-second per-goal timeout and a frame
+# narrowed from the whole 4096-byte reserved area to the 552 bytes the chain
+# writes. Splitting the offset arithmetic into sigframe_fpsimd_vreg_offset above
+# is what that attempt bought, and the loop that consumes it stays test-covered.
+# The ACSL on the function itself is left in place: it is correct, it states the
+# frame, and it is what a stronger model would need to start from.
+#
+# What the attempt did settle is that signal.c parses at all, which it did not
+# before: its one _Atomic(T *) is now spelled as the qualifier form, and the two
+# Darwin headers it reaches for have stubs (frama-c-stubs/mach, frama-c-stubs/
+# sys/ucontext.h). That is a prerequisite for any later proof in this file.
 
 VERIFY_DIRENT_SRC  := src/proved/dirent.h
 VERIFY_DIRENT_FCTS := dirent_reclen dirent_record_bounds

--- a/scripts/check-mutants.py
+++ b/scripts/check-mutants.py
@@ -505,6 +505,22 @@ MUTATIONS = [
         "    *base = candidate;",
         "    *base = floor - floor % SIGFRAME_ALIGN;",
     ),
+    (
+        "sigframe",
+        "src/proved/sigframe.h",
+        "sigframe_fpsimd_vreg_offset",
+        "shift every vector register one slot up (V31 writes past the record)",
+        "    return SIGFRAME_FPSIMD_VREG_BASE + n * SIGFRAME_FPSIMD_VREG_BYTES;",
+        "    return SIGFRAME_FPSIMD_VREG_BASE + (n + 1) * SIGFRAME_FPSIMD_VREG_BYTES;",
+    ),
+    (
+        "sigframe",
+        "src/proved/sigframe.h",
+        "sigframe_fpsimd_vreg_offset",
+        "drop the header base (V0 lands on FPSR and FPCR)",
+        "    return SIGFRAME_FPSIMD_VREG_BASE + n * SIGFRAME_FPSIMD_VREG_BYTES;",
+        "    return n * SIGFRAME_FPSIMD_VREG_BYTES;",
+    ),
     # ---- verify-elf --------------------------------------------------------
     (
         "elf",

--- a/src/proved/sigframe.h
+++ b/src/proved/sigframe.h
@@ -91,3 +91,35 @@ static inline int sigframe_base(uint64_t sp,
     *base = candidate;
     return 1;
 }
+
+/* Layout of the FPSIMD record inside sigcontext.__reserved: an 8-byte framing
+ * header, FPSR and FPCR, then V0-V31 at 16 bytes each. The record is the first
+ * in the chain, so these offsets are relative to both the record and the
+ * reserved area.
+ */
+#define SIGFRAME_FPSIMD_VREG_BASE 16U
+#define SIGFRAME_FPSIMD_VREG_BYTES 16U
+#define SIGFRAME_FPSIMD_VREG_COUNT 32U
+#define SIGFRAME_FPSIMD_BYTES    \
+    (SIGFRAME_FPSIMD_VREG_BASE + \
+     SIGFRAME_FPSIMD_VREG_COUNT * SIGFRAME_FPSIMD_VREG_BYTES)
+
+/* Byte offset of vector register n within the FPSIMD record.
+ *
+ * Split out of the store loop in signal.c so the bound is proved once here
+ * rather than re-derived by the prover at every iteration, which is where a
+ * whole-loop proof of that function times out. The postcondition is what the
+ * caller needs: the 16 bytes at the returned offset land inside the record.
+ */
+/*@
+  requires n < SIGFRAME_FPSIMD_VREG_COUNT;
+  assigns \nothing;
+  ensures \result == SIGFRAME_FPSIMD_VREG_BASE +
+                     n * SIGFRAME_FPSIMD_VREG_BYTES;
+  ensures \result >= SIGFRAME_FPSIMD_VREG_BASE;
+  ensures \result + SIGFRAME_FPSIMD_VREG_BYTES <= SIGFRAME_FPSIMD_BYTES;
+ */
+static inline uint32_t sigframe_fpsimd_vreg_offset(uint32_t n)
+{
+    return SIGFRAME_FPSIMD_VREG_BASE + n * SIGFRAME_FPSIMD_VREG_BYTES;
+}

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -284,7 +284,7 @@ int fork_ipc_send_fd_table(int ipc_sock)
 {
     ipc_fd_entry_t fd_entries[FD_TABLE_SIZE];
     int host_fds_to_send[FD_TABLE_SIZE];
-    bool host_fds_duped[FD_TABLE_SIZE];
+    fd_lifetime_t *host_fd_pins[FD_TABLE_SIZE];
     uint32_t num_fds = 0;
 
     pthread_mutex_lock(&fd_lock);
@@ -302,17 +302,22 @@ int fork_ipc_send_fd_table(int ipc_sock)
         if (fd_type_is_synthetic(t))
             continue;
 
-        int host_fd;
-        bool was_duped = false;
+        /* Pin rather than dup. SCM_RIGHTS does not consume the sender's
+         * descriptor, so the dup only ever existed to keep the host fd valid
+         * across the window between dropping fd_lock and sendmsg, where a
+         * sibling's close could free the number for the next open to claim. The
+         * pin covers that window without a second descriptor, and without the
+         * close that retired it: closing any descriptor for a file drops the
+         * whole process's POSIX record locks on it (fcntl(2)), so the dup
+         * silently dropped every lock the guest held every time it forked.
+         */
+        fd_lifetime_t *pin = NULL;
         if (t != FD_STDIO) {
-            int duped = dup(fd_table[i].host_fd);
-            if (duped < 0)
+            pin = fd_lifetime_pin_locked(i);
+            if (!pin)
                 continue;
-            host_fd = duped;
-            was_duped = true;
-        } else {
-            host_fd = fd_table[i].host_fd;
         }
+        int host_fd = fd_table[i].host_fd;
 
         fd_entries[num_fds].guest_fd = i;
         fd_entries[num_fds].type = fd_table[i].type;
@@ -327,7 +332,7 @@ int fork_ipc_send_fd_table(int ipc_sock)
         memcpy(fd_entries[num_fds].proc_path, fd_table[i].proc_path,
                sizeof(fd_entries[num_fds].proc_path));
         host_fds_to_send[num_fds] = host_fd;
-        host_fds_duped[num_fds] = was_duped;
+        host_fd_pins[num_fds] = pin;
         num_fds++;
     }
     pthread_mutex_unlock(&fd_lock);
@@ -345,15 +350,23 @@ int fork_ipc_send_fd_table(int ipc_sock)
         }
     }
 
+    /* Release only. The pin leaves a lifetime installed on every non-stdio slot
+     * for the rest of the process, which refuses fd_close_regular_relaxed for
+     * all of them, and tearing them back down here was tried and reverted: it
+     * is not a leak, since the slot frees the object at close, and the close it
+     * slows down does not measurably slow down. Median over three runs of 200
+     * fds held across a fork, closed after: 1.04x an unpinned close without the
+     * teardown, 1.02x with, against run-to-run noise of about 10%.
+     */
     for (uint32_t fi = 0; fi < num_fds; fi++)
-        if (host_fds_duped[fi])
-            close(host_fds_to_send[fi]);
+        if (host_fd_pins[fi])
+            fd_lifetime_release(host_fd_pins[fi]);
     return 0;
 
 fail:
     for (uint32_t fi = 0; fi < num_fds; fi++)
-        if (host_fds_duped[fi])
-            close(host_fds_to_send[fi]);
+        if (host_fd_pins[fi])
+            fd_lifetime_release(host_fd_pins[fi]);
     return -1;
 }
 
@@ -504,16 +517,14 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
                 if (dir_fd < 0) {
                     log_error("fork-child: dup failed for DIR gfd %d: %s", gfd,
                               strerror(errno));
-                    close(host_fds[i]);
-                    fd_mark_closed(gfd);
+                    fd_retire_published(gfd, host_fds[i]);
                     continue;
                 }
                 DIR *dir = fdopendir(dir_fd);
                 if (!dir) {
                     close(dir_fd);
                     log_error("fork-child: fdopendir failed for gfd %d", gfd);
-                    close(host_fds[i]);
-                    fd_mark_closed(gfd);
+                    fd_retire_published(gfd, host_fds[i]);
                     continue;
                 }
                 void *ds = dir_stream_create(dir);
@@ -521,8 +532,7 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
                     closedir(dir);
                     log_error("fork-child: dir_stream_create failed for gfd %d",
                               gfd);
-                    close(host_fds[i]);
-                    fd_mark_closed(gfd);
+                    fd_retire_published(gfd, host_fds[i]);
                     continue;
                 }
                 fd_table[gfd].dir = ds;

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -2797,21 +2797,23 @@ int proc_intercept_open(const guest_t *g,
             return -1;
         }
 
-        /* fd_to_host_dup atomically duplicates under fd_lock so a concurrent
-         * close+reopen on another vCPU cannot redirect the lseek to an
-         * unrelated host fd that took the freed slot. The probe pollutes errno
-         * with ESPIPE on non-seekable fds (sockets, pipes), so save and restore
-         * around the call to keep the caller's view clean.
+        /* Pin under fd_lock so a concurrent close+reopen on another vCPU cannot
+         * redirect the lseek to an unrelated host fd that took the freed slot.
+         * A dup would answer that too, but retiring it would drop the guest's
+         * record locks on the file (fcntl(2)), and reading /proc/self/fdinfo
+         * must not unlock anything. The probe pollutes errno with ESPIPE on
+         * non-seekable fds (sockets, pipes), so save and restore around the
+         * call to keep the caller's view clean.
          */
         off_t pos = 0;
-        int dup_fd = fd_to_host_dup(n);
-        if (dup_fd >= 0) {
+        host_fd_ref_t probe_ref;
+        if (host_fd_ref_open(n, &probe_ref) == 0) {
             int saved_errno = errno;
-            off_t probe = lseek(dup_fd, 0, SEEK_CUR);
+            off_t probe = lseek(probe_ref.fd, 0, SEEK_CUR);
             if (probe >= 0)
                 pos = probe;
             errno = saved_errno;
-            close(dup_fd);
+            host_fd_ref_close(&probe_ref);
         }
 
         char extra[160];

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -960,6 +960,237 @@ int64_t exec_run_handoff(hv_vcpu_t vcpu, guest_t *g, bool verbose)
     return rc == SYSCALL_EXEC_HAPPENED ? SYSCALL_EXEC_HAPPENED : 0;
 }
 
+/* Where segment i of a loaded image lands in the guest, given the base the
+ * image was mapped at. The page-table region list and the /proc/self/maps list
+ * are both derived from these, which is the only reason the two agree; each
+ * used to recompute the arithmetic itself, twice over for the executable and
+ * the interpreter.
+ */
+static inline uint64_t exec_seg_start(const elf_info_t *info,
+                                      int i,
+                                      uint64_t base)
+{
+    return info->segments[i].gpa + base;
+}
+
+static inline uint64_t exec_seg_end(const elf_info_t *info,
+                                    int i,
+                                    uint64_t base)
+{
+    return info->segments[i].gpa + info->segments[i].memsz + base;
+}
+
+/* What the post-PNR rebuild needs from the pre-PNR resolution, gathered in one
+ * place because two phases already take the whole set and the phases still
+ * inlined in sys_execve take most of it. Every member is settled before
+ * guest_reset and read-only afterwards.
+ */
+typedef struct {
+    unsigned int shim_size;
+    const elf_info_t *elf_info;
+    uint64_t elf_load_base;
+    const exec_interp_t *interp;
+    uint64_t interp_base;
+    const char *path; /* Guest-visible name, for /proc/self/maps */
+} exec_image_t;
+
+/* Describe the replacement image's address space and install its page tables.
+ *
+ * Runs past the point of no return, so every failure here is fatal rather than
+ * an errno: the old image is already gone and there is nothing to return to.
+ * That is also why the bounds check before each append is a goto to one fatal
+ * exit instead of an error path.
+ *
+ * Also publishes the two mmap watermarks (g->mmap_rx_end, g->mmap_end) that the
+ * fresh regions establish.
+ *
+ * Returns the new TTBR0.
+ */
+static uint64_t exec_install_address_space(guest_t *g, const exec_image_t *img)
+{
+    const unsigned int shim_size = img->shim_size;
+    const elf_info_t *elf_info = img->elf_info;
+    const uint64_t elf_load_base = img->elf_load_base;
+    const exec_interp_t *interp = img->interp;
+    const uint64_t interp_base = img->interp_base;
+
+    /* Worst case: 7 fixed regions (shim, shim-data, vDSO, brk, stack, mmap RX,
+     * mmap RW) plus up to ELF_MAX_SEGMENTS for both the executable and the
+     * interpreter. Sized comfortably to keep the bounds-check loops simple
+     * after the point of no return.
+     */
+#define MAX_REGIONS (8 + 2 * ELF_MAX_SEGMENTS)
+    mem_region_t regions[MAX_REGIONS];
+    int nregions = 0;
+
+    /* Fixed regions (shim, shim-data, vDSO, brk, stack, mmap RX, mmap RW): 7
+     * entries. Bounds-check before each to prevent array overflow. After the
+     * point of no return, overflow is fatal (exit).
+     */
+
+    /* Keep the shim executable-only; HVF faults on merged RWX mappings. */
+    if (nregions >= MAX_REGIONS)
+        goto too_many_regions;
+    regions[nregions++] = (mem_region_t) {.gpa_start = g->shim_base,
+                                          .gpa_end = g->shim_base + shim_size,
+                                          .perms = MEM_PERM_RX};
+
+    /* EL1 exception handlers use this block for stack and scratch state.
+     * EL1-only so EL0 cannot read or store directly to the identity cache,
+     * urandom ring, or attention word that the shim fast paths consult. Matches
+     * bootstrap.c; if this regresses to plain RW, execve quietly defeats the
+     * protection on every new image.
+     */
+    if (nregions >= MAX_REGIONS)
+        goto too_many_regions;
+    regions[nregions++] =
+        (mem_region_t) {.gpa_start = g->shim_data_base,
+                        .gpa_end = g->shim_data_base + BLOCK_2MIB,
+                        .perms = MEM_PERM_RW_EL1_ONLY};
+
+    /* The vDSO sits in the same 2MiB block as the shim. The page-table builder
+     * splits the block into 4KiB L3 pages when its regions don't fully cover
+     * it, so the vDSO must appear here to keep the trampoline page valid and RX
+     * after rebuild.
+     */
+    if (nregions >= MAX_REGIONS)
+        goto too_many_regions;
+    regions[nregions++] = (mem_region_t) {.gpa_start = VDSO_BASE,
+                                          .gpa_end = VDSO_BASE + VDSO_SIZE,
+                                          .perms = MEM_PERM_RX};
+
+    /* Translate ELF p_flags into guest page permissions, for the executable and
+     * then the interpreter shifted by its own base. Silent drops would leave a
+     * loaded segment unmapped, so treat overflow as fatal (this is already past
+     * the point of no return).
+     */
+    const elf_info_t *lists[] = {elf_info, &interp->info};
+    const uint64_t bases[] = {elf_load_base, interp_base};
+    for (size_t l = 0; l < ARRAY_SIZE(lists); l++) {
+        for (int i = 0; i < lists[l]->num_segments; i++) {
+            if (nregions >= MAX_REGIONS)
+                goto too_many_regions;
+            regions[nregions++] = (mem_region_t) {
+                .gpa_start = exec_seg_start(lists[l], i, bases[l]),
+                .gpa_end = exec_seg_end(lists[l], i, bases[l]),
+                .perms = elf_pf_to_prot(lists[l]->segments[i].flags)};
+        }
+    }
+
+    /* brk region (RW). Pre-mapped up to MMAP_RX_BASE. */
+    if (nregions >= MAX_REGIONS)
+        goto too_many_regions;
+    regions[nregions++] = (mem_region_t) {.gpa_start = g->brk_base,
+                                          .gpa_end = MMAP_RX_BASE,
+                                          .perms = MEM_PERM_RW};
+
+    /* The dynamic stack bounds were recomputed above from the new brk. */
+    if (nregions >= MAX_REGIONS)
+        goto too_many_regions;
+    regions[nregions++] = (mem_region_t) {.gpa_start = g->stack_base,
+                                          .gpa_end = g->stack_top,
+                                          .perms = MEM_PERM_RW};
+
+    /* PROT_EXEC mmap allocations start in a separate RX area to preserve W^X
+     * with 2MiB page-table blocks.
+     */
+    if (nregions >= MAX_REGIONS)
+        goto too_many_regions;
+    regions[nregions++] = (mem_region_t) {.gpa_start = MMAP_RX_BASE,
+                                          .gpa_end = MMAP_RX_INITIAL_END,
+                                          .perms = MEM_PERM_RX};
+    g->mmap_rx_end = MMAP_RX_INITIAL_END;
+
+    /* Non-executable mmap allocations start high to match Linux address-space
+     * layout and avoid low executable/heap regions.
+     */
+    if (nregions >= MAX_REGIONS)
+        goto too_many_regions;
+    regions[nregions++] = (mem_region_t) {.gpa_start = MMAP_BASE,
+                                          .gpa_end = MMAP_INITIAL_END,
+                                          .perms = MEM_PERM_RW};
+    g->mmap_end = MMAP_INITIAL_END;
+
+    uint64_t ttbr0 = guest_build_page_tables(g, regions, nregions);
+    if (!ttbr0) {
+        log_fatal(
+            "execve failed after point of no return: "
+            "failed to build page tables");
+        exit(128);
+    }
+    return ttbr0;
+
+too_many_regions:
+    log_fatal(
+        "execve failed after point of no return: "
+        "too many memory regions (max %d)",
+        MAX_REGIONS);
+    exit(128);
+}
+
+/* Republish the guest's /proc/self/maps view for the replacement image.
+ *
+ * Runs alongside exec_install_address_space and describes the same address
+ * space, one layer up: that call installs the hardware mapping, this one names
+ * it for the guest. The two lists must agree, so a region added to one belongs
+ * in the other.
+ *
+ * Also punches the two holes that carry no mapping at all: the stack guard page
+ * and the NULL page, whose PTEs are invalidated rather than described.
+ */
+static void exec_publish_maps(guest_t *g, const exec_image_t *img)
+{
+    const unsigned int shim_size = img->shim_size;
+    const elf_info_t *elf_info = img->elf_info;
+    const uint64_t elf_load_base = img->elf_load_base;
+    const exec_interp_t *interp = img->interp;
+    const uint64_t interp_base = img->interp_base;
+    const char *path = img->path;
+
+    /* Rebuild /proc/self/maps metadata in parallel with the new page tables. */
+    guest_region_add(g, g->shim_base, g->shim_base + shim_size,
+                     LINUX_PROT_READ | LINUX_PROT_EXEC, LINUX_MAP_PRIVATE, 0,
+                     "[shim]");
+
+    /* Report PROT_NONE for [shim-data] to match the EL1-only mapping (see
+     * matching bootstrap.c registration). EL0 dereferences fault, so user
+     * tooling reading /proc/self/maps should see the same access state.
+     */
+    guest_region_add(g, g->shim_data_base, g->shim_data_base + BLOCK_2MIB,
+                     LINUX_PROT_NONE, LINUX_MAP_PRIVATE, 0, "[shim-data]");
+
+    /* Same two lists, same order, same spans as exec_install_address_space.
+     * interp->display_path was resolved before guest_reset, so naming the
+     * interpreter here needs no filesystem lookup past the point of no return.
+     */
+    const elf_info_t *lists[] = {elf_info, &interp->info};
+    const uint64_t bases[] = {elf_load_base, interp_base};
+    const char *names[] = {path, interp->display_path};
+    for (size_t l = 0; l < ARRAY_SIZE(lists); l++) {
+        for (int i = 0; i < lists[l]->num_segments; i++) {
+            guest_region_add(g, exec_seg_start(lists[l], i, bases[l]),
+                             exec_seg_end(lists[l], i, bases[l]),
+                             elf_pf_to_prot(lists[l]->segments[i].flags),
+                             LINUX_MAP_PRIVATE, lists[l]->segments[i].offset,
+                             names[l]);
+        }
+    }
+
+    /* Leave the lowest stack page unmapped so downward overflow faults before
+     * corrupting adjacent mappings.
+     */
+    guest_invalidate_ptes(g, g->stack_base, g->stack_base + STACK_GUARD_SIZE);
+    guest_region_add(g, g->stack_base, g->stack_base + STACK_GUARD_SIZE,
+                     LINUX_PROT_NONE, LINUX_MAP_PRIVATE | LINUX_MAP_ANONYMOUS,
+                     0, "[stack-guard]");
+    guest_region_add(g, g->stack_base + STACK_GUARD_SIZE, g->stack_top,
+                     LINUX_PROT_READ | LINUX_PROT_WRITE,
+                     LINUX_MAP_PRIVATE | LINUX_MAP_ANONYMOUS, 0, "[stack]");
+
+    /* Preserve Linux-style NULL dereference faults after exec. */
+    guest_invalidate_ptes(g, 0, 0x1000);
+}
+
 /* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_execve(hv_vcpu_t vcpu,
                    guest_t *g,
@@ -1737,166 +1968,15 @@ int64_t sys_execve(hv_vcpu_t vcpu,
     g->stack_top = stack_top;
     g->stack_base = stack_top - STACK_SIZE;
 
-    /* Worst case: 7 fixed regions (shim, shim-data, vDSO, brk, stack, mmap RX,
-     * mmap RW) plus up to ELF_MAX_SEGMENTS for both the executable and the
-     * interpreter. Sized comfortably to keep the bounds-check loops simple
-     * after the point of no return.
-     */
-#define MAX_REGIONS (8 + 2 * ELF_MAX_SEGMENTS)
-    mem_region_t regions[MAX_REGIONS];
-    int nregions = 0;
+    const exec_image_t image = {.shim_size = shim_size,
+                                .elf_info = &elf_info,
+                                .elf_load_base = elf_load_base,
+                                .interp = &interp,
+                                .interp_base = interp_base,
+                                .path = path};
+    uint64_t ttbr0 = exec_install_address_space(g, &image);
 
-    /* Fixed regions (shim, shim-data, vDSO, brk, stack, mmap RX, mmap RW): 7
-     * entries. Bounds-check before each to prevent array overflow. After the
-     * point of no return, overflow is fatal (exit).
-     */
-
-    /* Keep the shim executable-only; HVF faults on merged RWX mappings. */
-    if (nregions >= MAX_REGIONS)
-        goto too_many_regions;
-    regions[nregions++] = (mem_region_t) {.gpa_start = g->shim_base,
-                                          .gpa_end = g->shim_base + shim_size,
-                                          .perms = MEM_PERM_RX};
-
-    /* EL1 exception handlers use this block for stack and scratch state.
-     * EL1-only so EL0 cannot read or store directly to the identity cache,
-     * urandom ring, or attention word that the shim fast paths consult. Matches
-     * bootstrap.c; if this regresses to plain RW, execve quietly defeats the
-     * protection on every new image.
-     */
-    if (nregions >= MAX_REGIONS)
-        goto too_many_regions;
-    regions[nregions++] =
-        (mem_region_t) {.gpa_start = g->shim_data_base,
-                        .gpa_end = g->shim_data_base + BLOCK_2MIB,
-                        .perms = MEM_PERM_RW_EL1_ONLY};
-
-    /* The vDSO sits in the same 2MiB block as the shim. The page-table builder
-     * splits the block into 4KiB L3 pages when its regions don't fully cover
-     * it, so the vDSO must appear here to keep the trampoline page valid and RX
-     * after rebuild.
-     */
-    if (nregions >= MAX_REGIONS)
-        goto too_many_regions;
-    regions[nregions++] = (mem_region_t) {.gpa_start = VDSO_BASE,
-                                          .gpa_end = VDSO_BASE + VDSO_SIZE,
-                                          .perms = MEM_PERM_RX};
-
-    /* Translate ELF p_flags into guest page permissions. Silent drops would
-     * leave the loaded segment unmapped, so treat overflow as fatal (the caller
-     * is already past the point of no return).
-     */
-    for (int i = 0; i < elf_info.num_segments; i++) {
-        if (nregions >= MAX_REGIONS)
-            goto too_many_regions;
-        regions[nregions++] = (mem_region_t) {
-            .gpa_start = elf_info.segments[i].gpa + elf_load_base,
-            .gpa_end = elf_info.segments[i].gpa + elf_info.segments[i].memsz +
-                       elf_load_base,
-            .perms = elf_pf_to_prot(elf_info.segments[i].flags)};
-    }
-
-    /* Interpreter segments use the same permission translation, shifted by
-     * interp_base. Same fatal-overflow rule as the executable's segments.
-     */
-    for (int i = 0; i < interp.info.num_segments; i++) {
-        if (nregions >= MAX_REGIONS)
-            goto too_many_regions;
-        regions[nregions++] = (mem_region_t) {
-            .gpa_start = interp.info.segments[i].gpa + interp_base,
-            .gpa_end = interp.info.segments[i].gpa +
-                       interp.info.segments[i].memsz + interp_base,
-            .perms = elf_pf_to_prot(interp.info.segments[i].flags)};
-    }
-
-    /* brk region (RW). Pre-mapped up to MMAP_RX_BASE. */
-    if (nregions >= MAX_REGIONS)
-        goto too_many_regions;
-    regions[nregions++] = (mem_region_t) {.gpa_start = g->brk_base,
-                                          .gpa_end = MMAP_RX_BASE,
-                                          .perms = MEM_PERM_RW};
-
-    /* The dynamic stack bounds were recomputed above from the new brk. */
-    if (nregions >= MAX_REGIONS)
-        goto too_many_regions;
-    regions[nregions++] = (mem_region_t) {.gpa_start = g->stack_base,
-                                          .gpa_end = g->stack_top,
-                                          .perms = MEM_PERM_RW};
-
-    /* PROT_EXEC mmap allocations start in a separate RX area to preserve W^X
-     * with 2MiB page-table blocks.
-     */
-    if (nregions >= MAX_REGIONS)
-        goto too_many_regions;
-    regions[nregions++] = (mem_region_t) {.gpa_start = MMAP_RX_BASE,
-                                          .gpa_end = MMAP_RX_INITIAL_END,
-                                          .perms = MEM_PERM_RX};
-    g->mmap_rx_end = MMAP_RX_INITIAL_END;
-
-    /* Non-executable mmap allocations start high to match Linux address-space
-     * layout and avoid low executable/heap regions.
-     */
-    if (nregions >= MAX_REGIONS)
-        goto too_many_regions;
-    regions[nregions++] = (mem_region_t) {.gpa_start = MMAP_BASE,
-                                          .gpa_end = MMAP_INITIAL_END,
-                                          .perms = MEM_PERM_RW};
-    g->mmap_end = MMAP_INITIAL_END;
-
-    uint64_t ttbr0 = guest_build_page_tables(g, regions, nregions);
-    if (!ttbr0) {
-        log_fatal(
-            "execve failed after point of no return: "
-            "failed to build page tables");
-        exit(128);
-    }
-
-    /* Rebuild /proc/self/maps metadata in parallel with the new page tables. */
-    guest_region_add(g, g->shim_base, g->shim_base + shim_size,
-                     LINUX_PROT_READ | LINUX_PROT_EXEC, LINUX_MAP_PRIVATE, 0,
-                     "[shim]");
-
-    /* Report PROT_NONE for [shim-data] to match the EL1-only mapping (see
-     * matching bootstrap.c registration). EL0 dereferences fault, so user
-     * tooling reading /proc/self/maps should see the same access state.
-     */
-    guest_region_add(g, g->shim_data_base, g->shim_data_base + BLOCK_2MIB,
-                     LINUX_PROT_NONE, LINUX_MAP_PRIVATE, 0, "[shim-data]");
-    for (int i = 0; i < elf_info.num_segments; i++) {
-        guest_region_add(g, elf_info.segments[i].gpa + elf_load_base,
-                         elf_info.segments[i].gpa + elf_info.segments[i].memsz +
-                             elf_load_base,
-                         elf_pf_to_prot(elf_info.segments[i].flags),
-                         LINUX_MAP_PRIVATE, elf_info.segments[i].offset, path);
-    }
-
-    /* interp.resolved was computed before guest_reset so no filesystem lookup
-     * is needed after the point of no return.
-     */
-    if (interp.info.num_segments > 0) {
-        for (int i = 0; i < interp.info.num_segments; i++) {
-            guest_region_add(g, interp.info.segments[i].gpa + interp_base,
-                             interp.info.segments[i].gpa +
-                                 interp.info.segments[i].memsz + interp_base,
-                             elf_pf_to_prot(interp.info.segments[i].flags),
-                             LINUX_MAP_PRIVATE, interp.info.segments[i].offset,
-                             interp.display_path);
-        }
-    }
-
-    /* Leave the lowest stack page unmapped so downward overflow faults before
-     * corrupting adjacent mappings.
-     */
-    guest_invalidate_ptes(g, g->stack_base, g->stack_base + STACK_GUARD_SIZE);
-    guest_region_add(g, g->stack_base, g->stack_base + STACK_GUARD_SIZE,
-                     LINUX_PROT_NONE, LINUX_MAP_PRIVATE | LINUX_MAP_ANONYMOUS,
-                     0, "[stack-guard]");
-    guest_region_add(g, g->stack_base + STACK_GUARD_SIZE, g->stack_top,
-                     LINUX_PROT_READ | LINUX_PROT_WRITE,
-                     LINUX_MAP_PRIVATE | LINUX_MAP_ANONYMOUS, 0, "[stack]");
-
-    /* Preserve Linux-style NULL dereference faults after exec. */
-    guest_invalidate_ptes(g, 0, 0x1000);
+    exec_publish_maps(g, &image);
 
     /* Build argc/argv/envp/auxv for the replacement image. */
     const char **argv_const = (const char **) argv;
@@ -1992,11 +2072,4 @@ int64_t sys_execve(hv_vcpu_t vcpu,
                         path_host_temp, interp_host_buf, interp_host_temp);
 
     return SYSCALL_EXEC_HAPPENED;
-
-too_many_regions:
-    log_fatal(
-        "execve failed after point of no return: "
-        "too many memory regions (max %d)",
-        MAX_REGIONS);
-    exit(128);
 }

--- a/src/syscall/fd.c
+++ b/src/syscall/fd.c
@@ -208,8 +208,7 @@ int64_t sys_timerfd_create(int clockid, int flags)
     int slot = timerfd_alloc();
     if (slot < 0) {
         pthread_mutex_unlock(&sfd_lock);
-        fd_mark_closed(gfd);
-        close(kq);
+        fd_retire_published(gfd, kq);
         return -LINUX_ENOMEM;
     }
 
@@ -656,9 +655,8 @@ int64_t sys_eventfd2(unsigned int initval, int flags)
     int slot = eventfd_slot_alloc();
     if (slot < 0) {
         pthread_mutex_unlock(&sfd_lock);
-        fd_mark_closed(gfd);
+        fd_retire_published(gfd, pipefd[0]);
         close(state_rd);
-        close(pipefd[0]);
         close(pipefd[1]);
         return -LINUX_ENOMEM;
     }
@@ -1133,8 +1131,7 @@ int64_t sys_signalfd4(guest_t *g,
     int slot = signalfd_slot_alloc();
     if (slot < 0) {
         pthread_mutex_unlock(&sfd_lock);
-        fd_mark_closed(gfd);
-        close(pipefd[0]);
+        fd_retire_published(gfd, pipefd[0]);
         close(pipefd[1]);
         return -LINUX_ENOMEM;
     }

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -10,6 +10,7 @@
  * access through fd_lock.
  */
 
+#include <assert.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -41,6 +42,12 @@ pthread_mutex_t fd_lock = PTHREAD_MUTEX_INITIALIZER; /* Lock order: 3 */
 fd_entry_t fd_table[FD_TABLE_SIZE];
 static uint64_t fd_next_generation = 1;
 static uint64_t fd_next_ofd_id = 1;
+
+struct fd_lifetime {
+    _Atomic unsigned int refs;
+    int host_fd;
+    int type;
+};
 
 /* RLIMIT_NOFILE tracking. Guest-side soft limit for RLIMIT_NOFILE. fd_alloc
  * checks this. Default matches typical Linux default (1024). Updated by
@@ -268,6 +275,7 @@ static inline void fd_init_entry(int fd,
     fd_bitmap_set_used(fd);
     fd_table[fd].type = type;
     fd_table[fd].host_fd = host_fd;
+    fd_table[fd].lifetime = NULL;
 
     /* Take the description state again, here, from the live source. The spec
      * carries a snapshot the caller made before this lock was held, and an
@@ -827,9 +835,10 @@ int fd_alloc_at_relaxed(int fd,
  * another thread could fd_alloc() this slot, populate it with a new
  * host_fd/dir, and then the current stale writes would corrupt the new entry.
  */
-void fd_mark_closed_unlocked(int fd)
+fd_lifetime_t *fd_mark_closed_unlocked(int fd)
 {
     uint64_t closing_ofd_id = fd_table[fd].ofd_id;
+    fd_lifetime_t *detached = fd_table[fd].lifetime;
 
     /* Clear before publishing FD_CLOSED/free. The EL1 urandom read fast path
      * intentionally avoids fd_lock, so it must not observe a stale urandom bit
@@ -838,6 +847,7 @@ void fd_mark_closed_unlocked(int fd)
     shim_globals_mark_urandom_fd(fd, false);
     fd_table[fd].type = FD_CLOSED;
     fd_table[fd].host_fd = -1;
+    fd_table[fd].lifetime = NULL;
     fd_table[fd].ofd_id = 0;
     fd_table[fd].dir = NULL;
     fd_table[fd].proc_path[0] = '\0';
@@ -854,13 +864,15 @@ void fd_mark_closed_unlocked(int fd)
      * single-threaded on the relaxed path).
      */
     epoll_note_fd_closed(fd, closing_ofd_id);
+    return detached;
 }
 
-void fd_mark_closed(int fd)
+fd_lifetime_t *fd_mark_closed(int fd)
 {
     pthread_mutex_lock(&fd_lock);
-    fd_mark_closed_unlocked(fd);
+    fd_lifetime_t *detached = fd_mark_closed_unlocked(fd);
     pthread_mutex_unlock(&fd_lock);
+    return detached;
 }
 
 /* Snapshot fd_table[fd] into *out and optionally close it. Caller must hold
@@ -911,8 +923,15 @@ bool fd_close_regular_relaxed(int fd, int *host_fd_out)
     if (!thread_is_single_active())
         return false;
 
+    /* Refuse a slot carrying a lifetime. The caller closes *host_fd_out raw and
+     * never touches the refcount, so admitting one here would strand the slot's
+     * reference and leak the object. The thread_is_single_active() gate above
+     * does not subsume this: the lifetime is created on the multi-threaded
+     * acquire path and outlives the return to a single active thread.
+     */
     fd_entry_t *entry = &fd_table[fd];
-    if (entry->type != FD_REGULAR || entry->dir || entry->cleanup)
+    if (entry->type != FD_REGULAR || entry->dir || entry->cleanup ||
+        entry->lifetime)
         return false;
 
     *host_fd_out = entry->host_fd;
@@ -933,6 +952,177 @@ int fd_to_host(int guest_fd)
     if (fd_table[guest_fd].type == FD_CLOSED)
         return -1;
     return fd_table[guest_fd].host_fd;
+}
+
+/* Take one reference on fd's lifetime with fd_lock held, creating it if this is
+ * the slot's first borrower. The single place a lifetime is ever born.
+ *
+ * spare, when it points at a non-NULL allocation, is one the caller made
+ * outside the lock; this consumes it and clears the caller's pointer, or leaves
+ * it untouched when the slot already carries a lifetime. A caller passing NULL
+ * allocates here instead, with the table lock held, which is only acceptable
+ * away from the per-syscall path: see fd_host_ref_acquire for why that one
+ * preallocates.
+ *
+ * Returns NULL when the slot is closed, carries no host descriptor, or the
+ * allocation fails. A caller that has already established the first two under
+ * this same lock hold can read NULL as out of memory.
+ */
+static fd_lifetime_t *fd_lifetime_pin_spare(int fd, fd_lifetime_t **spare)
+{
+    if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
+        return NULL;
+    if (fd_table[fd].type == FD_CLOSED || fd_table[fd].host_fd < 0)
+        return NULL;
+
+    fd_lifetime_t *lifetime = fd_table[fd].lifetime;
+    if (!lifetime) {
+        if (spare && *spare) {
+            lifetime = *spare;
+            *spare = NULL;
+        } else {
+            lifetime = malloc(sizeof(*lifetime));
+            if (!lifetime)
+                return NULL;
+        }
+        atomic_init(&lifetime->refs, 1);
+        lifetime->host_fd = fd_table[fd].host_fd;
+        lifetime->type = fd_table[fd].type;
+        fd_table[fd].lifetime = lifetime;
+    }
+    atomic_fetch_add(&lifetime->refs, 1);
+    return lifetime;
+}
+
+int fd_host_ref_acquire(int guest_fd,
+                        fd_entry_t *out,
+                        fd_lifetime_t **lifetime_out)
+{
+    *lifetime_out = NULL;
+    if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE)) {
+        errno = EBADF;
+        return -1;
+    }
+
+    /* Two passes at most. The first runs with no spare and succeeds outright
+     * for any fd that already carries a lifetime, which after its first borrow
+     * is every fd; only a first borrow drops the lock to allocate and comes
+     * back. Allocating up front instead would be simpler, but it would make
+     * every multi-threaded fd call pay a malloc/free pair, and sys_ppoll pays
+     * it per polled descriptor.
+     *
+     * The allocation stays outside the lock either way. Inside, it would nest
+     * the allocator's own lock under the order-3 table lock, which
+     * check-lock-order.py cannot see because it only knows file-scope
+     * pthread_mutex_t, and every first touch of an fd would pay a possible
+     * allocator stall with the whole table held.
+     */
+    fd_lifetime_t *spare = NULL;
+    for (;;) {
+        pthread_mutex_lock(&fd_lock);
+        if (!fd_snapshot_locked(guest_fd, out, false) || out->host_fd < 0) {
+            pthread_mutex_unlock(&fd_lock);
+            free(spare);
+            errno = EBADF;
+            return -1;
+        }
+
+        /* Committing needs either an existing lifetime to share or a spare to
+         * install. Without one, fall out and allocate. A slot that acquired a
+         * lifetime while the lock was down takes the first branch on the retry
+         * and the spare goes back to the allocator untouched.
+         */
+        if (out->lifetime || spare) {
+            fd_lifetime_t *lifetime = fd_lifetime_pin_spare(guest_fd, &spare);
+            if (!lifetime) {
+                /* Unreachable: the slot checks above passed under this same
+                 * lock hold, and this branch never allocates. Handled rather
+                 * than asserted so a future change cannot hand back a host fd
+                 * with a NULL lifetime, which reads as a successful pin.
+                 */
+                pthread_mutex_unlock(&fd_lock);
+                free(spare);
+                errno = ENOMEM;
+                return -1;
+            }
+            out->lifetime = lifetime;
+            *lifetime_out = lifetime;
+            int host_fd = out->host_fd;
+            pthread_mutex_unlock(&fd_lock);
+            free(spare);
+            return host_fd;
+        }
+        pthread_mutex_unlock(&fd_lock);
+
+        spare = malloc(sizeof(*spare));
+        if (!spare) {
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+}
+
+void fd_lifetime_release(fd_lifetime_t *lifetime)
+{
+    unsigned int prev = atomic_fetch_sub(&lifetime->refs, 1);
+
+    /* An unbalanced release wraps refs and the object silently never frees,
+     * which surfaces later as an fd leak with no trace of its origin. Catch it
+     * where it happens instead.
+     */
+    assert(prev != 0);
+    if (prev != 1)
+        return;
+    if (lifetime->type != FD_STDIO)
+        close(lifetime->host_fd);
+    free(lifetime);
+}
+
+fd_lifetime_t *fd_lifetime_pin_locked(int fd)
+{
+    return fd_lifetime_pin_spare(fd, NULL);
+}
+
+/* Retire a slot the caller published in fd_table, closing the host fd it owns.
+ *
+ * Prefer this over fd_mark_closed plus a raw close on the host fd: once a slot
+ * is published a sibling can pin it, and a raw close then pulls the descriptor
+ * out from under that sibling while stranding the slot's own reference. The
+ * close is deferred to the last release when a pin exists.
+ *
+ * A slot that no longer holds host_fd is left entirely alone, descriptor
+ * included. Reaching that means a sibling already closed this guest fd, and
+ * that close retired the descriptor on its way out, so closing it here would be
+ * a second close of a number the host may since have handed to someone else.
+ *
+ * host_fd narrows which slot this retires but does not identify it: if the
+ * sibling's replacement happens to reuse the same number, the check passes and
+ * this retires the replacement. Distinguishing that needs the allocation
+ * generation, which the plain fd_alloc does not hand back. The residue is a
+ * guest operating on an fd number it was never given, which linux-wire.h
+ * already calls a guest-level bug.
+ */
+void fd_retire_published(int fd, int host_fd)
+{
+    if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE)) {
+        if (host_fd >= 0)
+            close(host_fd);
+        return;
+    }
+
+    /* A synthetic slot can carry no host descriptor at all (the FUSE file and
+     * directory types); retiring one still has to clear the slot.
+     */
+    pthread_mutex_lock(&fd_lock);
+    bool still_ours =
+        fd_table[fd].type != FD_CLOSED && fd_table[fd].host_fd == host_fd;
+    fd_lifetime_t *lifetime = still_ours ? fd_mark_closed_unlocked(fd) : NULL;
+    pthread_mutex_unlock(&fd_lock);
+
+    if (lifetime)
+        fd_lifetime_release(lifetime);
+    else if (still_ours && host_fd >= 0)
+        close(host_fd);
 }
 
 /* Snapshot an fd entry under fd_lock.
@@ -1123,31 +1313,6 @@ void (*fd_cleanup_for_type(int type))(int)
     return fd_type_cleanup[type];
 }
 
-/* Look up a guest FD, dup its host fd, and classify the slot, all in one
- * fd_lock window. Caller owns the returned descriptor and must close it.
- *
- * Returns -1 on failure, with *st_out reporting FD_CLOSED.
- */
-int fd_to_host_dup_state(int guest_fd, fd_block_state_t *st_out)
-{
-    /* fd_snapshot_and_dup already takes the whole entry and the dup in one
-     * fd_lock window, which is the atomicity a transfer needs: the pin keeps
-     * the description alive, and the classification has to describe that same
-     * description rather than whatever takes the fd number next. Composing with
-     * it rather than repeating it also inherits its host_fd < 0 guard, which a
-     * hand-rolled copy here did not have and would have dup(-1)'d for the FUSE
-     * types that carry no host descriptor.
-     */
-    fd_entry_t snap;
-    int owned = fd_snapshot_and_dup(guest_fd, &snap);
-    if (owned < 0) {
-        *st_out = (fd_block_state_t) {.type = FD_CLOSED};
-        return -1;
-    }
-    *st_out = fd_block_state_of(&snap);
-    return owned;
-}
-
 /* Look up a guest FD and return a dup'd host fd that the caller owns. The dup
  * is performed under fd_lock so that close() on another thread cannot
  * invalidate the host fd between lookup and dup. Caller must close the returned
@@ -1209,7 +1374,8 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
          snap->fasync_owner_type != FASYNC_OWNER_NONE))
         asyncio_disarm(snap->host_fd);
 
-    /* Keep stdin/stdout/stderr open on the host */
-    if (snap->type != FD_STDIO)
+    if (snap->lifetime)
+        fd_lifetime_release(snap->lifetime);
+    else if (snap->type != FD_STDIO)
         close(snap->host_fd);
 }

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -221,7 +221,7 @@ static int64_t stat_at_path(guest_t *g,
     }
 
     int64_t rc = 0;
-    host_fd_ref_t dir_ref = {.fd = -1, .owned = false};
+    host_fd_ref_t dir_ref = HOST_FD_REF_INIT;
     if ((flags & LINUX_AT_EMPTY_PATH) && pathp[0] == '\0') {
         /* Linux: AT_EMPTY_PATH with dirfd == AT_FDCWD operates on the current
          * working directory.
@@ -234,13 +234,17 @@ static int64_t stat_at_path(guest_t *g,
                 goto done;
             }
         } else {
+            /* Pin, not dup: fstatat needs the descriptor to stay valid, not to
+             * be private, and retiring a dup would drop the guest's record
+             * locks on the file (fcntl(2)).
+             */
             fd_entry_t snap;
-            dir_ref.fd = fd_snapshot_and_dup(dirfd, &snap);
-            dir_ref.owned = true;
-            if (dir_ref.fd < 0) {
-                rc = -LINUX_EBADF;
+            if (fd_host_ref_acquire(dirfd, &snap, &dir_ref.lifetime) < 0) {
+                /* EBADF or ENOMEM; the helper distinguishes them. */
+                rc = linux_errno();
                 goto done;
             }
+            dir_ref.fd = snap.host_fd;
             if (snap.type == FD_PATH && snap.proc_path[0] != '\0') {
                 int intercepted = proc_intercept_stat(snap.proc_path, mac_st);
                 if (intercepted == 0)

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -2135,8 +2135,7 @@ int64_t sys_pipe2(guest_t *g, uint64_t fds_gva, int linux_flags)
     guest_fds[1] = fd_alloc(FD_PIPE, host_fds[1], NULL);
     if (guest_fds[1] < 0) {
         int saved_errno = errno;
-        fd_mark_closed(guest_fds[0]);
-        close(host_fds[0]);
+        fd_retire_published(guest_fds[0], host_fds[0]);
         close(host_fds[1]);
         errno = saved_errno;
         return linux_errno();
@@ -2164,10 +2163,8 @@ int64_t sys_pipe2(guest_t *g, uint64_t fds_gva, int linux_flags)
 
     int32_t fds[2] = {guest_fds[0], guest_fds[1]};
     if (guest_write_small(g, fds_gva, fds, sizeof(fds)) < 0) {
-        fd_mark_closed(guest_fds[0]);
-        fd_mark_closed(guest_fds[1]);
-        close(host_fds[0]);
-        close(host_fds[1]);
+        fd_retire_published(guest_fds[0], host_fds[0]);
+        fd_retire_published(guest_fds[1], host_fds[1]);
         return -LINUX_EFAULT;
     }
 
@@ -2977,13 +2974,13 @@ int64_t sys_fchmodat(guest_t *g,
 
     /* An fd magic link names the descriptor's file, and Linux resolves it
      * inside the syscall. Act on the descriptor so nothing can redirect the
-     * chmod between resolution and use; see path_fd_magiclink_dup().
+     * chmod between resolution and use; see path_fd_magiclink_open().
      */
     if (!(flags & LINUX_AT_SYMLINK_NOFOLLOW)) {
-        int magic_fd = path_fd_magiclink_dup(path);
-        if (magic_fd >= 0) {
-            int mrc = fchmod(magic_fd, mode);
-            close_keep_errno(magic_fd);
+        host_fd_ref_t magic;
+        if (path_fd_magiclink_open(path, &magic) == 0) {
+            int mrc = fchmod(magic.fd, mode);
+            host_fd_ref_close(&magic);
             return mrc < 0 ? linux_errno() : 0;
         }
     }
@@ -3156,16 +3153,16 @@ int64_t sys_fchownat(guest_t *g,
      * descriptor, not on a pathname resolved from it a moment earlier.
      */
     if (!(flags & LINUX_AT_SYMLINK_NOFOLLOW)) {
-        int magic_fd = path_fd_magiclink_dup(path);
-        if (magic_fd >= 0) {
-            int host_rc = fchown(magic_fd, owner, group);
+        host_fd_ref_t magic;
+        if (path_fd_magiclink_open(path, &magic) == 0) {
+            int host_rc = fchown(magic.fd, owner, group);
             int saved_errno = errno;
             struct stat host_st;
             const struct stat *st_ptr =
-                fstat(magic_fd, &host_st) == 0 ? &host_st : NULL;
+                fstat(magic.fd, &host_st) == 0 ? &host_st : NULL;
             errno = saved_errno;
             int64_t out = chown_result(host_rc, st_ptr, owner, group);
-            close_keep_errno(magic_fd);
+            host_fd_ref_close(&magic);
             return out;
         }
     }
@@ -3317,10 +3314,10 @@ int64_t sys_utimensat(guest_t *g,
          * the descriptor, not on a pathname resolved from it a moment earlier.
          */
         if (!(flags & LINUX_AT_SYMLINK_NOFOLLOW)) {
-            int magic_fd = path_fd_magiclink_dup(path);
-            if (magic_fd >= 0) {
-                int mrc = futimens(magic_fd, times_gva ? ts : NULL);
-                close_keep_errno(magic_fd);
+            host_fd_ref_t magic;
+            if (path_fd_magiclink_open(path, &magic) == 0) {
+                int mrc = futimens(magic.fd, times_gva ? ts : NULL);
+                host_fd_ref_close(&magic);
                 host_fd_ref_close(&dir_ref);
                 return mrc < 0 ? linux_errno() : 0;
             }

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -1523,7 +1523,7 @@ int fuse_proc_open(int linux_flags)
     if (fuse_bind_dev_fd_locked(guest_fd, slot) < 0) {
         fuse_session_put_locked(slot);
         pthread_mutex_unlock(&fuse_lock);
-        fd_mark_closed(guest_fd);
+        fd_retire_published(guest_fd, notify_pipe[0]);
         errno = EMFILE;
         return -1;
     }
@@ -2413,8 +2413,10 @@ int64_t fuse_dev_read(int guest_fd,
     host_fd_ref_t notify_ref;
     fd_block_state_t dev_st;
     uint64_t dev_gen = 0;
-    if (host_fd_ref_open_io_state(guest_fd, &notify_ref, &dev_gen, &dev_st) < 0)
-        return -LINUX_EBADF;
+    int64_t err =
+        host_fd_ref_open_io_state(guest_fd, &notify_ref, &dev_gen, &dev_st);
+    if (err < 0)
+        return err;
 
     pthread_mutex_lock(&fuse_lock);
     fuse_session_t *session = fuse_session_by_fd_locked(guest_fd);
@@ -2877,7 +2879,7 @@ int fuse_dup_fd(int src_fd,
         fuse_session_t *session = fuse_session_by_fd_locked(src_fd);
         if (!session) {
             pthread_mutex_unlock(&fuse_lock);
-            fd_mark_closed(guest_fd);
+            fd_retire_published(guest_fd, new_host_fd);
             errno = EBADF;
             return -1;
         }
@@ -2885,7 +2887,7 @@ int fuse_dup_fd(int src_fd,
         if (fuse_bind_dev_fd_locked(guest_fd, session) < 0) {
             fuse_session_put_locked(session);
             pthread_mutex_unlock(&fuse_lock);
-            fd_mark_closed(guest_fd);
+            fd_retire_published(guest_fd, new_host_fd);
             errno = EMFILE;
             return -1;
         }

--- a/src/syscall/inotify.c
+++ b/src/syscall/inotify.c
@@ -629,9 +629,8 @@ int64_t sys_inotify_init1(int flags)
     int slot = inotify_slot_alloc();
     if (slot < 0) {
         pthread_mutex_unlock(&inotify_lock);
-        fd_mark_closed(gfd);
+        fd_retire_published(gfd, pipefd[0]);
         close(kq);
-        close(pipefd[0]);
         close(pipefd[1]);
         return -LINUX_ENOMEM;
     }

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -625,24 +625,74 @@ static inline bool fd_nonblock_shadowed(int type, bool nonblock_owned)
  */
 int fd_to_host_dup(int guest_fd);
 
-/* The same dup, with the slot's transfer classification taken in the same
- * fd_lock window. A caller that pins a host fd and then asks what kind of fd it
- * was has a gap: the pin keeps the description alive, but the guest fd number
- * can be reused for another kind of object in between, and the answer then
- * describes something the caller is not holding.
+/* Refcount that keeps a host fd open across a concurrent syscall. Defined in
+ * fdtable.c; opaque to every caller.
  */
-int fd_to_host_dup_state(int guest_fd, fd_block_state_t *st_out);
+typedef struct fd_lifetime fd_lifetime_t;
 
-/* Mark an FD slot as closed (set type = FD_CLOSED and update bitmap). Does NOT
- * close the host FD or free type-specific resources (DIR*, epoll instance);
- * caller must do that first.
+/* Pin the host fd of a live slot and snapshot the entry, in one fd_lock window.
+ * The pin keeps the host descriptor open for the duration of a host call even
+ * if a sibling closes the guest fd, which is what the per-call dup used to buy;
+ * unlike the dup it does not consume a host descriptor, and it leaves POSIX
+ * record locks alone (closing any descriptor for an inode drops the process's
+ * locks on it, so the old dup released an F_SETLK the moment it went away).
+ *
+ * The snapshot describes the same description the pin holds: the guest fd
+ * number can be reused for another kind of object as soon as fd_lock is
+ * dropped, so a classification taken afterwards would describe something the
+ * caller is not holding.
+ *
+ * Returns the host fd, or -1 with errno set to EBADF (no such live slot) or
+ * ENOMEM. The caller must pass *lifetime_out to fd_lifetime_release exactly
+ * once; the slot holds its own separate reference.
  */
-void fd_mark_closed(int fd);
+int fd_host_ref_acquire(int guest_fd,
+                        fd_entry_t *out,
+                        fd_lifetime_t **lifetime_out);
+
+/* Pin a live slot with fd_lock already held.
+ *
+ * Returns NULL when the slot is closed, carries no host descriptor, or the
+ * allocation fails. For a caller already walking the table under the lock;
+ * allocates inside it, so fork-scale callers only.
+ */
+fd_lifetime_t *fd_lifetime_pin_locked(int fd);
+
+/* Drop one reference. The last release closes the host fd (except for FD_STDIO,
+ * which elfuse did not open) and frees the object.
+ */
+void fd_lifetime_release(fd_lifetime_t *lifetime);
+
+/* Mark an FD slot as closed (set type = FD_CLOSED and update bitmap) and detach
+ * its lifetime. Does NOT close the host FD or free type-specific resources
+ * (DIR*, epoll instance); caller must do that first.
+ *
+ * Detaching is not releasing. The returned lifetime carries the slot's own
+ * reference and the caller now owns it: either hand it to fd_lifetime_release,
+ * or ignore the return only because a snapshot taken before this call still
+ * carries the same pointer and will reach fd_cleanup_entry. A caller that does
+ * neither strands the reference and the host fd never closes.
+ *
+ * A caller that just wants to retire a published slot and close its host fd
+ * should call fd_retire_published instead of open-coding either shape.
+ */
+fd_lifetime_t *fd_mark_closed(int fd);
 
 /* Same as fd_mark_closed but requires fd_lock to be already held. Used by
  * sys_execve CLOEXEC loop which holds fd_lock for the entire scan.
  */
-void fd_mark_closed_unlocked(int fd);
+fd_lifetime_t *fd_mark_closed_unlocked(int fd);
+
+/* Retire a slot the caller published in fd_table and close the host fd it owns,
+ * deferring the close to the last in-flight borrower when one holds a pin. The
+ * rollback path for a syscall that published a slot and then failed.
+ *
+ * A slot that no longer holds host_fd is left entirely alone, its descriptor
+ * included: reaching that means a sibling already closed this guest fd and that
+ * close retired the descriptor. See the definition for what the check does and
+ * does not prove.
+ */
+void fd_retire_published(int fd, int host_fd);
 
 /* Atomically snapshot an fd entry and mark it closed.
  *
@@ -733,21 +783,31 @@ int64_t sys_mmap_anon(guest_t *g, uint64_t addr, uint64_t length, int prot);
  */
 void fd_set_rlimit_nofile(int cur);
 
-/* Borrowed-or-owned host fd reference.
+/* Borrowed-or-pinned host fd reference.
  *
  * Single-threaded guests borrow the raw host fd directly (no dup, no close).
- * Multi-threaded guests dup under fd_lock to prevent TOCTOU races with
- * concurrent close() from CLONE_THREAD siblings.
+ * Multi-threaded guests pin the slot's host fd until the syscall completes.
  */
 typedef struct {
     host_fd_t fd;
-    bool owned;
+    fd_lifetime_t *lifetime;
 } host_fd_ref_t;
+
+/* An empty ref, safe to hand to host_fd_ref_close without ever opening it.
+ *
+ * Naming fd is enough: a designated initializer zeroes every member it does not
+ * name, so lifetime comes out NULL. Spell it this way rather than listing them,
+ * which is how one initializer came to say ".owned = 0" and three others to
+ * omit a member added later.
+ */
+#define HOST_FD_REF_INIT ((host_fd_ref_t) {.fd = -1})
+
+static inline fd_block_state_t fd_block_state_of(const fd_entry_t *e);
 
 static inline int host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
 {
     ref->fd = -1;
-    ref->owned = false;
+    ref->lifetime = NULL;
 
     if (thread_is_single_active()) {
         int host_fd = fd_to_host(guest_fd);
@@ -757,11 +817,11 @@ static inline int host_fd_ref_open(guest_fd_t guest_fd, host_fd_ref_t *ref)
         return 0;
     }
 
-    int host_fd = fd_to_host_dup(guest_fd);
+    fd_entry_t snap;
+    int host_fd = fd_host_ref_acquire(guest_fd, &snap, &ref->lifetime);
     if (host_fd < 0)
         return -1;
     ref->fd = host_fd;
-    ref->owned = true;
     return 0;
 }
 
@@ -775,7 +835,13 @@ static inline int host_fd_ref_open_state(guest_fd_t guest_fd,
                                          fd_block_state_t *st_out)
 {
     ref->fd = -1;
-    ref->owned = false;
+    ref->lifetime = NULL;
+
+    /* Settle the classification before anything can fail. Every failure exit
+     * below has to leave one behind, or a caller that reads it after a refused
+     * open reads whatever was on its stack.
+     */
+    *st_out = (fd_block_state_t) {.type = FD_CLOSED};
 
     if (thread_is_single_active()) {
         int host_fd = fd_to_host(guest_fd);
@@ -786,11 +852,12 @@ static inline int host_fd_ref_open_state(guest_fd_t guest_fd,
         return 0;
     }
 
-    int host_fd = fd_to_host_dup_state(guest_fd, st_out);
+    fd_entry_t snap;
+    int host_fd = fd_host_ref_acquire(guest_fd, &snap, &ref->lifetime);
     if (host_fd < 0)
         return -1;
+    *st_out = fd_block_state_of(&snap);
     ref->fd = host_fd;
-    ref->owned = true;
     return 0;
 }
 
@@ -801,10 +868,10 @@ static inline void host_fd_ref_close(host_fd_ref_t *ref)
      * failure; a non-zero close error must not clobber that value.
      */
     int saved_errno = errno;
-    if (ref->owned && ref->fd >= 0)
-        close(ref->fd);
+    if (ref->lifetime)
+        fd_lifetime_release(ref->lifetime);
     ref->fd = -1;
-    ref->owned = false;
+    ref->lifetime = NULL;
     errno = saved_errno;
 }
 
@@ -813,7 +880,7 @@ static inline int host_dirfd_ref_open(guest_fd_t dirfd, host_fd_ref_t *ref)
 {
     if (dirfd == LINUX_AT_FDCWD) {
         ref->fd = AT_FDCWD;
-        ref->owned = false;
+        ref->lifetime = NULL;
         return 0;
     }
     return host_fd_ref_open(dirfd, ref);
@@ -853,7 +920,7 @@ static inline fd_block_state_t fd_block_state_of(const fd_entry_t *e)
  * window, which is what lets a transfer act on the object it is holding rather
  * than on whatever took the fd number afterwards. Both out-params are optional.
  *
- * Returns 0 on success, -LINUX_EBADF otherwise.
+ * Returns 0 on success or a negative Linux errno.
  */
 static inline int64_t host_fd_ref_open_io_state(guest_fd_t guest_fd,
                                                 host_fd_ref_t *ref,
@@ -861,7 +928,7 @@ static inline int64_t host_fd_ref_open_io_state(guest_fd_t guest_fd,
                                                 fd_block_state_t *st_out)
 {
     ref->fd = -1;
-    ref->owned = false;
+    ref->lifetime = NULL;
     if (st_out)
         *st_out = (fd_block_state_t) {.type = FD_CLOSED};
 
@@ -890,19 +957,21 @@ static inline int64_t host_fd_ref_open_io_state(guest_fd_t guest_fd,
         return 0;
     }
 
-    int host_fd = fd_snapshot_and_dup(guest_fd, &snap);
+    /* linux_errno rather than a flat EBADF: fd_host_ref_acquire distinguishes a
+     * slot that is not open from an allocation it could not make, and a guest
+     * under memory pressure must not be told its descriptor is invalid.
+     */
+    int host_fd = fd_host_ref_acquire(guest_fd, &snap, &ref->lifetime);
     if (host_fd < 0)
-        return -LINUX_EBADF;
+        return linux_errno();
     if (snap.type == FD_PATH) {
-        int saved_errno = errno;
-        close(host_fd);
-        errno = saved_errno;
+        fd_lifetime_release(ref->lifetime);
+        ref->lifetime = NULL;
         return -LINUX_EBADF;
     }
     if (st_out)
         *st_out = fd_block_state_of(&snap);
     ref->fd = host_fd;
-    ref->owned = true;
     if (out_gen)
         *out_gen = snap.generation;
     return 0;

--- a/src/syscall/linux-wire.h
+++ b/src/syscall/linux-wire.h
@@ -555,7 +555,19 @@ typedef struct {
      */
     _Atomic int type; /* FD_CLOSED, FD_STDIO, FD_REGULAR, FD_DIR */
     int host_fd;      /* Underlying macOS file descriptor */
-    uint64_t ofd_id;  /* Shared by dup aliases of one open file description */
+
+    /* Refcount pinning host_fd open across a concurrent syscall, created on
+     * first borrow and NULL until then. This slot holds one reference and each
+     * in-flight borrower holds another; the last release closes host_fd. Not an
+     * ABI field: elfuse-internal, and declared here only because the fd table
+     * entry is.
+     *
+     * fd_mark_closed_unlocked detaches this pointer without releasing it, so
+     * the slot's reference travels in the snapshot the caller took first and is
+     * released by fd_cleanup_entry. See fd_host_ref_acquire in internal.h.
+     */
+    struct fd_lifetime *lifetime;
+    uint64_t ofd_id; /* Shared by dup aliases of one open file description */
     uint64_t generation; /* Bumped each time this guest fd slot is reused. Lets
                           * long-lived references (e.g. epoll registrations)
                           * detect a close+reopen ABA where the slot now holds a

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -905,7 +905,7 @@ static int64_t sys_mmap_high_va(guest_t *g,
         return -LINUX_ENOMEM;
 
     bool is_anon = (flags & LINUX_MAP_ANONYMOUS) != 0;
-    host_fd_ref_t backing_ref = {.fd = -1, .owned = false};
+    host_fd_ref_t backing_ref = HOST_FD_REF_INIT;
     int host_backing_fd = -1;
     int track_backing_fd = -1;
     bool close_host_backing_fd = false;
@@ -2673,7 +2673,7 @@ int64_t sys_mmap(guest_t *g,
     bool needs_exec = (prot & LINUX_PROT_EXEC) != 0;
     bool is_prot_none = (prot == LINUX_PROT_NONE);
     bool is_noreserve = is_anon && (flags & LINUX_MAP_NORESERVE) != 0;
-    host_fd_ref_t backing_ref = {.fd = -1, .owned = 0};
+    host_fd_ref_t backing_ref = HOST_FD_REF_INIT;
     int host_backing_fd = -1, track_backing_fd = -1;
 
     /* Tracks whether hvf_apply_file_overlay has installed a host

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -100,8 +100,7 @@ static void recvmsg_cleanup_scm_rights(const int *scm_gfds,
                                        int scm_nfds)
 {
     for (int i = 0; i < scm_nfds; i++) {
-        fd_mark_closed(scm_gfds[i]);
-        close(scm_hfds[i]);
+        fd_retire_published(scm_gfds[i], scm_hfds[i]);
     }
 }
 

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -444,8 +444,7 @@ int64_t sys_socketpair(guest_t *g,
     }
     int gfd1 = fd_alloc(FD_SOCKET, fds[1], absock_unregister_fd);
     if (gfd1 < 0) {
-        fd_mark_closed(gfd0);
-        close(fds[0]);
+        fd_retire_published(gfd0, fds[0]);
         close(fds[1]);
         return -LINUX_EMFILE;
     }
@@ -458,10 +457,8 @@ int64_t sys_socketpair(guest_t *g,
 
     int32_t guest_fds[2] = {gfd0, gfd1};
     if (guest_write_small(g, sv_gva, guest_fds, sizeof(guest_fds)) < 0) {
-        fd_mark_closed(gfd0);
-        close(fds[0]);
-        fd_mark_closed(gfd1);
-        close(fds[1]);
+        fd_retire_published(gfd0, fds[0]);
+        fd_retire_published(gfd1, fds[1]);
         return -LINUX_EFAULT;
     }
 
@@ -554,7 +551,7 @@ static int64_t do_accept(guest_t *g,
     if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
         return -LINUX_EBADF;
 
-    host_fd_ref_t host_ref = {.fd = -1, .owned = false};
+    host_fd_ref_t host_ref = HOST_FD_REF_INIT;
     uint64_t listener_generation = 0;
     int listener_passcred_fallback = 0;
     int listener_type = FD_CLOSED;
@@ -570,11 +567,11 @@ static int64_t do_accept(guest_t *g,
                                 &listener_passcred_fallback);
     } else {
         fd_entry_t listener_snap = {.type = FD_CLOSED};
-        int host_fd = fd_snapshot_and_dup(fd, &listener_snap);
+        int host_fd =
+            fd_host_ref_acquire(fd, &listener_snap, &host_ref.lifetime);
         if (host_fd < 0)
-            return -LINUX_EBADF;
+            return linux_errno();
         host_ref.fd = host_fd;
-        host_ref.owned = true;
         sock_st = fd_block_state_of(&listener_snap);
         listener_type = listener_snap.type;
         listener_generation = listener_snap.generation;
@@ -645,15 +642,13 @@ static int64_t do_accept(guest_t *g,
      */
     if (addr_gva) {
         if (!addrlen_gva) {
-            close(new_fd);
-            fd_mark_closed(gfd);
+            fd_retire_published(gfd, new_fd);
             return -LINUX_EFAULT;
         }
         uint32_t guest_addrlen;
         if (guest_read_small(g, addrlen_gva, &guest_addrlen,
                              sizeof(guest_addrlen)) < 0) {
-            close(new_fd);
-            fd_mark_closed(gfd);
+            fd_retire_published(gfd, new_fd);
             return -LINUX_EFAULT;
         }
         uint8_t linux_sa[128];
@@ -669,8 +664,7 @@ static int64_t do_accept(guest_t *g,
             if (guest_write_small(g, addr_gva, linux_sa, write_len) < 0 ||
                 guest_write_small(g, addrlen_gva, &actual_len,
                                   sizeof(actual_len)) < 0) {
-                close(new_fd);
-                fd_mark_closed(gfd);
+                fd_retire_published(gfd, new_fd);
                 return -LINUX_EFAULT;
             }
         }

--- a/src/syscall/netlink.c
+++ b/src/syscall/netlink.c
@@ -471,8 +471,7 @@ int64_t netlink_socket(int protocol, int type)
 
     netlink_state_t *ns = nl_alloc(gfd);
     if (!ns) {
-        fd_mark_closed(gfd);
-        close(pipefd[0]);
+        fd_retire_published(gfd, pipefd[0]);
         close(pipefd[1]);
         return -LINUX_ENOMEM;
     }

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -290,28 +290,59 @@ int path_fd_magiclink_guest_fd(const char *path)
     return parse_fd_magiclink(path);
 }
 
-int path_fd_magiclink_dup(const char *path)
+/* Whether an f*() call on the slot's host fd acts on the file the magic link
+ * names. A FUSE or synthetic fd is served by an emulation layer rather than by
+ * the host file behind it, so those keep the path form and the intercepts that
+ * go with it.
+ */
+static inline bool magiclink_type_acts_on_host_fd(int type)
 {
+    return type == FD_REGULAR || type == FD_DIR || type == FD_PATH ||
+           type == FD_STDIO;
+}
+
+int path_fd_magiclink_open(const char *path, host_fd_ref_t *ref)
+{
+    ref->fd = -1;
+    ref->lifetime = NULL;
+
     int fd = parse_fd_magiclink(path);
     if (fd < 0)
         return -1;
 
-    /* Only descriptors whose host fd is the object itself. A FUSE or synthetic
-     * fd is served by an emulation layer rather than by the host file behind
-     * it, so an f*() call would act on the wrong thing; those keep the path
-     * form and the intercepts that go with it.
+    /* Pin rather than dup. A sibling vCPU closing this slot would otherwise
+     * leave the number free for the next open to claim, which is the only
+     * reason a second descriptor was ever taken here; the pin covers it without
+     * one. It also has to be a pin rather than a dup because the caller acts on
+     * a file the guest may hold record locks on, and retiring a dup would drop
+     * every one of them (fcntl(2)): a guest chmod of its own /proc/self/fd/N
+     * would silently unlock the file.
+     *
+     * The classification below and the pin have to come out of the same fd_lock
+     * hold. Taking them separately leaves a window where a sibling closes the
+     * slot and the next open claims the number, and the caller then acts on the
+     * replacement while the type it was admitted on describes the object that
+     * is gone.
      */
     fd_entry_t snap;
-    if (!fd_snapshot(fd, &snap))
-        return -1;
-    if (snap.type != FD_REGULAR && snap.type != FD_DIR &&
-        snap.type != FD_PATH && snap.type != FD_STDIO)
-        return -1;
+    if (thread_is_single_active()) {
+        if (!fd_snapshot(fd, &snap) || snap.host_fd < 0)
+            return -1;
+        if (!magiclink_type_acts_on_host_fd(snap.type))
+            return -1;
+        ref->fd = snap.host_fd;
+        return 0;
+    }
 
-    /* dup under fd_lock: a sibling vCPU closing this slot would otherwise leave
-     * the number free for the next open to claim.
-     */
-    return fd_to_host_dup(fd);
+    int host_fd = fd_host_ref_acquire(fd, &snap, &ref->lifetime);
+    if (host_fd < 0)
+        return -1;
+    if (!magiclink_type_acts_on_host_fd(snap.type)) {
+        host_fd_ref_close(ref);
+        return -1;
+    }
+    ref->fd = host_fd;
+    return 0;
 }
 
 /* Resolve an absolute fd magic link to the host path its descriptor is open on.
@@ -320,8 +351,8 @@ int path_fd_magiclink_dup(const char *path)
  * descriptor has no host path (a pipe, socket, or anonymous fd, where F_GETPATH
  * fails and the caller's own /proc intercepts remain the right answer).
  *
- * Callers that can act on a descriptor should prefer path_fd_magiclink_dup(): a
- * pathname taken here and used later is a TOCTOU, since a rename or an
+ * Callers that can act on a descriptor should prefer path_fd_magiclink_open():
+ * a pathname taken here and used later is a TOCTOU, since a rename or an
  * unlink-and-recreate in between leaves it naming a different inode, where
  * Linux resolves the link inside the syscall and cannot be redirected.
  */
@@ -329,13 +360,13 @@ static int resolve_fd_magiclink_host_path(const char *path,
                                           char *out,
                                           size_t outsz)
 {
-    int host_fd = path_fd_magiclink_dup(path);
-    if (host_fd < 0)
+    host_fd_ref_t ref;
+    if (path_fd_magiclink_open(path, &ref) < 0)
         return 0;
 
     char resolved[MAXPATHLEN];
-    int rc = fcntl(host_fd, F_GETPATH, resolved);
-    close(host_fd);
+    int rc = fcntl(ref.fd, F_GETPATH, resolved);
+    host_fd_ref_close(&ref);
     if (rc < 0)
         return 0;
 
@@ -728,6 +759,11 @@ int sys_path_has_symlink(guest_fd_t dirfd, const char *path)
     bool clamp = false;
     size_t depth = 0;
 
+    /* Function-scoped because base_fd borrows dir_ref.fd for the whole walk:
+     * the pin has to outlive every use of the descriptor it keeps open.
+     */
+    host_fd_ref_t dir_ref = HOST_FD_REF_INIT;
+
     if (path[0] == '/') {
         /* The resolver splices an intermediate link into its target, so its
          * output cannot reveal the link to the component walk below. Ask the
@@ -779,19 +815,24 @@ int sys_path_has_symlink(guest_fd_t dirfd, const char *path)
             clamp = true;
         }
 
-        host_fd_ref_t dir_ref;
         if (host_dirfd_ref_open(dirfd, &dir_ref) < 0) {
             errno = EBADF;
             return -1;
         }
         if (dir_ref.fd == AT_FDCWD) {
             base_fd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-            if (base_fd < 0)
+            if (base_fd < 0) {
+                host_fd_ref_close(&dir_ref);
                 return -1;
+            }
             owned_base_fd = true;
         } else {
+            /* Borrowed, not owned: dir_ref holds the pin and the close at out:
+             * drops it. Claiming ownership here would close the table's own
+             * host fd, which every other alias of this description still uses.
+             */
             base_fd = dir_ref.fd;
-            owned_base_fd = dir_ref.owned;
+            owned_base_fd = false;
         }
     }
 
@@ -915,6 +956,7 @@ int sys_path_has_symlink(guest_fd_t dirfd, const char *path)
 out:
     if (owned_current_fd && current_fd >= 0)
         close(current_fd);
+    host_fd_ref_close(&dir_ref);
     return rc;
 }
 

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -283,7 +283,7 @@ int path_openat2_check_fd_xdev(int guest_fd, int start_class);
 int path_parse_proc_name(const char *name);
 
 /* The guest descriptor an absolute fd magic link names, or -1 when the path is
- * not that shape. Unlike path_fd_magiclink_dup this hands back the guest fd
+ * not that shape. Unlike path_fd_magiclink_open this hands back the guest fd
  * number itself, for callers that need the table entry rather than the object:
  * opening one of these paths produces a second name for a description the
  * process already holds, so the new slot has to inherit that entry's answers
@@ -291,10 +291,15 @@ int path_parse_proc_name(const char *name);
  */
 int path_fd_magiclink_guest_fd(const char *path);
 
-/* An owned dup of the descriptor an absolute fd magic link names
- * ("/proc/self/fd/<n>", the own-pid spelling, "/dev/fd/<n>", "/dev/std*"), or
- * -1 when the path is not that shape or its descriptor is not backed by a plain
- * host object. The caller closes it.
+/* Fill *ref with a reference to the descriptor an absolute fd magic link names
+ * ("/proc/self/fd/<n>", the own-pid spelling, "/dev/fd/<n>", "/dev/std*").
+ *
+ * Returns 0, or -1 when the path is not that shape or its descriptor is not
+ * backed by a plain host object. On success the caller must hand *ref to
+ * host_fd_ref_close and must not close ref->fd itself: this is the guest's own
+ * descriptor, borrowed, not a private duplicate. Closing it directly would shut
+ * the guest's fd, and on a file the guest has locked it would drop every record
+ * lock the process holds on it.
  *
  * Metadata syscalls should act on this rather than on the translated pathname.
  * Linux resolves the magic link inside the syscall, so nothing can redirect it;
@@ -302,4 +307,4 @@ int path_fd_magiclink_guest_fd(const char *path);
  * different inode if the file is renamed, or unlinked and recreated, in
  * between.
  */
-int path_fd_magiclink_dup(const char *path);
+int path_fd_magiclink_open(const char *path, host_fd_ref_t *ref);

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -220,7 +220,7 @@ int64_t sys_ppoll(guest_t *g,
     uint32_t unpollable_count = 0;
     bool unpollable_checked = false;
     for (uint32_t i = 0; i < nfds; i++) {
-        host_refs[i] = (host_fd_ref_t) {.fd = -1, .owned = false};
+        host_refs[i] = HOST_FD_REF_INIT;
         unpollable[i] = (poll_unpollable_t) {.fd = -1};
         int guest_fd = guest_fds[i].fd;
         int host_fd = -1;
@@ -688,7 +688,7 @@ int64_t sys_pselect6(guest_t *g,
                     continue;
                 }
                 int i = (int) fd_index;
-                host_fd_ref_t ref = {.fd = -1, .owned = false};
+                host_fd_ref_t ref = HOST_FD_REF_INIT;
                 if (host_fd_ref_open_io(i, &ref) < 0)
                     goto pselect_badf;
                 int host_fd = ref.fd;

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -426,7 +426,7 @@ static inline bool *thread_saved_valid_ptr(void)
  * a stale value or fail to see a fresh registration. The release-acquire pair
  * seals the window.
  */
-static _Atomic(guest_t *) attention_guest;
+static guest_t *_Atomic attention_guest;
 
 void signal_init(void)
 {
@@ -1893,6 +1893,22 @@ int64_t signal_sigaltstack(guest_t *g, uint64_t ss_gva, uint64_t old_ss_gva)
 #define ESR_MAGIC 0x45535201U
 #define ESR_CONTEXT_SIZE 16 /* { __u32 magic, size; __u64 esr; } */
 
+/* Worst case the chain below writes: both records plus the terminator. The
+ * assert is what keeps the contract on build_sigcontext_reserved honest if a
+ * record grows or a third one is added.
+ */
+#define SIGCONTEXT_CHAIN_MAX_BYTES (FPSIMD_CONTEXT_SIZE + ESR_CONTEXT_SIZE + 8)
+
+_Static_assert(SIGCONTEXT_CHAIN_MAX_BYTES <= SIGCONTEXT_RESERVED_BYTES,
+               "sigcontext record chain must fit the reserved area");
+
+/* The proved offset bound in src/proved/sigframe.h derives the record size
+ * independently. Both spell 528 today and nothing else ties them, so a change
+ * to either would leave the proof describing a record that no longer exists.
+ */
+_Static_assert(FPSIMD_CONTEXT_SIZE == SIGFRAME_FPSIMD_BYTES,
+               "proved FPSIMD record size must match the one written here");
+
 /* Build the extended context chain in the __reserved area. Linux kernel
  * (arch/arm64/kernel/signal.c) builds:
  *   1. FPSIMD context (always present)
@@ -1900,6 +1916,13 @@ int64_t signal_sigaltstack(guest_t *g, uint64_t ss_gva, uint64_t old_ss_gva)
  *   3. Terminator (magic=0, size=0)
  * The @esr parameter is the raw ESR_EL1 value; if non-zero, the ESR context
  * block is included.
+ *
+ * The contract states the buffer the caller owes, which is what lets the
+ * running offset be proved in bounds rather than merely read as obviously so.
+ */
+/*@
+  requires \valid(reserved + (0 .. SIGCONTEXT_CHAIN_MAX_BYTES - 1));
+  assigns reserved[0 .. SIGCONTEXT_CHAIN_MAX_BYTES - 1];
  */
 static void build_sigcontext_reserved(uint8_t *reserved,
                                       uint64_t esr,
@@ -1923,10 +1946,22 @@ static void build_sigcontext_reserved(uint8_t *reserved,
     memcpy(reserved + off + 8, &fpsr32, 4);
     memcpy(reserved + off + 12, &fpcr32, 4);
 
-    /* Save V0-V31 (128-bit each, at offset 16) */
-    for (int i = 0; i < 32; i++) {
-        hv_simd_fp_uchar16_t vreg = vcpu_get_simd(vcpu, (unsigned) i);
-        memcpy(reserved + off + 16 + (size_t) i * 16, &vreg, 16);
+    /* Save V0-V31 (128-bit each, at offset 16) off is still zero here: FPSIMD
+     * is the first record in the chain, and the invariant says so rather than
+     * leaving the prover to guess, which is what bounds the 32 stores below
+     * inside the reserved area.
+     */
+    hv_simd_fp_uchar16_t vreg;
+    /*@
+      loop invariant 0 <= i <= SIGFRAME_FPSIMD_VREG_COUNT;
+      loop invariant off == 0;
+      loop assigns i, vreg, reserved[0 .. SIGCONTEXT_CHAIN_MAX_BYTES - 1];
+      loop variant SIGFRAME_FPSIMD_VREG_COUNT - i;
+     */
+    for (uint32_t i = 0; i < SIGFRAME_FPSIMD_VREG_COUNT; i++) {
+        vreg = vcpu_get_simd(vcpu, i);
+        memcpy(reserved + off + sigframe_fpsimd_vreg_offset(i), &vreg,
+               SIGFRAME_FPSIMD_VREG_BYTES);
     }
     off += FPSIMD_CONTEXT_SIZE;
 

--- a/src/syscall/signal.h
+++ b/src/syscall/signal.h
@@ -126,15 +126,22 @@ typedef struct {
 #define LINUX_SEGV_MAPERR 1 /* Address not mapped to object */
 #define LINUX_SEGV_ACCERR 2 /* Invalid permissions for mapped object */
 
-/* Linux sigcontext (aarch64). From arch/arm64/include/uapi/asm/sigcontext.h */
+/* Linux sigcontext (aarch64). From arch/arm64/include/uapi/asm/sigcontext.h
+ * Size of the sigcontext extension area, matching Linux. Named rather than
+ * spelled inline because build_sigcontext_reserved's contract is stated against
+ * it: the running offset that walks the record chain is only provably in bounds
+ * against a bound the prover can see.
+ */
+#define SIGCONTEXT_RESERVED_BYTES 4096
+
 typedef struct {
     uint64_t fault_address;
     uint64_t regs[31]; /* X0-X30 */
     uint64_t sp;       /* SP_EL0 */
     uint64_t pc;       /* ELR_EL1 at time of signal */
     uint64_t pstate;   /* SPSR_EL1 at time of signal */
-    /* Extension space for FPSIMD, ESR, SVE contexts (4096 bytes) */
-    uint8_t __reserved[4096] __attribute__((aligned(16)));
+    /* Extension space for FPSIMD, ESR, SVE contexts */
+    uint8_t __reserved[SIGCONTEXT_RESERVED_BYTES] __attribute__((aligned(16)));
 } linux_sigcontext_t;
 
 /* Linux stack_t and sigaltstack constants. */

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -154,6 +154,7 @@ test-robust-futex
 test-fd-race
 test-dup-setfl-race
 test-pipe-steal
+test-fd-pin-lock
 
 [section] Multithreaded fork tests
 test-mt-fork

--- a/tests/test-fd-pin-lock.c
+++ b/tests/test-fd-pin-lock.c
@@ -1,0 +1,261 @@
+/*
+ * Test that concurrent fd syscalls do not drop the process's record locks
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression coverage for host-fd lifetime pinning. A multi-threaded guest used
+ * to run every fd syscall against a private dup of the host descriptor, closed
+ * on return. POSIX record locks are released when the process closes any
+ * descriptor for the inode (fcntl(2), "Record locking"), so that close threw
+ * away the F_SETLK the very same call had just taken: the lock lasted only
+ * until the syscall returned. Pinning holds the table's own descriptor instead
+ * of duplicating it, so nothing closes and the lock survives.
+ *
+ * The sibling thread is load-bearing twice over. It keeps the guest off the
+ * single-active fast path, which never dup'd and so never had the bug, and its
+ * own fd syscalls each take and drop a pin on the very descriptor holding the
+ * lock, which is the case that has to stay quiet.
+ *
+ * Both fork orders are covered. A child forked before the lock isolates the
+ * pin; a child forked after it covers the same defect one layer down, in the
+ * fork path itself. Sending the fd table over SCM_RIGHTS used to dup every
+ * descriptor and close the dup once the send completed, and that close dropped
+ * every record lock the guest held, so a fork silently unlocked the parent.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+#define LOCK_BYTE 4096
+
+static pthread_barrier_t barrier;
+static int lock_fd = -1;
+static atomic_int sibling_stop;
+static atomic_int sibling_calls;
+static atomic_int sibling_failed;
+
+static int set_lock(int fd, short type)
+{
+    struct flock fl = {
+        .l_type = type,
+        .l_whence = SEEK_SET,
+        .l_start = LOCK_BYTE,
+        .l_len = 1,
+    };
+    return fcntl(fd, F_SETLK, &fl);
+}
+
+/* Runs fd syscalls against the locked descriptor for as long as the main thread
+ * holds the lock. Each one acquires and releases a pin on it.
+ *
+ * Loops until told to stop rather than a fixed count, so the checks the main
+ * thread runs in between are concurrent with it by construction. A counted loop
+ * can drain before the main thread reaches its first check, which leaves the
+ * check measuring nothing and passing anyway.
+ */
+static void *sibling(void *arg)
+{
+    (void) arg;
+    pthread_barrier_wait(&barrier);
+    while (!atomic_load(&sibling_stop)) {
+        /* Both reach the host descriptor and so take a pin on it. F_GETFD does
+         * not: elfuse answers the close-on-exec bit from the fd table without
+         * touching the host fd, so it would leave half this loop inert.
+         *
+         * A failure here is recorded rather than just ending the loop. Exiting
+         * quietly would let every check the main thread runs pass while the
+         * sibling contributed nothing, which is the one way this test can go
+         * green without having tested concurrency at all.
+         */
+        if (fcntl(lock_fd, F_GETFL) < 0) {
+            atomic_store(&sibling_failed, errno);
+            break;
+        }
+        struct stat st;
+        if (fstat(lock_fd, &st) < 0) {
+            atomic_store(&sibling_failed, errno);
+            break;
+        }
+        atomic_fetch_add(&sibling_calls, 1);
+    }
+    return NULL;
+}
+
+/* Asks the child to try the same lock and report whether it got it.
+ *
+ * Returns 1 if the child took the lock (meaning this process no longer holds
+ * it), 0 if it was correctly refused, -1 if the exchange itself failed.
+ */
+static int child_can_lock(int go_wr, int rep_rd)
+{
+    if (write(go_wr, "x", 1) != 1)
+        return -1;
+    int taken = -1;
+    if (read(rep_rd, &taken, sizeof(taken)) != (ssize_t) sizeof(taken))
+        return -1;
+    return taken;
+}
+
+int main(void)
+{
+    int passes = 0, fails = 0;
+    const char *path = "/tmp/elfuse-test-fd-pin-lock";
+
+    lock_fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    if (lock_fd < 0) {
+        perror("open");
+        return 1;
+    }
+
+    int go[2], report[2];
+    if (pipe(go) < 0 || pipe(report) < 0) {
+        perror("pipe");
+        close(lock_fd);
+        unlink(path);
+        return 1;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        perror("fork");
+        close(lock_fd);
+        unlink(path);
+        return 1;
+    }
+    if (child == 0) {
+        close(go[1]);
+        close(report[0]);
+        int cfd = open(path, O_RDWR);
+        char b;
+        while (read(go[0], &b, 1) == 1) {
+            /* -1, not 0, when the child never got to try. A refusal and a
+             * failed open both leave the lock untaken, and reporting them the
+             * same way lets every "the child was refused" check pass on a child
+             * that did nothing.
+             */
+            int taken = cfd < 0 ? -1 : (set_lock(cfd, F_WRLCK) == 0 ? 1 : 0);
+            if (taken == 1)
+                set_lock(cfd, F_UNLCK);
+            if (write(report[1], &taken, sizeof(taken)) !=
+                (ssize_t) sizeof(taken))
+                break;
+        }
+        _exit(0);
+    }
+    close(go[0]);
+    close(report[1]);
+
+    atomic_store(&sibling_stop, 0);
+    atomic_store(&sibling_calls, 0);
+    atomic_store(&sibling_failed, 0);
+    pthread_barrier_init(&barrier, NULL, 2);
+    pthread_t th;
+    if (pthread_create(&th, NULL, sibling, NULL) != 0) {
+        perror("pthread_create");
+        close(go[1]);
+        close(report[0]);
+        waitpid(child, NULL, 0);
+        pthread_barrier_destroy(&barrier);
+        close(lock_fd);
+        unlink(path);
+        return 1;
+    }
+
+    /* Releases the sibling, which runs until the second barrier below. Every
+     * check between the two happens with a second thread live, so the guest is
+     * off the single-active path throughout.
+     */
+    pthread_barrier_wait(&barrier);
+
+    while (atomic_load(&sibling_calls) == 0 &&
+           atomic_load(&sibling_failed) == 0)
+        sched_yield();
+
+    TEST("the sibling began fd syscalls");
+    EXPECT_TRUE(atomic_load(&sibling_failed) == 0,
+                "sibling made no successful fd calls");
+
+    TEST("the region starts unlocked");
+    EXPECT_EQ(child_can_lock(go[1], report[0]), 1,
+              "child could not take a free lock");
+
+    TEST("F_SETLK on a multi-threaded guest");
+    EXPECT_EQ(set_lock(lock_fd, F_WRLCK), 0, "F_SETLK F_WRLCK rejected");
+
+    TEST("the lock outlives the syscall that took it");
+    EXPECT_EQ(child_can_lock(go[1], report[0]), 0,
+              "a second process took the lock this one still holds");
+
+    /* The sibling has been running fd syscalls against lock_fd since the first
+     * barrier, concurrently with every check above. Stop it and ask again.
+     */
+    atomic_store(&sibling_stop, 1);
+    pthread_join(th, NULL);
+
+    TEST("the sibling actually ran fd syscalls");
+    EXPECT_TRUE(
+        atomic_load(&sibling_failed) == 0 && atomic_load(&sibling_calls) > 0,
+        "sibling made no successful fd calls");
+
+    TEST("the lock survives a sibling's fd syscalls");
+    EXPECT_EQ(child_can_lock(go[1], report[0]), 0,
+              "a sibling's fd syscalls released this process's lock");
+
+    /* Fork with the lock already held. The state transfer must not close any
+     * descriptor for this file in the parent, or the lock dies here.
+     */
+    TEST("the lock survives a fork");
+    int post[2];
+    if (pipe(post) < 0) {
+        EXPECT_TRUE(0, "pipe failed");
+    } else {
+        pid_t late = fork();
+        if (late == 0) {
+            close(post[0]);
+            int cfd = open(path, O_RDWR);
+
+            /* -1, not 0, when the child never got to try: see child_can_lock. A
+             * failed open must not read as a refusal here either.
+             */
+            int taken = cfd < 0 ? -1 : (set_lock(cfd, F_WRLCK) == 0 ? 1 : 0);
+            ssize_t ignored = write(post[1], &taken, sizeof(taken));
+            (void) ignored;
+            _exit(0);
+        }
+        close(post[1]);
+        int taken = -1;
+        ssize_t n = read(post[0], &taken, sizeof(taken));
+        close(post[0]);
+        if (late > 0)
+            waitpid(late, NULL, 0);
+        EXPECT_TRUE(n == (ssize_t) sizeof(taken) && taken == 0,
+                    "forking released this process's lock");
+    }
+
+    TEST("F_UNLCK releases it");
+    EXPECT_EQ(set_lock(lock_fd, F_UNLCK), 0, "F_UNLCK rejected");
+    EXPECT_EQ(child_can_lock(go[1], report[0]), 1,
+              "child still refused the lock after F_UNLCK");
+
+    close(go[1]);
+    close(report[0]);
+    waitpid(child, NULL, 0);
+
+    pthread_barrier_destroy(&barrier);
+    close(lock_fd);
+    unlink(path);
+
+    SUMMARY("test-fd-pin-lock");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -736,6 +736,7 @@ run_unit_tests()
     test_check "$runner" "test-poll" "0 failed" "$bindir/test-poll"
     test_rc "$runner" "test-flock" 0 "$bindir/test-flock"
     test_rc "$runner" "test-ofd-lock" 0 "$bindir/test-ofd-lock"
+    test_rc "$runner" "test-fd-pin-lock" 0 "$bindir/test-fd-pin-lock"
     test_rc "$runner" "test-times" 0 "$bindir/test-times"
     test_rc "$runner" "test-syscall-smoke" 0 "$bindir/test-syscall-smoke"
     test_rc "$runner" "test-process-vm" 0 "$bindir/test-process-vm"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins host file descriptors instead of duplicating them for multi-threaded fd syscalls, preserving POSIX record locks and avoiding extra host fds. Splits exec’s post-PNR address-space rebuild and extends AArch64 signal-frame verification.

- Adds a refcounted fd_lifetime and APIs: fd_host_ref_acquire, fd_lifetime_release, fd_lifetime_pin_locked, and fd_retire_published. Replaces per-call dup with a pin in fd I/O paths, /proc/self/fd magiclink operations, dirfd uses in fstatat, the fdinfo lseek probe, and the fork SCM_RIGHTS transfer. Prevents lock loss on fork and fixes three FUSE leaks.
- Refines fd_retire_published: retires only if the slot still owns that host fd to avoid double-close after a sibling replaced the slot.
- Changes host_fd_ref_t to carry a lifetime pin and adds HOST_FD_REF_INIT. Removes dup+classify helpers; fd_mark_closed(_unlocked) now return a detached lifetime the caller must release or let fd_cleanup_entry consume.
- path_fd_magiclink_open replaces the dup variant and now pins and classifies under one fd_lock hold, removing a TOCTOU window; path APIs document the borrowed ref and require host_fd_ref_close (not close).
- Error semantics: helpers that open-and-classify now return negative Linux errno (distinguish ENOMEM vs EBADF) and initialize output state on failure.
- Adds test-fd-pin-lock to prove multi-threaded guests keep F_SETLK locks across syscalls and fork; asserts the sibling actually exercised fd syscalls.
- Exec refactor: factors rebuild into exec_install_address_space and exec_publish_maps, sharing math via exec_seg_start/exec_seg_end; preserves region order and publishes mmap watermarks.
- Proofing: adds Mach and ucontext stubs, tightens Hypervisor accessor contracts with assigns clauses, converts attention_guest to the qualifier atomic form, proves FPSIMD vector offsets via sigframe_fpsimd_vreg_offset, names SIGCONTEXT_RESERVED_BYTES, and updates verify.mk with mutants and claims.

**Review focus**
- Rollbacks must call fd_retire_published; do not raw-close host fds after publishing a slot. Confirm the “still ours” guard prevents double-close.
- Call sites must release pins (host_fd_ref_close or fd_lifetime_release) and never mix pins with raw closes.
- API renames: use path_fd_magiclink_open and fd_host_ref_acquire; avoid removed dup+classify helpers.

<sup>Written for commit 1c1d467e2d791be8dd22a0a53d8da9d358eadf13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

