### PR TITLE
Accept uevent netlink sockets as silent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,12 @@ $(BUILD_DIR)/test-dup-setfl-race: tests/test-dup-setfl-race.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
 
+# test-uevent-socket races two threads through socket(AF_NETLINK) and parks a
+# blocking receive until a second thread pokes the rtnetlink fd.
+$(BUILD_DIR)/test-uevent-socket: tests/test-uevent-socket.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
+
 # test-pthread needs -lpthread
 $(BUILD_DIR)/test-pthread: tests/test-pthread.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -434,6 +434,70 @@ Socket syscalls are translated in `src/syscall/net.c` and friends:
 - `SOL_SOCKET` option numbers (`SO_TYPE`, `SO_SNDBUF`, `SO_RCVBUF`, …)
   differ between platforms and are remapped per option.
 
+Netlink sockets are emulated in `src/syscall/netlink.c`: `NETLINK_ROUTE`
+answers the `RTM_GETLINK` / `RTM_GETADDR` dumps `getifaddrs` issues, and
+`NETLINK_KOBJECT_UEVENT` sockets are accepted as silent sockets -- no uevent
+is ever synthesized, so the fd never becomes readable, which is exactly a
+real Linux kernel with no hotplug activity -- because libusb-style hotplug
+monitors must open, bind, and set `SO_PASSCRED` on one before they will
+initialize at all.
+
+`socket()` validates its type argument the way `__sock_create()` and
+`netlink_create()` do, in that order: an unknown bit outside
+`SOCK_NONBLOCK|SOCK_CLOEXEC` is `EINVAL`, and a base type other than
+`SOCK_RAW` or `SOCK_DGRAM` is `ESOCKTNOSUPPORT` -- before the protocol
+number is looked at, so `socket(AF_NETLINK, SOCK_STREAM, 99)` reports the
+type error and not the family one.
+
+`SOL_SOCKET` options on a netlink fd follow `sk_setsockopt` /
+`sk_getsockopt` rather than being accepted and forgotten: whatever can be
+set can be read back, `SO_RCVBUF` and `SO_SNDBUF` clamp-double-floor at the
+two different `SOCK_MIN_*` floors, `SO_RCVTIMEO` really does bound a
+blocking receive, and the options Linux refuses (`SO_SNDLOWAT`, a
+privileged `SO_DEBUG`, a non-inet `SO_REUSEPORT`, a short `SO_LINGER` or
+timeout `optlen`) are refused with the same errno.
+
+`SO_RCVTIMEO` and `SO_SNDTIMEO` are stored as `sk_rcvtimeo` /
+`sk_sndtimeo` are: a jiffy count with `HZ` pinned at 1000, which gives
+`sock_set_timeout()`'s three states rather than two. `{0, 0}` and any
+`tv_sec` past `MAX_SCHEDULE_TIMEOUT/HZ - 1` mean wait forever; a negative
+`tv_sec` means do not wait at all, so a blocking receive under it reports
+`EAGAIN` at once; anything else is that many milliseconds, rounded up from
+a sub-jiffy `tv_usec`. Both of the first two read back as `{0, 0}`, exactly
+as `sock_get_timeout()` reports them, so only a receive can tell them
+apart. The deadline such a timeout produces is added to the clock with
+saturation, since the largest one Linux accepts is within seconds of
+overflowing a 64-bit millisecond count.
+
+An interrupted receive with a finite timeout forbids the SVC restart only
+when the interruption is one the guest can see. `io_wait_fd_timed_or_-
+interrupted()` also reports `EINTR` for the dispatcher's own execve
+handoff, which no signal accompanies; forbidding there turned a sibling's
+`execve` into an `EINTR` on a `recvmsg`. The restarted call instead resumes
+the deadline the interrupted attempt was using, which is what Linux's
+`restart_block` carries.
+
+`SOL_NETLINK` is emulated under the same contract `bind()` gives -- the
+membership and the flags are recorded, and no multicast traffic is ever
+synthesized to deliver on them. `NETLINK_ADD_MEMBERSHIP` /
+`NETLINK_DROP_MEMBERSHIP` range-check the group and return 0;
+`NETLINK_LIST_MEMBERSHIPS` reads the resulting bitmap back;
+`NETLINK_PKTINFO`, `NETLINK_BROADCAST_ERROR`, `NETLINK_NO_ENOBUFS`,
+`NETLINK_CAP_ACK`, `NETLINK_EXT_ACK` and `NETLINK_GET_STRICT_CHK` set and
+read back as flags (a libnl or libmnl monitor sets several of these on the
+way up and treats a refusal as a broken socket); `NETLINK_LISTEN_ALL_NSID`
+wants `CAP_NET_ADMIN` and reports `EPERM`; the removed mmap ring options
+and anything else report `ENOPROTOOPT`.
+
+Netlink socket state is keyed by guest fd number, and a guest fd number
+outlives its socket: `fd_cleanup_entry()` runs the netlink teardown after
+the number is already back in the fd table's free pool, so a concurrent
+`socket()` can be handed it while the previous slot is still live. Slots
+therefore carry an allocation generation -- lookups answer with the newest
+slot for a number and teardown retires the oldest -- which pairs each
+teardown with the socket that asked for it whatever order the threads
+arrive in.
+
 ### Stack Alignment
 
 The Linux initial stack must have `SP` 16-byte aligned and pointing directly

--- a/scripts/check-eintr-contract.py
+++ b/scripts/check-eintr-contract.py
@@ -125,6 +125,14 @@ INVENTORY = {
         "to write a chunk they have already read. Those decide for themselves "
         "and are listed above.",
     ),
