### PR TITLE
Drop all MAP_SHARED overlays before execve’s guest_reset to prevent zeroing host files and to keep shared regions intact

### DIFF
--- a/frama-c-stubs/CommonCrypto/CommonDigest.h
+++ b/frama-c-stubs/CommonCrypto/CommonDigest.h
@@ -1,0 +1,39 @@
+/*
+ * CommonCrypto/CommonDigest.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * core/rosetta.c keys its AOT cache by the SHA-256 of the guest binary, and
+ * takes it through Darwin's CommonCrypto. Only the SHA-256 arm is declared,
+ * since that is all the file names.
+ *
+ * The context layout is copied from the SDK header rather than invented. It is
+ * a local whose address is passed to all three calls, so the analyzer has to
+ * agree with the compiler about its size for anything it concludes about the
+ * surrounding frame to be about the real program. The functions are
+ * declarations only: what SHA-256 computes is not a property any proof here
+ * rests on, and a hand-written body would only give the analyzer a second
+ * implementation to be wrong about.
+ *
+ * Same placement rule as the Hypervisor stub: outside src/, reachable only
+ * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define CC_SHA256_DIGEST_LENGTH 32
+
+typedef uint32_t CC_LONG;
+
+typedef struct CC_SHA256state_st {
+    CC_LONG count[2];
+    CC_LONG hash[8];
+    CC_LONG wbuf[16];
+} CC_SHA256_CTX;
+
+int CC_SHA256_Init(CC_SHA256_CTX *c);
+int CC_SHA256_Update(CC_SHA256_CTX *c, const void *data, CC_LONG len);
+int CC_SHA256_Final(unsigned char *md, CC_SHA256_CTX *c);

--- a/frama-c-stubs/Hypervisor/hv_vcpu.h
+++ b/frama-c-stubs/Hypervisor/hv_vcpu.h
@@ -1,0 +1,25 @@
+/*
+ * Hypervisor/hv_vcpu.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A real SDK splits the framework across several headers and has
+ * Hypervisor/Hypervisor.h pull hv_vcpu.h in, so a source may include either
+ * spelling and get the same declarations. Three of ours name hv_vcpu.h directly
+ * (core/bootstrap.h, core/bootstrap.c, core/launch.c), and stopped on "file not
+ * found" even though the sibling stub already declared every vCPU call they
+ * use.
+ *
+ * So this carries no declarations of its own. Putting them here instead would
+ * split one closed set across two files and let the two drift, which is the
+ * failure the sibling's own header comment is written against. It exists to
+ * make the second spelling resolve.
+ *
+ * Same placement rule as the sibling: outside src/, reachable only through
+ * FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <Hypervisor/Hypervisor.h>

--- a/frama-c-stubs/libkern/OSCacheControl.h
+++ b/frama-c-stubs/libkern/OSCacheControl.h
@@ -1,0 +1,27 @@
+/*
+ * libkern/OSCacheControl.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Darwin's cache maintenance calls. elfuse issues sys_icache_invalidate after
+ * writing instructions the guest is about to fetch: the shim, the loaded
+ * segments at bootstrap and again at execve, and the Rosetta image. Frama-C
+ * models a portable libc, which has no such header, so the three sources naming
+ * it (core/bootstrap.c, core/rosetta.c, syscall/exec.c) stopped before parsing.
+ *
+ * Declarations only, and deliberately no body: what these do is invisible to
+ * the analyzer's memory model, which has no instruction cache to be stale. A
+ * hand-written body would be a claim about hardware rather than about the
+ * program. Signatures match the SDK header.
+ *
+ * Same placement rule as the Hypervisor stub: outside src/, reachable only
+ * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+void sys_icache_invalidate(void *start, size_t len);
+void sys_dcache_flush(void *start, size_t len);

--- a/frama-c-stubs/mach-o/dyld.h
+++ b/frama-c-stubs/mach-o/dyld.h
@@ -4,9 +4,12 @@
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
  *
- * core/bootstrap.c calls _NSGetExecutablePath to find elfuse's own binary,
- * which is how a re-exec locates the image to spawn. One declaration is the
- * whole of what the file needs from this header.
+ * Two sources call _NSGetExecutablePath to find elfuse's own binary.
+ * core/bootstrap.c records it once at startup through proc_set_elfuse_path,
+ * which is what /proc/self/exe and the shebang loop answer from.
+ * runtime/forkipc.c is the one that spawns it: clone posix_spawns the same
+ * binary so the child carries the same entitlement and build. One declaration
+ * is the whole of what either file needs from this header.
  *
  * Same placement rule as the Hypervisor stub: outside src/, reachable only
  * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.

--- a/frama-c-stubs/mach-o/dyld.h
+++ b/frama-c-stubs/mach-o/dyld.h
@@ -1,0 +1,19 @@
+/*
+ * mach-o/dyld.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * core/bootstrap.c calls _NSGetExecutablePath to find elfuse's own binary,
+ * which is how a re-exec locates the image to spawn. One declaration is the
+ * whole of what the file needs from this header.
+ *
+ * Same placement rule as the Hypervisor stub: outside src/, reachable only
+ * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+int _NSGetExecutablePath(char *buf, uint32_t *bufsize);

--- a/frama-c-stubs/macos-libc.h
+++ b/frama-c-stubs/macos-libc.h
@@ -43,3 +43,76 @@
 #ifndef ETOOMANYREFS
 #define ETOOMANYREFS 59
 #endif
+
+/* limits.h: longest single path component. POSIX rather than Darwin-specific,
+ * but Frama-C's limits.h omits it, and path.c sizes a component buffer with it.
+ * 255, as Darwin's sys/syslimits.h says.
+ */
+#ifndef NAME_MAX
+#define NAME_MAX 255
+#endif
+
+/* termios.h: echo control characters as ^X. In the BSD set Darwin carries and
+ * the modeled libc does not; io.c translates it in both directions between the
+ * guest and host termios lflag words, so it is one arm of a switch whose other
+ * arms are real values.
+ */
+#ifndef ECHOCTL
+#define ECHOCTL 0x00000040
+#endif
+
+/* termios.h: the BSD local-mode bits Darwin carries and the modeled libc stops
+ * short of. io.c translates the lflag word in both directions between the guest
+ * and the host, so each of these is one arm of a mask whose other arms are real
+ * values; a collision would fold two guest flags onto one host flag.
+ */
+#ifndef ECHOKE
+#define ECHOKE 0x00000001
+#endif
+#ifndef ECHOPRT
+#define ECHOPRT 0x00000020
+#endif
+#ifndef EXTPROC
+#define EXTPROC 0x00000800
+#endif
+#ifndef FLUSHO
+#define FLUSHO 0x00800000
+#endif
+#ifndef PENDIN
+#define PENDIN 0x20000000
+#endif
+
+/* sys/ioctl.h: modem control lines, for TIOCMGET and TIOCMSET. The same
+ * argument applies: io.c maps the guest's bits onto these.
+ */
+#ifndef TIOCM_DTR
+#define TIOCM_DTR 0x0002
+#endif
+#ifndef TIOCM_RTS
+#define TIOCM_RTS 0x0004
+#endif
+
+/* fcntl.h: deallocate a byte range, Darwin's answer to Linux
+ * FALLOC_FL_PUNCH_HOLE. io.c takes this fast path in sys_fallocate, so both the
+ * command number and the argument struct have to be here: the modeled libc has
+ * neither, and without the struct the local declaration is an incomplete type
+ * rather than an unresolved name. Layout and field order match Darwin's
+ * sys/fcntl.h, since io.c fills it by designated initializer.
+ */
+#ifndef F_PUNCHHOLE
+#define F_PUNCHHOLE 99
+struct fpunchhole {
+    unsigned int fp_flags;
+    unsigned int reserved;
+    off_t fp_offset;
+    off_t fp_length;
+};
+#endif
+
+/* netinet/in.h: set the IP don't-fragment bit. Darwin's nearest answer to Linux
+ * IP_MTU_DISCOVER, which is what net.c is translating when it reaches for this;
+ * the guest's PMTUDISC_DO and PMTUDISC_PROBE both land here.
+ */
+#ifndef IP_DONTFRAG
+#define IP_DONTFRAG 28
+#endif

