### PR TITLE
Decide epoll_ctl EPERM from the target alone

### DIFF
--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -325,6 +325,7 @@ int fork_ipc_send_fd_table(int ipc_sock)
         fd_entries[num_fds].foreign_description =
             fd_table[i].foreign_description;
         fd_entries[num_fds].nonblock_owned = fd_table[i].nonblock_owned;
+        fd_entries[num_fds].path_poll_capable = fd_table[i].path_poll_capable;
         fd_entries[num_fds].seals = fd_table[i].seals;
         fd_entries[num_fds].ofd_id = fd_table[i].ofd_id;
         fd_entries[num_fds].fasync_owner_type = fd_table[i].fasync_owner_type;
@@ -467,6 +468,8 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
             fd_refresh_urandom_bitmap(gfd);
             memcpy(fd_table[gfd].proc_path, fd_entries[i].proc_path,
                    sizeof(fd_table[gfd].proc_path));
+            fd_table[gfd].path_poll_capable =
+                fd_entries[i].path_poll_capable != 0;
             fd_table[gfd].seals = fd_entries[i].seals;
         } else if (fd_type_is_synthetic(fd_entries[i].type)) {
             /* Defense in depth: the parent's fork_ipc_send_fd_table already
@@ -500,6 +503,8 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
             fd_refresh_urandom_bitmap(gfd);
             memcpy(fd_table[gfd].proc_path, fd_entries[i].proc_path,
                    sizeof(fd_table[gfd].proc_path));
+            fd_table[gfd].path_poll_capable =
+                fd_entries[i].path_poll_capable != 0;
             fd_table[gfd].seals = fd_entries[i].seals;
             if (fd_entries[i].type == FD_URANDOM)
                 urandom_fd_reset_cache(gfd);

--- a/src/runtime/fork-state.h
+++ b/src/runtime/fork-state.h
@@ -19,7 +19,7 @@
 /* Fork IPC protocol identity. Bump this whenever the header layout or ordered
  * fork payload changes incompatibly.
  */
-#define FORK_IPC_PROTOCOL_MAGIC 0x454C4650U /* "ELFP" */
+#define FORK_IPC_PROTOCOL_MAGIC 0x454C4651U /* "ELFQ" */
 
 #define IPC_MAGIC_HEADER FORK_IPC_PROTOCOL_MAGIC
 #define IPC_MAGIC_SENTINEL 0x454C4F4BU /* "ELOK" */
@@ -116,8 +116,12 @@ typedef struct {
      * again: whether the description came from outside elfuse (the launcher's
      * stdio, or an alias of it) and whether elfuse owns its O_NONBLOCK. See
      * fd_alias_carried.
+     *
+     * path_poll_capable rides along for the same reason and cannot be rebuilt
+     * on the far side: the child holds the descriptor, not the guest path the
+     * parent classified it from.
      */
-    int32_t foreign_description, nonblock_owned;
+    int32_t foreign_description, nonblock_owned, path_poll_capable;
     char proc_path[FD_VIRTUAL_PATH_MAX];
 } ipc_fd_entry_t;
 

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -307,6 +307,7 @@ static inline void fd_init_entry(int fd,
                 (src->linux_flags & FD_DESCRIPTION_FLAGS);
             fd_alias_spec.foreign_description = src->foreign_description;
             fd_alias_spec.nonblock_owned = src->nonblock_owned;
+            fd_alias_spec.path_poll_capable = src->path_poll_capable;
         }
     }
 
