### PR TITLE
Add Unicode box-drawing diagrams in comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,12 +146,29 @@ A patch written in a style foreign to its surroundings costs the reviewer more t
 author.
 
 Three project-wide rules that no formatter will fix for you:
-* Source comments and commit messages are ASCII only.
-  No em dashes, no typographic quotes, no non-ASCII arrows.
-  Write `-`, `--`, or `:` instead, and drop the markdown: inside a comment a symbol or path is
-  written bare, as EPOLL_CTL_MOD or tests/foo.c, not wrapped in backticks.
+* Comment prose and commit messages are ASCII only. The one thing that is not prose, a diagram, is
+  the one exception, and it is spelled out below.
+  No em dashes, no typographic quotes, and no non-ASCII arrows outside a diagram.
+  Reword an em dash away with a comma, a colon, parentheses, or two sentences.
+  A spaced `--` carries the em dash's register rather than replacing it, and a bare `-` joining two
+  clauses does the same, so reach for the rewording first.
+  Both stay legal and neither earns a review comment on its own, but prose leaning on them has
+  disguised the em dash rather than removed it.
+  Drop the markdown as well: inside a comment a symbol or path is written bare, as EPOLL_CTL_MOD or
+  tests/foo.c, not wrapped in backticks.
   This governs what goes into a `.c`, `.h`, or `.S` file and into a commit message.
   Markdown documents, this one included, use ordinary markdown.
+
+  The exception, in full: a diagram drawn inside a comment may use the Unicode box-drawing block
+  (U+2500 to U+257F), plus the geometric arrowhead that terminates an edge, of which the diagrams in
+  this tree use one, U+25BE.
+  A flow or a layout a reader has to see is worth more than the byte width of its borders, and those
+  glyphs have corners, junctions, and arrowheads that `+`, `-`, and `|` only approximate.
+  The exception covers the picture and nothing else.
+  The sentence introducing it, and every other comment in the file, stay ASCII, and a commit message
+  has no exception at all.
+  Draw the whole picture in one charset rather than mixing the two, and keep it inside the column
+  limit like any other comment.
 * Comments use `/* ... */` exclusively.
   `//` never appears, not even for a single line.
 * Filenames use kebab-case (`proc-state.c`), identifiers use snake_case (`proc_state`).
@@ -213,9 +230,9 @@ A labelled pair such as `Usage:` and `Example:` needs a blank comment line betwe
 the reflow reads them as one paragraph and splices the two commands onto a single line.
 
 What it will not touch, so you can still lay these out by hand: blank lines inside a comment, the
-existing indentation, a preformatted region (a table, an ASCII diagram, a code fence), an SPDX
+existing indentation, a preformatted region (a table, a diagram, a code fence), an SPDX
 identifier, and a tool directive such as `clang-format off`.