--- a/scripts/check-stub-constants.py
+++ b/scripts/check-stub-constants.py
@@ -31,7 +31,25 @@ DEFAULT_STUB = ROOT / "frama-c-stubs" / "macos-libc.h"
 # Only object-like defines with an integer value. A macro with parameters or a
 # non-numeric body is not a constant this can compare, and is reported as
 # unchecked rather than silently passed.
-DEFINE = re.compile(r"^#define\s+([A-Z_][A-Z_0-9]*)\s+(0x[0-9a-fA-F]+|\d+)\s*$", re.M)
+DEFINE = re.compile(
+    r"^#define\s+([A-Z_][A-Z_0-9]*)\s+(0[xX][0-9a-fA-F]+|\d+)\s*$", re.M
+)
+
+
+def c_int(token):
+    """Value of a C integer literal, octal included.
+
+    int(token, 0) is not this function: Python rejects a leading zero, and
+    Darwin writes whole families that way. TIOCM_DTR is 0002 in sys/ioccom.h,
+    so a gate using int(_, 0) does not report a mismatch on it, it raises
+    ValueError and takes the build down with a traceback.
+    """
+    text = token.lower()
+    if text.startswith("0x"):
+        return int(text, 16)
+    if len(text) > 1 and text.startswith("0"):
+        return int(text, 8)
+    return int(text, 10)
 
 
 def sdk_path():