@@ -339,6 +340,14 @@ static inline void fd_init_entry(int fd,
         fd_table[fd].linux_flags = accmode < 0 ? 0 : accmode;
     fd_table[fd].dir = NULL;
     fd_table[fd].proc_path[0] = '\0';
+
+    /* An alias shares the description, so it shares the answer: a dup of an
+     * intercepted open is the same file by another name, and epoll_ctl on the
+     * two names has to agree. Only an open that resolved a path decides this
+     * from scratch, which is why fd_alloc_opened_host leaves an alias alone.
+     */
+    fd_table[fd].path_poll_capable =
+        fd_alias_pending && fd_alias_spec.path_poll_capable;
     fd_table[fd].seals = 0;
 
     /* Whether a host read/write can block, so the fast-path and slow-path
@@ -851,6 +860,7 @@ fd_lifetime_t *fd_mark_closed_unlocked(int fd)
     fd_table[fd].ofd_id = 0;
     fd_table[fd].dir = NULL;
     fd_table[fd].proc_path[0] = '\0';
+    fd_table[fd].path_poll_capable = false;
     fd_table[fd].linux_flags = 0;
     fd_table[fd].seals = 0;
     fd_table[fd].fasync_owner_type = FASYNC_OWNER_NONE;

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -492,6 +492,14 @@ static int fd_alloc_opened_host(int host_fd,
         if (have_proc_path)
             memcpy(fd_table[guest_fd].proc_path, proc_path_buf,
                    sizeof(proc_path_buf));
+
+        /* An alias already carries the description's answer, and the path would
+         * describe the magic link rather than the file behind it:
+         * /proc/self/fd/N is a per-process procfs name whatever it points at.
+         */
+        if (!spec)
+            fd_table[guest_fd].path_poll_capable =
+                path_intercept_poll_capable(virtual_path);
         bool readable_urandom =
             type == FD_URANDOM &&
             (linux_flags & LINUX_O_ACCMODE) != LINUX_O_WRONLY;

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -216,6 +216,13 @@ typedef struct {
     bool foreign_description;
     bool nonblock_owned;
 
+    /* Whether Linux gives the source's file a poll method. It is a fact about
+     * the description, not about the name: every alias of one open
+     * /proc/self/mountinfo has to answer epoll_target_supported the same way,
+     * and fstat cannot recover the answer from elfuse's staging file.
+     */
+    bool path_poll_capable;
+
     /* The live source to re-read under fd_lock, or -1 for a site with no
      * in-process source. The fields above are a snapshot the caller took before
      * the allocation, and an F_SETFL landing in between sweeps the aliases that
@@ -252,6 +259,7 @@ static inline fd_alias_spec_t fd_alias_of(int src_guest_fd,
         .linux_flags = src->linux_flags & FD_DESCRIPTION_FLAGS,
         .foreign_description = src->foreign_description,
         .nonblock_owned = src->nonblock_owned,
+        .path_poll_capable = src->path_poll_capable,
         .src_guest_fd = src_guest_fd,
         .src_generation = src->generation,
     };
@@ -268,6 +276,7 @@ static inline fd_alias_spec_t fd_alias_host_shared(const fd_entry_t *src)
         .src_guest_fd = -1,
         .foreign_description = src->foreign_description,
         .nonblock_owned = src->nonblock_owned,
+        .path_poll_capable = src->path_poll_capable,
     };
 }
 

--- a/src/syscall/linux-wire.h
+++ b/src/syscall/linux-wire.h
@@ -579,6 +579,15 @@ typedef struct {
                           * pointer for FD_EPOLL entries (NULL otherwise)
                           */
     char proc_path[FD_VIRTUAL_PATH_MAX]; /* Virtual /proc dir root for *at */
+
+    /* Linux gives the file this path intercept stands for a poll method, so
+     * epoll_ctl accepts it. Recorded at open because fstat cannot recover it
+     * later: an intercepted tree is served from elfuse's own staging file, and
+     * the host object then describes the staging rather than the file the guest
+     * named. False for every non-intercepted open, where the host object is the
+     * file and answers for itself. path_intercept_poll_capable decides it.
+     */
+    bool path_poll_capable;
     int seals;      /* F_SEAL_* bits (non-zero only for memfd_create fds) */
     bool can_block; /* host read/write on this fd may block (pipe, socket, fifo,
                      * char/tty); false for regular files and directories. Set

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -76,6 +76,11 @@ bool path_might_use_open_intercept(const char *path)
  * when the path names no process directory at all: "/proc/self/stat" and
  * "/proc/41/stat" both yield "stat", "/proc/self" yields "", and
  * "/proc/meminfo" yields NULL.
+ *
+ * A "task/<tid>/" segment is stripped with the process directory it sits in, so
+ * "/proc/41/task/41/mounts" yields "mounts" too. Linux answers the thread
+ * spelling of these names the way it answers the process one, measured on 6.12
+ * over mounts, mountinfo, net/dev and stat.
  */
 static const char *proc_pid_dir_suffix(const char *path)
 {
@@ -96,7 +101,18 @@ static const char *proc_pid_dir_suffix(const char *path)
             return NULL;
         p = d;
     }
-    return *p == '/' ? p + 1 : p;
+    if (*p == '/')
+        p++;
+
+    if (!strncmp(p, "task/", 5)) {
+        const char *d = p + 5;
+        const char *tid = d;
+        while (*d >= '0' && *d <= '9')
+            d++;
+        if (d != tid && (*d == '\0' || *d == '/'))
+            p = (*d == '/') ? d + 1 : d;
+    }
+    return p;
 }
 
 /* Whether Linux gives the file behind this intercepted guest path a poll

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -72,6 +72,75 @@ bool path_might_use_open_intercept(const char *path)
     return false;
 }
 
+/* The part of a guest /proc path that follows the process directory, or NULL
+ * when the path names no process directory at all: "/proc/self/stat" and
+ * "/proc/41/stat" both yield "stat", "/proc/self" yields "", and
+ * "/proc/meminfo" yields NULL.
+ */
+static const char *proc_pid_dir_suffix(const char *path)
+{
+    if (strncmp(path, "/proc/", 6) != 0)
+        return NULL;
+
+    const char *p = path + 6;
+    if (!strncmp(p, "self", 4) && (p[4] == '\0' || p[4] == '/')) {
+        p += 4;
+    } else if (!strncmp(p, "thread-self", 11) &&
+               (p[11] == '\0' || p[11] == '/')) {
+        p += 11;
+    } else {
+        const char *d = p;
+        while (*d >= '0' && *d <= '9')
+            d++;
+        if (d == p || (*d != '\0' && *d != '/'))
+            return NULL;
+        p = d;
+    }
+    return *p == '/' ? p + 1 : p;
+}
+
+/* Whether Linux gives the file behind this intercepted guest path a poll
+ * method, which is the only thing epoll_ctl reads EPERM off. fstat cannot
+ * answer it: elfuse serves several intercepted trees from ordinary host files,
+ * so the host object describes elfuse's staging rather than the file the guest
+ * named, and the path is what still knows.
+ *
+ * The answer per family was measured against Linux 6.12 rather than reasoned
+ * from the file's contents, because the two do not track each other: a
+ * per-process procfs file is opened through proc_single_file_operations, which
+ * carries no poll, while every proc_create entry gets proc_reg_poll whether or
+ * not it has anything to report. /proc/<pid>/mounts and mountinfo are the
+ * exception that makes the split visible -- they go through mounts_operations
+ * so a guest can wait for the mount table to change, while mountstats next to
+ * them does not and is refused. The /proc/<pid>/net subtree is the other
+ * exception, measured on Linux rather than reached here: elfuse serves
+ * /proc/net but not yet the per-process spelling of it, so that arm is
+ * unreachable today and is present so it does not become wrong the day it is.
+ */
+bool path_intercept_poll_capable(const char *path)
+{
+    if (!path || path[0] != '/')
+        return false;
+
+    const char *pid_rel = proc_pid_dir_suffix(path);
+    if (pid_rel)
+        return !strcmp(pid_rel, "mounts") || !strcmp(pid_rel, "mountinfo") ||
+               !strncmp(pid_rel, "net/", 4);
+
+    /* sysfs attributes are pollable through kernfs, and /etc/mtab is a symlink
+     * onto the mount table. What is left of the intercept surface --
+     * /etc/passwd and /etc/group, the utmp files, /dev and the FUSE mounts --
+     * is a plain file, a character device or a fifo, all of which the host
+     * object describes correctly, so the caller's fstat and kqueue probe answer
+     * for them.
+     */
+    if (!strncmp(path, "/proc/", 6))
+        return true;
+    if (path_prefix_match(path, SYSFS_CPU_PREFIX, sizeof(SYSFS_CPU_PREFIX) - 1))
+        return true;
+    return !strcmp(path, "/etc/mtab");
+}
+
 bool path_might_use_stat_intercept(const char *path)
 {
     if (!path || path[0] != '/')

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -145,14 +145,22 @@ bool path_intercept_poll_capable(const char *path)
 
     /* sysfs attributes are pollable through kernfs, and /etc/mtab is a symlink
      * onto the mount table. What is left of the intercept surface --
-     * /etc/passwd and /etc/group, the utmp files, /dev and the FUSE mounts --
-     * is a plain file, a character device or a fifo, all of which the host
-     * object describes correctly, so the caller's fstat and kqueue probe answer
-     * for them.
+     * /etc/passwd and /etc/group, the utmp files, most of /dev and the FUSE
+     * mounts -- is a plain file, a character device or a fifo, all of which the
+     * host object describes correctly, so the caller's fstat and kqueue probe
+     * answer for them.
+     *
+     * /dev/random is the exception, and it does not extend to the /dev/urandom
+     * beside it. random_fops carries .poll and urandom_fops does not, since a
+     * read from urandom never waits, so Linux 6.12 answers 0 for the first and
+     * EPERM for the second. macOS refuses a knote on both, which leaves the
+     * host object unable to tell them apart.
      */
     if (!strncmp(path, "/proc/", 6))
         return true;
     if (path_prefix_match(path, SYSFS_CPU_PREFIX, sizeof(SYSFS_CPU_PREFIX) - 1))
+        return true;
+    if (!strcmp(path, "/dev/random"))
         return true;
     return !strcmp(path, "/etc/mtab");
 }

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -141,6 +141,14 @@ static inline int path_component_copy(char *dst,
 
 bool path_might_use_open_intercept(const char *path);
 bool path_might_use_stat_intercept(const char *path);
+
+/* Whether Linux gives the file behind this intercepted path a poll method.
+ * epoll_ctl asks it because fstat describes elfuse's staging file rather than
+ * the file the guest named. Enumerates the same surface as
+ * path_might_use_open_intercept and belongs next to it: an intercept added to
+ * one without the other is a target answered from the wrong object.
+ */
+bool path_intercept_poll_capable(const char *path);
 int path_check_intercept_access(const struct stat *st, int mode, int flags);
 
 /* Resolve a guest path against dirfd into every spelling a syscall handler

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <sys/event.h>
+#include <sys/stat.h>
 #include <poll.h>
 
 #include "utils.h"
@@ -1365,6 +1366,42 @@ int64_t sys_epoll_create1(int flags)
     return gfd;
 }
 
+/* Whether the kqueue accepts any knote on this fd, which tells a refused write
+ * filter apart from a target kqueue rejects outright. The probe knote is added
+ * disabled on purpose: sys_epoll_pwait blocks on this same kqueue without
+ * inst->lock, and an enabled probe on a ready target would hand that wait an
+ * event whose NULL udata reads back as guest fd 0. The target carries no other
+ * registration here, so the paired delete takes nothing else with it.
+ */
+static bool epoll_target_pollable(int kq, int host_fd)
+{
+    struct kevent probe;
+    EV_SET(&probe, host_fd, EVFILT_READ, EV_ADD | EV_DISABLE, 0, 0, NULL);
+    if (kevent(kq, &probe, 1, NULL, 0, NULL) < 0)
+        return false;
+    EV_SET(&probe, host_fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+    kevent(kq, &probe, 1, NULL, 0, NULL);
+    return true;
+}
+
+/* Whether Linux would take this target at all. A plain file has no poll method
+ * and kqueue does not mind, so that refusal originates here; fstat answers it
+ * rather than the fd type, since FD_REGULAR also covers a fifo or a tty opened
+ * by path. An open that resolved a path through an intercept answers from
+ * path_poll_capable instead, because fstat would be describing elfuse's staging
+ * file: /proc/self/mountinfo and /sys/devices/system/cpu/online are ordinary
+ * host files here and pollable on Linux, while /proc/self/stat and /etc/passwd
+ * are the same kind of host file and are not.
+ */
+static bool epoll_target_supported(int kq, const fd_entry_t *snap)
+{
+    struct stat st;
+    if (!snap->path_poll_capable && fstat(snap->host_fd, &st) == 0 &&
+        S_ISREG(st.st_mode))
+        return false;
+    return epoll_target_pollable(kq, snap->host_fd);
+}
+
 int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 {
     /* The event is copied before anything else, because that is where the
@@ -1458,9 +1495,15 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     }
 
     if (op == LINUX_EPOLL_CTL_DEL) {
-        /* Linux returns ENOENT when removing an unregistered fd */
+        /* Linux returns ENOENT when removing an unregistered fd, but it tests
+         * the target's poll support before it looks at the operation, so a
+         * target it would never have accepted answers EPERM here too. Only the
+         * unregistered path pays for the check.
+         */
         if (!reg->active) {
-            ret = -LINUX_ENOENT;
+            ret = epoll_target_supported(epoll_ref.fd, &target_snap)
+                      ? -LINUX_ENOENT
+                      : -LINUX_EPERM;
             goto out_locked;
         }
 
@@ -1488,6 +1531,21 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         goto out_locked;
     }
 
+    /* The plain-file half of epoll_target_supported, inline so an ADD does not
+     * pay for the kqueue probe: the registration below already asks kqueue the
+     * rest of the question. It sits ahead of the EEXIST and ENOENT checks
+     * because do_epoll_ctl tests the target's poll support before it looks up
+     * the registration, so EPERM outranks both.
+     */
+    if (!target_snap.path_poll_capable) {
+        struct stat target_st;
+        if (fstat(target_host_fd, &target_st) == 0 &&
+            S_ISREG(target_st.st_mode)) {
+            ret = -LINUX_EPERM;
+            goto out_locked;
+        }
+    }
+
     /* Linux semantics: ADD fails with EEXIST if already registered; MOD fails
      * with ENOENT if not registered. oneshot_armed registrations (EPOLLONESHOT
      * fired, waiting for re-arm) are still valid for MOD.
@@ -1497,7 +1555,8 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         goto out_locked;
     }
     if (op == LINUX_EPOLL_CTL_MOD && !reg->active && !reg->oneshot_armed) {
-        ret = -LINUX_ENOENT;
+        ret = epoll_target_supported(epoll_ref.fd, &target_snap) ? -LINUX_ENOENT
+                                                                 : -LINUX_EPERM;
         goto out_locked;
     }
 
@@ -1565,9 +1624,40 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         nchanges++;
     }
 
-    if (nchanges > 0) {
-        if (kevent(epoll_ref.fd, changes, nchanges, NULL, 0, NULL) < 0) {
+    /* A mask naming no readiness filter registers nothing, so the loop below
+     * never asks kqueue whether the target takes a knote at all. Linux tests
+     * poll support before it reads the event, and answers EPERM for a directory
+     * or a character device whatever the mask says, so ask here.
+     */
+    if (nchanges == 0 && !epoll_target_pollable(epoll_ref.fd, target_host_fd)) {
+        ret = -LINUX_EPERM;
+        goto out_locked;
+    }
+
+    /* Linux decides EPERM from the target alone, never from the requested
+     * events: epoll_ctl(2) accepts EPOLLOUT on a timerfd or on a nested epoll
+     * fd, neither of which ever reports itself writable. Both are kqueues here,
+     * and kqueue refuses EVFILT_WRITE on a kqueue with EINVAL, so register one
+     * filter per call and drop a refused write filter instead of failing the
+     * whole ADD. A batched call would also stop at the first failed change and
+     * leave the survivor registered. EINVAL on the read filter, or on a write
+     * filter whose target takes no knote at all, is the EPERM case.
+     */
+    bool read_registered = false;
+    for (int i = 0; i < nchanges; i++) {
+        if (kevent(epoll_ref.fd, &changes[i], 1, NULL, 0, NULL) == 0) {
+            if (changes[i].filter == EVFILT_READ)
+                read_registered = true;
+            continue;
+        }
+        if (errno != EINVAL) {
             ret = linux_errno();
+            goto out_locked;
+        }
+        if (changes[i].filter == EVFILT_READ ||
+            !(read_registered ||
+              epoll_target_pollable(epoll_ref.fd, target_host_fd))) {
+            ret = -LINUX_EPERM;
             goto out_locked;
         }
     }

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1402,6 +1402,23 @@ static bool epoll_target_supported(int kq, const fd_entry_t *snap)
     return epoll_target_pollable(kq, snap->host_fd);
 }
 
+/* Remove the filters an aborted registration pass already armed. Each carries
+ * the udata of a registration the caller is about to abandon, and a knote left
+ * on a live target wakes the next sys_epoll_pwait with an event that wait can
+ * only drop, returning 0 ahead of its timeout. Deleting a filter this pass
+ * dropped rather than armed fails with ENOENT and is ignored, the way every
+ * other delete here is.
+ */
+static void epoll_undo_changes(int kq, const struct kevent *changes, int n)
+{
+    for (int i = 0; i < n; i++) {
+        struct kevent del;
+        EV_SET(&del, changes[i].ident, changes[i].filter, EV_DELETE, 0, 0,
+               NULL);
+        kevent(kq, &del, 1, NULL, 0, NULL);
+    }
+}
+
 int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 {
     /* The event is copied before anything else, because that is where the
@@ -1645,6 +1662,17 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      * whole ADD. A batched call would also stop at the first failed change and
      * leave the survivor registered. EINVAL on the read filter, or on a write
      * filter whose target takes no knote at all, is the EPERM case.
+     *
+     * An error that is not EINVAL abandons a registration this loop may have
+     * already armed filters for, each carrying the udata of an entry the bail
+     * never activates. Undo them: sys_epoll_pwait does reap such a knote, but
+     * only after it has woken the wait and counted the event, so the call
+     * returns 0 ahead of its timeout. MOD arrives here with its old filters
+     * already deleted, so this is also what keeps a half-failed re-registration
+     * from leaving one behind. The EPERM arm below needs no undo: it is
+     * reachable only while nothing is armed, since a refused read filter is the
+     * first change and a refused write filter without a registered read one
+     * means the mask named no read filter at all.
      */
     bool read_registered = false;
     for (int i = 0; i < nchanges; i++) {
@@ -1655,6 +1683,7 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         }
         if (errno != EINVAL) {
             ret = linux_errno();
+            epoll_undo_changes(epoll_ref.fd, changes, i);
             goto out_locked;
         }
         if (changes[i].filter == EVFILT_READ ||

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1049,6 +1049,13 @@ typedef struct {
                          * reporting but allow MOD.
                          */
     bool pty_master;    /* Registration is for a tracked pty master. */
+
+    /* The target is pollable on Linux but takes no knote here, so read
+     * readiness can never arrive through kqueue. /dev/random is the only such
+     * target today. Linux reports it readable as soon as the pool is seeded and
+     * from then on always, which is what the wait synthesizes.
+     */
+    bool always_readable;
 } epoll_reg_t;
 
 /* Per-epoll-instance data, stored in fd_table[epfd].dir. Each instance has its
@@ -1075,6 +1082,7 @@ typedef struct {
     pthread_mutex_t lock;
     int active_count;
     int pty_master_count;
+    int always_readable_count;
     epoll_reg_t regs[FD_TABLE_SIZE];
 } epoll_instance_t;
 
@@ -1085,9 +1093,12 @@ static void epoll_reg_deactivate_locked(epoll_instance_t *inst,
         inst->active_count--;
     if (reg->pty_master && inst->pty_master_count > 0)
         inst->pty_master_count--;
+    if (reg->always_readable && inst->always_readable_count > 0)
+        inst->always_readable_count--;
     reg->active = false;
     reg->oneshot_armed = false;
     reg->pty_master = false;
+    reg->always_readable = false;
     reg->generation = 0;
     reg->ofd_id = 0;
 }
@@ -1395,9 +1406,13 @@ static bool epoll_target_pollable(int kq, int host_fd)
  */
 static bool epoll_target_supported(int kq, const fd_entry_t *snap)
 {
+    /* A settled path answers for itself. The kqueue probe would veto
+     * /dev/random, which Linux polls and macOS refuses a knote on.
+     */
+    if (snap->path_poll_capable)
+        return true;
     struct stat st;
-    if (!snap->path_poll_capable && fstat(snap->host_fd, &st) == 0 &&
-        S_ISREG(st.st_mode))
+    if (fstat(snap->host_fd, &st) == 0 && S_ISREG(st.st_mode))
         return false;
     return epoll_target_pollable(kq, snap->host_fd);
 }
@@ -1708,6 +1723,11 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      * leave the survivor registered. EINVAL on the read filter, or on a write
      * filter whose target takes no knote at all, is the EPERM case.
      *
+     * A target the path already settled is never that case: /dev/random is
+     * pollable on Linux and takes no knote here, so its refusal drops the
+     * filter the way a kqueue's write filter does. Read readiness then has no
+     * knote to arrive on, which always_readable carries to the wait.
+     *
      * An error that is not EINVAL abandons a registration this loop may have
      * already armed filters for, each carrying the udata of an entry the bail
      * never activates. Undo them: sys_epoll_pwait does reap such a knote, but
@@ -1720,6 +1740,7 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      * means the mask named no read filter at all.
      */
     bool read_registered = false;
+    bool read_refused = false;
     for (int i = 0; i < nchanges; i++) {
         if (kevent(epoll_ref.fd, &changes[i], 1, NULL, 0, NULL) == 0) {
             if (changes[i].filter == EVFILT_READ)
@@ -1730,6 +1751,11 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
             ret = linux_errno();
             epoll_undo_changes(epoll_ref.fd, changes, i);
             goto out_locked;
+        }
+        if (target_snap.path_poll_capable) {
+            if (changes[i].filter == EVFILT_READ)
+                read_refused = true;
+            continue;
         }
         if (changes[i].filter == EVFILT_READ ||
             !(read_registered ||
@@ -1755,9 +1781,15 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     else if (!target_pty_master && reg->pty_master &&
              inst->pty_master_count > 0)
         inst->pty_master_count--;
+    if (read_refused && !reg->always_readable)
+        inst->always_readable_count++;
+    else if (!read_refused && reg->always_readable &&
+             inst->always_readable_count > 0)
+        inst->always_readable_count--;
     reg->active = true;
     reg->oneshot_armed = false;
     reg->pty_master = target_pty_master;
+    reg->always_readable = read_refused;
 
     ret = 0;
 
@@ -1767,6 +1799,18 @@ out:
     host_fd_ref_close(&epoll_ref);
     epoll_instance_release(inst);
     return ret;
+}
+
+/* Whether this instance holds a registration whose read readiness kqueue can
+ * never deliver. Same shape as a pending hangup: the wait must not block to its
+ * deadline waiting for an event that cannot arrive.
+ */
+static bool epoll_has_always_readable(epoll_instance_t *inst)
+{
+    pthread_mutex_lock(&inst->lock);
+    bool any = inst->always_readable_count > 0;
+    pthread_mutex_unlock(&inst->lock);
+    return any;
 }
 
 /* Collect guest fds registered in this instance whose pty master has hung up.
@@ -1901,7 +1945,8 @@ int64_t sys_epoll_pwait(guest_t *g,
     int hup_probe;
     uint64_t hup_probe_gen;
     bool hup_ready =
-        epoll_collect_hung_up(inst, &hup_probe, &hup_probe_gen, 1) > 0;
+        epoll_collect_hung_up(inst, &hup_probe, &hup_probe_gen, 1) > 0 ||
+        epoll_has_always_readable(inst);
     struct timespec zero_ts = {.tv_sec = 0, .tv_nsec = 0};
 
     /* Collect kqueue events. For indefinite waits, use a short timeout and loop
@@ -2048,6 +2093,33 @@ int64_t sys_epoll_pwait(guest_t *g,
         out[idx]._pad = 0;
         out[idx].data = reg->data;
         epoll_merge_event(&out[idx], &kevents[i], reg);
+    }
+
+    /* Stamp EPOLLIN for the registrations whose read readiness kqueue cannot
+     * deliver. /dev/random is the only such target: Linux reports it readable
+     * once the pool is seeded and from then on always, so the answer is a
+     * property of the registration rather than something to sample. Unlike the
+     * hangup scan below this reads regs[] under the lock it already holds, so
+     * there is no unlocked snapshot to re-verify against a generation.
+     */
+    if (inst->always_readable_count > 0) {
+        for (int gfd = 0; gfd < FD_TABLE_SIZE && nout < maxevents; gfd++) {
+            epoll_reg_t *areg = &inst->regs[gfd];
+            if (!areg->always_readable || !areg->active || areg->oneshot_armed)
+                continue;
+            if (!(areg->events & LINUX_EPOLLIN))
+                continue;
+            int idx = out_index[gfd];
+            if (idx < 0) {
+                idx = nout++;
+                out_index[gfd] = (int16_t) idx;
+                out_gfds[idx] = gfd;
+                out[idx].events = 0;
+                out[idx]._pad = 0;
+                out[idx].data = areg->data;
+            }
+            out[idx].events |= LINUX_EPOLLIN;
+        }
     }
 
     /* Stamp EPOLLHUP for the masters the host cannot report on. Linux delivers

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1509,22 +1509,25 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 
         /* Remove all filters for this fd. EPOLLRDHUP alone registers
          * EVFILT_READ (see ADD path), so check both EPOLLIN and EPOLLRDHUP.
+         * Each delete goes in its own kevent call for the reason the MOD path
+         * below already states: a batched call with a NULL eventlist stops at
+         * the first failed change and leaks the survivor, and events names a
+         * filter that may not be registered -- a dropped write filter, or the
+         * one EPOLLONESHOT already removed. Errors are ignored either way,
+         * since the fd may already be closed.
          */
-        struct kevent changes[2];
-        int nchanges = 0;
         {
+            struct kevent del;
             if (reg->events & (LINUX_EPOLLIN | LINUX_EPOLLRDHUP)) {
-                EV_SET(&changes[nchanges], target_host_fd, EVFILT_READ,
-                       EV_DELETE, 0, 0, NULL);
-                nchanges++;
+                EV_SET(&del, target_host_fd, EVFILT_READ, EV_DELETE, 0, 0,
+                       NULL);
+                kevent(epoll_ref.fd, &del, 1, NULL, 0, NULL);
             }
             if (reg->events & LINUX_EPOLLOUT) {
-                EV_SET(&changes[nchanges], target_host_fd, EVFILT_WRITE,
-                       EV_DELETE, 0, 0, NULL);
-                nchanges++;
+                EV_SET(&del, target_host_fd, EVFILT_WRITE, EV_DELETE, 0, 0,
+                       NULL);
+                kevent(epoll_ref.fd, &del, 1, NULL, 0, NULL);
             }
-            /* Ignore errors from EV_DELETE (fd might already be closed) */
-            kevent(epoll_ref.fd, changes, nchanges, NULL, 0, NULL);
             epoll_reg_deactivate_locked(inst, reg);
         }
         ret = 0;

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1419,6 +1419,35 @@ static void epoll_undo_changes(int kq, const struct kevent *changes, int n)
     }
 }
 
+/* epoll_target_supported for the paths that have no instance to probe on,
+ * because the epoll descriptor is not one or the op never named a registration.
+ * The probe needs any kqueue rather than this instance's, so a call that is
+ * already failing borrows one; the paths that succeed never reach here and
+ * still pay nothing.
+ */
+static bool epoll_target_supported_standalone(const fd_entry_t *snap)
+{
+    if (snap->path_poll_capable)
+        return true;
+    struct stat st;
+    if (fstat(snap->host_fd, &st) == 0 && S_ISREG(st.st_mode))
+        return false;
+    int kq = kqueue();
+    if (kq < 0)
+        return true;
+    bool ok = epoll_target_pollable(kq, snap->host_fd);
+    close(kq);
+    return ok;
+}
+
+/* EINVAL unless the target has no poll method, which the kernel decides first.
+ */
+static int64_t epoll_einval_unless_unsupported(const fd_entry_t *snap)
+{
+    return epoll_target_supported_standalone(snap) ? -LINUX_EINVAL
+                                                   : -LINUX_EPERM;
+}
+
 int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 {
     /* The event is copied before anything else, because that is where the
@@ -1442,15 +1471,6 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     if (ref_err < 0)
         return ref_err;
 
-    /* Pin the instance so a concurrent close(epfd) cannot free it under us. */
-    epoll_instance_t *inst = epoll_instance_acquire(epfd);
-    if (!inst) {
-        host_fd_ref_close(&epoll_ref);
-        return -LINUX_EINVAL;
-    }
-
-    int64_t ret;
-
     /* Validate the target fd and read its persistent host fd in a single
      * fd_lock snapshot, so the kqueue knote ident is taken from the same entry
      * that was validated. A kqueue knote is keyed by the fd number and the
@@ -1460,12 +1480,31 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      * under one fd_lock. The snapshot's generation then guards the cross-call
      * ABA below. Result mapping uses udata (the guest fd), so the ident only
      * needs to stay open and refer to the same open file description.
+     *
+     * Ahead of the instance lookup because do_epoll_ctl reaches both fdgets
+     * first, and because the target decides EPERM ahead of every EINVAL below.
      */
     fd_entry_t target_snap;
     if (!fd_snapshot(fd, &target_snap)) {
-        ret = -LINUX_EBADF;
-        goto out;
+        host_fd_ref_close(&epoll_ref);
+        return -LINUX_EBADF;
     }
+
+    /* Pin the instance so a concurrent close(epfd) cannot free it under us.
+     *
+     * A target with no poll method outranks this EINVAL: do_epoll_ctl tests
+     * file_can_poll before is_file_epoll. Measured on Linux 6.12,
+     * epoll_ctl(plain_file, ADD, plain_file, &ev) is EPERM while the same call
+     * on a pipe is EINVAL.
+     */
+    epoll_instance_t *inst = epoll_instance_acquire(epfd);
+    if (!inst) {
+        int64_t err = epoll_einval_unless_unsupported(&target_snap);
+        host_fd_ref_close(&epoll_ref);
+        return err;
+    }
+
+    int64_t ret;
 
     /* The op and the pairing, in that order and here rather than at the top,
      * because the kernel decides both inside do_epoll_ctl after both fdgets:
@@ -1479,7 +1518,7 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
      */
     if (op != LINUX_EPOLL_CTL_ADD && op != LINUX_EPOLL_CTL_DEL &&
         op != LINUX_EPOLL_CTL_MOD) {
-        ret = -LINUX_EINVAL;
+        ret = epoll_einval_unless_unsupported(&target_snap);
         goto out;
     }
     if (fd == epfd) {
@@ -1553,9 +1592,15 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 
     /* The plain-file half of epoll_target_supported, inline so an ADD does not
      * pay for the kqueue probe: the registration below already asks kqueue the
-     * rest of the question. It sits ahead of the EEXIST and ENOENT checks
-     * because do_epoll_ctl tests the target's poll support before it looks up
-     * the registration, so EPERM outranks both.
+     * rest of the question.
+     *
+     * do_epoll_ctl decides poll support earlier than this position alone
+     * suggests: file_can_poll runs ahead of is_file_epoll and ahead of the op
+     * switch, not merely ahead of the registration lookup. Everything it
+     * outranks that this function answers sooner is answered by
+     * epoll_einval_unless_unsupported at those two sites, so by the time a call
+     * reaches here the only checks left below are the EEXIST and ENOENT this
+     * position covers.
      */
     if (!target_snap.path_poll_capable) {
         struct stat target_st;

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -73,6 +73,7 @@ test-epoll-aba
 test-epoll-close
 test-epoll-dup
 test-epoll-refcount
+test-epoll-del-leak
 test-timerfd
 test-large-io-boundary
 test-ioctl-cloexec

--- a/tests/test-epoll-del-leak.c
+++ b/tests/test-epoll-del-leak.c
@@ -1,0 +1,104 @@
+/*
+ * EPOLL_CTL_DEL removes every filter, including one whose sibling is gone
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * events names the filters a registration asked for, not the filters kqueue
+ * still holds: EPOLLONESHOT removes only the filter that fired, and an ADD
+ * drops a write filter the target refuses. Deleting them in one batched call
+ * stops at the first change kqueue rejects and leaves the rest registered, and
+ * a leftover knote wakes the next epoll_wait on that instance with an event for
+ * an fd that is no longer registered. This pins the DEL path in
+ * src/syscall/poll.c sys_epoll_ctl.
+ *
+ * Syscalls exercised: epoll_create1(20), epoll_ctl(21), epoll_pwait(22),
+ *                     socketpair(199), fcntl(25), read(63), write(64)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+static long elapsed_ms(const struct timespec *t0)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return (now.tv_sec - t0->tv_sec) * 1000 +
+           (now.tv_nsec - t0->tv_nsec) / 1000000;
+}
+
+int main(void)
+{
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) < 0) {
+        printf("socketpair failed\n");
+        return 1;
+    }
+    fcntl(sv[0], F_SETFL, O_NONBLOCK);
+    fcntl(sv[1], F_SETFL, O_NONBLOCK);
+
+    char buf[4096];
+    memset(buf, 'x', sizeof(buf));
+    while (write(sv[0], buf, sizeof(buf)) > 0)
+        ;
+    if (write(sv[1], "a", 1) != 1) {
+        printf("peer send buffer full too\n");
+        return 1;
+    }
+
+    int ep = epoll_create1(0);
+    struct epoll_event ev = {.events = EPOLLIN | EPOLLOUT | EPOLLONESHOT,
+                             .data.fd = sv[0]};
+    if (epoll_ctl(ep, EPOLL_CTL_ADD, sv[0], &ev) != 0) {
+        printf("ADD failed errno=%d\n", errno);
+        return 1;
+    }
+
+    struct epoll_event out[4];
+    int n = epoll_wait(ep, out, 4, 1000);
+    TEST("oneshot reports read only (write filter survives)");
+    if (n == 1 && (out[0].events & EPOLLIN) && !(out[0].events & EPOLLOUT))
+        PASS();
+    else {
+        char m[96];
+        snprintf(m, sizeof(m), "n=%d events=0x%x", n,
+                 n > 0 ? out[0].events : 0);
+        FAIL(m);
+    }
+
+    TEST("DEL succeeds");
+    if (epoll_ctl(ep, EPOLL_CTL_DEL, sv[0], NULL) == 0)
+        PASS();
+    else
+        FAIL("DEL failed");
+
+    while (read(sv[1], buf, sizeof(buf)) > 0)
+        ;
+
+    struct timespec t0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    n = epoll_wait(ep, out, 4, 300);
+    long el = elapsed_ms(&t0);
+    TEST("an emptied epoll is not woken by a leftover filter");
+    if (n == 0 && el >= 250)
+        PASS();
+    else {
+        char m[96];
+        snprintf(m, sizeof(m), "n=%d after %ldms (expected 0 after ~300ms)", n,
+                 el);
+        FAIL(m);
+    }
+
+    SUMMARY("test-epoll-del-leak");
+    return fails ? 1 : 0;
+}

--- a/tests/test-epoll-unsupported.c
+++ b/tests/test-epoll-unsupported.c
@@ -1,0 +1,402 @@
+/*
+ * epoll_ctl decides EPERM from the target, not from the requested events
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * epoll_ctl(2) reports EPERM from the target alone: a target with no poll
+ * support is refused whatever the event mask asks for, and a target that never
+ * becomes writable still accepts EPOLLOUT. macOS kqueue disagrees in both
+ * directions. It refuses a knote on a directory or a character device, refuses
+ * EVFILT_WRITE on a kqueue (which is what a timerfd and a nested epoll fd are
+ * here), and accepts one on a plain file that Linux refuses. This pins all
+ * three against src/syscall/poll.c sys_epoll_ctl.
+ *
+ * Syscalls exercised: epoll_create1(20), epoll_ctl(21), epoll_pwait(22),
+ *                     openat(56), close(57), pipe2(59),
+ *                     timerfd_create(85), timerfd_settime(86)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/stat.h>
+#include <sys/timerfd.h>
+#include <sys/wait.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* ADD fd to a fresh epoll instance and report the raw result. */
+static int add_to_fresh_epoll(int fd, uint32_t events)
+{
+    int epfd = epoll_create1(0);
+    if (epfd < 0)
+        return -1;
+    struct epoll_event ev = {.events = events, .data.fd = fd};
+    int rc = epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev);
+    int saved = errno;
+    close(epfd);
+    errno = saved;
+    return rc;
+}
+
+/* Closes @fd: every caller passes a freshly opened descriptor. */
+static void expect_eperm(const char *label, int fd, uint32_t events)
+{
+    TEST(label);
+    if (fd < 0) {
+        FAIL("open failed");
+        return;
+    }
+    EXPECT_ERRNO(add_to_fresh_epoll(fd, events), EPERM, "expected EPERM");
+    close(fd);
+}
+
+/* Open @path and require the EPERM that Linux answers for it. */
+static void expect_eperm_path(const char *path)
+{
+    TEST(path);
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        FAIL("open failed");
+        return;
+    }
+    EXPECT_ERRNO(add_to_fresh_epoll(fd, EPOLLIN), EPERM, "expected EPERM");
+    close(fd);
+}
+
+/* Open @path and require that epoll_ctl accepts it. */
+static void expect_accepted_path(const char *path)
+{
+    TEST(path);
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        FAIL("open failed");
+        return;
+    }
+    EXPECT_EQ(add_to_fresh_epoll(fd, EPOLLIN), 0, "target was refused");
+    close(fd);
+}
+
+/* Run one operation on a never-registered target and check the errno. */
+static void expect_op_errno(const char *label,
+                            const char *path,
+                            int op,
+                            int expected)
+{
+    TEST(label);
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        FAIL("open failed");
+        return;
+    }
+    int epfd = epoll_create1(0);
+    if (epfd < 0) {
+        FAIL("epoll_create1 failed");
+        close(fd);
+        return;
+    }
+    struct epoll_event ev = {.events = EPOLLIN, .data.fd = fd};
+    EXPECT_ERRNO(epoll_ctl(epfd, op, fd, &ev), expected, "wrong errno");
+    close(epfd);
+    close(fd);
+}
+
+static void expect_accepted(const char *label, int fd, uint32_t events)
+{
+    TEST(label);
+    if (fd < 0) {
+        FAIL("target fd unavailable");
+        return;
+    }
+    EXPECT_EQ(add_to_fresh_epoll(fd, events), 0, "ADD was refused");
+}
+
+int main(void)
+{
+    printf("epoll_ctl target-support tests\n");
+
+    /* No poll support: EPERM whichever events are asked for. The EPOLLOUT-only
+     * case is the one that cannot read the answer off the write filter alone.
+     */
+    expect_eperm("/dev/null EPOLLIN", open("/dev/null", O_RDWR), EPOLLIN);
+    expect_eperm("/dev/null EPOLLOUT", open("/dev/null", O_RDWR), EPOLLOUT);
+    expect_eperm("/dev/zero EPOLLIN", open("/dev/zero", O_RDONLY), EPOLLIN);
+    expect_eperm("/dev/urandom EPOLLIN", open("/dev/urandom", O_RDONLY),
+                 EPOLLIN);
+    expect_eperm("directory EPOLLIN|EPOLLOUT",
+                 open("/", O_RDONLY | O_DIRECTORY), EPOLLIN | EPOLLOUT);
+
+    /* A plain file has no poll method on Linux. A fifo opened by path does, and
+     * so does /proc/self/mountinfo, which is a plain file to fstat: both are
+     * here because the obvious fd-type test would refuse them.
+     */
+    expect_eperm("regular file EPOLLIN", open("/etc/hosts", O_RDONLY), EPOLLIN);
+    expect_eperm("regular file EPOLLOUT", open("/etc/hosts", O_RDONLY),
+                 EPOLLOUT);
+
+    /* A mask naming no readiness filter still has to consult the target: Linux
+     * decides EPERM before it reads the event, so an empty mask is refused on
+     * exactly the targets a full one is.
+     */
+    expect_eperm("/dev/null no filter", open("/dev/null", O_RDWR), 0);
+    expect_eperm("directory no filter", open("/", O_RDONLY | O_DIRECTORY), 0);
+    expect_eperm("regular file EPOLLET only", open("/etc/hosts", O_RDONLY),
+                 EPOLLET);
+
+    /* Linux tests the target's poll support before it looks at the operation,
+     * so an unsupported target answers EPERM to MOD and DEL as well, while a
+     * supported but unregistered one still answers ENOENT.
+     */
+    expect_op_errno("regular file MOD", "/etc/hosts", EPOLL_CTL_MOD, EPERM);
+    expect_op_errno("regular file DEL", "/etc/hosts", EPOLL_CTL_DEL, EPERM);
+    expect_op_errno("/dev/null MOD", "/dev/null", EPOLL_CTL_MOD, EPERM);
+    expect_op_errno("/dev/null DEL", "/dev/null", EPOLL_CTL_DEL, EPERM);
+    expect_op_errno("unregistered MOD", "/proc/self/mountinfo", EPOLL_CTL_MOD,
+                    ENOENT);
+    expect_op_errno("unregistered DEL", "/proc/self/mountinfo", EPOLL_CTL_DEL,
+                    ENOENT);
+
+    /* Named after this process so two runs of the suite cannot collide on the
+     * unlink and see each other's fifo.
+     */
+    char fifo_path[64];
+    snprintf(fifo_path, sizeof(fifo_path), "/tmp/elfuse-epoll-fifo-%d",
+             (int) getpid());
+    unlink(fifo_path);
+    TEST("fifo opened by path");
+    if (mkfifo(fifo_path, 0600) != 0) {
+        FAIL("mkfifo failed");
+    } else {
+        int ff = open(fifo_path, O_RDONLY | O_NONBLOCK);
+        EXPECT_EQ(add_to_fresh_epoll(ff, EPOLLIN), 0, "fifo was refused");
+        close(ff);
+    }
+    unlink(fifo_path);
+
+    /* Trees elfuse serves from ordinary host files. fstat calls every one of
+     * them a plain file; Linux polls them, so the plain-file rule has to go by
+     * the path classification rather than by fstat alone.
+     */
+    expect_accepted_path("/proc/self/mountinfo");
+    expect_accepted_path("/proc/self/mounts");
+    expect_accepted_path("/sys/devices/system/cpu/online");
+    expect_accepted_path("/etc/mtab");
+    expect_accepted_path("/proc/meminfo");
+    expect_accepted_path("/proc/cpuinfo");
+    expect_accepted_path("/proc/uptime");
+    expect_accepted_path("/proc/net/dev");
+    expect_accepted_path("/proc/sys/vm/mmap_min_addr");
+
+    /* The same host storage, refused. A per-process procfs file is opened
+     * through proc_single_file_operations, which carries no poll method, so
+     * Linux answers EPERM for all of these while accepting the mount tables two
+     * lines up. "elfuse staged this file" cannot tell the two groups apart,
+     * which is why the classification goes by path.
+     */
+    expect_eperm_path("/proc/self/stat");
+    expect_eperm_path("/proc/self/status");
+    expect_eperm_path("/proc/self/maps");
+    expect_eperm_path("/proc/self/smaps");
+    expect_eperm_path("/proc/self/cmdline");
+    expect_eperm_path("/proc/self/environ");
+    expect_eperm_path("/proc/self/auxv");
+    expect_eperm_path("/proc/self/io");
+    expect_eperm_path("/proc/self/limits");
+    expect_eperm_path("/proc/self/oom_score");
+    expect_eperm_path("/proc/self/oom_score_adj");
+    expect_eperm_path("/proc/self/fdinfo/0");
+    expect_eperm_path("/etc/passwd");
+    expect_eperm_path("/etc/group");
+
+    /* The numeric spelling of the process directory reaches the same rule, and
+     * carries the mount-table exception with it.
+     */
+    char pidpath[64];
+    snprintf(pidpath, sizeof(pidpath), "/proc/%d/stat", (int) getpid());
+    expect_eperm_path(pidpath);
+    snprintf(pidpath, sizeof(pidpath), "/proc/%d/mountinfo", (int) getpid());
+    expect_accepted_path(pidpath);
+
+    /* The marker belongs to the open file description, so a dup answers the
+     * same way its source does. fd_init_entry clears it for every fresh slot,
+     * which without the alias carry would make the copy read as a plain file.
+     */
+    TEST("dup of an intercepted open");
+    int mntfd = open("/proc/self/mountinfo", O_RDONLY);
+    if (mntfd < 0) {
+        FAIL("open failed");
+    } else {
+        int dupfd = dup(mntfd);
+        if (dupfd < 0) {
+            FAIL("dup failed");
+        } else {
+            EXPECT_EQ(add_to_fresh_epoll(dupfd, EPOLLIN), 0, "dup was refused");
+            close(dupfd);
+        }
+        close(mntfd);
+    }
+    int hostsfd = open("/etc/hosts", O_RDONLY);
+    expect_eperm("dup of a regular file", hostsfd < 0 ? -1 : dup(hostsfd),
+                 EPOLLIN);
+    close(hostsfd);
+
+    /* The other direction: an intercepted open Linux refuses stays refused
+     * through the dup, so the carry cannot be a blanket "intercepted means
+     * pollable" either.
+     */
+    int statfd = open("/proc/self/stat", O_RDONLY);
+    expect_eperm("dup of a refused intercept", statfd < 0 ? -1 : dup(statfd),
+                 EPOLLIN);
+    close(statfd);
+
+    /* Opening a magic link is a dup here and a reopen on Linux, so the answer
+     * has to come from the description behind the link rather than from the
+     * link's own path -- /proc/self/fd/N is a per-process procfs name whatever
+     * it points at, and classifying it as one would refuse all four of these.
+     */
+    static const struct {
+        const char *label, *path;
+        bool accepted;
+    } magic[] = {
+        {"magic link to mountinfo", "/proc/self/mountinfo", true},
+        {"magic link to /proc/self/stat", "/proc/self/stat", false},
+        {"magic link to a regular file", "/etc/hosts", false},
+        {"magic link to a pipe", NULL, true},
+    };
+    int pipefds[2];
+    if (pipe(pipefds) < 0) {
+        perror("pipe");
+        return 1;
+    }
+    for (size_t i = 0; i < sizeof(magic) / sizeof(magic[0]); i++) {
+        TEST(magic[i].label);
+        int target = magic[i].path ? open(magic[i].path, O_RDONLY) : pipefds[0];
+        if (target < 0) {
+            FAIL("open failed");
+            continue;
+        }
+        char link[64];
+        snprintf(link, sizeof(link), "/proc/self/fd/%d", target);
+        int viafd = open(link, O_RDONLY);
+        if (viafd < 0) {
+            FAIL("magic link open failed");
+        } else if (magic[i].accepted) {
+            EXPECT_EQ(add_to_fresh_epoll(viafd, EPOLLIN), 0, "link refused");
+        } else {
+            EXPECT_ERRNO(add_to_fresh_epoll(viafd, EPOLLIN), EPERM,
+                         "expected EPERM");
+        }
+        close(viafd);
+        if (magic[i].path)
+            close(target);
+    }
+    close(pipefds[0]);
+    close(pipefds[1]);
+
+    /* Never writable, still accepted. */
+    int tfd = timerfd_create(CLOCK_MONOTONIC, 0);
+    expect_accepted("timerfd EPOLLOUT", tfd, EPOLLOUT);
+    expect_accepted("timerfd EPOLLIN|EPOLLOUT", tfd, EPOLLIN | EPOLLOUT);
+    int nested = epoll_create1(0);
+    expect_accepted("nested epoll EPOLLOUT", nested, EPOLLOUT);
+    close(nested);
+
+    int p[2];
+    if (pipe(p) < 0) {
+        perror("pipe");
+        return 1;
+    }
+    expect_accepted("pipe read end EPOLLIN", p[0], EPOLLIN);
+
+    /* Reuse one instance across a probe. Registering only EPOLLOUT on a timerfd
+     * runs the pollability probe, which adds and removes a disabled read knote
+     * on this same kqueue. A later MOD to EPOLLIN still has to arm, which is
+     * the shape a skipped probe delete would silently break.
+     */
+    TEST("MOD to EPOLLIN after a probe");
+    int reuse = epoll_create1(0);
+    int tfd2 = timerfd_create(CLOCK_MONOTONIC, 0);
+    struct epoll_event out_only = {.events = EPOLLOUT, .data.fd = tfd2};
+    struct epoll_event in_only = {.events = EPOLLIN, .data.fd = tfd2};
+    if (reuse < 0 || tfd2 < 0 ||
+        epoll_ctl(reuse, EPOLL_CTL_ADD, tfd2, &out_only) != 0 ||
+        epoll_ctl(reuse, EPOLL_CTL_MOD, tfd2, &in_only) != 0) {
+        FAIL("ADD or MOD refused");
+    } else {
+        struct itimerspec arm = {{0, 0}, {0, 50 * 1000 * 1000}};
+        timerfd_settime(tfd2, 0, &arm, NULL);
+        struct epoll_event got[2];
+        EXPECT_TRUE(epoll_wait(reuse, got, 2, 2000) == 1, "timer never fired");
+    }
+    close(tfd2);
+    close(reuse);
+
+    /* A refused target must not poison the instance for later registrations. */
+    TEST("instance usable after EPERM");
+    int after = epoll_create1(0);
+    int devnull = open("/dev/null", O_RDWR);
+    struct epoll_event nul = {.events = EPOLLOUT, .data.fd = devnull};
+    int refused = epoll_ctl(after, EPOLL_CTL_ADD, devnull, &nul) < 0;
+    struct epoll_event again = {.events = EPOLLIN, .data.fd = p[0]};
+    EXPECT_TRUE(refused && epoll_ctl(after, EPOLL_CTL_ADD, p[0], &again) == 0,
+                "instance unusable after a refused target");
+    close(devnull);
+    close(after);
+
+    /* A dropped write filter must not take the read filter with it: the timer
+     * still has to report EPOLLIN and nothing else.
+     */
+    TEST("timerfd fires EPOLLIN only");
+    int epfd = epoll_create1(0);
+    struct epoll_event ev = {.events = EPOLLIN | EPOLLOUT, .data.fd = tfd};
+    if (epfd < 0 || epoll_ctl(epfd, EPOLL_CTL_ADD, tfd, &ev) != 0) {
+        FAIL("ADD failed");
+    } else {
+        struct itimerspec its = {{0, 0}, {0, 50 * 1000 * 1000}};
+        timerfd_settime(tfd, 0, &its, NULL);
+        struct epoll_event out[2];
+        int n = epoll_wait(epfd, out, 2, 2000);
+        EXPECT_TRUE(n == 1 && out[0].events == EPOLLIN, "timer edge wrong");
+    }
+    close(epfd);
+    close(tfd);
+    close(p[0]);
+    close(p[1]);
+
+    /* The intercept marker travels in the fd table, which fork rebuilds over
+     * IPC. A child that loses it would refuse a synthesized target its parent
+     * accepts, so this pins both answers on the far side of a fork.
+     */
+    TEST("marker survives fork");
+    int sysfd = open("/sys/devices/system/cpu/online", O_RDONLY);
+    int regfd = open("/etc/hosts", O_RDONLY);
+    if (sysfd < 0 || regfd < 0) {
+        FAIL("open failed");
+    } else {
+        fflush(stdout);
+        pid_t child = fork();
+        if (child == 0) {
+            int ok = add_to_fresh_epoll(sysfd, EPOLLIN) == 0 &&
+                     add_to_fresh_epoll(regfd, EPOLLIN) == -1 && errno == EPERM;
+            _exit(ok ? 0 : 1);
+        }
+        int status = 1;
+        if (child > 0)
+            waitpid(child, &status, 0);
+        EXPECT_TRUE(child > 0 && WIFEXITED(status) && WEXITSTATUS(status) == 0,
+                    "child disagreed with the parent");
+    }
+    close(sysfd);
+    close(regfd);
+
+    SUMMARY("test-epoll-unsupported");
+    return fails > 0 ? 1 : 0;
+}

--- a/tests/test-epoll-unsupported.c
+++ b/tests/test-epoll-unsupported.c
@@ -109,6 +109,41 @@ static void expect_op_errno(const char *label,
     close(fd);
 }
 
+/* Register @path for @events and require the readiness Linux reports for it.
+ * @want is the event mask a zero-timeout wait must produce, or 0 for none.
+ */
+static void expect_ready(const char *label,
+                         const char *path,
+                         uint32_t events,
+                         uint32_t want)
+{
+    TEST(label);
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        FAIL("open failed");
+        return;
+    }
+    int epfd = epoll_create1(0);
+    if (epfd < 0) {
+        FAIL("epoll_create1 failed");
+        close(fd);
+        return;
+    }
+    struct epoll_event ev = {.events = events, .data.fd = fd};
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) != 0) {
+        FAIL("ADD was refused");
+    } else {
+        struct epoll_event out[2];
+        int n = epoll_wait(epfd, out, 2, 0);
+        if (want)
+            EXPECT_TRUE(n == 1 && out[0].events == want, "wrong readiness");
+        else
+            EXPECT_EQ(n, 0, "expected no ready event");
+    }
+    close(epfd);
+    close(fd);
+}
+
 /* Require the errno of one epoll_ctl against a target with no poll method, and
  * the errno of the same call against a pollable one. Linux decides EPERM from
  * the target before it validates either the op or the epoll descriptor, so the
@@ -153,10 +188,31 @@ int main(void)
     expect_eperm("/dev/null EPOLLIN", open("/dev/null", O_RDWR), EPOLLIN);
     expect_eperm("/dev/null EPOLLOUT", open("/dev/null", O_RDWR), EPOLLOUT);
     expect_eperm("/dev/zero EPOLLIN", open("/dev/zero", O_RDONLY), EPOLLIN);
-    expect_eperm("/dev/urandom EPOLLIN", open("/dev/urandom", O_RDONLY),
-                 EPOLLIN);
     expect_eperm("directory EPOLLIN|EPOLLOUT",
                  open("/", O_RDONLY | O_DIRECTORY), EPOLLIN | EPOLLOUT);
+
+    /* The two random devices split, and not the way their names suggest.
+     * random_fops carries .poll and urandom_fops does not, since a read from
+     * urandom never waits, so Linux 6.12 accepts the first and answers EPERM
+     * for the second. macOS refuses a knote on both, so nothing but the path
+     * separates them here.
+     */
+    expect_eperm("/dev/urandom EPOLLIN", open("/dev/urandom", O_RDONLY),
+                 EPOLLIN);
+    expect_accepted("/dev/random EPOLLIN", open("/dev/random", O_RDONLY),
+                    EPOLLIN);
+    expect_accepted("/dev/random EPOLLOUT", open("/dev/random", O_RDONLY),
+                    EPOLLOUT);
+    expect_accepted("/dev/random EPOLLIN|EPOLLOUT",
+                    open("/dev/random", O_RDONLY), EPOLLIN | EPOLLOUT);
+
+    /* Accepting the registration is only half of it: no knote can carry the
+     * readiness, so the wait has to answer from the registration itself. Linux
+     * reports the pool readable and never writable.
+     */
+    expect_ready("/dev/random reports EPOLLIN", "/dev/random", EPOLLIN,
+                 EPOLLIN);
+    expect_ready("/dev/random reports no EPOLLOUT", "/dev/random", EPOLLOUT, 0);
 
     /* A plain file has no poll method on Linux. A fifo opened by path does, and
      * so does /proc/self/mountinfo, which is a plain file to fstat: both are

--- a/tests/test-epoll-unsupported.c
+++ b/tests/test-epoll-unsupported.c
@@ -109,6 +109,30 @@ static void expect_op_errno(const char *label,
     close(fd);
 }
 
+/* Require the errno of one epoll_ctl against a target with no poll method, and
+ * the errno of the same call against a pollable one. Linux decides EPERM from
+ * the target before it validates either the op or the epoll descriptor, so the
+ * pair is what shows the ordering rather than a lucky single answer.
+ */
+static void expect_outranks_einval(const char *label, int epfd, int op)
+{
+    TEST(label);
+    int plain = open("/etc/hosts", O_RDONLY);
+    int pipefd[2];
+    if (plain < 0 || pipe(pipefd) != 0) {
+        FAIL("setup failed");
+        close(plain);
+        return;
+    }
+    struct epoll_event ev = {.events = EPOLLIN, .data.fd = plain};
+    bool eperm = epoll_ctl(epfd, op, plain, &ev) == -1 && errno == EPERM;
+    bool einval = epoll_ctl(epfd, op, pipefd[0], &ev) == -1 && errno == EINVAL;
+    EXPECT_TRUE(eperm && einval, "EPERM does not outrank this EINVAL");
+    close(pipefd[0]);
+    close(pipefd[1]);
+    close(plain);
+}
+
 static void expect_accepted(const char *label, int fd, uint32_t events)
 {
     TEST(label);
@@ -396,6 +420,25 @@ int main(void)
     }
     close(sysfd);
     close(regfd);
