### PR TITLE
Correct the comments that still describe a per-call dup

### DIFF
--- a/src/elfuse-limits.h
+++ b/src/elfuse-limits.h
@@ -13,11 +13,12 @@
 /* Maximum number of guest-visible file descriptors. */
 #define FD_TABLE_SIZE 1024
 
-/* Host descriptors kept available for elfuse's internal operations. Blocking
- * I/O may hold two duplicated descriptors per guest thread (for example,
- * copy_file_range()), while another bounded slice covers runtime pipes, fork
- * IPC, debugger sockets, and sysroot/FUSE plumbing. Operations whose descriptor
- * use grows with their input set, such as ppoll(), require separate accounting.
+/* Host descriptors kept available for elfuse's internal operations: runtime
+ * pipes, fork IPC, debugger sockets, and sysroot/FUSE plumbing. A syscall's own
+ * reference to a guest descriptor is not part of that budget, because
+ * host_fd_ref_open borrows or pins the fd table's descriptor rather than
+ * duplicating it, so the reserve does not scale with thread count or with the
+ * length of a call's fd set.
  */
 #define HOST_FD_RESERVE 256
 

--- a/src/runtime/procemu-pty.c
+++ b/src/runtime/procemu-pty.c
@@ -1263,9 +1263,10 @@ static bool pty_slot_hung_up_locked(int slot)
 
 bool proc_pty_master_hung_up(int guest_fd, uint64_t expect_generation)
 {
-    /* Keyed on the guest fd rather than a host one: callers reach the master
-     * through host_fd_ref, which hands out a dup, and the keepalive table is
-     * keyed by the canonical host fd that dup does not share.
+    /* Keyed on the guest fd rather than a host one: the caller brings a
+     * generation to check, and only the guest fd leads back to the table entry
+     * carrying it. A host fd number alone cannot tell a live master from one a
+     * sibling closed and an unrelated open recycled.
      */
     fd_entry_t snap;
     if (!fd_snapshot(guest_fd, &snap))

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -1624,8 +1624,7 @@ int64_t sys_fcntl(guest_t *g, int fd, int cmd, uint64_t arg)
 
         /* O_ASYNC is elfuse-managed: track the armed bit and (dis)arm the SIGIO
          * watcher. asyncio_apply rescans the slot under fd_lock and uses each
-         * alias's real backing fd, not host_ref.fd (a per-syscall dup for
-         * multi-threaded callers).
+         * alias's real backing fd rather than the one this call pinned.
          */
         asyncio_apply(fd, fd_snap.generation, ((int) arg & LINUX_O_ASYNC));
         host_fd_ref_close(&host_ref);

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -2563,10 +2563,9 @@ int64_t sys_process_vm_writev(guest_t *g,
 int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
 {
     /* FIOCLEX/FIONCLEX are the ioctl form of fcntl(F_SETFD): they set/clear the
-     * guest close-on-exec flag, which lives in fd_table linux_flags (not the
-     * host fd's FD_CLOEXEC, which is per-descriptor and would be lost on the
-     * dup that host_fd_ref hands multi-threaded callers, so mirror the F_SETFD
-     * path in sys_fcntl). They need no host fd, so dispatch them before
+     * guest close-on-exec flag, which lives in fd_table linux_flags because
+     * that is where F_GETFD answers from, so mirror the F_SETFD path in
+     * sys_fcntl. They need no host fd, so dispatch them before
      * host_fd_ref_open_io(): that helper rejects O_PATH (FD_PATH) fds with
      * EBADF, but Linux allows these ioctls -- like fcntl(F_SETFD) -- on O_PATH
      * descriptors. Validate the slot and mutate the flag in a single fd_lock
@@ -3084,9 +3083,9 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         /* Get the slave pty number associated with a /dev/ptmx master fd. Pass
          * the guest fd: proc_pty_master_adopt snapshots the canonical (host_fd,
          * generation) under fd_lock, performs the slave open on a private dup,
-         * then re-validates the slot before publishing the keepalive. Passing
-         * the per-syscall host_fd_ref dup or a raw host fd would race with
-         * sibling close+reuse.
+         * then re-validates the slot before publishing the keepalive. A bare
+         * host fd carries no generation, so it could not be revalidated against
+         * a sibling close+reuse.
          */
         uint32_t val = proc_pty_master_adopt(fd);
         if (val == UINT32_MAX) {
@@ -3171,7 +3170,7 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
          * does: the slave handed out here counts toward the master's hangup
          * accounting, and that table is keyed by pts number. Pass the guest fd
          * so the adopt validates against the canonical (host_fd, generation)
-         * rather than this call's host_fd_ref dup.
+         * rather than a bare descriptor with no generation to check.
          */
         uint32_t pts_num = proc_pty_master_adopt(fd);
         char slave[64];
@@ -3214,8 +3213,7 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
             proc_pty_note_guest_slave(host_slave_fd, pts_num);
 
         /* Track CLOEXEC + accmode in the guest table so exec honors them; the
-         * host fd's own FD_CLOEXEC is per-descriptor and would be lost on the
-         * dup that host_fd_ref hands multi-threaded callers.
+         * guest table is where F_GETFD answers from.
          */
         fd_publish_linux_flags(guest_fd, linux_flags);
         return guest_fd;

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -23,7 +23,7 @@
 #include "syscall/fuse.h"
 #include "proved/pathdepth.h"
 
-#include "syscall/internal.h" /* fd_to_host_dup */
+#include "syscall/internal.h" /* host_dirfd_ref_open */
 #include "syscall/path.h"
 #include "syscall/proc.h"
 

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1388,15 +1388,12 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     /* Validate the target fd and read its persistent host fd in a single
      * fd_lock snapshot, so the kqueue knote ident is taken from the same entry
      * that was validated. A kqueue knote is keyed by the fd number and the
-     * kernel drops it the moment that fd is closed, so the ident must be the
-     * persistent host fd from the fd table -- not the dup that
-     * host_fd_ref_open() hands multi-threaded callers, which
-     * host_fd_ref_close() closes when the syscall returns (silently tearing the
-     * registration down). Snapshotting (rather than host_fd_ref_open() + a
-     * separate fd_to_host()) keeps the validate and the ident read atomic under
-     * one fd_lock. The snapshot's generation then guards the cross-call ABA
-     * below. Result mapping uses udata (the guest fd), so the ident only needs
-     * to stay open and refer to the same open file description.
+     * kernel drops it the moment that fd is closed, so the ident has to be the
+     * fd table's own host fd. Snapshotting, rather than host_fd_ref_open() plus
+     * a separate fd_to_host(), keeps the validate and the ident read atomic
+     * under one fd_lock. The snapshot's generation then guards the cross-call
+     * ABA below. Result mapping uses udata (the guest fd), so the ident only
+     * needs to stay open and refer to the same open file description.
      */
     fd_entry_t target_snap;
     if (!fd_snapshot(fd, &target_snap)) {

--- a/src/syscall/syscall.c
+++ b/src/syscall/syscall.c
@@ -2562,8 +2562,8 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
      * it.
      *
      * Single-threaded guests can use the raw host fd directly because there is
-     * no concurrent close() race. Multi-threaded guests still dup the fd under
-     * fd_lock to prevent TOCTOU races with CLONE_THREAD siblings.
+     * no concurrent close() race. Multi-threaded guests pin it under fd_lock
+     * instead, which holds it valid against a CLONE_THREAD sibling's close.
      */
     int nr = (int) x8;
     const syscall_entry_t *entry = NULL;
@@ -2606,8 +2606,8 @@ int syscall_dispatch(hv_vcpu_t vcpu, guest_t *g, int *exit_code, bool verbose)
 
             /* Pre-filter: only fast-path fd types that map 1:1 to host
              * read/write. This read is racy but benign; if the type changed,
-             * fd_to_host_dup will either fail or the slow path handles it
-             * correctly on fallthrough.
+             * host_fd_ref_open_state will either fail or the slow path handles
+             * it correctly on fallthrough.
              */
             int tp = fd_table[fd].type;
             if (tp != FD_REGULAR && tp != FD_STDIO && tp != FD_PIPE &&


### PR DESCRIPTION
#324 replaced the per-call `dup()` in the host fd reference helpers with a refcount pin. The code moved; a set of comments did not, and they now explain themselves by a descriptor that no longer exists.

`src/elfuse-limits.h` is the load-bearing one, because it is the file the shell harnesses derive their limits from. It justified `HOST_FD_RESERVE` with "blocking I/O may hold two duplicated descriptors per guest thread (for example, `copy_file_range()`)" and closed with "operations whose descriptor use grows with their input set, such as `ppoll()`, require separate accounting". Neither holds: `copy_file_range` takes `host_fd_ref_open_io_state`, `ppoll` takes `host_fd_ref_open_io_gen`, and no helper in that family duplicates anything. Anyone sizing the reserve from that paragraph would be sizing it for a cost that is gone.

The second commit is the sweep. Ten further sites explained themselves the same way, across `poll.c`, `io.c`, `fs.c`, `syscall.c`, `path.c` and `procemu-pty.c`. Most of the conclusions they defended are still correct, so the rewrites give the reason that holds now rather than dropping the comment: the pty sites pass a guest fd because only that leads back to the generation they revalidate against, `FIOCLEX` keeps close-on-exec in `linux_flags` because that is where `F_GETFD` answers from, and `sys_epoll_ctl` snapshots because the validate, the ident read and the generation capture have to land in one `fd_lock` window. Two sites simply named a function their path no longer calls.

Comments only, no behavior change. The value of `HOST_FD_RESERVE` is untouched.

Rebased on 8063764:

```
make check         # 7/7, 82/84, 27/27, 4/4 passed, 0 failed, guardrail PASS
make check-format  # all 49 scripts pass
make indent        # no diff
```

The skips are environmental and untouched by this change: two BusyBox cases want a raw socket and an interactive terminal, and the `dyn-glibc` guardrail lane wants a cross toolchain at `/opt/toolchain/aarch64-linux-gnu`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects comments that referenced a per-call dup() to reflect the current refcount pin/borrow behavior. This matters because `src/elfuse-limits.h` guides limit sizing; the old text implied scaling that no longer exists. Comments only; no behavior change and `HOST_FD_RESERVE` is unchanged.

- Notes for review
  - `src/elfuse-limits.h`: clarifies the reserve covers bounded internal plumbing and does not scale with thread count or with a call’s fd set length.
  - PTY/ioctl/epoll paths: explains why callers pass a guest fd (generation-based revalidation), why close-on-exec lives in `linux_flags` and is handled like `F_SETFD` (including allowing `O_PATH`), and why `sys_epoll_ctl` snapshots under `fd_lock` to bind validation and ident read to the same table entry.
  - Cleans up two stale function-name references: the read/write fast path uses `host_fd_ref_open_state`, and `path.c` references `host_dirfd_ref_open`.

<sup>Written for commit c9d274ca52cf7c401dfcb0849f17aeb8abb1b759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