@@ -59,7 +77,9 @@ def sdk_values(include_dir, names):
     and a scan costs roughly 0.75s, which a per-constant loop multiplied by the
     number of stub constants for no reason.
     """
-    pattern = r"^#define[ \t]+(" + "|".join(names) + r")[ \t]+(0x[0-9a-fA-F]+|[0-9]+)"
+    pattern = (
+        r"^#define[ \t]+(" + "|".join(names) + r")[ \t]+(0[xX][0-9a-fA-F]+|[0-9]+)"
+    )
     hit = subprocess.run(
         ["grep", "-rhoE", pattern, str(include_dir)],
         stdout=subprocess.PIPE,
@@ -70,7 +90,7 @@ def sdk_values(include_dir, names):
     for line in hit:
         parts = line.split()
         if len(parts) >= 3 and parts[1] in found:
-            found[parts[1]].add(int(parts[2], 0))
+            found[parts[1]].add(c_int(parts[2]))
     return found
 
 
@@ -98,7 +118,7 @@ def main():
     found = sdk_values(include_dir, [name for name, _ in defines])
     wrong, missing = [], []
     for name, raw in defines:
-        want = int(raw, 0)
+        want = c_int(raw)
         got = found[name]
         if not got:
             missing.append(name)

--- a/src/runtime/procemu.h
+++ b/src/runtime/procemu.h
@@ -14,7 +14,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
 #include "core/guest.h"

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -43,6 +43,7 @@
 #include "syscall/wakeup-pipe.h" /* wakeup_pipe_signal */
 #include "syscall/fuse.h"
 #include "syscall/internal.h"
+#include "syscall/mem.h"
 #include "syscall/path.h"
 #include "syscall/proc.h"
 #include "syscall/signal.h"
@@ -1835,6 +1836,23 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         g->is_rosetta = true;
         proc_set_rosetta_active(true);
     }
+
+    /* Before the memset, not after: guest_reset writes through each region's
+     * host VA, which for an overlaid region is the backing file's page cache.
+     * Dropping the overlays first sends those zeroes to the slab instead, and
+     * leaves the new image with anonymous backing at that VA rather than a host
+     * file. Fatal on failure for the same reason the whole region past the
+     * point of no return is: the alternative is zeroing a user's file.
+     */
+    int overlay_err = mmap_exec_drop_overlays(g);
+    if (overlay_err < 0) {
+        log_fatal(
+            "execve failed after point of no return: "
+            "MAP_SHARED overlay teardown failed: %d",
+            overlay_err);
+        exit(128);
+    }
+
     guest_reset(g);
 
     /* The replacement image must not inherit process-wide shutdown requests

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -2520,6 +2520,17 @@ static int cleanup_overlays_in_range(guest_t *g, uint64_t start, uint64_t end)
     return err;
 }
 
+int mmap_exec_drop_overlays(guest_t *g)
+{
+    /* The whole primary window: an overlay only ever binds a host VA inside it
+     * (hvf_apply_file_overlay resolves through host_base + ipa), so a high-VA
+     * region carries none and the walk stops at the first one anyway. Both
+     * boundaries fall outside the region array, so the splits are no-ops and
+     * this cannot fail for want of a region slot.
+     */
+    return cleanup_overlays_in_range(g, 0, g->guest_size);
+}
+
 /* Memory syscalls (tightly coupled to guest.h). */
 
 static bool heap_tail_can_extend(const guest_region_t *tail,

--- a/src/syscall/mem.h
+++ b/src/syscall/mem.h
@@ -98,3 +98,18 @@ int mmap_fork_restore_overlays(guest_t *g,
                                const bool *parent_active,
                                const uint64_t *parent_ovl_start,
                                const uint64_t *parent_ovl_end);
+
+/* Undo every live MAP_SHARED host overlay before execve resets the address
+ * space. guest_reset zeroes each tracked region by writing through its host VA,
+ * and an overlay still installed there is the backing file's own page cache, so
+ * those zeroes reach the file: a guest that mmaps a file MAP_SHARED and execs
+ * truncates its contents to zero on the host. Removing the overlay first
+ * restores plain slab backing, which is also what the new image needs, since an
+ * overlay left in place would hand it a host file at that VA.
+ *
+ * Caller holds mmap_lock.
+ *
+ * Returns 0, or -errno with the overlays that could not be torn down still
+ * marked active; the caller must not reset guest memory after a failure.
+ */
+int mmap_exec_drop_overlays(guest_t *g);

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -364,7 +364,7 @@ static bool resolve_fd_magiclink_host_path(const char *path,
     if (path_fd_magiclink_open(path, &ref) < 0)
         return false;
 
-    char resolved[MAXPATHLEN];
+    char resolved[PATH_MAX];
     int rc = fcntl(ref.fd, F_GETPATH, resolved);
     host_fd_ref_close(&ref);
     if (rc < 0)

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -138,9 +138,6 @@ test-mmap-shared-ro
 [section] Cross-fork MAP_SHARED coherence tests
 test-cross-fork-mapshared          # diff=skip
 
-[section] MAP_SHARED across execve tests
-test-exec-shared-mmap
-
 [section] madvise MADV_DONTNEED tests
 test-madvise
 

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -138,6 +138,9 @@ test-mmap-shared-ro
 [section] Cross-fork MAP_SHARED coherence tests
 test-cross-fork-mapshared          # diff=skip
 
+[section] MAP_SHARED across execve tests
+test-exec-shared-mmap
+
 [section] madvise MADV_DONTNEED tests
 test-madvise
 

--- a/tests/test-exec-shared-mmap.c
+++ b/tests/test-exec-shared-mmap.c
@@ -1,0 +1,259 @@
+/*
+ * MAP_SHARED mappings across execve
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Linux drops the whole mm on execve, so a MAP_SHARED file mapping the old
+ * image held is simply unmapped and the file keeps its bytes. elfuse recycles
+ * one address space instead: guest_reset zeroes each tracked region by writing
+ * through its host VA, and for an overlaid region that host VA is the backing
+ * file's own page cache. Without mmap_exec_drop_overlays running first, those
+ * zeroes reach the file, and a guest that maps a file MAP_SHARED and execs
+ * truncates its contents to zero on the host.
+ *
+ * Checked in the image after the exec: the file still holds what the pre-exec
+ * image wrote, writes into a fresh anonymous mapping at the address the shared
+ * mapping used do not reach it (an overlay left installed would hand the new
+ * image the host file at that VA), and a forked peer holding a
+ * MAP_SHARED|MAP_ANONYMOUS region still sees its bytes. That last one is the
+ * other backing an overlay can have: the region is promoted to a temp-file
+ * overlay at fork, and the promotion outlives it.
+ *
+ * Syscalls exercised: execve(221), mmap(222), munmap(215), msync(227),
+ *                     openat(56), ftruncate(46), clone(220), wait4(260),
+ *                     pipe2(59), read(63), write(64)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define FILE_TEMPLATE "/tmp/elfuse-exec-shared-mmap-XXXXXX"
+#define MARK "ALIVE!!!"
+#define MARK_LEN 8
+#define MAP_LEN 65536
+#define ANON_MARK "PEER!!!!"
+
+extern char **environ;
+
+static void die(const char *what)
+{
+    fprintf(stderr, "test-exec-shared-mmap: %s: %s\n", what, strerror(errno));
+    exit(1);
+}
+
+/* The forked peer: hold the anon-shared mapping open while the parent execs,
+ * then report through @wr whether the bytes are still there. '1' is intact, '0'
+ * is zeroed, and the pipe closing without a byte means the parent's new image
+ * never got far enough to ask.
+ */
+static void peer_main(char *map, int rd, int wr)
+{
+    char c;
+    ssize_t n;
+
+    do {
+        n = read(rd, &c, 1);
+    } while (n < 0 && errno == EINTR);
+    if (n <= 0)
+        _exit(2);
+
+    char verdict = memcmp(map, ANON_MARK, MARK_LEN) == 0 ? '1' : '0';
+    do {
+        n = write(wr, &verdict, 1);
+    } while (n < 0 && errno == EINTR);
+    _exit(0);
+}
+
+/* Everything after the exec. The arguments carry what only the pre-exec image
+ * knew: the backing file it created, where its shared mapping lived, and the
+ * pipe ends to the peer.
+ */
+static int stage2(const char *path,
+                  uint64_t shared_addr,
+                  int peer_rd,
+                  int peer_wr,
+                  pid_t peer)
+{
+    printf("test-exec-shared-mmap: post-exec checks\n");
+
+    TEST("file survives execve");
+    int fd = open(path, O_RDONLY);
+    char buf[MARK_LEN + 1] = {0};
+    if (fd < 0) {
+        FAIL("open");
+    } else {
+        ssize_t n = read(fd, buf, MARK_LEN);
+        close(fd);
+        if (n == MARK_LEN && memcmp(buf, MARK, MARK_LEN) == 0)
+            PASS();
+        else
+            FAIL("file contents were zeroed by the exec");
+    }
+
+    TEST("remap of the file sees the bytes");
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        FAIL("open");
+    } else {
+        char *p = mmap(NULL, MAP_LEN, PROT_READ, MAP_SHARED, fd, 0);
+        close(fd);
+        if (p == MAP_FAILED)
+            FAIL("mmap");
+        else if (memcmp(p, MARK, MARK_LEN) == 0)
+            PASS();
+        else
+            FAIL("mapping reads zero");
+        if (p != MAP_FAILED)
+            munmap(p, MAP_LEN);
+    }
+
+    /* The hint is where the old image's shared mapping was. The region table is
+     * empty again after the reset, so elfuse honors it, and an overlay left
+     * installed would still be bound to that host VA underneath. Reading zero
+     * there proves nothing on its own (the reset zeroes the file too, through
+     * the very overlay this is looking for), so write a pattern and go back to
+     * the file: the new image's private memory must not reach it.
+     */
+    TEST("vacated range does not write through");
+    char *p = mmap((void *) (uintptr_t) shared_addr, MAP_LEN,
+                   PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (p == MAP_FAILED) {
+        FAIL("mmap");
+    } else if ((uint64_t) (uintptr_t) p != shared_addr) {
+        /* Not the address asked for, so the check has nothing to say. Report it
+         * rather than passing on a mapping that was never the one at risk.
+         */
+        printf("SKIP: hint 0x%llx not honored (got %p)\n",
+               (unsigned long long) shared_addr, (void *) p);
+        munmap(p, MAP_LEN);
+    } else {
+        memset(p, 'S', MAP_LEN);
+        munmap(p, MAP_LEN);
+        fd = open(path, O_RDONLY);
+        char after[MARK_LEN + 1] = {0};
+        ssize_t n = fd < 0 ? -1 : read(fd, after, MARK_LEN);
+        if (fd >= 0)
+            close(fd);
+        if (n == MARK_LEN && memcmp(after, MARK, MARK_LEN) == 0)
+            PASS();
+        else
+            FAIL("the new image's private memory reached the file");
+    }
+
+    TEST("peer keeps its anon-shared bytes");
+    if (peer <= 0) {
+        FAIL("no peer: the pre-exec image failed to start one");
+    } else {
+        char go = 'g', verdict = 0;
+        ssize_t n;
+        do {
+            n = write(peer_wr, &go, 1);
+        } while (n < 0 && errno == EINTR);
+        do {
+            n = read(peer_rd, &verdict, 1);
+        } while (n < 0 && errno == EINTR);
+        int status = 0;
+        waitpid(peer, &status, 0);
+        if (n != 1)
+            FAIL("peer reported nothing");
+        else if (verdict == '1')
+            PASS();
+        else
+            FAIL("peer's shared region was zeroed by the exec");
+    }
+
+    unlink(path);
+    SUMMARY("test-exec-shared-mmap");
+    return fails == 0 ? 0 : 1;
+}
+
+/* The pre-exec image: build the two shared mappings, hand one to a forked peer,
+ * and exec self.
+ */
+static int stage1(const char *self)
+{
+    /* A unique name rather than a fixed one: two lanes of the matrix can share
+     * a host /tmp, and a fixed name would let one truncate the file the other
+     * is checking (and would follow a symlink planted at that path).
+     */
+    char path[sizeof(FILE_TEMPLATE)];
+    memcpy(path, FILE_TEMPLATE, sizeof(FILE_TEMPLATE));
+    int fd = mkstemp(path);
+    if (fd < 0)
+        die("mkstemp");
+    if (ftruncate(fd, MAP_LEN) < 0)
+        die("ftruncate");
+
+    char *shared =
+        mmap(NULL, MAP_LEN, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (shared == MAP_FAILED)
+        die("mmap file");
+    close(fd);
+    memcpy(shared, MARK, MARK_LEN);
+    if (msync(shared, MAP_LEN, MS_SYNC) < 0)
+        die("msync");
+
+    /* Anon-shared plus a peer holding it. The fork is what promotes the region
+     * to an overlay, so the mapping has to exist before it.
+     */
+    char *anon = mmap(NULL, MAP_LEN, PROT_READ | PROT_WRITE,
+                      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (anon == MAP_FAILED)
+        die("mmap anon-shared");
+    memcpy(anon, ANON_MARK, MARK_LEN);
+
+    int to_peer[2], from_peer[2];
+    if (pipe(to_peer) < 0 || pipe(from_peer) < 0)
+        die("pipe");
+    pid_t peer = fork();
+    if (peer < 0)
+        die("fork");
+    if (peer == 0) {
+        close(to_peer[1]);
+        close(from_peer[0]);
+        peer_main(anon, to_peer[0], from_peer[1]);
+    }
+    close(to_peer[0]);
+    close(from_peer[1]);
+
+    /* Block-buffered under the harness pipe, and execve discards whatever is
+     * still sitting in the buffer.
+     */
+    fflush(stdout);
+    fflush(stderr);
+
+    char addrbuf[32], rdbuf[16], wrbuf[16], peerbuf[16];
+    snprintf(addrbuf, sizeof(addrbuf), "0x%llx",
+             (unsigned long long) (uintptr_t) shared);
+    snprintf(rdbuf, sizeof(rdbuf), "%d", from_peer[0]);
+    snprintf(wrbuf, sizeof(wrbuf), "%d", to_peer[1]);
+    snprintf(peerbuf, sizeof(peerbuf), "%d", (int) peer);
+
+    char *argv[] = {(char *) self, "stage2", addrbuf, rdbuf,
+                    wrbuf,         peerbuf,  path,    NULL};
+    execve(self, argv, environ);
+    die("execve");
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc >= 7 && !strcmp(argv[1], "stage2"))
+        return stage2(argv[6], strtoull(argv[2], NULL, 0), atoi(argv[3]),
+                      atoi(argv[4]), (pid_t) atoi(argv[5]));
+
+    return stage1(argv[0]);
+}

--- a/tests/test-exec-shared-mmap.c
+++ b/tests/test-exec-shared-mmap.c
@@ -133,11 +133,16 @@ static int stage2(const char *path,
     if (p == MAP_FAILED) {
         FAIL("mmap");
     } else if ((uint64_t) (uintptr_t) p != shared_addr) {
-        /* Not the address asked for, so the check has nothing to say. Report it
-         * rather than passing on a mapping that was never the one at risk.
+        /* A failure, not a skip. The region table is empty after the reset, so
+         * elfuse honors this hint in both the fixed and the broken build
+         * (measured: the broken one reaches the check and fails it). If it ever
+         * stops being honored, this check silently stops testing anything, and
+         * a run that reports success without having looked is worse than a red
+         * one. Whoever changes the allocator gets to see this and decide.
          */
-        printf("SKIP: hint 0x%llx not honored (got %p)\n",
+        printf("hint 0x%llx not honored (got %p): ",
                (unsigned long long) shared_addr, (void *) p);
+        FAIL("could not place the mapping at the vacated address");
         munmap(p, MAP_LEN);
     } else {
         memset(p, 'S', MAP_LEN);

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -858,6 +858,9 @@ run_unit_tests()
     printf "\nCross-fork MAP_SHARED coherence\n"
     test_rc "$runner" "test-cross-fork-mapshared" 0 "$bindir/test-cross-fork-mapshared"
 
+    printf "\nMAP_SHARED across execve\n"
+    test_rc "$runner" "test-exec-shared-mmap" 0 "$bindir/test-exec-shared-mmap"
+
     printf "\nmadvise MADV_DONTNEED\n"
     test_rc "$runner" "test-madvise" 0 "$bindir/test-madvise"
 


### PR DESCRIPTION
Close #330 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops all MAP_SHARED overlays before execve’s guest_reset to prevent zeroing host files and to keep shared regions intact. Previously, guest_reset wrote through overlay-backed host VAs and truncated mapped files (and anon-shared overlays promoted at fork); failure to drop overlays now exits to avoid corrupting user data.

- In sys_execve, call mmap_exec_drop_overlays(g) right before guest_reset. The function removes overlays over [0, guest_size) under mmap_lock; it returns -errno, and execve now exit(128) on failure.
- Adds tests/test-exec-shared-mmap.c and runs it only from tests/test-matrix.sh (kept out of manifest to avoid duplicate runs). The test verifies file contents survive exec, the vacated range no longer writes through to the file, and a forked peer’s MAP_SHARED|MAP_ANONYMOUS region remains intact; it now fails (not skips) if it cannot place the mapping at the vacated address.
- Analyzer parsing and utilities: new stub headers CommonCrypto/CommonDigest.h, Hypervisor/hv_vcpu.h, libkern/OSCacheControl.h, and mach-o/dyld.h; macos-libc.h adds missing constants (NAME_MAX, termios, ioctl, F_PUNCHHOLE, IP_DONTFRAG); path.c uses PATH_MAX; procemu.h drops an unused sys/mount.h; scripts/check-stub-constants.py now reads octal defines.

<sup>Written for commit 461081dc71bf2bc9a4decd61eceaff95020bfa09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