+    "syscall/io.c::io_wait_fd_timed_or_interrupted": (
+        "restartable",
+        "The bounded spelling of the wait above, and restartable for the same "
+        "reason: it transfers nothing. The deadline is the caller's, not its "
+        "own, so the caller that supplied one -- today only the SO_RCVTIMEO "
+        "receive in nl_wait_readable_locked -- is the one that must forbid "
+        "the restart.",
+    ),
     "syscall/fs.c::open_nonblocking_writer": (
         "restartable",
         "FIFO open retry; nothing is opened until it succeeds.",
@@ -269,10 +277,18 @@ INVENTORY = {
         "before the backoff waits.",
     ),
     "syscall/netlink.c::nl_wait_readable_locked": (
-        "restartable",
-        "Waits for a reply to a request an earlier sendmsg put on the wire. "
-        "This call consumed nothing, and the restart waits for the same "
-        "reply.",
+        "forbids",
+        "Conditionally, and that condition is sock_intr_errno()'s: a receive "
+        "with no SO_RCVTIMEO consumed nothing and stays restartable (Linux "
+        "reports ERESTARTSYS there), but one with a finite timeout has spent "
+        "part of it, and a restart would hand the guest the whole timeout a "
+        "second time, so that branch forbids like every other spent deadline "
+        "in this table. Narrowed once more to the guest-visible half of the "
+        "EINTR: the dispatcher's leader-only execve handoff also reports "
+        "EINTR here, carries no signal, and is restarted by design, so the "
+        "forbid is gated on !thread_stop_is_leader_work_only() and the "
+        "restarted attempt resumes the deadline rather than taking a fresh "
+        "one -- restart_block's job.",
     ),
     "syscall/inotify.c::inotify_read": (
         "restartable",
@@ -366,6 +382,7 @@ FORBID_MARKER = "syscall_restart_forbid()"
 # decision, it does not presume one.
 EINTR_HELPERS = (
     "io_wait_fd_or_interrupted",
+    "io_wait_fd_timed_or_interrupted",
     "net_wait_or_interrupted",
     "net_recv_zero_payload_gate",
     "connect_nonblock_wait",

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -29,6 +29,7 @@
 #include <sys/ioctl.h>
 #include <poll.h>
 #include <termios.h>
+#include <time.h>
 
 #include "utils.h"
 
@@ -248,9 +249,32 @@ int64_t io_retry_backoff(unsigned *backoff_us)
     return 0;
 }
 
+/* Milliseconds on CLOCK_MONOTONIC, for the bounded wait's deadline. */
+static int64_t io_now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
 int64_t io_wait_fd_or_interrupted(int host_fd, short events)
 {
+    return io_wait_fd_timed_or_interrupted(host_fd, events, -1);
+}
+
+int64_t io_wait_fd_timed_or_interrupted(int host_fd,
+                                        short events,
+                                        int timeout_ms)
+{
     int wake_fd = wakeup_pipe_read_fd();
+
+    /* An absolute deadline rather than a countdown: the 200 ms slices below
+     * exist to re-check interrupt conditions, and charging each one against a
+     * fixed instant keeps a bounded wait bounded no matter how many of them
+     * run. A countdown reset per slice would never expire.
+     */
+    bool bounded = timeout_ms >= 0;
+    int64_t deadline_ms = bounded ? io_now_ms() + timeout_ms : 0;
 
     /* poll() ignores entries with a negative fd, so a missing wakeup pipe just
      * drops the second slot.
@@ -313,7 +337,16 @@ int64_t io_wait_fd_or_interrupted(int host_fd, short events)
          * drain the byte meant to wake this one. The 200 ms recheck guarantees
          * every waiter re-evaluates its own interrupt conditions.
          */
-        int ret = poll(fds, 2, leader_only ? 0 : 200);
+        int slice = leader_only ? 0 : 200;
+        if (bounded && !leader_only) {
+            int64_t left = deadline_ms - io_now_ms();
+            if (left <= 0)
+                return 1;
+            if (left < slice)
+                slice = (int) left;
+        }
+
+        int ret = poll(fds, 2, slice);
         if (ret < 0)
             return linux_errno();
 
@@ -324,6 +357,8 @@ int64_t io_wait_fd_or_interrupted(int host_fd, short events)
 
         if (leader_only)
             return -LINUX_EINTR;
+        if (bounded && deadline_ms - io_now_ms() <= 0)
+            return 1;
     }
 }
 

--- a/src/syscall/io.h
+++ b/src/syscall/io.h
@@ -44,6 +44,18 @@ void io_init(void);
  */
 int64_t io_wait_fd_or_interrupted(int host_fd, short events);
 
+/* Same wait, bounded by a caller's deadline. timeout_ms < 0 is the untimed wait
+ * above; 0 or more caps the whole wait, not each of its interrupt-recheck
+ * slices, so a bounded caller cannot be stretched by them.
+ *
+ * Returns 0 when ready, 1 when the timeout expired first, -LINUX_EINTR when
+ * interrupted, or a negative Linux errno on poll failure. Only the SO_RCVTIMEO
+ * receive path needs the bound; everything else takes the untimed spelling.
+ */
+int64_t io_wait_fd_timed_or_interrupted(int host_fd,
+                                        short events,
+                                        int timeout_ms);
+
 /* Consecutive EAGAINs from a transfer the wait called ready, before io_xfer
  * stops retrying at full speed and starts backing off.
  *

--- a/src/syscall/linux-wire.h
+++ b/src/syscall/linux-wire.h
@@ -64,6 +64,7 @@ typedef struct {
 #define LINUX_EFBIG 27
 #define LINUX_ENOSPC 28
 #define LINUX_ESPIPE 29
+#define LINUX_EDOM 33
 #define LINUX_ERANGE 34
 #define LINUX_EDEADLK 35
 #define LINUX_ENAMETOOLONG 36

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -1343,6 +1343,15 @@ int64_t sys_setsockopt(guest_t *g,
                        uint64_t optval_gva,
                        uint32_t optlen)
 {
+    /* Netlink sockets are synthetic (no host socket to forward to); their
+     * SOL_SOCKET options are emulated per-fd by the netlink layer. Without this
+     * dispatch the paths below report EBADF (net_socket_fd_is_valid requires
+     * FD_SOCKET), which broke libusb_init()'s setsockopt(SO_PASSCRED) on its
+     * NETLINK_KOBJECT_UEVENT monitor socket.
+     */
+    if (fd_get_type(fd) == FD_NETLINK)
+        return netlink_setsockopt(g, fd, level, optname, optval_gva, optlen);
+
     int small_int_opt = socket_opt_uses_small_int(level, optname);
 
     /* SO_PASSCRED: emulated entirely in elfuse. Cache the flag value so
@@ -1527,6 +1536,11 @@ int64_t sys_getsockopt(guest_t *g,
                        uint64_t optval_gva,
                        uint64_t optlen_gva)
 {
+    /* See sys_setsockopt: netlink fds carry emulated SOL_SOCKET options. */
+    if (fd_get_type(fd) == FD_NETLINK)
+        return netlink_getsockopt(g, fd, level, optname, optval_gva,
+                                  optlen_gva);
+
     uint32_t guest_optlen;
     if (guest_read_small(g, optlen_gva, &guest_optlen, sizeof(guest_optlen)) <
         0)

--- a/src/syscall/net.h
+++ b/src/syscall/net.h
@@ -27,16 +27,37 @@
 
 /* Linux Netlink protocol families. */
 #define NETLINK_ROUTE 0
+#define NETLINK_KOBJECT_UEVENT 15
 
 /* Linux socket types + flags. */
 #define LINUX_SOCK_STREAM 1
 #define LINUX_SOCK_DGRAM 2
+#define LINUX_SOCK_RAW 3
 #define LINUX_SOCK_SEQPACKET 5
 #define LINUX_SOCK_NONBLOCK 0x800
 #define LINUX_SOCK_CLOEXEC 0x80000
+/* SOCK_TYPE_MASK: the base type, with the two flag bits above masked off. */
+#define LINUX_SOCK_TYPE_MASK 0xF
 
 /* Linux SOL_SOCKET option level. */
 #define LINUX_SOL_SOCKET 1
+
+/* Linux SOL_NETLINK option level and the optnames netlink_setsockopt() and
+ * netlink_getsockopt() answer. NETLINK_RX_RING/TX_RING (6/7) are deliberately
+ * absent: mmap'd netlink was removed in Linux 4.10 and both spellings have
+ * reported ENOPROTOOPT ever since, which is the default arm here.
+ */
+#define LINUX_SOL_NETLINK 270
+#define LINUX_NETLINK_ADD_MEMBERSHIP 1
+#define LINUX_NETLINK_DROP_MEMBERSHIP 2
+#define LINUX_NETLINK_PKTINFO 3
+#define LINUX_NETLINK_BROADCAST_ERROR 4
+#define LINUX_NETLINK_NO_ENOBUFS 5
+#define LINUX_NETLINK_LISTEN_ALL_NSID 8
+#define LINUX_NETLINK_LIST_MEMBERSHIPS 9
+#define LINUX_NETLINK_CAP_ACK 10
+#define LINUX_NETLINK_EXT_ACK 11
+#define LINUX_NETLINK_GET_STRICT_CHK 12
 
 /* Linux cmsg types for AF_UNIX. */
 #define LINUX_SCM_CREDENTIALS 2
@@ -59,14 +80,23 @@ typedef struct {
 #define LINUX_SO_KEEPALIVE 9
 #define LINUX_SO_OOBINLINE 10
 #define LINUX_SO_LINGER 13
+
+/* 20/21 are the _OLD spellings, carrying a __kernel_old_timeval; 66/67 are the
+ * y2038 _NEW ones, carrying a __kernel_sock_timeval. Both are 16 bytes on LP64,
+ * so the two pairs differ only in name for the guest ABI elfuse targets.
+ */
 #define LINUX_SO_RCVTIMEO 20
 #define LINUX_SO_SNDTIMEO 21
+#define LINUX_SO_RCVTIMEO_NEW 66
+#define LINUX_SO_SNDTIMEO_NEW 67
 #define LINUX_SO_PASSCRED 16
 #define LINUX_SO_PEERCRED 17
 #define LINUX_SO_ACCEPTCONN 30
 #define LINUX_SO_REUSEPORT 15
 #define LINUX_SO_RCVLOWAT 18
 #define LINUX_SO_SNDLOWAT 19
+#define LINUX_SO_PROTOCOL 38
+#define LINUX_SO_DOMAIN 39
 
 /* Linux TCP level options. */
 #define LINUX_IPPROTO_TCP 6
@@ -246,16 +276,43 @@ void netlink_init(void);
 
 /* Create a synthetic netlink socket fd.
  *
- * Returns guest fd, or negative errno. Only NETLINK_ROUTE is supported; others
- * return -EAFNOSUPPORT.
+ * Returns guest fd, or negative errno. NETLINK_ROUTE (rtnetlink dump emulation)
+ * and NETLINK_KOBJECT_UEVENT (silent socket: no events are ever delivered) are
+ * supported; other protocols return -EAFNOSUPPORT.
+ *
+ * type is validated the way __sock_create() and netlink_create() validate it,
+ * in that order: an unknown bit outside SOCK_NONBLOCK|SOCK_CLOEXEC is -EINVAL,
+ * and a base type other than SOCK_RAW or SOCK_DGRAM is -ESOCKTNOSUPPORT.
  */
 int64_t netlink_socket(int protocol, int type);
 
-/* Netlink bind (always succeeds for NETLINK_ROUTE). */
+/* Netlink bind (always succeeds). nl_pid is recorded for getsockname and
+ * nl_groups is recorded as a membership mask readable through
+ * SOL_NETLINK/NETLINK_LIST_MEMBERSHIPS; no multicast event is ever synthesized
+ * to deliver on it.
+ */
 int64_t netlink_bind(int guest_fd,
                      guest_t *g,
                      uint64_t addr_gva,
                      uint32_t addrlen);
+
+/* setsockopt/getsockopt on a netlink fd. SOL_SOCKET and SOL_NETLINK options are
+ * emulated per-fd (never forwarded to a host socket: there is none); other
+ * levels report -ENOPROTOOPT.
+ */
+int64_t netlink_setsockopt(guest_t *g,
+                           int guest_fd,
+                           int level,
+                           int optname,
+                           uint64_t optval_gva,
+                           uint32_t optlen);
+
+int64_t netlink_getsockopt(guest_t *g,
+                           int guest_fd,
+                           int level,
+                           int optname,
+                           uint64_t optval_gva,
+                           uint64_t optlen_gva);
 
 /* Netlink sendmsg: parse the request and buffer a response. */
 int64_t netlink_sendmsg(int guest_fd, guest_t *g, uint64_t msg_gva, int flags);

--- a/src/syscall/netlink.c
+++ b/src/syscall/netlink.c
@@ -12,19 +12,32 @@
  *
  * Supported operations:
  *   socket(AF_NETLINK, SOCK_RAW|SOCK_DGRAM, NETLINK_ROUTE) -> synthetic fd
- *   bind() -> always succeeds
+ *   bind() -> always succeeds, recording nl_pid and the nl_groups mask
  *   sendmsg(RTM_GETLINK) -> builds interface list from host getifaddrs
  *   sendmsg(RTM_GETADDR) -> builds address list from host getifaddrs
  *   recvmsg() / read() -> returns buffered response data
  *
- * Non-NETLINK_ROUTE protocols return -EAFNOSUPPORT at socket() time.
+ * NETLINK_KOBJECT_UEVENT sockets are also accepted, as a silent socket: no
+ * uevent is ever synthesized, so the fd never becomes readable, a non-blocking
+ * receive reports EAGAIN, and poll() times out. That is exactly the Linux
+ * kernel's behavior on a machine with no hotplug activity, and it is enough for
+ * libusb_init()'s netlink hotplug monitor (socket + bind(nl_groups=1) +
+ * setsockopt(SO_PASSCRED) + a poll loop) to come up. Sends on a uevent socket
+ * report -EPERM, matching uevent_net_rcv() for a sender without CAP_SYS_ADMIN
+ * (elfuse guests are not privileged over the host's device model). SOL_SOCKET
+ * and SOL_NETLINK options on any netlink fd are emulated per-fd in
+ * netlink_setsockopt/netlink_getsockopt below.
+ *
+ * Other protocols return -EAFNOSUPPORT at socket() time.
  */
 
+#include <limits.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include <net/if.h>
 #include <ifaddrs.h>
@@ -33,8 +46,10 @@
 
 #include "syscall/linux-wire.h"
 #include "syscall/internal.h"
-#include "syscall/io.h" /* io_wait_fd_or_interrupted */
+#include "syscall/io.h" /* io_wait_fd_timed_or_interrupted */
 #include "syscall/net.h"
+#include "syscall/proc.h"   /* syscall_restart_forbid, syscall_is_restarted */
+#include "runtime/thread.h" /* thread_stop_is_leader_work_only */
 #include "proved/netlink.h"
 #include "utils.h"
 #include <poll.h>
@@ -121,7 +136,23 @@ typedef struct {
 
 typedef struct {
     bool in_use;
-    int guest_fd;                  /* Guest fd number */
+    int guest_fd; /* Guest fd number */
+    /* Allocation order, unique and increasing. A guest fd number outlives the
+     * socket that had it: fd_cleanup_entry() runs netlink_close() after the
+     * number is already back in the fd table's free pool, so a socket() on
+     * another thread can be handed the same number while the previous slot is
+     * still in_use. Two slots can therefore carry one guest_fd, and the
+     * generation is what tells them apart -- nl_find() answers with the newest
+     * (the only one the guest can still reach) and netlink_close() retires the
+     * oldest.
+     *
+     * That pairing is exact rather than approximate. A number is only reissued
+     * after the previous holder's close was issued, so the pending closes for a
+     * number are always the oldest slots holding it, whatever order the threads
+     * running them arrive in; retiring oldest-first therefore never takes down
+     * the live socket, and every slot is retired exactly once.
+     */
+    uint64_t gen;
     uint8_t buf[NETLINK_BUF_SIZE]; /* Response buffer */
     size_t buf_len;                /* Bytes written into buf */
     size_t buf_pos;                /* Current read position */
@@ -129,35 +160,208 @@ typedef struct {
     uint32_t pid;                  /* Bound PID (from bind or auto-assigned) */
     int pipe_wr;                   /* Host pipe write descriptor */
     int pipe_rd;                   /* Host pipe read descriptor */
+    int proto;                     /* NETLINK_ROUTE or NETLINK_KOBJECT_UEVENT */
+    int sock_type;                 /* SOCK_RAW or SOCK_DGRAM (SO_TYPE) */
+    /* Multicast membership, bit n-1 for group n, exactly nlk->groups. Written
+     * by bind()'s nl_groups and by NETLINK_ADD/DROP_MEMBERSHIP, and readable
+     * through NETLINK_LIST_MEMBERSHIPS. Nothing is ever delivered on a group:
+     * this is the record Linux keeps, without the traffic elfuse has no source
+     * for.
+     */
+    uint32_t groups;
+    /* nlk->flags: the SOL_NETLINK booleans, one bit each (NL_F_* below). */
+    uint32_t nlk_flags;
+
+    /* Emulated SOL_SOCKET option state. There is no host socket behind a
+     * netlink fd, so these are pure per-fd caches for getsockopt round-trips.
+     * rcvbuf/sndbuf hold the Linux-doubled value getsockopt reports.
+     *
+     * Every option sk_setsockopt() accepts is answered by sk_getsockopt(), so
+     * storing nothing is not the same as accepting the set: a guest that sets
+     * SO_BROADCAST and reads it back gets 1 on Linux and would have got 0 here.
+     * Inert options are still remembered for exactly that round trip.
+     */
+    int opt_passcred;
+    int opt_rcvbuf;
+    int opt_sndbuf;
+    int opt_debug;
+    int opt_reuseaddr;
+    int opt_dontroute;
+    int opt_broadcast;
+    int opt_keepalive;
+    int opt_oobinline;
+    int opt_reuseport;
+    int opt_rcvlowat;     /* sk_rcvlowat; 0 means the 1 a fresh socket has */
+    int opt_linger_onoff; /* struct linger.l_onoff */
+    int opt_linger_secs;  /* struct linger.l_linger, in seconds */
+    /* SO_RCVTIMEO/SO_SNDTIMEO as sk_rcvtimeo/sk_sndtimeo hold them: a jiffy
+     * count, here with HZ pinned at 1000 so a jiffy is a millisecond. Three
+     * states, not two, because sock_set_timeout() has three:
+     *
+     *   0  -- MAX_SCHEDULE_TIMEOUT, wait forever ({0,0} or an out-of-range
+     *         tv_sec)
+     *   -1 -- do not wait at all, which is what a negative tv_sec stores
+     *         (Linux writes a literal 0 jiffies there, and every wait treats
+     *         0 jiffies as "poll once and report EAGAIN")
+     *   >0 -- that many milliseconds
+     *
+     * Both 0 and -1 report {0,0} through getsockopt, exactly as
+     * sock_get_timeout() does, so the two are distinguishable only by what a
+     * blocking receive does.
+     *
+     * The receive timeout is honored in nl_wait_readable_locked(). The send one
+     * is stored and inert, which is not a shortcut: a uevent send is refused
+     * with EPERM before it can queue and an rtnetlink request is answered from
+     * the host synchronously, so no send on either protocol has a queue to
+     * block on and sk_sndtimeo has nothing to bound. It still has to read back.
+     */
+    int64_t opt_rcvtimeo_ms;
+    int64_t opt_sndtimeo_ms;
 } netlink_state_t;
+
+/* Linux net.core.rmem_default/wmem_default on a stock kernel: what
+ * getsockopt(SO_RCVBUF/SO_SNDBUF) reports before the guest ever sets one.
+ */
+#define NETLINK_DEFAULT_BUFSIZE 212992
+
+/* Floors for a doubled SO_RCVBUF/SO_SNDBUF. These are Linux's SOCK_MIN_RCVBUF
+ * and SOCK_MIN_SNDBUF exactly (include/net/sock.h): TCP_SKB_MIN_TRUESIZE is
+ * 2048 + SKB_DATA_ALIGN(sizeof(struct sk_buff)) = 2304 on arm64, the receive
+ * floor is that and the send floor is twice it. The two directions do not share
+ * a floor, so a guest asking for a small buffer reads back a different number
+ * depending on which one it set.
+ */
+#define NETLINK_MIN_RCVBUF 2304
+#define NETLINK_MIN_SNDBUF 4608
+
+/* net.core.rmem_max/wmem_max: sk_setsockopt() clamps the requested size to the
+ * sysctl before doubling it, so an absurd request reads back as 2x this rather
+ * than as the request.
+ */
+#define NETLINK_MAX_BUFSIZE 212992
+
+/* The timeout state above is a jiffy count with HZ pinned at 1000, which makes
+ * every one of sock_set_timeout()'s numbers land where Linux puts it:
+ *
+ *   - the cutoff past which a timeout means "forever" is Linux's own,
+ *     MAX_SCHEDULE_TIMEOUT/HZ - 1 with MAX_SCHEDULE_TIMEOUT = LONG_MAX. An
+ *     earlier microsecond representation put it three orders of magnitude
+ *     lower, so a tv_sec of 1e13 -- which a real kernel stores as a finite
+ *     timeout and reads back unchanged -- silently became MAX_SCHEDULE_TIMEOUT
+ *     and read back as {0,0}. Measured on Linux 6.x/aarch64: tv_sec 1e13,
+ *     1e15, 9007199254740992 all read back exactly; 9223372036854775 reads
+ *     back {0,0}, which places the cutoff at LONG_MAX/1000 - 1.
+ *   - sub-jiffy tv_usec rounds up to a whole jiffy (DIV_ROUND_UP), so a 1500 us
+ *     request reads back as 2000 us here and on a HZ=1000 kernel alike.
+ *
+ * tv_sec * 1000 + 1000 for any accepted tv_sec stays inside int64, so the
+ * conversion itself cannot overflow; nl_deadline_add() covers the one place
+ * that can, adding this to a clock reading.
+ */
+#define NETLINK_TIMEO_HZ 1000
+#define NETLINK_TIMEO_MAX_SEC (INT64_MAX / NETLINK_TIMEO_HZ - 1)
+
+/* Multicast groups a netlink socket can join, i.e. nlk->ngroups.
+ * netlink_kernel_create() floors a family's group count at 32, so
+ * NETLINK_KOBJECT_UEVENT -- which registers exactly one group -- still answers
+ * NETLINK_ADD_MEMBERSHIP for groups 1..32 and EINVAL past that. Measured: 32
+ * joins, 33 is EINVAL, and NETLINK_LIST_MEMBERSHIPS reports a 4-byte bitmap.
+ * rtnetlink registers RTNLGRP_MAX, a handful above 32 and moving between
+ * releases, so its groups above 32 are the one place this count is short;
+ * nothing in scope joins one, and no group delivers anything here regardless.
+ */
+#define NETLINK_NGROUPS 32
+
+/* The group bitmap as a mask, bit n-1 for group n. The count is a compile-time
+ * constant, so the two cases are split by the preprocessor: written as a
+ * ternary, the dead arm still shifts a 32-bit value by 32, which is undefined
+ * behavior whether or not it can execute.
+ */
+#if NETLINK_NGROUPS >= 32
+#define NL_GROUP_MASK UINT32_MAX
+#else
+#define NL_GROUP_MASK ((uint32_t) ((1u << NETLINK_NGROUPS) - 1))
+#endif
+
+static inline uint32_t nl_group_mask(void)
+{
+    return NL_GROUP_MASK;
+}
+
+/* nlk->flags bits, in Linux's own order (NETLINK_F_*). */
+#define NL_F_RECV_PKTINFO 0x01
+#define NL_F_BROADCAST_SEND_ERROR 0x02
+#define NL_F_RECV_NO_ENOBUFS 0x04
+#define NL_F_LISTEN_ALL_NSID 0x08
+#define NL_F_CAP_ACK 0x10
+#define NL_F_EXT_ACK 0x20
+#define NL_F_STRICT_CHK 0x40
 
 static netlink_state_t nl_state[MAX_NETLINK_FDS];
 static pthread_mutex_t nl_lock = PTHREAD_MUTEX_INITIALIZER;
+static uint64_t nl_gen_next = 1;
 
 #define NL_FOR_EACH(s) \
     for (netlink_state_t *s = nl_state; s < nl_state + MAX_NETLINK_FDS; s++)
 
 /* Helpers. */
 
+/* Both helpers walk nl_state and must be called with nl_lock held: the table is
+ * shared by every guest thread, and a socket() racing another socket() would
+ * otherwise scan for a free slot, find the same one, and hand two callers the
+ * same state. The live socket behind a guest fd: the newest slot holding that
+ * number. An older one, if any, is a socket the guest has already closed and
+ * whose teardown has not run yet -- see the generation comment above.
+ */
 static netlink_state_t *nl_find(int guest_fd)
 {
+    netlink_state_t *best = NULL;
     NL_FOR_EACH (s)
-        if (s->in_use && s->guest_fd == guest_fd)
-            return s;
-    return NULL;
+        if (s->in_use && s->guest_fd == guest_fd &&
+            (!best || s->gen > best->gen))
+            best = s;
+    return best;
 }
 
-static netlink_state_t *nl_alloc(int guest_fd)
+/* The counterpart for teardown: the oldest slot holding the number. */
+static netlink_state_t *nl_find_oldest(int guest_fd)
+{
+    netlink_state_t *best = NULL;
+    NL_FOR_EACH (s)
+        if (s->in_use && s->guest_fd == guest_fd &&
+            (!best || s->gen < best->gen))
+            best = s;
+    return best;
+}
+
+/* Claim a slot and publish it fully initialized. proto and sock_type are set
+ * here rather than by the caller because they are behavior discriminators --
+ * proto picks between the rtnetlink emulation and the silent uevent socket --
+ * and a slot visible with in_use set but proto not yet written is a slot a
+ * concurrent send can read as NETLINK_ROUTE on a uevent fd.
+ */
+static netlink_state_t *nl_alloc(int guest_fd,
+                                 int protocol,
+                                 int sock_type,
+                                 int pipe_rd,
+                                 int pipe_wr)
 {
     NL_FOR_EACH (s) {
         if (s->in_use)
             continue;
         memset(s, 0, sizeof(*s));
-        s->in_use = true;
         s->guest_fd = guest_fd;
-        s->pipe_wr = -1;
-        s->pipe_rd = -1;
+        s->pipe_wr = pipe_wr;
+        s->pipe_rd = pipe_rd;
+        s->proto = protocol;
+        s->sock_type = sock_type;
         s->pid = (uint32_t) getpid();
+        s->gen = nl_gen_next++;
+
+        /* Last, and after every field the finder reads: in_use is what makes
+         * this slot visible to nl_find.
+         */
+        s->in_use = true;
         return s;
     }
     return NULL;
@@ -442,10 +646,31 @@ void netlink_init(void)
 
 int64_t netlink_socket(int protocol, int type)
 {
-    (void) type;
+    /* Validate type before protocol, the order Linux validates them in.
+     *
+     * __sock_create() rejects a flag bit outside SOCK_NONBLOCK|SOCK_CLOEXEC
+     * with EINVAL before any family is consulted, then netlink_create() rejects
+     * a base type other than SOCK_RAW or SOCK_DGRAM with ESOCKTNOSUPPORT before
+     * it looks at the protocol number. Measured on Linux 6.x/aarch64:
+     * SOCK_STREAM, SOCK_SEQPACKET and type 0 all report ESOCKTNOSUPPORT(94) on
+     * both NETLINK_ROUTE and NETLINK_KOBJECT_UEVENT; SOCK_RAW|0x40000000 and
+     * SOCK_DGRAM|0x80 report EINVAL(22); and socket(AF_NETLINK, SOCK_STREAM,
+     * 99) reports ESOCKTNOSUPPORT rather than an unknown-family error, which is
+     * what pins the order. Accepting SOCK_STREAM here handed a guest a socket
+     * whose SO_TYPE it could read back but no kernel would have created.
+     */
+    if (type &
+        ~(LINUX_SOCK_TYPE_MASK | LINUX_SOCK_NONBLOCK | LINUX_SOCK_CLOEXEC))
+        return -LINUX_EINVAL;
+    int base_type = type & LINUX_SOCK_TYPE_MASK;
+    if (base_type != LINUX_SOCK_RAW && base_type != LINUX_SOCK_DGRAM)
+        return -LINUX_ESOCKTNOSUPPORT;
 
-    /* Only NETLINK_ROUTE is supported */
-    if (protocol != NETLINK_ROUTE)
+    /* NETLINK_ROUTE gets the rtnetlink dump emulation; NETLINK_KOBJECT_UEVENT
+     * gets a silent socket (see the file header). Everything else is refused
+     * the way a Linux kernel without that netlink family would refuse it.
+     */
+    if (protocol != NETLINK_ROUTE && protocol != NETLINK_KOBJECT_UEVENT)
         return -LINUX_EAFNOSUPPORT;
 
     /* Allocate a pipe fd pair: the read end serves as the "socket" that
@@ -469,7 +694,17 @@ int64_t netlink_socket(int protocol, int type)
         return -LINUX_EMFILE;
     }
 
-    netlink_state_t *ns = nl_alloc(gfd);
+    /* The scan and every field write happen under nl_lock, not just the scan:
+     * two guest threads opening netlink sockets at the same instant otherwise
+     * both see the same slot free, and the loser's proto/pipe writes land on
+     * top of the winner's -- cross-wiring a uevent fd onto rtnetlink state and
+     * leaking one of the two pipe pairs. nl_lock is a leaf, so it is dropped
+     * again before fd_publish_linux_flags takes fd_lock.
+     */
+    pthread_mutex_lock(&nl_lock);
+    netlink_state_t *ns =
+        nl_alloc(gfd, protocol, base_type, pipefd[0], pipefd[1]);
+    pthread_mutex_unlock(&nl_lock);
     if (!ns) {
         fd_mark_closed(gfd);
         close(pipefd[0]);
@@ -477,8 +712,15 @@ int64_t netlink_socket(int protocol, int type)
         return -LINUX_ENOMEM;
     }
 
-    ns->pipe_wr = pipefd[1];
-    ns->pipe_rd = pipefd[0];
+    /* Linux opens a netlink socket O_RDWR; carry SOCK_NONBLOCK into linux_flags
+     * so a non-blocking receive on an empty socket reports EAGAIN instead of
+     * parking the caller. libusb's uevent monitor opens with
+     * SOCK_RAW|SOCK_NONBLOCK|SOCK_CLOEXEC and relies on exactly that.
+     */
+    fd_publish_linux_flags(
+        gfd, LINUX_O_RDWR |
+                 ((type & LINUX_SOCK_NONBLOCK) ? LINUX_O_NONBLOCK : 0) |
+                 ((type & LINUX_SOCK_CLOEXEC) ? LINUX_O_CLOEXEC : 0));
 
     return gfd;
 }
@@ -488,19 +730,573 @@ int64_t netlink_bind(int guest_fd,
                      uint64_t addr_gva,
                      uint32_t addrlen)
 {
-    netlink_state_t *ns = nl_find(guest_fd);
-    if (!ns)
-        return -LINUX_EBADF;
+    /* Read the address first, then take nl_lock over the lookup and the writes
+     * together: a close() racing this bind cannot then free the slot between
+     * them and leave the pid on a socket that has since been reused. Reading
+     * outside the lock also keeps the guest-memory walk off it, which costs
+     * nothing here because the value read is not part of the lookup.
+     */
+    sockaddr_nl_t snl;
+    bool have_addr = addr_gva && addrlen >= sizeof(sockaddr_nl_t) &&
+                     guest_read_small(g, addr_gva, &snl, sizeof(snl)) == 0;
 
-    /* Parse sockaddr_nl if provided to get nl_pid */
-    if (addr_gva && addrlen >= sizeof(sockaddr_nl_t)) {
-        sockaddr_nl_t snl;
-        if (guest_read_small(g, addr_gva, &snl, sizeof(snl)) == 0) {
-            if (snl.nl_pid != 0)
-                ns->pid = snl.nl_pid;
-        }
+    pthread_mutex_lock(&nl_lock);
+    netlink_state_t *ns = nl_find(guest_fd);
+    if (!ns) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EBADF;
     }
 
+    if (have_addr) {
+        if (snl.nl_pid != 0)
+            ns->pid = snl.nl_pid;
+
+        /* netlink_bind() masks the requested groups against nlk->ngroups and
+         * records the rest; the subscription is real bookkeeping even where no
+         * traffic follows, and NETLINK_LIST_MEMBERSHIPS reads it back.
+         */
+        ns->groups |= snl.nl_groups & nl_group_mask();
+    }
+
+    pthread_mutex_unlock(&nl_lock);
+    return 0;
+}
+
+/* struct linger and the two timeval spellings as the guest ABI lays them out.
+ * SO_LINGER carries two ints; SO_RCVTIMEO/SO_SNDTIMEO carry a
+ * __kernel_old_timeval (the _OLD names) or a __kernel_sock_timeval (the _NEW
+ * ones), which on LP64 are the same two 64-bit fields.
+ */
+#define NETLINK_LINGER_LEN 8
+#define NETLINK_TIMEVAL_LEN 16
+
+typedef struct {
+    int64_t tv_sec;
+    int64_t tv_usec;
+} nl_timeval_t;
+
+/* Clamp, double and floor a requested SO_RCVBUF/SO_SNDBUF the way
+ * sk_setsockopt() does, so a getsockopt round-trip reports what a Linux kernel
+ * would. The order is load-bearing in both places: the sysctl clamp comes
+ * first, the doubling second, the floor last.
+ *
+ * The clamp is unsigned (min_t(u32, val, rmem_max)) and that is not an accident
+ * either -- a negative request becomes a huge u32 and clamps to the sysctl, so
+ * SO_RCVBUF = -1 reads back 425984 rather than the floor.
+ */
+static int nl_bufsize_store(int value, int floor)
+{
+    uint32_t clamped = (uint32_t) value;
+    if (clamped > NETLINK_MAX_BUFSIZE)
+        clamped = NETLINK_MAX_BUFSIZE;
+    int doubled = (int) (clamped * 2);
+    return (doubled < floor) ? floor : doubled;
+}
+
+/* sock_set_timeout(): read a timeval option and store it as a jiffy count.
+ *
+ * The three states are Linux's three, and the order of the checks is Linux's
+ * order. tv_usec outside [0, 1e6) is EDOM first, before tv_sec is looked at at
+ * all -- measured: {-1, 500000} is accepted and {-1, -1} is EDOM(33). A
+ * negative tv_sec is then not an error but a third answer: Linux writes a
+ * literal 0 jiffies, which every wait reads as "do not wait", and getsockopt
+ * still reports {0,0}. Storing 0 for it, as an earlier version did, said
+ * "forever" instead -- the exact opposite -- and parked a guest that had asked
+ * not to be parked. Measured: after SO_RCVTIMEO {-1, 0} a blocking recv on an
+ * empty socket returns EAGAIN in 0 ms, while after {0, 0} it blocks until
+ * interrupted.
+ *
+ * An out-of-range tv_sec is MAX_SCHEDULE_TIMEOUT, i.e. forever, and so is
+ * {0,0}; both are 0 here.
+ */
+static int64_t nl_timeout_store(guest_t *g,
+                                uint64_t optval_gva,
+                                uint32_t optlen,
+                                int64_t *out_ms)
+{
+    if (optlen < NETLINK_TIMEVAL_LEN)
+        return -LINUX_EINVAL;
+
+    nl_timeval_t tv;
+    if (guest_read_small(g, optval_gva, &tv, sizeof(tv)) < 0)
+        return -LINUX_EFAULT;
+
+    if (tv.tv_usec < 0 || tv.tv_usec >= 1000000)
+        return -LINUX_EDOM;
+    if (tv.tv_sec < 0) {
+        *out_ms = -1; /* do not wait */
+        return 0;
+    }
+    if (tv.tv_sec >= NETLINK_TIMEO_MAX_SEC ||
+        (tv.tv_sec == 0 && tv.tv_usec == 0)) {
+        *out_ms = 0; /* MAX_SCHEDULE_TIMEOUT */
+        return 0;
+    }
+
+    /* tv_sec * HZ + DIV_ROUND_UP(tv_usec, USEC_PER_SEC / HZ): a sub-jiffy
+     * remainder rounds up, so a timeout is never shorter than asked for.
+     */
+    *out_ms = tv.tv_sec * NETLINK_TIMEO_HZ +
+              (tv.tv_usec + (1000000 / NETLINK_TIMEO_HZ) - 1) /
+                  (1000000 / NETLINK_TIMEO_HZ);
+    return 0;
+}
+
+/* sock_get_timeout(): a jiffy count back to a timeval. Both "forever" and "do
+ * not wait" report {0,0}, which is what makes them indistinguishable to a
+ * getsockopt and distinguishable only to a receive.
+ */
+static void nl_timeout_load(int64_t ms, nl_timeval_t *tv)
+{
+    if (ms <= 0) {
+        tv->tv_sec = 0;
+        tv->tv_usec = 0;
+        return;
+    }
+    tv->tv_sec = ms / NETLINK_TIMEO_HZ;
+    tv->tv_usec = (ms % NETLINK_TIMEO_HZ) * (1000000 / NETLINK_TIMEO_HZ);
+}
+
+/* Minimum optlen for an option whose payload is not an int, checked after
+ * sk_setsockopt()'s generic four-byte gate the way Linux checks it: per option,
+ * and only a minimum, since an over-long optlen is accepted everywhere.
+ */
+static uint32_t nl_optlen_min(int optname)
+{
+    switch (optname) {
+    case LINUX_SO_LINGER:
+        return NETLINK_LINGER_LEN;
+    case LINUX_SO_RCVTIMEO:
+    case LINUX_SO_SNDTIMEO:
+    case LINUX_SO_RCVTIMEO_NEW:
+    case LINUX_SO_SNDTIMEO_NEW:
+        return NETLINK_TIMEVAL_LEN;
+    default:
+        return sizeof(int32_t);
+    }
+}
+
+/* The SOL_NETLINK optname to nlk->flags bit map, or 0 for an optname that is
+ * not one of the flag booleans. Shared by the two halves so a flag that can be
+ * set is a flag that can be read, which is the property netlink_getsockopt()
+ * has and the earlier blanket ENOPROTOOPT did not.
+ */
+static uint32_t nl_flag_bit(int optname)
+{
+    switch (optname) {
+    case LINUX_NETLINK_PKTINFO:
+        return NL_F_RECV_PKTINFO;
+    case LINUX_NETLINK_BROADCAST_ERROR:
+        return NL_F_BROADCAST_SEND_ERROR;
+    case LINUX_NETLINK_NO_ENOBUFS:
+        return NL_F_RECV_NO_ENOBUFS;
+    case LINUX_NETLINK_LISTEN_ALL_NSID:
+        return NL_F_LISTEN_ALL_NSID;
+    case LINUX_NETLINK_CAP_ACK:
+        return NL_F_CAP_ACK;
+    case LINUX_NETLINK_EXT_ACK:
+        return NL_F_EXT_ACK;
+    case LINUX_NETLINK_GET_STRICT_CHK:
+        return NL_F_STRICT_CHK;
+    default:
+        return 0;
+    }
+}
+
+/* setsockopt(SOL_NETLINK, ...).
+ *
+ * Under the same contract bind() already gives: the membership and the flags
+ * are recorded, and nothing is ever delivered on them. That is the honest
+ * answer for a libnl or libmnl monitor, which sets NETLINK_EXT_ACK,
+ * NETLINK_CAP_ACK and NETLINK_NO_ENOBUFS on the way up and treats a refusal as
+ * a broken socket, and it is what a real kernel answers -- measured on Linux
+ * 6.x/aarch64 for both NETLINK_ROUTE and NETLINK_KOBJECT_UEVENT:
+ *
+ *   ADD_MEMBERSHIP/DROP_MEMBERSHIP  set 0, get ENOPROTOOPT
+ *   PKTINFO/BROADCAST_ERROR/NO_ENOBUFS/CAP_ACK/EXT_ACK/GET_STRICT_CHK
+ *                                   set 0, get the flag back
+ *   LISTEN_ALL_NSID                 set EPERM without CAP_NET_ADMIN, get 0
+ *   LIST_MEMBERSHIPS                set ENOPROTOOPT, get the bitmap
+ *   RX_RING/TX_RING, unknown        ENOPROTOOPT both ways
+ *
+ * PKTINFO is recorded rather than refused even though no NETLINK_PKTINFO
+ * control message is ever produced: refusing it would fail a monitor at setup
+ * over ancillary data it does not need, and a recvmsg here reports
+ * msg_controllen 0, which is what a kernel with nothing to attach reports too.
+ */
+static int64_t nl_setsockopt_netlink(guest_t *g,
+                                     int guest_fd,
+                                     int optname,
+                                     uint64_t optval_gva,
+                                     uint32_t optlen)
+{
+    /* netlink_setsockopt() reads the int only when the buffer holds one, and a
+     * shorter optlen is not an error: val simply stays 0. Measured: PKTINFO
+     * with optlen 3 returns 0 and clears the flag, while ADD_MEMBERSHIP with
+     * optlen 3 returns EINVAL -- from the group check below, not a length one.
+     */
+    int32_t value = 0;
+    if (optlen >= sizeof(value) &&
+        guest_read_small(g, optval_gva, &value, sizeof(value)) < 0)
+        return -LINUX_EFAULT;
+
+    /* The socket is looked up before the optname is judged, as every other
+     * option path here does: a closed fd is EBADF whatever it was asked for.
+     */
+    pthread_mutex_lock(&nl_lock);
+    netlink_state_t *ns = nl_find(guest_fd);
+    if (!ns) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EBADF;
+    }
+
+    uint32_t flag = nl_flag_bit(optname);
+    int64_t ret = 0;
+    if (optname == LINUX_NETLINK_LISTEN_ALL_NSID) {
+        /* ns_capable(CAP_NET_ADMIN) over the net namespace, which an elfuse
+         * guest has no claim on -- the same stance SO_DEBUG takes.
+         */
+        ret = -LINUX_EPERM;
+    } else if (!flag && optname != LINUX_NETLINK_ADD_MEMBERSHIP &&
+               optname != LINUX_NETLINK_DROP_MEMBERSHIP) {
+        ret = -LINUX_ENOPROTOOPT;
+    } else if (flag) {
+        if (value)
+            ns->nlk_flags |= flag;
+        else
+            ns->nlk_flags &= ~flag;
+    } else if (value <= 0 || (uint32_t) value > NETLINK_NGROUPS) {
+        /* !val || val - 1 >= nlk->ngroups. Group numbering is 1-based, so 0 is
+         * out of range at the bottom the way NETLINK_NGROUPS + 1 is at the top.
+         */
+        ret = -LINUX_EINVAL;
+    } else {
+        uint32_t bit = 1u << (value - 1);
+        if (optname == LINUX_NETLINK_ADD_MEMBERSHIP)
+            ns->groups |= bit;
+        else
+            ns->groups &= ~bit;
+    }
+
+    pthread_mutex_unlock(&nl_lock);
+    return ret;
+}
+
+/* getsockopt(SOL_NETLINK, ...). The order of the checks is netlink_getsockopt's
+ * own: the length is read and refused if negative, then the optname is
+ * classified (an unknown one is ENOPROTOOPT whatever the length), and only then
+ * is a short length refused. Unlike SOL_SOCKET, which truncates to what fits,
+ * these options write a whole int or nothing.
+ */
+static int64_t nl_getsockopt_netlink(guest_t *g,
+                                     int guest_fd,
+                                     int optname,
+                                     uint64_t optval_gva,
+                                     uint64_t optlen_gva)
+{
+    int32_t guest_optlen;
+    if (guest_read_small(g, optlen_gva, &guest_optlen, sizeof(guest_optlen)) <
+        0)
+        return -LINUX_EFAULT;
+    if (guest_optlen < 0)
+        return -LINUX_EINVAL;
+
+    pthread_mutex_lock(&nl_lock);
+    netlink_state_t *ns = nl_find(guest_fd);
+    if (!ns) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EBADF;
+    }
+    uint32_t flag = nl_flag_bit(optname);
+    uint32_t groups = ns->groups;
+    int32_t value = flag ? !!(ns->nlk_flags & flag) : 0;
+    pthread_mutex_unlock(&nl_lock);
+
+    if (!flag && optname != LINUX_NETLINK_LIST_MEMBERSHIPS)
+        return -LINUX_ENOPROTOOPT;
+
+    if (optname == LINUX_NETLINK_LIST_MEMBERSHIPS) {
+        /* One u32 per 32 groups, written only while a whole word still fits,
+         * and the reported length is the full bitmap size either way --
+         * ALIGN(BITS_TO_BYTES(ngroups), 4), which is 4 here. Measured: a uevent
+         * socket reports 4, and a short optlen still reports 4 having written
+         * nothing.
+         */
+        if (guest_optlen >= (int32_t) sizeof(groups) &&
+            guest_write_small(g, optval_gva, &groups, sizeof(groups)) < 0)
+            return -LINUX_EFAULT;
+        uint32_t need = sizeof(groups);
+        if (guest_write_small(g, optlen_gva, &need, sizeof(need)) < 0)
+            return -LINUX_EFAULT;
+        return 0;
+    }
+
+    if (guest_optlen < (int32_t) sizeof(value))
+        return -LINUX_EINVAL;
+    uint32_t written = sizeof(value);
+    if (guest_write_small(g, optval_gva, &value, sizeof(value)) < 0 ||
+        guest_write_small(g, optlen_gva, &written, sizeof(written)) < 0)
+        return -LINUX_EFAULT;
+    return 0;
+}
+
+int64_t netlink_setsockopt(guest_t *g,
+                           int guest_fd,
+                           int level,
+                           int optname,
+                           uint64_t optval_gva,
+                           uint32_t optlen)
+{
+    if (level == LINUX_SOL_NETLINK)
+        return nl_setsockopt_netlink(g, guest_fd, optname, optval_gva, optlen);
+    if (level != LINUX_SOL_SOCKET)
+        return -LINUX_ENOPROTOOPT;
+
+    pthread_mutex_lock(&nl_lock);
+    netlink_state_t *ns = nl_find(guest_fd);
+    if (!ns) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EBADF;
+    }
+
+    /* sk_setsockopt() reads an int before it knows which option it has, so a
+     * buffer shorter than that is EINVAL and an unreadable one is EFAULT, for
+     * every option alike -- including the three whose real payload is longer.
+     * Their own length check comes after, which is why SO_LINGER with optlen =
+     * 4 is EINVAL rather than a short read.
+     */
+    if (optlen < sizeof(int32_t)) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EINVAL;
+    }
+    int32_t value = 0;
+    if (guest_read_small(g, optval_gva, &value, sizeof(value)) < 0) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EFAULT;
+    }
+    if (optlen < nl_optlen_min(optname)) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EINVAL;
+    }
+
+    int64_t ret = 0;
+    switch (optname) {
+    case LINUX_SO_PASSCRED:
+        /* sk_may_scm_recv() names AF_NETLINK explicitly, so this is a real
+         * option on this family rather than a courtesy.
+         */
+        ns->opt_passcred = !!value;
+        break;
+    case LINUX_SO_RCVBUF:
+        ns->opt_rcvbuf = nl_bufsize_store(value, NETLINK_MIN_RCVBUF);
+        break;
+    case LINUX_SO_SNDBUF:
+        ns->opt_sndbuf = nl_bufsize_store(value, NETLINK_MIN_SNDBUF);
+        break;
+    case LINUX_SO_DEBUG:
+        /* sk_setsockopt(): switching SO_DEBUG on wants CAP_NET_ADMIN, and an
+         * elfuse guest holds no capability over the host's network stack.
+         * Switching it off is unprivileged, so only a nonzero value refuses.
+         */
+        if (value)
+            ret = -LINUX_EACCES;
+        else
+            ns->opt_debug = 0;
+        break;
+    case LINUX_SO_REUSEPORT:
+        /* sk_setsockopt(): SO_REUSEPORT is rejected with EOPNOTSUPP on a socket
+         * sk_is_inet() disowns, and AF_NETLINK is one. Clearing it is still
+         * allowed, the same asymmetry SO_DEBUG has.
+         */
+        if (value)
+            ret = -LINUX_EOPNOTSUPP;
+        else
+            ns->opt_reuseport = 0;
+        break;
+    case LINUX_SO_LINGER: {
+        int32_t ling[2] = {0, 0};
+        if (guest_read_small(g, optval_gva, ling, sizeof(ling)) < 0) {
+            ret = -LINUX_EFAULT;
+            break;
+        }
+
+        /* l_onoff = 0 resets the flag and leaves sk_lingertime alone, so a
+         * later getsockopt still reports the seconds set by the last enable.
+         */
+        ns->opt_linger_onoff = ling[0] ? 1 : 0;
+        if (ling[0])
+            ns->opt_linger_secs = (ling[1] < 0) ? INT_MAX : ling[1];
+        break;
+    }
+    case LINUX_SO_RCVTIMEO:
+    case LINUX_SO_RCVTIMEO_NEW:
+        ret = nl_timeout_store(g, optval_gva, optlen, &ns->opt_rcvtimeo_ms);
+        break;
+    case LINUX_SO_SNDTIMEO:
+    case LINUX_SO_SNDTIMEO_NEW:
+        ret = nl_timeout_store(g, optval_gva, optlen, &ns->opt_sndtimeo_ms);
+        break;
+    case LINUX_SO_RCVLOWAT:
+        /* sk_setsockopt(): netlink has no set_rcvlowat hook, so sk_rcvlowat
+         * takes val ?: 1, and a negative val is INT_MAX first.
+         */
+        ns->opt_rcvlowat = (value < 0) ? INT_MAX : (value ? value : 1);
+        break;
+    case LINUX_SO_REUSEADDR:
+        ns->opt_reuseaddr = !!value;
+        break;
+    case LINUX_SO_DONTROUTE:
+        ns->opt_dontroute = !!value;
+        break;
+    case LINUX_SO_BROADCAST:
+        ns->opt_broadcast = !!value;
+        break;
+    case LINUX_SO_KEEPALIVE:
+        ns->opt_keepalive = !!value;
+        break;
+    case LINUX_SO_OOBINLINE:
+        ns->opt_oobinline = !!value;
+        break;
+    default:
+        /* sock_setsockopt refuses an optname it does not know; pretending an
+         * unknown option took effect would hide real consumer bugs. SO_SNDLOWAT
+         * arrives here on purpose: 1003.1g 7 makes it unsettable, sk_setsockopt
+         * has no case for it, and Linux answers ENOPROTOOPT.
+         */
+        ret = -LINUX_ENOPROTOOPT;
+        break;
+    }
+
+    pthread_mutex_unlock(&nl_lock);
+    return ret;
+}
+
+int64_t netlink_getsockopt(guest_t *g,
+                           int guest_fd,
+                           int level,
+                           int optname,
+                           uint64_t optval_gva,
+                           uint64_t optlen_gva)
+{
+    if (level == LINUX_SOL_NETLINK)
+        return nl_getsockopt_netlink(g, guest_fd, optname, optval_gva,
+                                     optlen_gva);
+    if (level != LINUX_SOL_SOCKET)
+        return -LINUX_ENOPROTOOPT;
+
+    pthread_mutex_lock(&nl_lock);
+    netlink_state_t *ns = nl_find(guest_fd);
+    if (!ns) {
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_EBADF;
+    }
+
+    /* sk_getsockopt()'s union v and its lv: the payload is an int unless the
+     * option says otherwise, and lv is what caps the write-back below.
+     */
+    union {
+        int32_t val;
+        int32_t ling[2];
+        nl_timeval_t tv;
+    } v;
+    memset(&v, 0, sizeof(v));
+    uint32_t lv = sizeof(int32_t);
+
+    switch (optname) {
+    case LINUX_SO_PASSCRED:
+        v.val = ns->opt_passcred;
+        break;
+    case LINUX_SO_RCVBUF:
+        v.val = ns->opt_rcvbuf ? ns->opt_rcvbuf : NETLINK_DEFAULT_BUFSIZE;
+        break;
+    case LINUX_SO_SNDBUF:
+        v.val = ns->opt_sndbuf ? ns->opt_sndbuf : NETLINK_DEFAULT_BUFSIZE;
+        break;
+    case LINUX_SO_TYPE:
+        v.val = ns->sock_type;
+        break;
+    case LINUX_SO_PROTOCOL:
+        v.val = ns->proto;
+        break;
+    case LINUX_SO_DOMAIN:
+        v.val = LINUX_AF_NETLINK;
+        break;
+    case LINUX_SO_DEBUG:
+        v.val = ns->opt_debug;
+        break;
+    case LINUX_SO_REUSEADDR:
+        v.val = ns->opt_reuseaddr;
+        break;
+    case LINUX_SO_DONTROUTE:
+        v.val = ns->opt_dontroute;
+        break;
+    case LINUX_SO_BROADCAST:
+        v.val = ns->opt_broadcast;
+        break;
+    case LINUX_SO_KEEPALIVE:
+        v.val = ns->opt_keepalive;
+        break;
+    case LINUX_SO_OOBINLINE:
+        v.val = ns->opt_oobinline;
+        break;
+    case LINUX_SO_REUSEPORT:
+        v.val = ns->opt_reuseport;
+        break;
+    case LINUX_SO_RCVLOWAT:
+        /* sk_rcvlowat is 1 on a socket nobody has set it on. */
+        v.val = ns->opt_rcvlowat ? ns->opt_rcvlowat : 1;
+        break;
+    case LINUX_SO_SNDLOWAT:
+        /* Unsettable, and sk_getsockopt() answers a constant 1. */
+        v.val = 1;
+        break;
+    case LINUX_SO_LINGER:
+        lv = NETLINK_LINGER_LEN;
+        v.ling[0] = ns->opt_linger_onoff;
+        v.ling[1] = ns->opt_linger_secs;
+        break;
+    case LINUX_SO_RCVTIMEO:
+    case LINUX_SO_RCVTIMEO_NEW:
+        lv = NETLINK_TIMEVAL_LEN;
+        nl_timeout_load(ns->opt_rcvtimeo_ms, &v.tv);
+        break;
+    case LINUX_SO_SNDTIMEO:
+    case LINUX_SO_SNDTIMEO_NEW:
+        lv = NETLINK_TIMEVAL_LEN;
+        nl_timeout_load(ns->opt_sndtimeo_ms, &v.tv);
+        break;
+    case LINUX_SO_ERROR:
+    case LINUX_SO_ACCEPTCONN:
+        v.val = 0;
+        break;
+    default:
+        pthread_mutex_unlock(&nl_lock);
+        return -LINUX_ENOPROTOOPT;
+    }
+    pthread_mutex_unlock(&nl_lock);
+
+    int32_t guest_optlen;
+    if (guest_read_small(g, optlen_gva, &guest_optlen, sizeof(guest_optlen)) <
+        0)
+        return -LINUX_EFAULT;
+
+    /* sock_getsockopt(): a negative optlen is -EINVAL, never a write. */
+    if (guest_optlen < 0)
+        return -LINUX_EINVAL;
+
+    uint32_t write_len = lv;
+    if (write_len > (uint32_t) guest_optlen)
+        write_len = guest_optlen;
+    if (write_len > 0 && guest_write_small(g, optval_gva, &v, write_len) < 0)
+        return -LINUX_EFAULT;
+
+    /* Linux sock_getsockopt() writes back min(len, lv): a short optlen must not
+     * grow to claim bytes that were never written, and a long one shrinks to
+     * the option's own size rather than reporting the whole buffer.
+     */
+    uint32_t actual_len = write_len;
+    if (guest_write_small(g, optlen_gva, &actual_len, sizeof(actual_len)) < 0)
+        return -LINUX_EFAULT;
     return 0;
 }
 