+
+    /* do_epoll_ctl tests file_can_poll before is_file_epoll and before the op
+     * switch, so a target with no poll method outranks both EINVALs this
+     * syscall would otherwise answer first.
+     */
+    {
+        int ep = epoll_create1(0);
+        int notep = open("/etc/hosts", O_RDONLY);
+        if (ep < 0 || notep < 0) {
+            TEST("EPERM outranks EINVAL");
+            FAIL("setup failed");
+        } else {
+            expect_outranks_einval("unknown op", ep, 99);
+            expect_outranks_einval("epfd is not an epoll fd", notep,
+                                   EPOLL_CTL_ADD);
+        }
+        close(ep);
+        close(notep);
+    }
 
     SUMMARY("test-epoll-unsupported");
     return fails > 0 ? 1 : 0;

--- a/tests/test-fork-ipc-protocol-host.c
+++ b/tests/test-fork-ipc-protocol-host.c
@@ -21,9 +21,10 @@
 #define PREVIOUS_ELFM_MAGIC 0x454C464DU
 #define PREVIOUS_ELFN_MAGIC 0x454C464EU
 #define PREVIOUS_ELFO_MAGIC 0x454C464FU
+#define PREVIOUS_ELFP_MAGIC 0x454C4650U
 
-_Static_assert(FORK_IPC_PROTOCOL_MAGIC == 0x454C4650U,
-               "fork IPC protocol magic must remain ELFP until the next "
+_Static_assert(FORK_IPC_PROTOCOL_MAGIC == 0x454C4651U,
+               "fork IPC protocol magic must remain ELFQ until the next "
                "incompatible wire-format change");
 _Static_assert(IPC_MAGIC_HEADER == FORK_IPC_PROTOCOL_MAGIC,
                "header magic must be the protocol identity");
@@ -37,6 +38,8 @@ _Static_assert(FORK_IPC_PROTOCOL_MAGIC != PREVIOUS_ELFN_MAGIC,
                "region fork metadata requires rejecting ELFN peers");
 _Static_assert(FORK_IPC_PROTOCOL_MAGIC != PREVIOUS_ELFO_MAGIC,
                "per-fd description ownership requires rejecting ELFO peers");
+_Static_assert(FORK_IPC_PROTOCOL_MAGIC != PREVIOUS_ELFP_MAGIC,
+               "the per-fd intercept marker requires rejecting ELFP peers");
 _Static_assert(IPC_MAGIC_SENTINEL != FORK_IPC_PROTOCOL_MAGIC,
                "process-state sentinel must not alias the header protocol");
 

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -754,6 +754,8 @@ run_unit_tests()
     test_check "$runner" "test-epoll-dup" "0 failed" "$bindir/test-epoll-dup"
     test_check "$runner" "test-epoll-refcount" "0 failed" \
         "$bindir/test-epoll-refcount"
+    test_check "$runner" "test-epoll-unsupported" "0 failed" \
+        "$bindir/test-epoll-unsupported"
     test_check "$runner" "test-timerfd" "0 failed" "$bindir/test-timerfd"
     test_rc "$runner" "test-eventfd-dup" 0 "$bindir/test-eventfd-dup"
     test_rc "$runner" "test-epoll-mt" 0 "$bindir/test-epoll-mt"

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -754,6 +754,8 @@ run_unit_tests()
     test_check "$runner" "test-epoll-dup" "0 failed" "$bindir/test-epoll-dup"
     test_check "$runner" "test-epoll-refcount" "0 failed" \
         "$bindir/test-epoll-refcount"
+    test_check "$runner" "test-epoll-del-leak" "0 failed" \
+        "$bindir/test-epoll-del-leak"
     test_check "$runner" "test-epoll-unsupported" "0 failed" \
         "$bindir/test-epoll-unsupported"
     test_check "$runner" "test-timerfd" "0 failed" "$bindir/test-timerfd"


### PR DESCRIPTION
## Summary

`sys_epoll_ctl` forwards macOS `kevent()` failures to the guest, and that disagrees with Linux in three directions at once.

Linux reads `EPERM` off the target file and nothing else, and it does so before it looks at the operation. A target with no poll method is refused whatever the event mask asks for and whatever the operation is; a target that never becomes writable still accepts `EPOLLOUT`.

kqueue refuses a knote on a directory or a character device with `EINVAL` rather than `EPERM`. It also refuses `EVFILT_WRITE` on a kqueue, and a guest timerfd and a guest epoll fd are both kqueues here, so `epoll_ctl(ADD, timerfd, EPOLLIN|EPOLLOUT)` failed where a real kernel returns 0. And in the other direction, kqueue accepts a knote on a plain file, which Linux refuses.

## What it changes for a guest

An event loop that registers a timerfd for both readiness directions used to get `EINVAL` and, on the common spelling, no timer at all. `epoll_ctl` on `/dev/null`, `/dev/zero`, a directory or a plain file now answers `EPERM` the way `epoll_ctl(2)` documents, for `ADD`, `MOD` and `DEL` alike, instead of `EINVAL` for `ADD` and `ENOENT` for the other two.

A mask that names no readiness filter at all -- `events = 0`, or `EPOLLET` on its own -- registers nothing and so used to ask kqueue nothing, which let a directory and `/dev/null` through. It consults the target directly now.

The batched changelist also leaked. `kevent()` stops at the first failed change, so a timerfd registered for `EPOLLIN|EPOLLOUT` left the read filter armed behind a call the guest was told had failed. Each filter is registered on its own now, and a refused write filter is dropped rather than failing the whole `ADD`, which matches a target Linux accepts but never reports writable.

## Why fstat cannot decide the plain-file half

The fd type cannot answer "is this a plain file": `FD_REGULAR` also covers a fifo, a socket or a tty opened by path, which `src/syscall/asyncio.c` already says in the `fd_keeps_fasync` comment. So the check asks the host object.

`fstat` alone is not enough either, and this is the part that took measuring. Several intercepted trees are served from ordinary host files: `/proc` from an anonymous temp file, `/sys/devices/system/cpu` and `/etc/mtab` from a scratch directory. Linux polls all three, so a rule keyed on `S_ISREG` refuses targets a real kernel accepts. An earlier revision of this branch did exactly that and regressed `/sys/devices/system/cpu/online` and `/etc/mtab` from 0 to `EPERM`.

The revision after it recorded one bit -- "this open went through an intercept" -- and exempted it from the plain-file rule. That bit is too coarse, because it conflates two groups Linux separates: `/proc/<pid>/mountinfo` is pollable and `/proc/<pid>/stat` is not, and both are ordinary host files here. So the fd table now records what Linux would actually answer, decided from the guest path by `path_intercept_poll_capable` and carried as `path_poll_capable`.

The split is not one a reader would guess from what the files contain. A per-process procfs file is opened through `proc_single_file_operations` and has no `->poll`, while every `proc_create` entry gets `proc_reg_poll` whether or not it has anything to report, which is why `/proc/meminfo` is accepted and `/proc/self/stat` is not. `/proc/<pid>/mounts`, `mountinfo` and the `/proc/<pid>/net` subtree are the exceptions inside the process directory; `mountstats` sitting next to them is not one. Every arm was measured against Linux 6.12 rather than read off the kernel source.

The classification lives beside `path_might_use_open_intercept` in `src/syscall/path.c` because the two enumerate the same surface: an intercept added to one without the other is a target answered from the wrong object.

The answer belongs to the open file description rather than to the name. It travels with the fd table across fork, an alias inherits it so that a dup and its source agree, and an opened magic link keeps what its source carried rather than being classified from `/proc/self/fd/N`, which is a per-process procfs path whatever it points at. The new fd table entry is on the fork IPC wire, so `FORK_IPC_PROTOCOL_MAGIC` moves `ELFP` to `ELFQ` and `tests/test-fork-ipc-protocol-host.c` gains the matching assertion. An old and a new host process can no longer fork to each other, which is what the magic exists to enforce.

## Why the probe knote is disabled

`epoll_target_pollable` exists because an `EPOLLOUT`-only `ADD` never asks kqueue about the read filter, so a refused write filter cannot otherwise be told from a target that takes no knote at all.

Its probe knote is added with `EV_DISABLE`, which is load bearing rather than tidiness. `sys_epoll_pwait` blocks in `kevent()` on this same kqueue without holding `inst->lock`, and an enabled probe on an already-ready target wakes that wait and hands it an event whose NULL `udata` reads back as guest fd 0, which `sys_epoll_pwait` then drops and returns 0 early with no retry. Measured on the host: with the probe enabled, a `kevent()` blocked for 2s on another thread returns after 300ms carrying `udata 0x0`; with `EV_DISABLE` it rides out the full 2s, and the probe still tells `/dev/null` and a directory (`EINVAL`) from a plain file and a kqueue (accepted).

## The DEL path leaked the same way (second commit)

The first revision of this branch listed the batched `EPOLL_CTL_DEL` under "what this does not fix", on the reading that the order of its two changes made it safe. That reading was wrong, and this branch is what makes it reachable.

`EPOLL_CTL_DEL` builds its changelist from `reg->events`, which names the filters the registration asked for rather than the filters kqueue still holds. The two diverge in two ways: `EPOLLONESHOT` removes only the filter that fired, and the `ADD` path above now drops a write filter the target refuses. So the first `EV_DELETE` is often for a filter that is already gone, `kevent()` stops there with `ENOENT`, and the deletes behind it never run.

The knote left behind wakes the next `epoll_pwait` on that instance with an event for an fd that is no longer registered, which the wait drops before returning 0 ahead of its timeout: the same spurious wakeup the disabled probe above avoids, reached through a different door.

Measured end to end on a socketpair whose send buffer is full, so the target is readable but not writable. With `EPOLLIN|EPOLLOUT|EPOLLONESHOT` registered, the read filter fires and `EV_ONESHOT` removes it, `DEL` then fails on the read delete and skips the write delete, and the `epoll_wait(300)` that follows returns after 0ms. Each delete goes in its own call now, the way `MOD` already did, and that wait rides out its full 300ms.

## What this does not fix

elfuse does not serve `/proc/<pid>/net` today, so that arm of the classification is unreachable here. It is present, and the comment above it says so, because the day the tree does serve it the rule would otherwise be silently wrong.

## Checks

Rebased on `d410047`. `2ab2139` and `3f488c5` moved the event copy to the top of `sys_epoll_ctl` and reordered the errors around it, so the plain-file test was rebased onto that shape and moved ahead of the `EEXIST` and `ENOENT` checks, which is where `do_epoll_ctl` reads the target's poll support. `tests/test-epoll.c`, 26 cases including the new error-order ones, passes under elfuse and under the reference kernel with this change on top.

`make check`, rc=0: 89 in the manifest suite, 7/7, 82/84 (the two skips need a raw socket and an interactive terminal), 27/27, 4/4, guardrail PASS.

`make check-format`, rc=0. `make indent`, a no-op. `make lint`, rc=0, with no new clang-tidy warning on a touched line.

`make test-matrix-elfuse-aarch64`, 270 passed, 0 failed. `make test-matrix-qemu-aarch64`, 249 passed, 0 failed.

`tests/test-epoll-del-leak.c` is three cases pinning the wait after a `DEL`. It is registered in both `tests/manifest.txt` and `tests/test-matrix.sh`, since the assertion is a timeout the reference kernel adjudicates as readily as elfuse does. On the build without the `DEL` change its third case fails, the wait returning after 0ms instead of 300ms.

`tests/test-epoll-unsupported.c` is 57 cases and produces byte-identical output under elfuse and under `qemu-system-aarch64` running the fixtures' Linux 6.12 kernel. It is registered in `tests/test-matrix.sh` rather than `tests/manifest.txt`, since a real kernel can adjudicate it. Reverting only the `src/` changes turns 20 of its assertions red, so the cases pin the change rather than restating it.

Beyond the suite, a probe over timerfd, eventfd, a nested epoll fd, a pipe, a socket, a plain file, a fifo opened by path, a directory, character devices, opened magic links, and forty-four paths under `/proc`, `/sys` and `/etc`, against `EPOLLIN`, `EPOLLOUT`, both, an empty mask, and all three operations, answers identically under elfuse and the reference kernel.

Fifteen of those paths disagreed before this change: `/etc/passwd`, `/etc/group`, `/proc/<pid>/stat` in its numeric spelling, `/proc/self/fdinfo/0`, and `stat`, `status`, `maps`, `smaps`, `cmdline`, `environ`, `auxv`, `io`, `limits`, `oom_score` and `oom_score_adj` under `/proc/self`. None of them is refused wrongly now, and no target the reference kernel accepts became refused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decides EPERM in epoll_ctl from the target alone to match Linux. Previously we forwarded kqueue errors and rejected EPOLLOUT on timerfd/nested epoll; now unsupported targets return EPERM for ADD/MOD/DEL, EPOLLOUT on timerfd/nested epoll is accepted, and partial registrations and deletes no longer leak.

- Plain files and other non-pollable fds return EPERM; intercepted opens record a path_poll_capable flag and carry it across dup and fork.
- Unregistered MOD/DEL return ENOENT only for pollable targets; non-pollable targets return EPERM.
- An empty or non-readiness mask consults the target and returns EPERM on unsupported fds.
- Read/write filters register via separate kevent calls; a refused write filter is dropped; EINVAL on the read filter (or when no knote is accepted) maps to EPERM.
- EPOLL_CTL_DEL deletes each filter in its own kevent call and ignores delete errors, so leftover knotes no longer wake epoll_pwait.
- Adds a disabled-read probe to detect unsupported targets without waking sys_epoll_pwait.
- Adds tests/tests-epoll-unsupported.c and tests/test-epoll-del-leak.c; wires them into tests/test-matrix.sh and manifest.

**Migration**
- Bumps fork IPC protocol magic to ELFQ; mixed old/new processes are incompatible. Upgrade all components together.

<sup>Written for commit 2548742d930360a3cf93ed1bd942b79c1e579b84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