-An ASCII diagram of a race window or a byte layout survives the reflow intact.
+A diagram of a race window or a byte layout survives the reflow intact.
 
 Single-line comments should be written in C89 style:
 ```c

--- a/src/main.c
+++ b/src/main.c
@@ -220,6 +220,12 @@ static int host_dc_zva_assert(void)
 #define ELFUSE_USAGE ELFUSE_USAGE_BODY(" ")
 #define ELFUSE_USAGE_WRAPPED ELFUSE_USAGE_BODY("\n              ")
 
+/* Over the function-size limit on purpose.
+ *
+ * Option parsing: one flag per arm, no shared state between them. Splitting
+ * trades a flat table for a dozen one-caller helpers and a struct to thread the
+ * results through.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int main(int argc, char **argv)
 {
@@ -652,9 +658,9 @@ int main(int argc, char **argv)
             goto cleanup;
         }
 
-        /* The current path is a script. Bound the resolution chain only once a
-         * further shebang is confirmed, so a max-depth chain ending in a real
-         * ELF still boots (matches sys_execve and the Linux kernel).
+        /* Bound the resolution chain only once a further shebang is confirmed,
+         * so a max-depth chain ending in a real ELF still boots (matches
+         * sys_execve and the Linux kernel).
          */
         if (shebang_depth >= ELF_SHEBANG_MAX_DEPTH) {
             log_error(

--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -8,6 +8,33 @@
  * Implements clone via posix_spawn + IPC state transfer. macOS HVF allows only
  * one VM per process, so fork spawns a new elfuse process and serializes the
  * full VM state (registers, memory, FDs) over a socketpair.
+ *
+ * Registers and the fd table are small. Guest memory is not, and how it crosses
+ * is the whole cost of a fork:
+ *
+ *                      ┌──────────────┐
+ *                      │ guest memory │
+ *                      └──────────────┘
+ *              ┌──────────────┘ └──────────┐
+ *              │                           │
+ *   ┌──────────▾─────────┐   ┌─────────────▾─────────────┐
+ *   │ no shm fd: copy it │   │ shm fd: try an APFS clone │
+ *   └────────────────────┘   └───────────────────────────┘
+ *                    ┌────────────────────┘ │
+ *                    │                      │
+ *        ┌───────────▾──────────┐   ┌───────▾──────┐
+ *        │ cloned: send that fd │   │ clone failed │
+ *        └──────────────────────┘   └──────────────┘
+ *              ┌───────────────────────────┘ │
+ *              │                             │
+ *              │                          ┌──┘
+ *    ┌─────────▾────────┐   ┌─────────────▾────────────┐
+ *    │ Rosetta: copy it │   │ native: send the live fd │
+ *    └──────────────────┘   └──────────────────────────┘
+ *
+ * What each branch costs, and why the two fallbacks are not interchangeable, is
+ * at the CoW block in sys_clone where the choice is made.
+ * tests/bench-fork-cost.sh is what measures it on a given host.
  */
 
 #include <stdbool.h>
@@ -82,6 +109,12 @@ void fork_notify_vfork_exec(void)
     fork_child_vfork_notify_fd = -1;
 }
 
+/* Over the function-size limit on purpose.
+ *
+ * The child's whole bring-up in receive order, and the order is the contract:
+ * every step depends on the one before it, and the rollback on failure differs
+ * per step. Splitting hides which stage a failure came from.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int fork_child_main(int ipc_fd,
                     int vfork_notify_fd,
@@ -300,6 +333,11 @@ int fork_child_main(int ipc_fd,
      * needs to recognize the slave fds inherited from the parent and put them
      * back on the books. Without it the parent's close of its own copy makes
      * the pty look hung up while this child still holds a live slave.
+     *
+     * From here on every bail gives the credit back before destroying the
+     * guest. Nothing below reaches the teardown that normally returns it, and a
+     * child that never runs must not leave the pty looking busy to the master
+     * the parent still holds.
      */
     proc_pty_adopt_inherited_slaves();
 
@@ -307,11 +345,6 @@ int fork_child_main(int ipc_fd,
     if (fork_ipc_recv_process_state(ipc_fd, &g, &sig) < 0) {
         log_error("fork-child: failed to receive process state");
 
-        /* Give back the credit the parent added for this child before bailing:
-         * nothing here reaches the teardown that normally returns it, and a
-         * child that never runs must not leave the pty looking busy to the
-         * master the parent still holds.
-         */
         proc_pty_release_process_slaves();
         guest_destroy(&g);
         return 1;
@@ -320,11 +353,6 @@ int fork_child_main(int ipc_fd,
     if (chown_overlay_recv(ipc_fd) < 0) {
         log_error("fork-child: failed to receive chown overlay");
 
-        /* Give back the credit the parent added for this child before bailing:
-         * nothing here reaches the teardown that normally returns it, and a
-         * child that never runs must not leave the pty looking busy to the
-         * master the parent still holds.
-         */
         proc_pty_release_process_slaves();
         guest_destroy(&g);
         return 1;
@@ -341,11 +369,6 @@ int fork_child_main(int ipc_fd,
         admission_ready != 1) {
         log_error("fork-child: parent did not commit child admission");
 
-        /* Give back the credit the parent added for this child before bailing:
-         * nothing here reaches the teardown that normally returns it, and a
-         * child that never runs must not leave the pty looking busy to the
-         * master the parent still holds.
-         */
         proc_pty_release_process_slaves();
         guest_destroy(&g);
         return 1;
@@ -401,11 +424,7 @@ int fork_child_main(int ipc_fd,
      * the single-threaded child at this point).
      */
     if (shim_globals_install_per_vcpu(vcpu, &g, hdr.child_pid) < 0) {
-        /* Give back the credit the parent added for this child before bailing:
-         * nothing here reaches the teardown that normally returns it, and a
-         * child that never runs must not leave the pty looking busy to the
-         * master the parent still holds.
-         */
+        /* Give the pty credit back, as every bail below the adopt does. */
         proc_pty_release_process_slaves();
         guest_destroy(&g);
         return 1;
@@ -1489,6 +1508,12 @@ static int fork_snapshot_shm_via_clonefile(int src_fd)
     return clone_fd;
 }
 
+/* Over the function-size limit on purpose.
+ *
+ * One transaction. The failure paths unwind state established earlier in the
+ * same function (quiesced siblings, promoted overlays, the snapshot fd), so the
+ * goto ladder has to see all of it.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_clone(hv_vcpu_t vcpu,
                   guest_t *g,

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -2267,6 +2267,11 @@ static int proc_open_mounts_node(const char *path)
     return PROC_NOT_INTERCEPTED;
 }
 
+/* Over the function-size limit on purpose.
+ *
+ * One arm per intercepted /proc, /sys and /dev path. The arms share only the
+ * guest and the buffer, so a split would be a jump table by another name.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int proc_intercept_open(const guest_t *g,
                         const char *path,

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -48,10 +48,6 @@
 #include "syscall/proc.h"
 #include "syscall/signal.h"
 
-/* fd_cleanup_entry() releases type-specific fd resources after the CLOEXEC
- * entry has been removed from the shared fd table.
- */
-
 /* Force HVF to commit the sysreg/GPR writes that sys_execve performs after a
  * guest_reset before vcpu_run resumes. HVF defers writes until the next
  * register-touch on the owning thread, and a stale read here is harmless. Use
@@ -705,9 +701,40 @@ static int64_t exec_preload_interp(const guest_t *g,
  * One slot, because two threads racing to replace the same image have no
  * meaningful joint outcome: the second waits for the first, and if the first
  * succeeded the second never wakes as a running thread (de_thread reaps it).
- * Linux serializes the same window on cred_guard_mutex. EMPTY -> PUBLISHED ->
- * TAKEN -> (EMPTY on success, DONE on failure). A successful exec never reaches
- * DONE: the requester is reaped by de_thread and has no one to report to.
+ * Linux serializes the same window on cred_guard_mutex.
+ *
+ *             ┌───────┐
+ *             │ EMPTY │
+ *             └───────┘
+ *                 │
+ *           ┌─────▾─────┐
+ *           │ PUBLISHED │
+ *           └───────────┘
+ *                 │
+ *             ┌───▾───┐
+ *             │ TAKEN │
+ *             └───────┘
+ *       ┌────────┘ └────┐
+ *       │               │
+ *   ┌───▾──┐   ┌────────▾────────┐
+ *   │ DONE │   │ leader frees it │
+ *   └──────┘   └─────────────────┘
+ *       └──────────┐
+ *                  │
+ *       ┌──────────▾─────────┐
+ *       │ requester frees it │
+ *       └────────────────────┘
+ *
+ * The leader runs the whole of sys_execve on its own vCPU. A successful exec
+ * never reaches DONE, because the requester is reaped by de_thread and has no
+ * one to report to, so the leader clears the slot itself. A failure before the
+ * point of no return posts its result in DONE, and the requester clears the
+ * slot once it has read it.
+ *
+ * One edge back to EMPTY is not drawn above: the requester copies host_path
+ * into the slot after publishing, so a name that does not fit withdraws its own
+ * request and answers ENAMETOOLONG without a leader ever seeing it. The leader
+ * tolerates that flap because it re-checks the state under the lock.
  */
 typedef enum {
     HANDOFF_EMPTY = 0,
@@ -1255,6 +1282,12 @@ static void exec_enter_new_image(hv_vcpu_t vcpu,
     exec_sync_vcpu_regs(vcpu);
 }
 
+/* Over the function-size limit on purpose.
+ *
+ * The point of no return runs through the middle of it. Before PNR every exit
+ * restores the old image; after it there is no exit but the fatal one. A split
+ * would put that boundary at a call edge, where it is invisible.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_execve(hv_vcpu_t vcpu,
                    guest_t *g,
@@ -1462,12 +1495,11 @@ int64_t sys_execve(hv_vcpu_t vcpu,
         if (rc == 0)
             break;
 
-        /* The file at the current path is a shebang script. */
         exec_is_script = true;
 
-        /* The current path is a script. Bound the resolution chain only once a
-         * further shebang is confirmed, so a max-depth chain ending in a real
-         * ELF still loads (matches the prior elf_load-first loop).
+        /* Bound the resolution chain only once a further shebang is confirmed,
+         * so a max-depth chain ending in a real ELF still loads (matches the
+         * prior elf_load-first loop).
          */
         if (shebang_depth >= ELF_SHEBANG_MAX_DEPTH) {
             err = -LINUX_ELOOP;

--- a/src/syscall/fuse.c
+++ b/src/syscall/fuse.c
@@ -3,6 +3,44 @@
  *
  * Copyright 2026 elfuse contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Both ends of the FUSE protocol live inside the guest VM, so a guest libfuse
+ * program works with no macFUSE, FUSE-T or FSKit on the host. What a real
+ * kernel would put in its /dev/fuse queue this file puts in a per-session one,
+ * and the daemon on the other side is an ordinary guest process reading and
+ * writing that character device through the usual syscall path.
+ *
+ * One request, end to end:
+ *
+ *                        ┌───────────────┐
+ *                        │ guest syscall │
+ *                        └───────────────┘
+ *                                └┐
+ *                                 │
+ *                       ┌─────────▾────────┐
+ *                       │ queue, then wait │
+ *                       └──────────────────┘
+ *            ┌──────────────────┘ └┐└──────────────────┐
+ *            │                     │                   │
+ *   ┌────────▾────────┐   ┌────────▾───────┐   ┌───────▾───────┐
+ *   │ daemon reads it │   │ gone: ENOTCONN │   │ signal: EINTR │
+ *   └─────────────────┘   └────────────────┘   └───────────────┘
+ *            └──────────┐
+ *                       │
+ *              ┌────────▾───────┐
+ *              │ daemon replies │
+ *              └────────────────┘
+ *                       └─────────┐
+ *                                 │
+ *                         ┌───────▾──────┐
+ *                         │ waiter wakes │
+ *                         └──────────────┘
+ *
+ * The frame carries a unique the daemon echoes back, which is how a reply finds
+ * its waiter; a request is answered exactly once and the waiter owns the copy
+ * it takes away. The two ways a wait ends without a reply are documented at
+ * fuse_request_locked, which is where they are decided, and the two locks this
+ * file takes are placed in the order at the top of syscall/internal.h.
  */
 
 #include <errno.h>
@@ -947,12 +985,19 @@ static int fuse_send_init_locked(fuse_session_t *session)
  * Returns 0 on success, or a negative Linux errno on failure. The caller must
  * hold session->lock.
  *
- * Known limitation: the wait uses a plain pthread_cond_wait, so a signal
- * delivered to a blocked consumer does not return -EINTR and does not emit a
- * FUSE_INTERRUPT frame to the daemon. Honoring SA_RESTART and emitting
- * FUSE_INTERRUPT requires integrating with the per-thread signal eventfd and
- * remains a deferred compatibility item. Until then, daemon death or session
- * close are the only paths that wake a blocked consumer.
+ * The wait is a short timed wait rather than a plain cond wait, because a
+ * pending guest signal is not something this condvar is ever signalled on: the
+ * quantum is what gives the loop a chance to look. Which signals end it, and
+ * why the restartable ones do not, is at the check itself.
+ *
+ * The other way it ends without a reply is the daemon going away: session close
+ * and daemon death both break the loop condition, and the tail reports
+ * -ENOTCONN for a request no reply can now reach.
+ *
+ * A request that does end that way is detached rather than freed, because the
+ * daemon may still answer it and the reply needs somewhere to land. Detachment
+ * has no other cause, and a request carrying it is the only one this function
+ * leaves alive; every other one is freed here before returning.
  */
 static int fuse_request_locked(fuse_session_t *session,
                                uint32_t opcode,

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -23,6 +23,31 @@
  * fuse_lock is always dropped before the session lock is used that way, so the
  * two claims do not meet.
  *
+ * That path, in acquisition order:
+ *
+ *            ┌───────────┐
+ *            │ fuse_lock │
+ *            └───────────┘
+ *                  │
+ *   ┌──────────────▾──────────────┐
+ *   │ pin session, drop fuse_lock │
+ *   └─────────────────────────────┘
+ *                  └┐
+ *                   │
+ *           ┌───────▾──────┐
+ *           │ session lock │
+ *           └──────────────┘
+ *          ┌───────┘ └────┐
+ *          │              │
+ *     ┌────▾────┐   ┌─────▾────┐
+ *     │ fd_lock │   │ sig_lock │
+ *     └─────────┘   └──────────┘
+ *
+ * cwd_lock is not drawn above it. It nests fuse_lock beneath it on the one path
+ * that pairs them, and fuse_path_matches_mount drops fuse_lock before returning
+ * into the cwd view, so cwd_lock is released before any session is pinned and
+ * never reaches the rest of this chain.
+ *
  * The numbered "Lock order: N" comments at the definitions predate this list
  * and are not indices into it. This list is the document; a number there says
  * only which locks that one was known to precede when it was written.

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -412,10 +412,9 @@ static bool io_eagain_should_wait(const fd_block_state_t *st, int host_fd)
  * alone. Everything else relies on elfuse owning O_NONBLOCK on the host fd
  * (fd_init_entry); macOS has no per-call equivalent for a pipe and no private
  * open file description to borrow either, since dup shares the status flags
- * (measured) and a pipe has no path to reopen. The one kind of fd elfuse does
- * not own is inherited stdio, where this blocks: the loop above it goes round
- * again only if a host signal truncated the transfer, which is the residual
- * parking window for those three descriptors.
+ * (measured) and a pipe has no path to reopen. On a description elfuse does not
+ * own (io.h names which) this blocks, and the loop above goes round again only
+ * if a host signal truncated the transfer.
  */
 static ssize_t io_xfer_once(int host_fd,
                             bool is_socket,
@@ -2559,6 +2558,11 @@ int64_t sys_process_vm_writev(guest_t *g,
 
 /* terminal I/O. */
 
+/* Over the function-size limit on purpose.
+ *
+ * A dispatch switch: one arm per request code, arms independent. The length is
+ * the ioctl surface, not nesting.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
 {

--- a/src/syscall/io.h
+++ b/src/syscall/io.h
@@ -83,16 +83,36 @@ int64_t io_wait_fd_timed_or_interrupted(int host_fd,
  * moved, which is what a blocking write(2) promises, and reports the partial
  * count when a signal arrives with bytes already gone.
  *
- * Two kinds of fd fall outside the no-parking guarantee, and a caller relying
- * on it during exec teardown has to know which. A socket transfers with
- * MSG_DONTWAIT, which macOS ignores for AF_UNIX sends, so a send into a full
- * buffer blocks in the kernel. Inherited stdio is a description elfuse does not
- * own, so its transfer is a plain blocking read or write. Everything else
- * elfuse owns O_NONBLOCK on and cannot park here.
+ * Which order the wait and the transfer run in is decided once, at the top,
+ * from the pinned state:
+ *
+ *                                ┌────────┐
+ *                                │ the fd │
+ *                                └────────┘
+ *             ┌─────────────────────┘ │ └────────────────┐
+ *             │                       │                  │
+ *             │                   ┌───┘                  │
+ *     ┌───────▾──────┐   ┌────────▾───────┐   ┌──────────▾──────────┐
+ *     │ cannot block │   │ elfuse owns it │   │ elfuse does not own │
+ *     └──────────────┘   └────────────────┘   └─────────────────────┘
+ *             │                   │                      └──┐
+ *             │                   │                         │
+ *           ┌─┘                   │                         │
+ *   ┌───────▾──────┐   ┌──────────▾──────────┐   ┌──────────▾──────────┐
+ *   │ one transfer │   │ transfer, then wait │   │ wait, then transfer │
+ *   └──────────────┘   └─────────────────────┘   └─────────────────────┘
+ *
+ * That last branch is the whole of the residual parking window, and a caller
+ * relying on the guarantee during exec teardown has to know which fds reach it:
+ * inherited stdio, whose open file description belongs to the launching
+ * process, and an SCM_RIGHTS arrival that was not already nonblocking.
+ * Everything else elfuse owns the flag on, sockets included. io_xfer itself
+ * says why the order differs per branch.
  *
  * events picks the direction: POLLIN reads, POLLOUT writes. iov is scratch the
- * caller owns, and a partial write rewrites it. Regular files, fds the guest
- * set nonblocking, and direction mismatches transfer straight through.
+ * caller owns, and a partial write rewrites it. Beyond the left branch above,
+ * an fd the guest set nonblocking and a direction mismatch also come back in
+ * one transfer, having never reached the wait.
  *
  * Returns 0 with *out set to the raw host result (errno live when it is -1), or
  * a negative Linux errno, in which case nothing moved and iov is untouched: the

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -888,6 +888,12 @@ static bool high_va_replaceable_gpa_base(guest_t *g,
     return true;
 }
 
+/* Over the function-size limit on purpose.
+ *
+ * The Rosetta high-VA mapping loop plus its rollback, which has to undo page
+ * tables installed by the loop it follows. The two cannot be separated without
+ * publishing the in-flight block state.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 static int64_t sys_mmap_high_va(guest_t *g,
                                 uint64_t addr,
@@ -2723,6 +2729,12 @@ static void mmap_fresh_dispose(mmap_fresh_t *fresh)
     errno = saved_errno;
 }
 
+/* Over the function-size limit on purpose.
+ *
+ * Flag combinations, not steps: MAP_FIXED, MAP_SHARED, the file-backed overlay
+ * and the anonymous path each qualify the others. Splitting by flag duplicates
+ * the interactions between them.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_mmap(guest_t *g,
                  uint64_t addr,
@@ -3499,6 +3511,11 @@ int64_t sys_mmap(guest_t *g,
 
 /* sys_mremap. */
 
+/* Over the function-size limit on purpose.
+ *
+ * Same shape as sys_mmap, with the grow-in-place and move cases sharing one
+ * rollback of the region table.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_mremap(guest_t *g,
                    uint64_t old_addr,

--- a/src/syscall/net-msg.c
+++ b/src/syscall/net-msg.c
@@ -461,6 +461,12 @@ static size_t msg_iov_total(const struct iovec *iov, int iovcnt)
     return total;
 }
 
+/* Over the function-size limit on purpose.
+ *
+ * The msghdr round trip: read the guest structure, transfer, then write back
+ * name, control and flags. The write-back has to see what the read established,
+ * and the SCM_RIGHTS arm has to unwind fds it installed.
+ */
 /* NOLINTNEXTLINE(readability-function-size) */
 int64_t sys_recvmsg(guest_t *g, int fd, uint64_t msg_gva, int flags)
 {

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -142,6 +142,55 @@ static inline int path_component_copy(char *dst,
 bool path_might_use_open_intercept(const char *path);
 bool path_might_use_stat_intercept(const char *path);
 int path_check_intercept_access(const struct stat *st, int mode, int flags);
+
+/* Resolve a guest path against dirfd into every spelling a syscall handler
+ * needs, and fill tx with them.
+ *
+ * This is the one place a guest name becomes a host name. A handler that
+ * reaches the host with a path it assembled itself has bypassed the sysroot
+ * redirect and the containment check together.
+ *
+ *                         ┌────────────┐
+ *                         │ guest path │
+ *                         └────────────┘
+ *                                │
+ *                    ┌───────────▾──────────┐
+ *                    │ proc or FUSE rewrite │
+ *                    └──────────────────────┘
+ *           ┌──────────────────┘ │ └─────────────────┐
+ *           │                    │                   │
+ *           │                   ┌┘                   │
+ *   ┌───────▾──────┐   ┌────────▾────────┐   ┌───────▾───────┐
+ *   │ dev/shm leaf │   │ sysroot resolve │   │ fd magic link │
+ *   └──────────────┘   └─────────────────┘   └───────────────┘
+ *           │                   └┐                   └─┐
+ *           │                    │                     │
+ *          ┌┘                    │                     │
+ *   ┌──────▾──────┐   ┌──────────▾──────────┐   ┌──────▾──────┐
+ *   │ backing dir │   │ containment recheck │   │ the fd path │
+ *   └─────────────┘   └─────────────────────┘   └─────────────┘
+ *                                │
+ *                        ┌───────▾───────┐
+ *                        │ casefold walk │
+ *                        └───────────────┘
+ *
+ * tx carries three spellings and they are not interchangeable. guest_path is
+ * what the guest asked for, after the /proc and FUSE rewrites; intercept_path
+ * is what the synthetic-filesystem intercepts match against; host_path is what
+ * reaches a macOS syscall. Only host_path moves down the pipeline.
+ *
+ * The two side arms return with host_path already final, skipping sysroot
+ * resolution deliberately rather than by omission; each says why where it is
+ * taken. flags choose which sysroot resolver runs (create, nofollow, or
+ * follow), and the same choice decides whether the casefold walk follows its
+ * final component. The last two steps run for a relative path only: an absolute
+ * one was already contained by the resolver and has no dirfd to be measured
+ * against.
+ *
+ * Returns 0 with tx filled, or -1 with errno set. A NULL path is not an error;
+ * every spelling comes back NULL and the caller's own AT_EMPTY_PATH handling
+ * decides what that means.
+ */
 int path_translate_at(guest_fd_t dirfd,
                       const char *path,
                       unsigned int flags,

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1367,10 +1367,6 @@ int64_t sys_epoll_create1(int flags)
 
 int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 {
-    /* Linux returns EINVAL when trying to add an epoll fd to itself */
-    if (fd == epfd)
-        return -LINUX_EINVAL;
-
     host_fd_ref_t epoll_ref;
     int64_t ref_err = host_fd_ref_open(epfd, &epoll_ref);
     if (ref_err < 0)
@@ -1398,6 +1394,42 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     fd_entry_t target_snap;
     if (!fd_snapshot(fd, &target_snap)) {
         ret = -LINUX_EBADF;
+        goto out;
+    }
+
+    /* Everything Linux decides before it looks at the op, in its order, all of
+     * it measured against Linux 6.18 rather than read off the source.
+     *
+     * The event copy comes first because `ep_op_has_event(op)` is `op !=
+     * EPOLL_CTL_DEL`, which is true for an unknown op too: epoll_ctl(ep, 99,
+     * fd, NULL) and epoll_ctl(ep, 99, fd, (void *) 1) are both EFAULT, not
+     * EINVAL. Testing the pointer for NULL instead of copying gets the first
+     * right and the second wrong. DEL reads no event, so a null pointer there
+     * is not an error.
+     *
+     * Then the unknown op. Without this the arms below test DEL, then ADD, then
+     * MOD, and any other value fell past all three into the registration path
+     * and armed a knote.
+     *
+     * Then the pairing. All three sit after the two snapshots above because
+     * Linux answers EBADF for either descriptor before any of this:
+     * epoll_ctl(-1, ADD, -1, &ev) is EBADF and not EINVAL, which is what the
+     * check that used to open this function got wrong.
+     */
+    linux_epoll_event_t ev_in;
+    bool have_ev_in = (op != LINUX_EPOLL_CTL_DEL);
+    if (have_ev_in &&
+        guest_read_small(g, event_gva, &ev_in, sizeof(ev_in)) < 0) {
+        ret = -LINUX_EFAULT;
+        goto out;
+    }
+    if (op != LINUX_EPOLL_CTL_ADD && op != LINUX_EPOLL_CTL_DEL &&
+        op != LINUX_EPOLL_CTL_MOD) {
+        ret = -LINUX_EINVAL;
+        goto out;
+    }
+    if (fd == epfd) {
+        ret = -LINUX_EINVAL;
         goto out;
     }
     int target_host_fd = target_snap.host_fd;
@@ -1469,12 +1501,12 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         goto out_locked;
     }
 
-    /* ADD or MOD: read the epoll_event from guest */
-    linux_epoll_event_t ev;
-    if (guest_read_small(g, event_gva, &ev, sizeof(ev)) < 0) {
-        ret = -LINUX_EFAULT;
-        goto out_locked;
-    }
+    /* Copied above, in the order Linux copies it. Reading it a second time here
+     * would let a sibling change the value between the fault check and the
+     * registration, and would report EFAULT after the EEXIST and ENOENT checks
+     * that Linux answers it before.
+     */
+    linux_epoll_event_t ev = ev_in;
 
     /* For MOD, remove old registrations first if they exist in kqueue.
      * EPOLLRDHUP alone registers EVFILT_READ (see ADD path), so check both

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1367,6 +1367,22 @@ int64_t sys_epoll_create1(int flags)
 
 int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
 {
+    /* The event is copied before anything else, because that is where the
+     * kernel copies it. SYSCALL_DEFINE4(epoll_ctl) runs the copy_from_user in
+     * the syscall wrapper and returns EFAULT there, before do_epoll_ctl reaches
+     * either fdget, so an unreadable event outranks a bad descriptor for every
+     * op that reads one. Measured against Linux 6.18: epoll_ctl(-1, ADD, fd,
+     * (void *) 1) is EFAULT, not EBADF.
+     *
+     * ep_op_has_event(op) is op != EPOLL_CTL_DEL, so an unknown op copies too,
+     * and DEL reads nothing: epoll_ctl(-1, DEL, -1, (void *) 1) is the one call
+     * in that family that answers EBADF.
+     */
+    linux_epoll_event_t ev_in;
+    if (op != LINUX_EPOLL_CTL_DEL &&
+        guest_read_small(g, event_gva, &ev_in, sizeof(ev_in)) < 0)
+        return -LINUX_EFAULT;
+
     host_fd_ref_t epoll_ref;
     int64_t ref_err = host_fd_ref_open(epfd, &epoll_ref);
     if (ref_err < 0)
@@ -1397,32 +1413,16 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
         goto out;
     }
 
-    /* Everything Linux decides before it looks at the op, in its order, all of
-     * it measured against Linux 6.18 rather than read off the source.
+    /* The op and the pairing, in that order and here rather than at the top,
+     * because the kernel decides both inside do_epoll_ctl after both fdgets:
+     * epoll_ctl(-1, 99, fd, &ev) is EBADF, not EINVAL.
      *
-     * The event copy comes first because `ep_op_has_event(op)` is `op !=
-     * EPOLL_CTL_DEL`, which is true for an unknown op too: epoll_ctl(ep, 99,
-     * fd, NULL) and epoll_ctl(ep, 99, fd, (void *) 1) are both EFAULT, not
-     * EINVAL. Testing the pointer for NULL instead of copying gets the first
-     * right and the second wrong. DEL reads no event, so a null pointer there
-     * is not an error.
-     *
-     * Then the unknown op. Without this the arms below test DEL, then ADD, then
-     * MOD, and any other value fell past all three into the registration path
-     * and armed a knote.
-     *
-     * Then the pairing. All three sit after the two snapshots above because
-     * Linux answers EBADF for either descriptor before any of this:
-     * epoll_ctl(-1, ADD, -1, &ev) is EBADF and not EINVAL, which is what the
-     * check that used to open this function got wrong.
+     * Without the op check the arms below test DEL, then ADD, then MOD, and any
+     * other value fell past all three into the registration path and armed a
+     * knote. The pairing check used to open this function, ahead of both
+     * lookups, which made epoll_ctl(-1, ADD, -1, &ev) answer EINVAL where the
+     * kernel answers EBADF.
      */
-    linux_epoll_event_t ev_in;
-    bool have_ev_in = (op != LINUX_EPOLL_CTL_DEL);
-    if (have_ev_in &&
-        guest_read_small(g, event_gva, &ev_in, sizeof(ev_in)) < 0) {
-        ret = -LINUX_EFAULT;
-        goto out;
-    }
     if (op != LINUX_EPOLL_CTL_ADD && op != LINUX_EPOLL_CTL_DEL &&
         op != LINUX_EPOLL_CTL_MOD) {
         ret = -LINUX_EINVAL;

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -3816,6 +3816,11 @@ static bool vcpu_handle_el0_fault(guest_t *g,
  *
  * Both modes check proc_exit_group_requested so the main thread also reacts to
  * exit_group called by a worker.
+ *
+ * Over the function-size limit on purpose: the HVC dispatch is one arm per call
+ * number. This is also the deepest nest in the tree at eight levels, which is
+ * worth knowing, because the depth is a switch inside a loop inside the
+ * leader/worker split rather than logic layered on logic.
  */
 /* NOLINTNEXTLINE(readability-function-size) */
 int vcpu_run_loop_with_hooks(hv_vcpu_t vcpu,

--- a/src/syscall/signal.c
+++ b/src/syscall/signal.c
@@ -12,6 +12,30 @@
  * handler eventually calls rt_sigreturn (SYS 139), which restores the saved
  * register state from the frame.
  *
+ * Three paths here rebuild EL0 register state behind the guest's back, and each
+ * has to answer the same question: does the EL1 shim still hold a saved GPR
+ * frame that would overwrite the rebuild on ERET?
+ *
+ *                         ┌────────────────────┐
+ *                         │ rebuilds EL0 state │
+ *                         └────────────────────┘
+ *              ┌───────────────────┘ └┐└────────────────────┐
+ *              │                      │                     │
+ *   ┌──────────▾──────────┐   ┌───────▾──────┐   ┌──────────▾─────────┐
+ *   │ signal in a syscall │   │ rt_sigreturn │   │ signal at bare EL0 │
+ *   └─────────────────────┘   └──────────────┘   └────────────────────┘
+ *              └─────────┐ ┌──────────┘           ┌─────────┘
+ *                        │ │                      │
+ *              ┌─────────▾─▾────────┐   ┌─────────▾────────┐
+ *              │ X8 = 2, drop frame │   │ no frame to drop │
+ *              └────────────────────┘   └──────────────────┘
+ *
+ * rt_sigreturn always has a frame to drop, having entered through one.
+ * deliver_signal_locked and signal_rt_sigreturn each say why at the point they
+ * write the marker. sys_execve is a fourth rebuilder, in exec.c, and takes
+ * neither shape: it re-enters through the shim's MMU-off _start with the GPRs
+ * zeroed, so there is no frame to drop and no marker to write.
+ *
  * Reference: Linux arch/arm64/kernel/signal.c
  */
 

--- a/src/syscall/translate.c
+++ b/src/syscall/translate.c
@@ -223,6 +223,14 @@ int translate_open_flags(int linux_flags)
 #undef _
     /* clang-format on */
 
+    /* O_SYNC includes an independent __O_SYNC bit. Linux normalizes that bit,
+     * alone or with O_DSYNC, to O_SYNC. An O_DSYNC-only request stays weaker.
+     */
+    if (linux_flags & (LINUX_O_SYNC & ~LINUX_O_DSYNC))
+        flags |= O_SYNC;
+    else if (linux_flags & LINUX_O_DSYNC)
+        flags |= O_DSYNC;
+
     return flags;
 }
 
@@ -238,6 +246,15 @@ int mac_to_linux_status_flags(int mac_flags)
         linux_flags |= LINUX_O_APPEND;
     if (mac_flags & O_ASYNC)
         linux_flags |= LINUX_O_ASYNC;
+
+    /* The same asymmetry in reverse: reporting LINUX_O_SYNC sets the O_DSYNC
+     * bit too, which is what Linux does, so the weaker flag is only reported
+     * when the stronger one is not set.
+     */
+    if (mac_flags & O_SYNC)
+        linux_flags |= LINUX_O_SYNC;
+    else if (mac_flags & O_DSYNC)
+        linux_flags |= LINUX_O_DSYNC;
     return linux_flags;
 }
 

--- a/tests/test-epoll.c
+++ b/tests/test-epoll.c
@@ -332,8 +332,30 @@ int main(void)
          * than read off the source. Each of these was a divergence: the first
          * three because the fd == epfd test used to open the function, ahead of
          * both descriptor lookups, and the last because the event was tested
-         * for NULL instead of being copied.
+         * for NULL instead of being copied. And above all of them, the copy.
+         * The kernel runs it in the syscall wrapper, before do_epoll_ctl
+         * reaches either fdget, so an unreadable event outranks a bad
+         * descriptor for every op that reads one. DEL reads none, which is the
+         * one call in this family that still answers EBADF.
          */
+        TEST("an unreadable event outranks a bad epfd");
+        EXPECT_ERRNO(
+            epoll_ctl(-1, EPOLL_CTL_ADD, vfd[0], (struct epoll_event *) 1),
+            EFAULT, "not EFAULT");
+
+        TEST("an unreadable event outranks a bad target fd");
+        EXPECT_ERRNO(
+            epoll_ctl(vep, EPOLL_CTL_ADD, -1, (struct epoll_event *) 1), EFAULT,
+            "not EFAULT");
+
+        TEST("an unreadable event outranks a bad epfd and a bad op");
+        EXPECT_ERRNO(epoll_ctl(-1, 99, -1, (struct epoll_event *) 1), EFAULT,
+                     "not EFAULT");
+
+        TEST("but DEL reads none, so a bad epfd wins there");
+        EXPECT_ERRNO(epoll_ctl(-1, EPOLL_CTL_DEL, -1, (struct epoll_event *) 1),
+                     EBADF, "not EBADF");
+
         TEST("a bad epfd outranks a bad op");
         EXPECT_ERRNO(epoll_ctl(-1, 99, vfd[0], &vev), EBADF, "not EBADF");
 

--- a/tests/test-epoll.c
+++ b/tests/test-epoll.c
@@ -300,6 +300,68 @@ int main(void)
         close(epfd);
     }
 
+    /* An op outside the three constants must be refused before anything is
+     * armed. The arms test DEL, then ADD, then MOD, so an unknown value used to
+     * fall past all three into the registration path and arm a knote.
+     *
+     * The null-event cases go with it: Linux reads no event for DEL, so a null
+     * pointer there is not an error, and faults for ADD and MOD.
+     */
+    int vep = epoll_create1(0);
+    int vfd[2];
+    if (vep >= 0 && pipe(vfd) == 0) {
+        struct epoll_event vev = {.events = EPOLLIN, .data.fd = vfd[0]};
+
+        TEST("an unknown epoll_ctl op is EINVAL");
+        EXPECT_ERRNO(epoll_ctl(vep, 99, vfd[0], &vev), EINVAL,
+                     "op 99 accepted");
+
+        TEST("and a negative op is EINVAL");
+        EXPECT_ERRNO(epoll_ctl(vep, -1, vfd[0], &vev), EINVAL,
+                     "op -1 accepted");
+
+        TEST("the rejected op armed nothing");
+        struct epoll_event got;
+        EXPECT_EQ(epoll_wait(vep, &got, 1, 0), 0, "a knote was registered");
+
+        TEST("a null event on ADD is EFAULT");
+        EXPECT_ERRNO(epoll_ctl(vep, EPOLL_CTL_ADD, vfd[0], NULL), EFAULT,
+                     "null event accepted");
+
+        /* The order these are decided in, measured against Linux 6.18 rather
+         * than read off the source. Each of these was a divergence: the first
+         * three because the fd == epfd test used to open the function, ahead of
+         * both descriptor lookups, and the last because the event was tested
+         * for NULL instead of being copied.
+         */
+        TEST("a bad epfd outranks a bad op");
+        EXPECT_ERRNO(epoll_ctl(-1, 99, vfd[0], &vev), EBADF, "not EBADF");
+
+        TEST("a bad target fd outranks a bad op");
+        EXPECT_ERRNO(epoll_ctl(vep, 99, -1, &vev), EBADF, "not EBADF");
+
+        TEST("a bad epfd outranks the self-add check");
+        EXPECT_ERRNO(epoll_ctl(-1, EPOLL_CTL_ADD, -1, &vev), EBADF,
+                     "not EBADF");
+
+        TEST("an unreadable event outranks a bad op");
+        EXPECT_ERRNO(epoll_ctl(vep, 99, vfd[0], (struct epoll_event *) 1),
+                     EFAULT, "not EFAULT");
+
+        TEST("an unreadable event outranks the self-add check");
+        EXPECT_ERRNO(epoll_ctl(vep, EPOLL_CTL_ADD, vep, NULL), EFAULT,
+                     "not EFAULT");
+
+        TEST("a null event on DEL is not an error for a registered fd");
+        EXPECT_EQ(epoll_ctl(vep, EPOLL_CTL_ADD, vfd[0], &vev), 0, "add failed");
+        EXPECT_EQ(epoll_ctl(vep, EPOLL_CTL_DEL, vfd[0], NULL), 0,
+                  "DEL rejected a null event");
+
+        close(vfd[0]);
+        close(vfd[1]);
+        close(vep);
+    }
+
     SUMMARY("test-epoll");
     return fails > 0 ? 1 : 0;
 }

--- a/tests/test-fcntl-flags.c
+++ b/tests/test-fcntl-flags.c
@@ -460,29 +460,44 @@ int main(void)
     unlink("/tmp/elfuse-fcntl-flags");
 
     /* A raw openat may carry __O_SYNC without O_DSYNC. Linux normalizes it to
-     * O_SYNC, while an O_DSYNC-only open remains weaker.
+     * O_SYNC, while an O_DSYNC-only open remains weaker. Every F_GETFL result
+     * is stored before it is masked. A failed call returns -1, whose bits
+     * satisfy every mask below, so testing the call inline would turn a failure
+     * into a row of green checks. check_accmode above guards the same way.
      */
     int sfd_sync = open(SYNC_FILE, O_RDWR | O_CREAT | O_SYNC, 0600);
     if (sfd_sync >= 0) {
+        int fl = fcntl(sfd_sync, F_GETFL);
         TEST("O_SYNC round trips through F_GETFL");
-        EXPECT_EQ(fcntl(sfd_sync, F_GETFL) & O_SYNC, O_SYNC, "flag was lost");
+        if (fl < 0)
+            FAIL("F_GETFL failed");
+        else
+            EXPECT_EQ(fl & O_SYNC, O_SYNC, "flag was lost");
         close(sfd_sync);
     }
     int sfd_raw_sync = syscall(SYS_openat, AT_FDCWD, SYNC_FILE,
                                O_RDWR | O_CREAT | (O_SYNC & ~O_DSYNC), 0600);
     if (sfd_raw_sync >= 0) {
+        int fl = fcntl(sfd_raw_sync, F_GETFL);
         TEST("standalone __O_SYNC normalizes through F_GETFL");
-        EXPECT_EQ(fcntl(sfd_raw_sync, F_GETFL) & O_SYNC, O_SYNC,
-                  "flag was lost");
+        if (fl < 0)
+            FAIL("F_GETFL failed");
+        else
+            EXPECT_EQ(fl & O_SYNC, O_SYNC, "flag was lost");
         close(sfd_raw_sync);
     }
     int sfd_dsync = open(SYNC_FILE, O_RDWR | O_CREAT | O_DSYNC, 0600);
     if (sfd_dsync >= 0) {
         int fl = fcntl(sfd_dsync, F_GETFL);
         TEST("O_DSYNC round trips through F_GETFL");
-        EXPECT_TRUE(fl & O_DSYNC, "flag was lost");
-        TEST("and an O_DSYNC open is not reported as O_SYNC");
-        EXPECT_EQ(fl & O_SYNC, O_DSYNC & O_SYNC, "the weaker flag was widened");
+        if (fl < 0) {
+            FAIL("F_GETFL failed");
+        } else {
+            EXPECT_TRUE(fl & O_DSYNC, "flag was lost");
+            TEST("and an O_DSYNC open is not reported as O_SYNC");
+            EXPECT_EQ(fl & O_SYNC, O_DSYNC & O_SYNC,
+                      "the weaker flag was widened");
+        }
         close(sfd_dsync);
     }
     unlink(SYNC_FILE);

--- a/tests/test-fcntl-flags.c
+++ b/tests/test-fcntl-flags.c
@@ -50,6 +50,7 @@ int passes = 0, fails = 0;
 
 /* Written where the guest can create it under either sysroot. */
 #define NOATIME_FILE "/tmp/fcntl-noatime.tmp"
+#define SYNC_FILE "/tmp/fcntl-sync.tmp"
 
 static void check_accmode(const char *what, int fd, int want)
 {
@@ -457,6 +458,34 @@ int main(void)
     if (rw >= 0)
         close(rw);
     unlink("/tmp/elfuse-fcntl-flags");
+
+    /* A raw openat may carry __O_SYNC without O_DSYNC. Linux normalizes it to
+     * O_SYNC, while an O_DSYNC-only open remains weaker.
+     */
+    int sfd_sync = open(SYNC_FILE, O_RDWR | O_CREAT | O_SYNC, 0600);
+    if (sfd_sync >= 0) {
+        TEST("O_SYNC round trips through F_GETFL");
+        EXPECT_EQ(fcntl(sfd_sync, F_GETFL) & O_SYNC, O_SYNC, "flag was lost");
+        close(sfd_sync);
+    }
+    int sfd_raw_sync = syscall(SYS_openat, AT_FDCWD, SYNC_FILE,
+                               O_RDWR | O_CREAT | (O_SYNC & ~O_DSYNC), 0600);
+    if (sfd_raw_sync >= 0) {
+        TEST("standalone __O_SYNC normalizes through F_GETFL");
+        EXPECT_EQ(fcntl(sfd_raw_sync, F_GETFL) & O_SYNC, O_SYNC,
+                  "flag was lost");
+        close(sfd_raw_sync);
+    }
+    int sfd_dsync = open(SYNC_FILE, O_RDWR | O_CREAT | O_DSYNC, 0600);
+    if (sfd_dsync >= 0) {
+        int fl = fcntl(sfd_dsync, F_GETFL);
+        TEST("O_DSYNC round trips through F_GETFL");
+        EXPECT_TRUE(fl & O_DSYNC, "flag was lost");
+        TEST("and an O_DSYNC open is not reported as O_SYNC");
+        EXPECT_EQ(fl & O_SYNC, O_DSYNC & O_SYNC, "the weaker flag was widened");
+        close(sfd_dsync);
+    }
+    unlink(SYNC_FILE);
 
     SUMMARY("test-fcntl-flags");
     return fails > 0 ? 1 : 0;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Unicode box-drawing diagrams in code comments (prose and commit messages stay ASCII) and aligns epoll_ctl and O_SYNC/O_DSYNC behavior with Linux 6.18. Behavior changes name the old vs new order so reviewers can spot deltas quickly.

- epoll_ctl now copies the event before fdgets, rejects unknown ops with EINVAL, allows NULL event on DEL, and matches Linux error precedence (EFAULT for unreadable events outranks EBADF except on DEL); the event is copied once to avoid TOCTOU.
- O_SYNC/O_DSYNC are carried to host opens and back; standalone __O_SYNC normalizes to O_SYNC, and F_GETFL reports O_SYNC/O_DSYNC asymmetry like Linux.
- Tests cover epoll_ctl error order (including unreadable event vs bad fds and bad ops) and O_SYNC/O_DSYNC round-trips.

**New Features**
- Allows Unicode box-drawing diagrams (U+2500–U+257F) and U+25BE in comments; all other comment prose and commit messages remain ASCII.
- Adds seven diagrams explaining core flows (lock-order exception, execve handoff states, io_xfer wait/transfer order, EL0 rebuild paths, FUSE request path, fork memory paths, and the path_translate_at pipeline).
- Replaces stale/duplicate comments and documents why each readability-function-size suppression exists.

<sup>Written for commit 3f488c5fa87baa36e4943cf4f339e87fc75f3447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