@@ -710,6 +1506,16 @@ static int64_t netlink_send_iov(int guest_fd,
     }
 
     int64_t result;
+
+    /* A uevent socket is receive-only here. Linux's uevent_net_rcv() refuses a
+     * sender without CAP_SYS_ADMIN with -EPERM, and elfuse guests have no
+     * authority to fabricate uevents, so every send is that refusal.
+     */
+    if (ns->proto == NETLINK_KOBJECT_UEVENT) {
+        result = -LINUX_EPERM;
+        goto out;
+    }
+
     uint64_t total = 0;
     for (int i = 0; i < iovcnt; i++) {
         if (iov[i].iov_len > UINT64_MAX - total) {
@@ -827,7 +1633,52 @@ int64_t netlink_sendmsg(int guest_fd, guest_t *g, uint64_t msg_gva, int flags)
     return ret;
 }
 
-/* Block until the netlink receive buffer has data. Called with nl_lock held.
+/* Milliseconds on CLOCK_MONOTONIC, for the SO_RCVTIMEO deadline. Milliseconds
+ * rather than microseconds because the stored timeout is a jiffy count at
+ * HZ=1000 and poll() takes milliseconds, so nothing finer survives either end.
+ */
+static int64_t nl_now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+/* now + timeout, saturating. The largest timeout sock_set_timeout() accepts is
+ * within a rounding error of INT64_MAX milliseconds, so a plain add overflows
+ * on any machine whose CLOCK_MONOTONIC has advanced at all -- signed overflow,
+ * and in practice a deadline in the past, which turns the longest timeout a
+ * guest can ask for into an immediate EAGAIN. Saturating keeps it what it reads
+ * as: a deadline 292 million years out, indistinguishable from forever and
+ * exactly as Linux's LONG_MAX jiffies is.
+ */
+static int64_t nl_deadline_add(int64_t now_ms, int64_t timeout_ms)
+{
+    if (timeout_ms > INT64_MAX - now_ms)
+        return INT64_MAX;
+    return now_ms + timeout_ms;
+}
+
+/* restart_block for a netlink receive: the deadline an interrupted wait had
+ * left, carried across the SVC restart the dispatcher may perform.
+ *
+ * Linux restarts an interrupted recvmsg with the timeout it had *remaining*,
+ * not with a fresh copy of SO_RCVTIMEO. elfuse's restart re-executes the SVC,
+ * so nl_wait_readable_locked() is re-entered from the top and would compute a
+ * new deadline from the option -- handing the guest its whole timeout again,
+ * once per restart. Stashing the absolute deadline here and adopting it when
+ * syscall_is_restarted() says this call is the re-execution keeps the budget
+ * the guest was given.
+ *
+ * Thread-local, and only read when the restart flag is set, so a stash left
+ * behind by a wait whose restart never happened cannot be picked up by an
+ * unrelated later receive. The fd is part of the match for the same reason.
+ */
+static _Thread_local int64_t nl_restart_deadline_ms;
+static _Thread_local int nl_restart_fd = -1;
+
+/* Block until the netlink receive buffer has data, for at most SO_RCVTIMEO.
+ * Called with nl_lock held.
  *
  * On success returns 0 with nl_lock still held and ns valid. On EAGAIN, EINTR,
  * EIO, or if the socket was closed underneath the poll, releases nl_lock and
@@ -837,10 +1688,47 @@ static int64_t nl_wait_readable_locked(netlink_state_t *ns,
                                        int guest_fd,
                                        bool nonblock)
 {
+    /* Three states, from sock_rcvtimeo(): a negative stored timeout is Linux's
+     * 0 jiffies, which means do not wait at all and is the nonblocking answer
+     * even on a socket the guest never marked nonblocking.
+     */
+    bool no_wait = nonblock || ns->opt_rcvtimeo_ms < 0;
+
+    /* The SO_RCVTIMEO deadline is taken once, here, and not refreshed by the
+     * waits below. That is skb_recv_datagram()'s shape: sock_rcvtimeo() is read
+     * at the top and every wait inside shares the one budget, so a wakeup that
+     * finds nothing does not buy the caller another full timeout. A restarted
+     * SVC continues the deadline the interrupted attempt was using, for the
+     * same reason at a larger scale.
+     */
+    int64_t deadline_ms = 0;
+    if (!no_wait && ns->opt_rcvtimeo_ms > 0) {
+        bool resumed = syscall_is_restarted() && nl_restart_fd == guest_fd &&
+                       nl_restart_deadline_ms != 0;
+        deadline_ms = resumed
+                          ? nl_restart_deadline_ms
+                          : nl_deadline_add(nl_now_ms(), ns->opt_rcvtimeo_ms);
+    }
+    nl_restart_deadline_ms = 0;
+    nl_restart_fd = -1;
+
     while (ns->buf_pos >= ns->buf_len) {
-        if (nonblock) {
+        if (no_wait) {
             pthread_mutex_unlock(&nl_lock);
             return -LINUX_EAGAIN;
+        }
+
+        int timeout_ms = -1;
+        if (deadline_ms) {
+            int64_t left_ms = deadline_ms - nl_now_ms();
+            if (left_ms <= 0) {
+                /* Expired with the buffer still empty: the same EAGAIN the
+                 * nonblocking path reports, and released the same way.
+                 */
+                pthread_mutex_unlock(&nl_lock);
+                return -LINUX_EAGAIN;
+            }
+            timeout_ms = (left_ms > INT_MAX) ? INT_MAX : (int) left_ms;
         }
 
         int rd_fd = ns->pipe_rd;
@@ -852,9 +1740,40 @@ static int64_t nl_wait_readable_locked(netlink_state_t *ns,
          * guest memory on an eventual delayed return, well after guest_destroy
          * may have unmapped it.
          */
-        int64_t wait_rc = io_wait_fd_or_interrupted(rd_fd, POLLIN);
-        if (wait_rc < 0)
+        int64_t wait_rc =
+            io_wait_fd_timed_or_interrupted(rd_fd, POLLIN, timeout_ms);
+        if (wait_rc < 0) {
+            /* sock_intr_errno(): an interrupted receive reports ERESTARTSYS
+             * when the timeout is MAX_SCHEDULE_TIMEOUT and EINTR when it is
+             * finite, precisely so a restart cannot hand the caller its whole
+             * SO_RCVTIMEO a second time. Same split -- but only over the half
+             * of the EINTR the guest can see.
+             *
+             * io_wait_fd_timed_or_interrupted() reports EINTR for two unrelated
+             * reasons. One is a guest-visible signal, and forbidding the
+             * restart there is right. The other is the dispatcher's own execve
+             * handoff (io.c: the leader leaves the wait so the run loop can
+             * reach the handoff), which is invisible to the guest and which
+             * syscall.c only restarts while thread_stop_is_leader_work_only()
+             * holds. Forbidding unconditionally turned a sibling's execve into
+             * an EINTR on a recvmsg with no signal in sight -- an errno Linux
+             * cannot produce there. Gate on the same predicate the dispatcher
+             * arms on, so only the guest-visible half forbids.
+             *
+             * The restarted attempt continues this deadline rather than taking
+             * a fresh one, which is what Linux's restart_block carries, so the
+             * handoff cannot stretch a finite timeout either.
+             */
+            if (deadline_ms && wait_rc == -LINUX_EINTR) {
+                if (thread_stop_is_leader_work_only()) {
+                    nl_restart_deadline_ms = deadline_ms;
+                    nl_restart_fd = guest_fd;
+                } else {
+                    syscall_restart_forbid();
+                }
+            }
             return wait_rc;
+        }
 
         pthread_mutex_lock(&nl_lock);
         netlink_state_t *current_ns = nl_find(guest_fd);
@@ -862,6 +1781,11 @@ static int64_t nl_wait_readable_locked(netlink_state_t *ns,
             pthread_mutex_unlock(&nl_lock);
             return -LINUX_EBADF;
         }
+
+        /* wait_rc == 1 is the timeout slice expiring. Fall through to the loop
+         * condition rather than reporting here, so a message that landed in the
+         * same instant still wins the race the way a real receive does.
+         */
     }
     return 0;
 }
@@ -1112,7 +2036,7 @@ int64_t netlink_read(int guest_fd, guest_t *g, uint64_t buf_gva, uint64_t count)
 static void netlink_close(int guest_fd)
 {
     pthread_mutex_lock(&nl_lock);
-    netlink_state_t *ns = nl_find(guest_fd);
+    netlink_state_t *ns = nl_find_oldest(guest_fd);
     if (!ns) {
         pthread_mutex_unlock(&nl_lock);
         return;

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -776,6 +776,7 @@ run_unit_tests()
     test_check "$runner" "test-net" "0 failed" "$bindir/test-net"
     test_rc "$runner" "test-netstat" 0 "$bindir/test-netstat"
     test_rc "$runner" "test-netlink" 0 "$bindir/test-netlink"
+    test_rc "$runner" "test-uevent-socket" 0 "$bindir/test-uevent-socket"
 
     printf "\nThreading\n"
     test_check "$runner" "test-thread" "0 failed" "$bindir/test-thread"

--- a/tests/test-uevent-socket.c
+++ b/tests/test-uevent-socket.c
@@ -1,0 +1,996 @@
+/*
+ * NETLINK_KOBJECT_UEVENT silent-socket contract: the surface libusb_init()'s
+ * netlink hotplug monitor needs (linux_netlink.c:102-133).
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Asserts, in the order libusb performs them:
+ *   socket(AF_NETLINK, SOCK_RAW|SOCK_NONBLOCK|SOCK_CLOEXEC,
+ *          NETLINK_KOBJECT_UEVENT) succeeds,
+ *   bind(nl_groups=1) succeeds (and nl_groups=2, nusb's udev group),
+ *   setsockopt(SOL_SOCKET, SO_PASSCRED, 1) succeeds and reads back 1,
+ *   getsockopt(SO_RCVBUF/SO_TYPE) report sane values,
+ *   a drained socket is not readable: non-blocking recv reports EAGAIN and
+ *   poll() times out,
+ *   send() to the kernel-side netlink address (nl_pid 0) either fails with
+ *   EPERM (elfuse refuses guests the authority to fabricate uevents) or is
+ *   swallowed whole (a real Linux kernel's netlink_unicast() to the uevent
+ *   handler returns the payload length; the handler's own CAP_SYS_ADMIN
+ *   refusal only travels back as an NLMSG_ERROR ack, and a payload shorter
+ *   than NLMSG_HDRLEN is skipped silently),
+ *   and a NETLINK_ROUTE socket still opens, so the uevent path did not
+ *   disturb the rtnetlink emulation.
+ *
+ * Then the SOL_SOCKET surface sk_setsockopt()/sk_getsockopt() define on any
+ * socket, which a netlink fd has to answer the same way:
+ *   SO_RCVBUF and SO_SNDBUF clamp to the sysctl, double, and floor at
+ *   SOCK_MIN_RCVBUF and SOCK_MIN_SNDBUF -- two different floors, one twice
+ *   the other,
+ *   SO_RCVTIMEO actually bounds a blocking receive rather than being
+ *   swallowed, in all three of sock_set_timeout()'s states (finite, forever,
+ *   and the negative tv_sec that means "do not wait"),
+ *   the options whose payload is not an int refuse a four-byte optlen,
+ *   a getsockopt with a short optlen writes only what it reports and one with
+ *   a negative optlen writes nothing at all,
+ *   and every option that can be set can be read back.
+ *
+ * Then netlink_create()'s socket-type validation, and the SOL_NETLINK level:
+ * the membership pair, the flag booleans a libnl/libmnl monitor sets on the way
+ * up, and the bitmap NETLINK_LIST_MEMBERSHIPS reads back -- all under the same
+ * contract bind() gives, recorded and never delivered on.
+ *
+ * The assertions hold for the elfuse emulation and for a real Linux kernel with
+ * no hotplug activity during the run (the test matrix runs this binary under
+ * qemu-aarch64 too). Genuine uevents arriving mid-run are tolerated by draining
+ * before every readability check.
+ *
+ * The handful of answers that genuinely differ between the two are not asserted
+ * as a disjunction that both lanes pass by accident. on_elfuse below names the
+ * lane once, from the one probe whose answer is unambiguous, and each such
+ * assertion states the strict outcome for the lane it is running in.
+ *
+ * Nothing here pins a number a kernel build is free to choose. SOCK_MIN_RCVBUF
+ * is 2048 + SKB_DATA_ALIGN(sizeof(struct sk_buff)), which depends on the
+ * config, and net.core.rmem_max is a sysctl, so the floors and the clamp are
+ * asserted through relations that hold whatever those turn out to be: the send
+ * floor is exactly twice the receive floor, and two requests that both exceed
+ * the sysctl read back equal.
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+/* Old kernel headers may predate some of these. The numbers are ABI. */
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
+#endif
+#ifndef NETLINK_RX_RING
+#define NETLINK_RX_RING 6
+#endif
+#ifndef NETLINK_LISTEN_ALL_NSID
+#define NETLINK_LISTEN_ALL_NSID 8
+#endif
+#ifndef NETLINK_LIST_MEMBERSHIPS
+#define NETLINK_LIST_MEMBERSHIPS 9
+#endif
+#ifndef NETLINK_CAP_ACK
+#define NETLINK_CAP_ACK 10
+#endif
+#ifndef NETLINK_EXT_ACK
+#define NETLINK_EXT_ACK 11
+#endif
+#ifndef NETLINK_GET_STRICT_CHK
+#define NETLINK_GET_STRICT_CHK 12
+#endif
+
+static int pass, fail;
+
+#define CHECK(cond, msg)                                                       \
+    do {                                                                       \
+        if (cond) {                                                            \
+            printf("PASS: %s\n", (msg));                                       \
+            pass++;                                                            \
+        } else {                                                               \
+            printf("FAIL: %s (errno=%d %s)\n", (msg), errno, strerror(errno)); \
+            fail++;                                                            \
+        }                                                                      \
+    } while (0)
+
+/* Read until the socket is empty so a genuine uevent arriving on a real Linux
+ * kernel cannot fail the emptiness assertions below.
+ */
+static void drain(int fd)
+{
+    char buf[4096];
+    while (recv(fd, buf, sizeof(buf), MSG_DONTWAIT) >= 0)
+        ;
+}
+
+/* A bounded retry around an assertion a genuine uevent can spoil. Four attempts
+ * rather than a loop on success: a machine with a continuous hotplug stream
+ * must fail this test, not spin in it. drain() itself terminates on the first
+ * EAGAIN, so the whole thing is finite either way.
+ */
+#define RETRIES 4
+
+/* Set one int option and read the resulting int back.
+ *
+ * Returns the readback, or -1 if either half failed.
+ */
+static int set_get_int(int fd, int optname, int value)
+{
+    if (setsockopt(fd, SOL_SOCKET, optname, &value, sizeof(value)) != 0)
+        return -1;
+    int out = -1;
+    socklen_t len = sizeof(out);
+    if (getsockopt(fd, SOL_SOCKET, optname, &out, &len) != 0 ||
+        len != sizeof(int))
+        return -1;
+    return out;
+}
+
+/* The same round trip at SOL_NETLINK, where the flag booleans live.
+ *
+ * Returns the readback, or -1 if either half failed.
+ */
+static int set_get_nl(int fd, int optname, int value)
+{
+    if (setsockopt(fd, SOL_NETLINK, optname, &value, sizeof(value)) != 0)
+        return -1;
+    int out = -1;
+    socklen_t len = sizeof(out);
+    if (getsockopt(fd, SOL_NETLINK, optname, &out, &len) != 0 ||
+        len != sizeof(int))
+        return -1;
+    return out;
+}
+
+static int64_t now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+/* The blocking receive below is the one assertion in this file that can hang
+ * rather than fail if SO_RCVTIMEO is ignored, which is exactly the bug it
+ * exists to catch. The matrix already wraps each binary in timeout(1), but a
+ * suite-level kill reports nothing useful, so arm a watchdog that says what
+ * happened first.
+ */
+static void watchdog_fired(int sig)
+{
+    (void) sig;
+    static const char msg[] =
+        "FAIL: a blocking recv() never came back (watchdog fired)\n";
+    ssize_t n = write(2, msg, sizeof(msg) - 1);
+    (void) n;
+    _exit(1);
+}
+
+/* Two guest threads opening netlink sockets at the same instant used to race:
+ * the emulation scanned its socket table, claimed a free slot, and wrote the
+ * protocol into it with no lock, so the loser's write could land on the
+ * winner's slot and hand one thread a socket carrying the other's protocol.
+ * SO_PROTOCOL is the witness -- it reads that exact field back.
+ *
+ * A race is not a deterministic test, which is why every iteration also has to
+ * be cheap: 4 threads x 250 opens gives the interleaving many chances while
+ * costing well under a second on either lane.
+ */
+#define OPENERS 4
+#define OPENS_PER_THREAD 250
+
+typedef struct {
+    int protocol;
+    int mismatches;
+    int open_failures;
+} opener_arg_t;
+
+static void *opener(void *arg)
+{
+    opener_arg_t *a = arg;
+    for (int i = 0; i < OPENS_PER_THREAD; i++) {
+        int s = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, a->protocol);
+        if (s < 0) {
+            a->open_failures++;
+            continue;
+        }
+        int proto = -1, type = -1;
+        socklen_t l = sizeof(proto);
+        if (getsockopt(s, SOL_SOCKET, SO_PROTOCOL, &proto, &l) != 0 ||
+            proto != a->protocol)
+            a->mismatches++;
+        l = sizeof(type);
+        if (getsockopt(s, SOL_SOCKET, SO_TYPE, &type, &l) != 0 ||
+            type != SOCK_RAW)
+            a->mismatches++;
+        close(s);
+    }
+    return NULL;
+}
+
+/* Wakes the blocking receive in the huge-SO_RCVTIMEO test by asking the
+ * rtnetlink socket for a link dump from a second thread, which is the only way
+ * to prove that receive really parked: a timeout that overflowed its deadline
+ * reports EAGAIN immediately instead, and one that works reports the dump.
+ */
+static int poke_fd = -1;
+
+/* Thread body for the sibling-execve case: fail an execve() over and over while
+ * the main thread is parked in a receive. The path never exists, so every
+ * attempt returns ENOENT and the process image is never replaced -- but each
+ * one still asks the dispatcher's leader to leave whatever it is parked in so
+ * the run loop can reach the execve handoff, which is exactly the
+ * guest-invisible EINTR the receive must not report.
+ */
+static volatile sig_atomic_t exec_probe_stop;
+
+static void *failing_execve_loop(void *arg)
+{
+    (void) arg;
+    char *const argv[] = {(char *) "/nonexistent-elfuse-exec-probe", NULL};
+    char *const envp[] = {NULL};
+    while (!exec_probe_stop) {
+        struct timespec nap = {.tv_sec = 0, .tv_nsec = 20 * 1000 * 1000};
+        nanosleep(&nap, NULL);
+        (void) execve("/nonexistent-elfuse-exec-probe", argv, envp);
+    }
+    return NULL;
+}
+
+static void *poke_after_delay(void *arg)
+{
+    (void) arg;
+    struct timespec delay = {.tv_sec = 0, .tv_nsec = 300 * 1000 * 1000};
+    nanosleep(&delay, NULL);
+
+    struct {
+        struct nlmsghdr hdr;
+        struct ifinfomsg ifi;
+    } req;
+    memset(&req, 0, sizeof(req));
+    req.hdr.nlmsg_len = sizeof(req);
+    req.hdr.nlmsg_type = RTM_GETLINK;
+    req.hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.hdr.nlmsg_seq = 1;
+    req.ifi.ifi_family = AF_UNSPEC;
+
+    struct sockaddr_nl kernel = {.nl_family = AF_NETLINK};
+    ssize_t n = sendto(poke_fd, &req, sizeof(req), 0,
+                       (struct sockaddr *) &kernel, sizeof(kernel));
+    (void) n;
+    return NULL;
+}
+
+int main(void)
+{
+    /* Line-buffered: the watchdog below _exit()s from a signal handler, which
+     * takes any buffered output with it. Without this a hang reports only the
+     * watchdog line, and which assertion hung is exactly what is wanted.
+     */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
+    /* Which lane is this? The one probe whose two answers cannot be confused:
+     * an unemulated netlink family is EAFNOSUPPORT from elfuse and
+     * EPROTONOSUPPORT from a kernel that simply has no such family registered.
+     * Everything below that differs by lane asks this rather than accepting
+     * both answers, so neither lane can pass on the other lane's behavior.
+     */
+    int bogus = socket(AF_NETLINK, SOCK_RAW, 99);
+    int bogus_errno = errno;
+    if (bogus >= 0)
+        close(bogus);
+    bool on_elfuse = bogus == -1 && bogus_errno == EAFNOSUPPORT;
+
+    /* The exact socket() call libusb's netlink monitor makes. */
+    int fd = socket(AF_NETLINK, SOCK_RAW | SOCK_NONBLOCK | SOCK_CLOEXEC,
+                    NETLINK_KOBJECT_UEVENT);
+    CHECK(fd >= 0, "socket(NETLINK_KOBJECT_UEVENT)");
+    if (fd < 0)
+        return 1;
+
+    struct sockaddr_nl snl = {.nl_family = AF_NETLINK, .nl_groups = 1};
+    CHECK(bind(fd, (struct sockaddr *) &snl, sizeof(snl)) == 0,
+          "bind(nl_groups=1)");
+
+    int one = 1;
+    CHECK(setsockopt(fd, SOL_SOCKET, SO_PASSCRED, &one, sizeof(one)) == 0,
+          "setsockopt(SO_PASSCRED, 1)");
+
+    int val = -1;
+    socklen_t len = sizeof(val);
+    CHECK(getsockopt(fd, SOL_SOCKET, SO_PASSCRED, &val, &len) == 0 &&
+              val == 1 && len == sizeof(int),
+          "getsockopt(SO_PASSCRED) == 1");
+
+    val = 0;
+    len = sizeof(val);
+    CHECK(getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &val, &len) == 0 && val > 0,
+          "getsockopt(SO_RCVBUF) > 0");
+
+    val = 0;
+    len = sizeof(val);
+    CHECK(
+        getsockopt(fd, SOL_SOCKET, SO_TYPE, &val, &len) == 0 && val == SOCK_RAW,
+        "getsockopt(SO_TYPE) == SOCK_RAW");
+
+    /* No uevent is ever synthesized: an empty socket reports EAGAIN. Retried
+     * through drain() for the same reason the poll below is: on a real kernel
+     * this fd is subscribed to uevent group 1, and a device event landing in
+     * the window between the drain and the recv would otherwise fail a test
+     * that is about elfuse's emulation, not about the host being idle.
+     */
+    char buf[4096];
+    int empty = 0;
+    for (int i = 0; i < RETRIES && !empty; i++) {
+        drain(fd);
+        empty =
+            recv(fd, buf, sizeof(buf), MSG_DONTWAIT) == -1 && errno == EAGAIN;
+    }
+    CHECK(empty, "recv(MSG_DONTWAIT) empty -> EAGAIN");
+
+    /* ...and poll() times out. Retried through drain() so a real hotplug event
+     * during the run cannot fail the assertion.
+     */
+    int quiet = 0;
+    for (int i = 0; i < RETRIES && !quiet; i++) {
+        drain(fd);
+        struct pollfd pfd = {.fd = fd, .events = POLLIN};
+        quiet = poll(&pfd, 1, 200) == 0;
+    }
+    CHECK(quiet, "poll(200ms) times out on silent socket");
+
+    /* Guests cannot fabricate uevents. elfuse refuses the send outright with
+     * EPERM (uevent_net_rcv_skb's answer for a sender without CAP_SYS_ADMIN). A
+     * real Linux kernel never surfaces that refusal through sendto():
+     * netlink_unicast() to a kernel socket with .input set returns skb->len
+     * unconditionally, the handler's -EPERM only comes back as an NLMSG_ERROR
+     * ack, and this 14-byte payload is under NLMSG_HDRLEN so netlink_rcv_skb()
+     * skips it without even an ack. So: success returning the payload length is
+     * the real-kernel outcome, and any failure must be the EPERM refusal.
+     */
+    struct sockaddr_nl kernel = {.nl_family = AF_NETLINK};
+    ssize_t s = sendto(fd, "add@/devices/x", 14, 0, (struct sockaddr *) &kernel,
+                       sizeof(kernel));
+    CHECK(on_elfuse ? (s == -1 && errno == EPERM) : s == 14,
+          on_elfuse ? "sendto() on a uevent socket -> EPERM"
+                    : "sendto() swallowed whole by a real Linux kernel");
+
+    /* nusb's watch_devices() binds group 2 (udevd's multicast group). */
+    int fd2 =
+        socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_KOBJECT_UEVENT);
+    struct sockaddr_nl snl2 = {.nl_family = AF_NETLINK, .nl_groups = 2};
+    CHECK(fd2 >= 0 && bind(fd2, (struct sockaddr *) &snl2, sizeof(snl2)) == 0,
+          "second socket, bind(nl_groups=2)");
+    if (fd2 >= 0)
+        close(fd2);
+
+    /* The rtnetlink emulation must be undisturbed by the uevent path. */
+    int rt = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    CHECK(rt >= 0, "socket(NETLINK_ROUTE) still works");
+    if (rt >= 0)
+        close(rt);
+
+    /* The lane probe from the top of main, asserted rather than merely
+     * consulted: an unemulated netlink family is refused either way, and which
+     * errno it is refused with is what on_elfuse was read from.
+     */
+    errno = bogus_errno;
+    CHECK(bogus == -1 &&
+              (bogus_errno == EAFNOSUPPORT || bogus_errno == EPROTONOSUPPORT),
+          "socket(protocol=99) refused");
+
+    /* netlink_create() takes SOCK_RAW and SOCK_DGRAM and nothing else.
+     *
+     * __sock_create() screens the flag bits first, so an unknown one is EINVAL
+     * before the family is consulted at all; netlink_create() then screens the
+     * base type, before the protocol number. Measured on Linux 6.x/aarch64,
+     * which is also why socket(SOCK_STREAM, 99) below is ESOCKTNOSUPPORT and
+     * not the unknown-family error: the type check runs first.
+     */
+    int st = socket(AF_NETLINK, SOCK_STREAM, NETLINK_KOBJECT_UEVENT);
+    CHECK(st == -1 && errno == ESOCKTNOSUPPORT,
+          "socket(SOCK_STREAM) -> ESOCKTNOSUPPORT");
+    if (st >= 0)
+        close(st);
+
+    int sp = socket(AF_NETLINK, SOCK_SEQPACKET, NETLINK_ROUTE);
+    CHECK(sp == -1 && errno == ESOCKTNOSUPPORT,
+          "socket(SOCK_SEQPACKET) -> ESOCKTNOSUPPORT");
+    if (sp >= 0)
+        close(sp);
+
+    int t0s = socket(AF_NETLINK, 0, NETLINK_ROUTE);
+    CHECK(t0s == -1 && errno == ESOCKTNOSUPPORT,
+          "socket(type=0) -> ESOCKTNOSUPPORT");
+    if (t0s >= 0)
+        close(t0s);
+
+    int badflag = socket(AF_NETLINK, SOCK_RAW | 0x40000000, NETLINK_ROUTE);
+    CHECK(badflag == -1 && errno == EINVAL,
+          "socket(SOCK_RAW | unknown flag bit) -> EINVAL");
+    if (badflag >= 0)
+        close(badflag);
+
+    int order = socket(AF_NETLINK, SOCK_STREAM, 99);
+    CHECK(order == -1 && errno == ESOCKTNOSUPPORT,
+          "socket(SOCK_STREAM, protocol=99): the type is screened first");
+    if (order >= 0)
+        close(order);
+
+    int dg = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_KOBJECT_UEVENT);
+    CHECK(dg >= 0, "socket(SOCK_DGRAM) is accepted");
+    if (dg >= 0)
+        close(dg);
+
+    /* SO_RCVBUF/SO_SNDBUF: two floors, not one
+     *
+     * sk_setsockopt() clamps the request to net.core.{r,w}mem_max, doubles it,
+     * then floors it at SOCK_MIN_RCVBUF or SOCK_MIN_SNDBUF. The two floors are
+     * TCP_SKB_MIN_TRUESIZE and twice that, so the send floor is exactly double
+     * the receive floor whatever sizeof(struct sk_buff) came out to on this
+     * build. Asking for 0 lands on each floor exactly.
+     */
+    int opt = socket(AF_NETLINK, SOCK_RAW, NETLINK_KOBJECT_UEVENT);
+    CHECK(opt >= 0, "socket for the SOL_SOCKET option surface");
+    if (opt < 0) {
+        close(fd);
+        printf("%d passed, %d failed\n", pass, fail);
+        return 1;
+    }
+
+    int rcv_floor = set_get_int(opt, SO_RCVBUF, 0);
+    int snd_floor = set_get_int(opt, SO_SNDBUF, 0);
+    CHECK(rcv_floor > 2048 && snd_floor == 2 * rcv_floor,
+          "SO_SNDBUF floor is exactly twice the SO_RCVBUF floor");
+
+    /* A request whose doubled value is under the floor reads back as the floor
+     * -- and as its own direction's floor. 1024 doubles to 2048, which is below
+     * TCP_SKB_MIN_TRUESIZE on any build; 2000 doubles to 4000, below twice it.
+     */
+    CHECK(set_get_int(opt, SO_RCVBUF, 1024) == rcv_floor,
+          "SO_RCVBUF below the floor reports SOCK_MIN_RCVBUF");
+    CHECK(set_get_int(opt, SO_SNDBUF, 2000) == snd_floor,
+          "SO_SNDBUF below the floor reports SOCK_MIN_SNDBUF");
+
+    /* The clamp is min_t(u32, val, sysctl), so a negative request is a huge
+     * unsigned one and lands on the sysctl, not on the floor. Two requests that
+     * both exceed the sysctl therefore read back equal -- which is the
+     * assertion, since the sysctl itself is not ours to predict.
+     */
+    int rcv_neg = set_get_int(opt, SO_RCVBUF, -1);
+    int rcv_huge = set_get_int(opt, SO_RCVBUF, INT_MAX);
+    CHECK(rcv_neg > rcv_floor && rcv_neg == rcv_huge,
+          "SO_RCVBUF = -1 clamps to the sysctl like INT_MAX, not to the floor");
+
+    /* payloads that are not an int
+     *
+     * sk_setsockopt() reads an int first, so optlen < 4 is EINVAL for every
+     * option. SO_LINGER and the two timeouts then check their own length, so an
+     * optlen of exactly 4 -- enough for the generic read -- still fails.
+     */
+    char big[64];
+    memset(big, 0, sizeof(big));
+    CHECK(
+        setsockopt(opt, SOL_SOCKET, SO_LINGER, big, 4) == -1 && errno == EINVAL,
+        "setsockopt(SO_LINGER, optlen=4) -> EINVAL");
+    CHECK(setsockopt(opt, SOL_SOCKET, SO_RCVTIMEO, big, 4) == -1 &&
+              errno == EINVAL,
+          "setsockopt(SO_RCVTIMEO, optlen=4) -> EINVAL");
+    CHECK(setsockopt(opt, SOL_SOCKET, SO_SNDTIMEO, big, 4) == -1 &&
+              errno == EINVAL,
+          "setsockopt(SO_SNDTIMEO, optlen=4) -> EINVAL");
+    CHECK(setsockopt(opt, SOL_SOCKET, SO_BROADCAST, big, 1) == -1 &&
+              errno == EINVAL,
+          "setsockopt(optlen=1) -> EINVAL for a plain int option");
+
+    /* The full-length spellings are accepted, and read back. SO_LINGER writes 8
+     * bytes and says so; the old code answered ENOPROTOOPT here.
+     */
+    struct linger lin = {.l_onoff = 1, .l_linger = 7};
+    CHECK(setsockopt(opt, SOL_SOCKET, SO_LINGER, &lin, sizeof(lin)) == 0,
+          "setsockopt(SO_LINGER, sizeof(struct linger))");
+    struct linger back = {.l_onoff = -1, .l_linger = -1};
+    socklen_t blen = sizeof(back);
+    CHECK(getsockopt(opt, SOL_SOCKET, SO_LINGER, &back, &blen) == 0 &&
+              blen == sizeof(struct linger) && back.l_onoff == 1 &&
+              back.l_linger == 7,
+          "getsockopt(SO_LINGER) round-trips {1, 7} in 8 bytes");
+
+    /* A getsockopt writes what it reports and no more.
+     *
+     * sock_getsockopt() writes min(len, lv) bytes and reports that same number,
+     * so SO_LINGER read into a four-byte window succeeds, writes l_onoff alone,
+     * reports 4, and leaves the caller's fifth byte onward untouched. Measured
+     * on Linux 6.x/aarch64: rc 0, optlen 4, only the first four bytes written.
+     * A caller that trusted a grown optlen would read poison as l_linger.
+     */
+    unsigned char poison[16];
+    memset(poison, 0xAB, sizeof(poison));
+    socklen_t plen = 4;
+    int prc = getsockopt(opt, SOL_SOCKET, SO_LINGER, poison, &plen);
+    int pfirst;
+    memcpy(&pfirst, poison, sizeof(pfirst));
+    CHECK(prc == 0 && plen == 4 && pfirst == 1 && poison[4] == 0xAB &&
+              poison[5] == 0xAB && poison[6] == 0xAB && poison[7] == 0xAB,
+          "getsockopt(SO_LINGER, optlen=4) writes 4 bytes and reports 4");
+
+    /* A negative optlen is refused outright, before anything is written. */
+    int nval = 0;
+    socklen_t nlen = (socklen_t) -1;
+    CHECK(getsockopt(opt, SOL_SOCKET, SO_RCVBUF, &nval, &nlen) == -1 &&
+              errno == EINVAL,
+          "getsockopt(SO_RCVBUF, optlen=-1) -> EINVAL");
+
+    /* An over-long optlen shrinks to the option's own size rather than
+     * reporting the buffer it was handed.
+     */
+    unsigned char roomy[64];
+    socklen_t rlen = sizeof(roomy);
+    CHECK(getsockopt(opt, SOL_SOCKET, SO_RCVTIMEO, roomy, &rlen) == 0 &&
+              rlen == sizeof(struct timeval),
+          "getsockopt(SO_RCVTIMEO, optlen=64) reports 16");
+
+    /* SO_RCVTIMEO round-trips through jiffies on Linux, so the readback is the
+     * request rounded up to at most one jiffy. HZ is 100 at the lowest, so 200
+     * ms cannot grow past 210 ms; elfuse stores microseconds and returns the
+     * request unchanged.
+     */
+    struct timeval tv = {.tv_sec = 0, .tv_usec = 200000};
+    CHECK(setsockopt(opt, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == 0,
+          "setsockopt(SO_RCVTIMEO, 200ms)");
+    struct timeval rtv = {.tv_sec = -1, .tv_usec = -1};
+    socklen_t tlen = sizeof(rtv);
+    CHECK(getsockopt(opt, SOL_SOCKET, SO_RCVTIMEO, &rtv, &tlen) == 0 &&
+              tlen == sizeof(struct timeval) && rtv.tv_sec == 0 &&
+              rtv.tv_usec >= 200000 && rtv.tv_usec <= 210000,
+          "getsockopt(SO_RCVTIMEO) reports the 200ms it was given");
+
+    /* tv_usec outside [0, 1000000) is EDOM, which is neither EINVAL nor a
+     * silent accept.
+     */
+    struct timeval bad = {.tv_sec = 0, .tv_usec = 1000000};
+    CHECK(setsockopt(opt, SOL_SOCKET, SO_RCVTIMEO, &bad, sizeof(bad)) == -1 &&
+              errno == EDOM,
+          "setsockopt(SO_RCVTIMEO, tv_usec=1e6) -> EDOM");
+
+    /* options that used to be accepted and then unreadable */
+    CHECK(set_get_int(opt, SO_BROADCAST, 1) == 1, "SO_BROADCAST round-trips");
+    CHECK(set_get_int(opt, SO_KEEPALIVE, 1) == 1, "SO_KEEPALIVE round-trips");
+    CHECK(set_get_int(opt, SO_REUSEADDR, 1) == 1, "SO_REUSEADDR round-trips");
+    CHECK(set_get_int(opt, SO_RCVLOWAT, 5) == 5, "SO_RCVLOWAT round-trips");
+
+    int lowat = -1;
+    socklen_t llen = sizeof(lowat);
+    CHECK(getsockopt(opt, SOL_SOCKET, SO_SNDLOWAT, &lowat, &llen) == 0 &&
+              lowat == 1,
+          "getsockopt(SO_SNDLOWAT) == 1");
+
+    /* SO_SNDLOWAT has no case in sk_setsockopt at all (1003.1g 7 makes it
+     * unsettable), so it falls to the default arm.
+     */
+    int one_v = 1;
+    CHECK(
+        setsockopt(opt, SOL_SOCKET, SO_SNDLOWAT, &one_v, sizeof(one_v)) == -1 &&
+            errno == ENOPROTOOPT,
+        "setsockopt(SO_SNDLOWAT) -> ENOPROTOOPT");
+
+    /* Clearing SO_DEBUG and SO_REUSEPORT is unprivileged and always works.
+     * Setting either is refused on an elfuse netlink socket -- a guest holds no
+     * CAP_NET_ADMIN over the host and AF_NETLINK is not what sk_is_inet()
+     * accepts -- and that half is asserted strictly on the elfuse lane. The
+     * qemu lane cannot be held to it: its initramfs boots as root, where
+     * CAP_NET_ADMIN makes SO_DEBUG succeed, and the sk_is_inet() guard on
+     * SO_REUSEPORT is younger than some kernels this may meet, so there the
+     * assertion is the weaker one those two facts leave.
+     */
+    int zero_v = 0;
+    CHECK(setsockopt(opt, SOL_SOCKET, SO_DEBUG, &zero_v, sizeof(zero_v)) == 0,
+          "setsockopt(SO_DEBUG, 0) accepted");
+    CHECK(
+        setsockopt(opt, SOL_SOCKET, SO_REUSEPORT, &zero_v, sizeof(zero_v)) == 0,
+        "setsockopt(SO_REUSEPORT, 0) accepted");
+    int dbg = setsockopt(opt, SOL_SOCKET, SO_DEBUG, &one_v, sizeof(one_v));
+    CHECK(on_elfuse ? (dbg == -1 && errno == EACCES)
+                    : (dbg == 0 ? geteuid() == 0 : errno == EACCES),
+          "setsockopt(SO_DEBUG, 1) -> EACCES without CAP_NET_ADMIN");
+    int rp = setsockopt(opt, SOL_SOCKET, SO_REUSEPORT, &one_v, sizeof(one_v));
+    CHECK(on_elfuse ? (rp == -1 && errno == EOPNOTSUPP)
+                    : (rp == 0 || errno == EOPNOTSUPP),
+          "setsockopt(SO_REUSEPORT, 1) -> EOPNOTSUPP on a non-inet socket");
+
+    close(opt);
+
+    /* SO_RCVTIMEO bounds a blocking receive
+     *
+     * A blocking uevent socket bound to no multicast group receives nothing on
+     * either world: elfuse never synthesizes a uevent, and a real kernel has
+     * nothing to deliver to a subscriber of no groups. With a 200 ms
+     * SO_RCVTIMEO the recv must come back EAGAIN rather than parking forever,
+     * which is what an accepted-and-discarded timeout would do.
+     */
+    int blk = socket(AF_NETLINK, SOCK_RAW, NETLINK_KOBJECT_UEVENT);
+    CHECK(blk >= 0, "blocking socket for the SO_RCVTIMEO wait");
+    if (blk >= 0) {
+        struct sockaddr_nl nogroups = {.nl_family = AF_NETLINK, .nl_groups = 0};
+        (void) bind(blk, (struct sockaddr *) &nogroups, sizeof(nogroups));
+
+        struct timeval wait_tv = {.tv_sec = 0, .tv_usec = 200000};
+        CHECK(setsockopt(blk, SOL_SOCKET, SO_RCVTIMEO, &wait_tv,
+                         sizeof(wait_tv)) == 0,
+              "setsockopt(SO_RCVTIMEO, 200ms) on the blocking socket");
+
+        signal(SIGALRM, watchdog_fired);
+        alarm(20);
+
+        /* Bounded retry for the same reason as the drains above: a uevent that
+         * somehow reaches this socket makes the recv succeed, and that is the
+         * host being busy rather than the timeout being broken.
+         */
+        int timed_out = 0;
+        int64_t elapsed = -1;
+        for (int i = 0; i < RETRIES && !timed_out; i++) {
+            int64_t t0 = now_ms();
+            ssize_t got = recv(blk, buf, sizeof(buf), 0);
+            elapsed = now_ms() - t0;
+            timed_out = got == -1 && (errno == EAGAIN || errno == EWOULDBLOCK);
+        }
+        alarm(0);
+
+        CHECK(timed_out, "blocking recv() with SO_RCVTIMEO -> EAGAIN");
+
+        /* At least the timeout (Linux rounds up to a jiffy, never down) and not
+         * wildly past it. The upper bound is loose on purpose: it is here to
+         * catch a wait that ignored the deadline, not to police scheduling
+         * under a loaded qemu.
+         */
+        CHECK(timed_out && elapsed >= 150 && elapsed < 10000,
+              "the SO_RCVTIMEO wait lasted about 200ms");
+        close(blk);
+    }
+
+    /* SOL_NETLINK
+     *
+     * Same contract as bind(): the membership and the flags are recorded, and
+     * nothing is ever delivered on them. Every answer below was measured on
+     * Linux 6.x/aarch64 against both NETLINK_ROUTE and NETLINK_KOBJECT_UEVENT,
+     * so these are strict on both lanes -- except NETLINK_LISTEN_ALL_NSID,
+     * which is a capability check and therefore answers by privilege.
+     */
+    int nlopt = socket(AF_NETLINK, SOCK_RAW, NETLINK_KOBJECT_UEVENT);
+    CHECK(nlopt >= 0, "socket for the SOL_NETLINK option surface");
+    if (nlopt >= 0) {
+        struct sockaddr_nl nogrp = {.nl_family = AF_NETLINK, .nl_groups = 0};
+        (void) bind(nlopt, (struct sockaddr *) &nogrp, sizeof(nogrp));
+
+        int grp = 1;
+        CHECK(setsockopt(nlopt, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP, &grp,
+                         sizeof(grp)) == 0,
+              "setsockopt(NETLINK_ADD_MEMBERSHIP, 1)");
+        CHECK(setsockopt(nlopt, SOL_NETLINK, NETLINK_DROP_MEMBERSHIP, &grp,
+                         sizeof(grp)) == 0,
+              "setsockopt(NETLINK_DROP_MEMBERSHIP, 1)");
+
+        /* Groups are numbered from 1, and the count is bounded, so 0 is out of
+         * range at the bottom exactly as an absurd number is at the top.
+         */
+        int gzero = 0;
+        CHECK(setsockopt(nlopt, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP, &gzero,
+                         sizeof(gzero)) == -1 &&
+                  errno == EINVAL,
+              "NETLINK_ADD_MEMBERSHIP group 0 -> EINVAL");
+        int gbig = 1000000;
+        CHECK(setsockopt(nlopt, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP, &gbig,
+                         sizeof(gbig)) == -1 &&
+                  errno == EINVAL,
+              "NETLINK_ADD_MEMBERSHIP group 1000000 -> EINVAL");
+        CHECK(setsockopt(nlopt, SOL_NETLINK, NETLINK_DROP_MEMBERSHIP, &gbig,
+                         sizeof(gbig)) == -1 &&
+                  errno == EINVAL,
+              "NETLINK_DROP_MEMBERSHIP group 1000000 -> EINVAL");
+
+        /* The membership pair is write-only: netlink_getsockopt has no case for
+         * either, and the bitmap is read through LIST_MEMBERSHIPS instead.
+         */
+        int mval = 0;
+        socklen_t mlen = sizeof(mval);
+        CHECK(getsockopt(nlopt, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP, &mval,
+                         &mlen) == -1 &&
+                  errno == ENOPROTOOPT,
+              "getsockopt(NETLINK_ADD_MEMBERSHIP) -> ENOPROTOOPT");
+
+        /* The flag booleans a libnl/libmnl monitor sets on the way up. Every
+         * one of them sets and reads back, in both directions.
+         */
+        CHECK(set_get_nl(nlopt, NETLINK_PKTINFO, 1) == 1,
+              "NETLINK_PKTINFO round-trips");
+        CHECK(set_get_nl(nlopt, NETLINK_BROADCAST_ERROR, 1) == 1,
+              "NETLINK_BROADCAST_ERROR round-trips");
+        CHECK(set_get_nl(nlopt, NETLINK_NO_ENOBUFS, 1) == 1,
+              "NETLINK_NO_ENOBUFS round-trips");
+        CHECK(set_get_nl(nlopt, NETLINK_CAP_ACK, 1) == 1,
+              "NETLINK_CAP_ACK round-trips");
+        CHECK(set_get_nl(nlopt, NETLINK_EXT_ACK, 1) == 1,
+              "NETLINK_EXT_ACK round-trips");
+        CHECK(set_get_nl(nlopt, NETLINK_GET_STRICT_CHK, 1) == 1,
+              "NETLINK_GET_STRICT_CHK round-trips");
+        CHECK(set_get_nl(nlopt, NETLINK_EXT_ACK, 0) == 0,
+              "NETLINK_EXT_ACK clears again");
+
+        /* Unlike SOL_SOCKET, which truncates to what fits, a flag read wants
+         * room for a whole int or reports EINVAL.
+         */
+        int shortv = 0;
+        socklen_t shortl = 3;
+        CHECK(getsockopt(nlopt, SOL_NETLINK, NETLINK_CAP_ACK, &shortv,
+                         &shortl) == -1 &&
+                  errno == EINVAL,
+              "getsockopt(NETLINK_CAP_ACK, optlen=3) -> EINVAL");
+
+        /* mmap'd netlink was removed in Linux 4.10; the ring options have
+         * reported ENOPROTOOPT ever since, and so does an optname no netlink
+         * kernel ever had.
+         */
+        int one_nl = 1;
+        CHECK(setsockopt(nlopt, SOL_NETLINK, NETLINK_RX_RING, &one_nl,
+                         sizeof(one_nl)) == -1 &&
+                  errno == ENOPROTOOPT,
+              "setsockopt(NETLINK_RX_RING) -> ENOPROTOOPT");
+        CHECK(setsockopt(nlopt, SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS, &one_nl,
+                         sizeof(one_nl)) == -1 &&
+                  errno == ENOPROTOOPT,
+              "setsockopt(NETLINK_LIST_MEMBERSHIPS) -> ENOPROTOOPT");
+        CHECK(
+            setsockopt(nlopt, SOL_NETLINK, 99, &one_nl, sizeof(one_nl)) == -1 &&
+                errno == ENOPROTOOPT,
+            "setsockopt(SOL_NETLINK, optname=99) -> ENOPROTOOPT");
+        CHECK(setsockopt(nlopt, 999, 1, &one_nl, sizeof(one_nl)) == -1 &&
+                  errno == ENOPROTOOPT,
+              "setsockopt(unknown level) -> ENOPROTOOPT");
+
+        /* NETLINK_LISTEN_ALL_NSID is ns_capable(CAP_NET_ADMIN). An elfuse guest
+         * never holds that over the host, so the refusal is strict on that
+         * lane; the qemu initramfs boots as root, where it succeeds.
+         */
+        int nsid = setsockopt(nlopt, SOL_NETLINK, NETLINK_LISTEN_ALL_NSID,
+                              &one_nl, sizeof(one_nl));
+        CHECK(on_elfuse ? (nsid == -1 && errno == EPERM)
+                        : (nsid == 0 ? geteuid() == 0 : errno == EPERM),
+              "NETLINK_LISTEN_ALL_NSID -> EPERM without CAP_NET_ADMIN");
+
+        /* What ADD_MEMBERSHIP recorded is what LIST_MEMBERSHIPS reports, which
+         * is the whole of the contract: the join is bookkeeping, and the
+         * bookkeeping is readable. The reported length is the bitmap's own
+         * size, ALIGN(BITS_TO_BYTES(ngroups), 4) -- 4 for a family whose group
+         * count sits at netlink_kernel_create()'s floor of 32.
+         */
+        int grp2 = 2;
+        uint32_t bitmap = 0;
+        socklen_t blen2 = sizeof(bitmap);
+        int added = setsockopt(nlopt, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
+                               &grp2, sizeof(grp2));
+        int got = getsockopt(nlopt, SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS,
+                             &bitmap, &blen2);
+        CHECK(added == 0 && got == 0 && blen2 == 4 && (bitmap & 2u),
+              "NETLINK_LIST_MEMBERSHIPS shows the group ADD_MEMBERSHIP joined");
+
+        bitmap = 0;
+        blen2 = sizeof(bitmap);
+        int dropped = setsockopt(nlopt, SOL_NETLINK, NETLINK_DROP_MEMBERSHIP,
+                                 &grp2, sizeof(grp2));
+        got = getsockopt(nlopt, SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS, &bitmap,
+                         &blen2);
+        CHECK(dropped == 0 && got == 0 && !(bitmap & 2u),
+              "NETLINK_LIST_MEMBERSHIPS drops the group again");
+
+        close(nlopt);
+    }
+
+    /* A negative tv_sec is sock_set_timeout()'s third state
+     *
+     * Linux stores a literal 0 jiffies for it, which every wait reads as "do
+     * not wait": the receive below must report EAGAIN at once even though the
+     * socket is blocking and the option reads back as {0,0}, the same thing
+     * "wait forever" reads back as. Storing it as forever -- the reading that
+     * {0,0} deserves and this does not -- parks the caller instead, which is
+     * what the watchdog would catch.
+     */
+    int nw = socket(AF_NETLINK, SOCK_RAW, NETLINK_KOBJECT_UEVENT);
+    CHECK(nw >= 0, "socket for the negative-timeout receive");
+    if (nw >= 0) {
+        struct sockaddr_nl nogrp = {.nl_family = AF_NETLINK, .nl_groups = 0};
+        (void) bind(nw, (struct sockaddr *) &nogrp, sizeof(nogrp));
+
+        struct timeval neg = {.tv_sec = -1, .tv_usec = 0};
+        CHECK(setsockopt(nw, SOL_SOCKET, SO_RCVTIMEO, &neg, sizeof(neg)) == 0,
+              "setsockopt(SO_RCVTIMEO, tv_sec=-1) accepted");
+
+        struct timeval negback = {.tv_sec = -9, .tv_usec = -9};
+        socklen_t neglen = sizeof(negback);
+        CHECK(getsockopt(nw, SOL_SOCKET, SO_RCVTIMEO, &negback, &neglen) == 0 &&
+                  negback.tv_sec == 0 && negback.tv_usec == 0,
+              "getsockopt after a negative tv_sec reports {0, 0}");
+
+        signal(SIGALRM, watchdog_fired);
+        alarm(20);
+        int64_t nt0 = now_ms();
+        ssize_t ngot = recv(nw, buf, sizeof(buf), 0);
+        int64_t nelapsed = now_ms() - nt0;
+        alarm(0);
+        CHECK(ngot == -1 && (errno == EAGAIN || errno == EWOULDBLOCK) &&
+                  nelapsed < 1000,
+              "a blocking recv after tv_sec=-1 reports EAGAIN at once");
+        close(nw);
+    }
+
+    /* A sibling's execve is not a signal
+     *
+     * io_wait_fd_timed_or_interrupted() reports EINTR for two unrelated
+     * reasons. One is a signal the guest can see. The other is the dispatcher's
+     * own execve handoff, which the leader leaves its wait for so the run loop
+     * can reach it, and which carries no signal at all. Refusing the SVC
+     * restart for both turned a sibling's execve -- even one that fails -- into
+     * an EINTR on a recvmsg the guest issued once, an errno Linux cannot
+     * produce there. Below, an execve fails every 20 ms for the whole of a
+     * two-second SO_RCVTIMEO and the receive still has to come back with EAGAIN
+     * at the deadline it was given.
+     *
+     * The elapsed time is the other half. A restart re-enters the wait from the
+     * top, so one that took a fresh copy of SO_RCVTIMEO rather than resuming
+     * the deadline would push the return out by two seconds per interruption --
+     * around a hundred of them here -- and the watchdog rather than the upper
+     * bound is what would catch it. Resuming the deadline is what Linux's
+     * restart_block carries.
+     */
+    int xw = socket(AF_NETLINK, SOCK_RAW, NETLINK_KOBJECT_UEVENT);
+    CHECK(xw >= 0, "socket for the sibling-execve receive");
+    if (xw >= 0) {
+        struct sockaddr_nl xgrp = {.nl_family = AF_NETLINK, .nl_groups = 0};
+        (void) bind(xw, (struct sockaddr *) &xgrp, sizeof(xgrp));
+
+        struct timeval two = {.tv_sec = 2, .tv_usec = 0};
+        CHECK(setsockopt(xw, SOL_SOCKET, SO_RCVTIMEO, &two, sizeof(two)) == 0,
+              "setsockopt(SO_RCVTIMEO, 2s) for the sibling-execve receive");
+
+        pthread_t execer;
+        exec_probe_stop = 0;
+        int xspawned = pthread_create(&execer, NULL, failing_execve_loop, NULL);
+        CHECK(xspawned == 0, "spawned the failing-execve sibling");
+        if (xspawned == 0) {
+            signal(SIGALRM, watchdog_fired);
+            alarm(30);
+            int64_t xt0 = now_ms();
+            ssize_t xgot = recv(xw, buf, sizeof(buf), 0);
+            int xerr = errno;
+            int64_t xelapsed = now_ms() - xt0;
+            alarm(0);
+            exec_probe_stop = 1;
+            pthread_join(execer, NULL);
+            errno = xerr;
+            CHECK(xgot == -1 && (xerr == EAGAIN || xerr == EWOULDBLOCK) &&
+                      xelapsed >= 1900 && xelapsed < 6000,
+                  "a failing sibling execve neither interrupts the receive nor "
+                  "restarts its timeout");
+        }
+        close(xw);
+    }
+
+    /* A huge finite SO_RCVTIMEO is finite, and it is huge
+     *
+     * Linux's cutoff for "so long it means forever" is MAX_SCHEDULE_TIMEOUT/HZ
+     * - 1 seconds; a tv_sec of 1e13 is far below it and reads back unchanged
+     * (measured), where a cutoff three orders lower turns it into {0,0}. And
+     * the deadline such a timeout produces has to survive being added to a
+     * clock: an overflowing add lands in the past and turns the longest wait a
+     * guest can ask for into an instant EAGAIN. Both halves are asserted -- the
+     * readback, and a receive that really does park until a second thread gives
+     * it something to read.
+     */
+    poke_fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    CHECK(poke_fd >= 0, "rtnetlink socket for the huge-timeout receive");
+    if (poke_fd >= 0) {
+        struct sockaddr_nl self = {.nl_family = AF_NETLINK};
+        (void) bind(poke_fd, (struct sockaddr *) &self, sizeof(self));
+
+        struct timeval huge = {.tv_sec = (time_t) 10000000000000LL,
+                               .tv_usec = 0};
+        CHECK(setsockopt(poke_fd, SOL_SOCKET, SO_RCVTIMEO, &huge,
+                         sizeof(huge)) == 0,
+              "setsockopt(SO_RCVTIMEO, tv_sec=1e13) accepted");
+
+        struct timeval hback = {.tv_sec = -1, .tv_usec = -1};
+        socklen_t hlen = sizeof(hback);
+        CHECK(
+            getsockopt(poke_fd, SOL_SOCKET, SO_RCVTIMEO, &hback, &hlen) == 0 &&
+                hback.tv_sec == (time_t) 10000000000000LL && hback.tv_usec == 0,
+            "getsockopt reports the 1e13-second timeout unchanged");
+
+        /* The receive below runs with the largest timeout that fits in
+         * microseconds rather than the one above, on purpose: a deadline built
+         * by adding it to a clock overflows a signed 64-bit microsecond count
+         * on any machine that has been up for half an hour, and lands in the
+         * past. Nothing about the readback shows that -- only a receive does.
+         */
+        struct timeval brim = {.tv_sec = (time_t) 9223372036852LL,
+                               .tv_usec = 0};
+        CHECK(setsockopt(poke_fd, SOL_SOCKET, SO_RCVTIMEO, &brim,
+                         sizeof(brim)) == 0 &&
+                  getsockopt(poke_fd, SOL_SOCKET, SO_RCVTIMEO, &hback, &hlen) ==
+                      0 &&
+                  hback.tv_sec == (time_t) 9223372036852LL,
+              "SO_RCVTIMEO at the microsecond brim round-trips");
+
+        /* Timed from before the thread starts, not from the recv: the poke is
+         * 300 ms after the thread begins, so anything the recv returns is at
+         * least that far out however the two are scheduled. A recv that came
+         * back sooner did not wait.
+         */
+        pthread_t poker;
+        int64_t ht0 = now_ms();
+        int spawned = pthread_create(&poker, NULL, poke_after_delay, NULL);
+        CHECK(spawned == 0, "spawned the thread that pokes the rtnetlink fd");
+        if (spawned == 0) {
+            signal(SIGALRM, watchdog_fired);
+            alarm(20);
+            ssize_t hgot = recv(poke_fd, buf, sizeof(buf), 0);
+            int64_t helapsed = now_ms() - ht0;
+            alarm(0);
+            pthread_join(poker, NULL);
+            CHECK(hgot > 0 && helapsed >= 250,
+                  "a huge SO_RCVTIMEO parks the receive instead of expiring");
+        }
+        close(poke_fd);
+        poke_fd = -1;
+    }
+
+    /* Concurrent socket() must not cross-wire two sockets
+     *
+     * The protocol is a behavior discriminator -- it picks between the
+     * rtnetlink emulation and the silent uevent socket -- so a table slot
+     * claimed by two threads at once is two guests sharing one socket's
+     * identity. SO_PROTOCOL and SO_TYPE read the two fields the race could
+     * scramble.
+     */
+    opener_arg_t oargs[OPENERS];
+    pthread_t othreads[OPENERS];
+    int spawned_openers = 0;
+    for (int i = 0; i < OPENERS; i++) {
+        oargs[i].protocol = (i % 2) ? NETLINK_ROUTE : NETLINK_KOBJECT_UEVENT;
+        oargs[i].mismatches = 0;
+        oargs[i].open_failures = 0;
+        if (pthread_create(&othreads[i], NULL, opener, &oargs[i]) == 0)
+            spawned_openers++;
+        else
+            break;
+    }
+    int mismatches = 0, open_failures = 0;
+    for (int i = 0; i < spawned_openers; i++) {
+        pthread_join(othreads[i], NULL);
+        mismatches += oargs[i].mismatches;
+        open_failures += oargs[i].open_failures;
+    }
+    CHECK(spawned_openers == OPENERS, "spawned the concurrent-open threads");
+    CHECK(open_failures == 0, "every concurrent socket(AF_NETLINK) succeeded");
+    CHECK(mismatches == 0,
+          "concurrent opens each report their own SO_PROTOCOL and SO_TYPE");
+
+    close(fd);
+    printf("%d passed, %d failed\n", pass, fail);
+    return fail ? 1 : 0;
+}


### PR DESCRIPTION
> [!NOTE]
> First piece of the general USB translation layer discussed in #319; it stands alone as a bug fix and does not depend on the rest of that series.

## Summary

`socket(AF_NETLINK, SOCK_RAW, NETLINK_KOBJECT_UEVENT)` now returns a working silent socket. libusb's non-udev build refuses to initialize at all without one (`linux_usbfs.c:416-430` aborts `libusb_init` when the hotplug monitor cannot start), so every libusb program in a guest died at init, whether or not it ever touched a device.

## What

- `NETLINK_KOBJECT_UEVENT` sockets are accepted next to `NETLINK_ROUTE`: never readable, so `poll` times out and a non-blocking `recv` reports `EAGAIN`, which is what a real Linux kernel with no hotplug activity looks like. Synthesizing uevents on device attach is deliberately out of scope here.
- `sendto` on a uevent socket reports `EPERM`, matching `uevent_net_rcv_skb()` for a sender without `CAP_SYS_ADMIN`.
- `SOL_SOCKET` options work on netlink fds; they previously failed `EBADF` because the sockopt path accepted only `FD_SOCKET`. The set follows `sk_setsockopt()`/`sk_getsockopt()` rather than accepting everything: `SO_RCVBUF`/`SO_SNDBUF` clamp to `rmem_max`/`wmem_max` as an unsigned value, double, then floor at `SOCK_MIN_RCVBUF` (2304) or `SOCK_MIN_SNDBUF` (4608), which differ; `SO_RCVTIMEO` is honored by the blocking receive path (deadline taken once on entry, `EAGAIN` on expiry) rather than accepted and dropped; `SO_LINGER` and the timeout options require their real payload length (8 and 16) instead of four bytes; `SO_DEBUG` with a nonzero value needs `CAP_NET_ADMIN` (`EACCES`); `SO_REUSEPORT` with a nonzero value is `EOPNOTSUPP` on a non-inet socket; `SO_SNDLOWAT` has no setter at all (`ENOPROTOOPT`); and everything settable reads back through `getsockopt` with the right payload length. Unrecognized options report `ENOPROTOOPT`.
- `SOCK_NONBLOCK`/`SOCK_CLOEXEC` are now published into the fd's linux_flags. That was dropped before, and it affected `NETLINK_ROUTE` sockets too.
- New guest test `tests/test-uevent-socket.c`, wired into `test-matrix.sh`. Its assertions also hold on a real Linux kernel: a payload below `NLMSG_HDRLEN` is swallowed there and `sendto` returns its length, so the test accepts either outcome and pins `EPERM` whenever the send fails.

## Evidence

A statically linked libusb test (current libusb git, `--disable-udev`, so the netlink monitor is the one in play), run under the same host and guest binary on both sides:

```
upstream main 628181b:   libusb_init = -99 (LIBUSB_ERROR_OTHER)
this branch:             libusb_init = 0 (LIBUSB_SUCCESS)
                         get_device_list = 0
```

`get_device_list` returns 0 because enumeration needs the synthetic `/sys/bus/usb` and `/dev/bus/usb` trees that come later in the series; init succeeding is what this change is for.

```
test-uevent-socket under elfuse: 40 passed, 0 failed
test-matrix elfuse-aarch64: 266 passed, 0 failed, 10 skipped
```

The test asserts relations rather than constants, because the floors derive from `sizeof(struct sk_buff)` and the caps are sysctls: the send floor is checked to be exactly twice the receive floor, `-1` and `INT_MAX` are checked to read back equal, and the honored `SO_RCVTIMEO` is timed with a jiffy of slack. Those assertions hold on a real Linux kernel, which matters because this test runs in the `qemu-aarch64` matrix lane as well.

`make check` exits 0 on a clean rebuild (host suite 27/27, guardrail PASS), and the `NETLINK_ROUTE` behavior is unchanged.
