### PR TITLE
Synthesize /dev/bus/usb and the USB sysfs tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ SRCS := \
     runtime/fork-state.c \
     runtime/procemu.c \
     runtime/procemu-pty.c \
+    runtime/usb-sysfs.c \
+    runtime/usb-desc.c \
     runtime/proctitle.c \
     syscall/syscall.c \
     syscall/fdtable.c \
@@ -83,7 +85,7 @@ OBJS := $(patsubst src/%.c,$(BUILD_DIR)/%.o,$(SRCS))
 DISPATCH_MANIFEST := src/syscall/dispatch.tbl
 DISPATCH_GENERATOR := scripts/gen-syscall-dispatch.py
 DISPATCH_HEADER := $(BUILD_DIR)/dispatch.h
-HVF_LDFLAGS := -framework Hypervisor -arch arm64
+HVF_LDFLAGS := -framework Hypervisor -framework IOKit -framework CoreFoundation -arch arm64
 
 # Generated headers under build/ that must exist before compiling sources that
 # include them.
@@ -263,6 +265,14 @@ $(BUILD_DIR)/test-string-builder-host: \
 # Header-only container; the test compiles it in through utils.h.
 $(BUILD_DIR)/test-dynamic-array-host: \
 		$(BUILD_DIR)/test-dynamic-array-host.o | $(BUILD_DIR)
+	@echo "  LD      $@"
+	$(Q)$(CC) $(CFLAGS) -o $@ $^
+
+## Build the USB descriptor walk host unit test (native macOS binary)
+# usb-desc.o is a pure leaf translation unit (byte bookkeeping, no IOKit and no
+# I/O), so the test links the code under test and nothing else.
+$(BUILD_DIR)/test-usb-desc-host: $(BUILD_DIR)/test-usb-desc-host.o \
+		$(BUILD_DIR)/runtime/usb-desc.o | $(BUILD_DIR)
 	@echo "  LD      $@"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ linker resolved against an external sysroot via `--sysroot`.
   case-colliding names on the default case-folding APFS (see
   [docs/filenames.md](docs/filenames.md))
 - Synthetic `/proc` and selected `/dev` emulation for user-space probes
+- Synthetic USB device tree: `/dev/bus/usb` plus `/sys/bus/usb/devices`
+  built from the IOKit registry, enough for libusb-style enumeration
+  (a udev-backed `lsusb` also needs `name_to_handle_at`, which is not
+  implemented yet; and macOS publishes no root hubs, so there are no
+  `usbN` entries and `lsusb -t` lists devices without their bus rows)
 - Guest-internal FUSE: `/dev/fuse` and `mount("fuse")` work without
   macFUSE / FUSE-T / FSKit
 - Built-in GDB Remote Serial Protocol stub usable from `gdb` or `lldb`

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -112,6 +112,7 @@ Key files:
 | `src/runtime/forkipc.c`, `fork-state.c` | `fork`/`clone` state transfer over the fork IPC channel |
 | `src/runtime/thread.c`, `futex.c` | guest thread table, futex wait queues |
 | `src/runtime/procemu.c` | `/proc`, `/dev`, and selected pseudo-files |
+| `src/runtime/usb-sysfs.c` | synthetic `/dev/bus/usb` and `/sys/bus/usb` trees from the IOKit registry |
 | `src/runtime/proctitle.c` | argv / comm rewriting for `prctl PR_SET_NAME` |
 | `src/debug/gdbstub.c`, `gdbstub-rsp.c`, `gdbstub-reg.c` | GDB RSP stub |
 
@@ -602,6 +603,7 @@ waiter enqueue, so the compare-and-wait is a single critical section.
 | Futex wait queues | `pthread_mutex` (per bucket) | `src/runtime/futex.c` |
 | FUSE (sessions, file/dir state) | global `fuse_lock` + per-session `session->lock` | `src/syscall/fuse.c` |
 | Sysroot snapshot | `pthread_mutex` | `src/syscall/proc-state.c` |
+| Synthetic USB tree (scratch dirs + device model) | `usb_lock` (leaf) | `src/runtime/usb-sysfs.c` |
 
 Lock ordering is documented inline in those files
 (`mmap_lock` is order 1, `fd_lock` is order 3, `sfd_lock` is order 5a)
@@ -951,8 +953,162 @@ listings refresh only when a new directory is opened. The synthetic
 cpumask files, and `cpuN` directories are captured on first access and then
 remain fixed.
 
+### Synthetic USB Device Tree
+
+`src/runtime/usb-sysfs.c` materializes two more scratch-directory trees,
+built from an IOKit enumeration of the USB registry that opens no device:
+`/sys/bus/usb/devices` and `/dev/bus/usb`. Device directories are named
+`<bus>-<ports>` (for example `2-1.4`), interface directories
+`<bus>-<ports>:<config>.<interface>`, following the Linux sysfs layout that
+libusb and nusb walk. `busnum` comes from the IOKit locationID's top byte
+plus one (macOS numbers controllers from 0, Linux busses from 1), `devnum`
+from the device's USB address, and the port path from the locationID
+nibbles. Each device directory carries the attribute
+files those enumerators read (`busnum`, `devnum`, `idVendor`, `idProduct`,
+`speed`, the `manufacturer` / `product` / `serial` strings when the device
+supplies them, the `dev` major:minor, and the rest of the descriptor
+fields), a `uevent` file, a `subsystem` symlink, and the binary
+`descriptors` blob.
+
+Two invariants matter to consumers. The `descriptors` attribute and the
+matching `/dev/bus/usb/BBB/DDD` node read byte-identically, because both
+serve one stored blob per device -- the rule Linux keeps between sysfs and
+the usbfs `read()` view. And `statfs` / `fstatfs` on `/sys` paths report
+`SYSFS_MAGIC`, without which libudev refuses to trust the tree and libusb
+falls back to a usbfs directory scan.
+
+The `/dev/bus/usb/BBB/DDD` nodes are 0444 placeholder files on disk (the
+`/dev/pts` placeholder pattern); the stat intercept reports them as
+character devices, major 189, minor `(bus - 1) * 128 + (dev - 1)`, and the
+open intercept diverts an open away from the placeholder. Opening a node
+serves the shared descriptors blob read-only; a writable open reports
+`EACCES`.
+
+One layout deviation is deliberate: the `/sys/bus/usb/devices` entries are
+real directories, not symlinks into `/sys/devices/...`, so `realpath()` of
+an entry canonicalizes to itself. libusb opens attributes relative to the
+entry and nusb canonicalizes the entry path; both tolerate this.
+
+The tree follows the `/sys/devices/system/cpu` one-shot rule: it is built
+lazily under `usb_lock` on first access and then stays fixed for the
+process. Hotplug support, once the uevent layer can observe attach and
+detach, would discard the tree so that the next access re-enumerates; until
+then a replugged device is not picked up within a run.
+
+A second, smaller deviation is in `/dev/bus/usb`: the device nodes are
+placeholder files, so `getdents64` reports them with `d_type` `DT_REG`
+where Linux reports `DT_CHR`. `stat()` is correct -- the intercept fills
+`S_IFCHR` with major 189 and the right minor, which is what libusb, nusb
+and `lsusb` consult -- so only a scanner that filters on `d_type` alone,
+without ever calling `stat`, would skip the nodes. No such consumer is
+known; creating real character devices needs privileges elfuse does not
+ask for, so the placeholder stays and the deviation is recorded here
+rather than papered over.
+
+One boundary is worth stating plainly: there are no `usbN` root-hub
+entries. macOS publishes no root hub as a USB device -- the registry match
+returns downstream devices only -- so the tree carries no bus entry and no
+parent link from a device up to it. Enumeration is unaffected (libusb
+leaves the parent NULL, nusb skips port-less names), but topology is: a
+`lsusb -t` listing shows the devices without the bus rows above them.
+
+The `configuration` attribute is the other one. It holds the string named
+by the active configuration's `iConfiguration`, and a string descriptor is
+fetched over an ep0 control transfer on an open device -- which this layer
+does not do. IOKit does not offer a way around it: an `IOUSBHostDevice`
+registry entry publishes `iManufacturer`, `iProduct` and `iSerialNumber`
+alongside the three strings the family caches for them, but no
+`iConfiguration` and no configuration string. So the file is emitted
+empty, and that is not a claim the configuration has no string: Linux's
+`usb_cache_string` returns NULL "if the index is 0 **or the string could
+not be read**", and `configuration_show` emits nothing in both cases, so
+an empty `configuration` on Linux means "no cached string" and every
+device here takes the second of those two routes to it. The file stays
+present rather than being omitted, because `dev_attr_grp` carries no
+`.is_visible` hook and so every Linux USB device has all four of
+`bNumInterfaces`, `bmAttributes`, `bMaxPower` and `configuration`; a value
+the kernel cannot supply is a zero-length read, never an `ENOENT`. The
+same rule is why those first three are emitted even for a device whose
+descriptor blob carries no usable configuration at all. The fidelity gap
+that remains is narrow and one-directional: a device whose
+`iConfiguration` is non-zero and whose string descriptor is readable shows
+that string on Linux and shows nothing here.
+
 Related implementation: `src/runtime/procemu.c`, `src/syscall/path.c`,
-`src/syscall/fs.c`, `src/syscall/proc-state.c`.
+`src/syscall/fs.c`, `src/syscall/proc-state.c`, `src/runtime/usb-sysfs.c`.
+
+### Limits Of The IOKit Mapping
+
+This tree enumerates devices; the pieces that follow open them and
+move data. It is worth stating where the approach stops, because three
+of the limits are macOS policy that no amount of translation moves, and
+the rest cost something permanent. The short version: the layer is
+complete for devices macOS does not claim, honest but limited for the
+ones it does, and structurally unable to present bus topology.
+
+Driver arbitration decides which devices are reachable at all. Once a
+class driver matches an interface, `USBInterfaceOpen` returns
+`kIOReturnExclusiveAccess`, and an unprivileged process has no way past
+it. On the ESP32-S3 used to develop this: interface 0 (CDC control) is
+held by `AppleUSBACMControl` and always refuses, interface 1 (CDC data)
+refuses whenever anything holds a `/dev/cu.usbmodem*` node, and
+interface 2 (a vendor JTAG class with no matching driver) opens freely.
+The documented escape, `USBDeviceReEnumerate` with
+`kUSBReEnumerateCaptureDeviceMask`, needs root or the
+`com.apple.vm.device-access` entitlement; an unentitled non-root caller
+gets a success return that changes nothing, the registry ID and the
+driver binding both intact. Mass storage is excluded from capture
+outright. So the layer serves vendor and bulk devices completely, while
+CDC and HID stay reachable only through the interfaces macOS already
+exposes -- `/dev/cu.*` and `IOHIDManager`. This is why the ttyACM /
+ttyUSB aliasing is a companion to the USB layer rather than a workaround
+for it.
+
+Cancellation granularity differs in a way that costs throughput.
+`USBDEVFS_DISCARDURB` cancels one URB; IOKit's `AbortPipe` cancels
+everything outstanding on the pipe. Preserving the Linux semantics means
+queueing inside elfuse and handing IOKit one transfer per endpoint at a
+time, which gives up the pipelining a bulk-heavy workload depends on.
+The alternative -- report the collateral cancellations as `-ECONNRESET`
+and let the guest resubmit, which libusb and nusb both do -- lets a
+cancel on one transfer disturb unrelated ones. Neither choice is free,
+and no macOS API removes the tradeoff.
+
+Reset is an unplug. `ResetDevice` has been a no-op since OS X 10.11, so
+the only real reset is `USBDeviceReEnumerate`, which tears down the user
+client and re-runs matching. Linux `USBDEVFS_RESET` keeps the fd valid
+and the device numbering stable. Emulating it means holding `busnum` and
+`devnum` steady across a registry identity that changed underneath,
+waiting for the re-attach, and diffing descriptors afterward -- and
+distinguishing "came back different" from "never came back", since
+firmware update flows (DFU) are both the workflow that leans on reset
+and the one where the descriptors legitimately change.
+
+Identity is topological, not device-based. A `locationID` encodes the
+port path, so unplugging one device and plugging another into the same
+port yields the same value. The enumeration cross-checks `idVendor`,
+`idProduct` and the serial string against the cached model and answers
+`-ENODEV` on a mismatch, which is safe but not complete: the model is a
+one-shot snapshot with no hotplug observer, so a device attached mid-run
+is unusable until the process restarts. Real hotplug would rewrite IOKit
+attach and detach notifications as uevents on the netlink socket -- a
+fair amount of machinery for something libusb tolerates the absence of.
+
+Bus topology has no macOS source, the boundary noted above: macOS
+publishes no root hub as a USB device, so there is no `usbN` entry, no
+parent link, and `lsusb -t` loses its bus rows. A plausible root hub
+could be synthesized, but it would be a device no registry entry backs,
+and its `maxchild`, port numbering and `/sys/bus/usb/devices/usb1` node
+would be invention too. The tree stays short rather than carrying a
+fabricated node.
+
+Two narrower ones. Isochronous transfers need explicit frame scheduling
+through `GetBusFrameNumber`, where usbfs lets `URB_ISO_ASAP` hand the
+timing to the controller, so audio and video capture do not map cleanly.
+And the permission models do not correspond: Linux gates usbfs through
+udev rules and file permissions, macOS gates IOKit through driver
+matching and entitlements, and there is no single spelling of "let this
+program use this device" that means the same on both.
 
 ## Path Resolution
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -30,7 +30,8 @@ NATIVE_TESTS := tests/test-multi-vcpu.c tests/test-rwx.c \
                 tests/test-string-builder-host.c \
                 tests/test-wakeup-pipe-host.c \
                 tests/test-stdio-nonblock-host.c \
-                tests/test-guest-env-host.c
+                tests/test-guest-env-host.c \
+                tests/test-usb-desc-host.c
 SPECIAL_TEST_SRCS := tests/test-lowbase-mem.c
 SPECIAL_TEST_BINS := $(BUILD_DIR)/test-lowbase-mem-200000 $(BUILD_DIR)/test-lowbase-mem-300000
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -36,10 +36,12 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-linkat-symlink-fallback test-casefold-host \
         test-casefold-walk-host test-absock-names-host \
         test-wakeup-pipe-host test-guest-env-host \
+        test-usb-desc-host \
         test-sysroot-name-unique \
         test-sysroot-name-relative \
         test-nosysroot-literal-names test-sysroot-outside-names \
-        test-sysroot-root \
+        test-sysroot-root test-usb-sysfs test-usb-sysfs-sysroot \
+        test-usb-sysfs-overflow \
         test-sysroot-symlink-target \
         test-sysroot-name-i18n test-sysroot-name-length \
         test-sysroot-name-staged test-sysroot-name-race \
@@ -144,6 +146,14 @@ check-tsan:
 # CI budget. "I/O subsystem" is included for its fd-table refcount/ABA races
 # (epoll-mt/aba/refcount, getdents-refcount) now that fd_entry_t.type is atomic;
 # the remaining compat sections (rseq, /proc, sockets) stay on the release lane.
+#
+# The USB tree is reached through CHECK_SHARED_LANES rather than through a
+# section here: it is not in tests/manifest.txt (it has no counterpart the
+# reference kernel can adjudicate, so test-matrix.sh does not register it, and
+# .ci/check-matrix-lists.sh rejects a manifest binary the matrix never runs).
+# It belongs on the sanitizer lane all the same -- the layer composes a dev_t
+# by shifting a major number, which is exactly the arithmetic UBSAN is there to
+# adjudicate, and nothing else on the lane builds that tree.
 SANITIZER_SECTIONS := Threading|Stress|Signal.*thread|Fork edge|CoW fork|Guard page|mremap|MAP_SHARED|madvise|futex|FD table race|Multithreaded|SysV shared|membarrier|I/O subsystem
 
 # One banner-plus-run pair, for a host unit binary run directly and for a
@@ -201,7 +211,8 @@ CHECK_HOST_UNIT_BINS := $(addprefix $(BUILD_DIR)/, \
         test-teardown-live-vcpu-host test-stdio-nonblock-host test-casefold-host \
         test-casefold-walk-host test-absock-names-host \
         test-dynamic-array-host test-string-builder-host \
-        test-wakeup-pipe-host test-guest-env-host)
+        test-wakeup-pipe-host test-guest-env-host \
+        test-usb-desc-host)
 
 # Lanes shared by check and check-sanitizer, in execution order: the host
 # unit binaries, then the name-contract lanes cheap enough for a sanitizer
@@ -221,6 +232,10 @@ $(call run-host-unit,test-string-builder-host,string builder unit test)
 $(call run-host-unit,test-wakeup-pipe-host,wakeup pipe concurrency unit test)
 $(call run-host-unit,test-stdio-nonblock-host,launcher stdio flags across a guest)
 $(call run-host-unit,test-guest-env-host,guest environment merge cross product)
+$(call run-host-unit,test-usb-desc-host,USB descriptor blob walk unit test)
+$(call run-lane,test-usb-sysfs,synthetic USB tree contract)
+$(call run-lane,test-usb-sysfs-sysroot,synthetic USB /sys sharing a populated sysroot)
+$(call run-lane,test-usb-sysfs-overflow,per-bus devnum cap under 127-device overflow)
 $(call run-lane,test-sysroot-name-unique,one on-disk name per guest name)
 $(call run-lane,test-sysroot-name-relative,relative and dirfd-relative names)
 $(call run-lane,test-sysroot-name-i18n,non-ASCII guest filenames)
@@ -385,6 +400,7 @@ test-sysroot-symlink-escape: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-symlink-esc
 	ln -sf "$$secret_dir/secret.txt" "$$tmpdir/d1/abs-link"; \
 	ln -sf "$$secret_dir/secret.txt" "$$tmpdir/d2/abs-link"; \
 	ln -sf "../d2/abs-link" "$$tmpdir/d1/chain-link"; \
+	ln -sf /dev "$$tmpdir/d1/dev-bridge"; \
 	depth=$$(printf '%s' "$$tmpdir/d1" | tr -cd '/' | wc -c | tr -d ' '); \
 	relback=""; i=0; \
 	while [ "$$i" -lt "$$depth" ]; do relback="../$$relback"; i=$$((i + 1)); done; \
@@ -1531,9 +1547,44 @@ test-casefold-host: $(BUILD_DIR)/test-casefold-host
 test-casefold-walk-host: $(BUILD_DIR)/test-casefold-walk-host
 	$(BUILD_DIR)/test-casefold-walk-host
 
+## Assert the synthetic USB tree's contract and its two agreeing views
+# The device-dependent half only runs against whatever is attached, so the lane
+# prints the device count rather than letting an empty bus read as full cover.
+test-usb-sysfs: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs
+
+## The /sys ours/not-ours split and the fchdir/cwd containment need a populated
+## /sys behind the synthetic USB view, so this lane stages a sysroot skeleton
+## (a net address, a THP knob, a node list) and runs the guest against it with
+## the deterministic USB fixture so the /sys/bus/usb assertions have devices.
+test-usb-sysfs-sysroot: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-sysroot
+	@set -e; \
+	tmpdir=$$(mktemp -d); \
+	sysroot="$$tmpdir/sysroot"; \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	mkdir -p "$$sysroot/sys/class/net/eth0" \
+		"$$sysroot/sys/kernel/mm/transparent_hugepage" \
+		"$$sysroot/sys/devices/system/node"; \
+	printf '02:42:ac:11:00:02\n' > "$$sysroot/sys/class/net/eth0/address"; \
+	printf 'always [madvise] never\n' \
+		> "$$sysroot/sys/kernel/mm/transparent_hugepage/enabled"; \
+	printf '0-3\n' > "$$sysroot/sys/devices/system/node/online"; \
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-usb-sysfs-sysroot
+
+## The devnum cap needs more than 127 address-less devices on one bus, which
+## the overflow fixture injects through the real fallback path. No sysroot: the
+## whole model is synthetic here.
+test-usb-sysfs-overflow: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-overflow
+	ELFUSE_USB_FIXTURE=overflow $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-overflow
+
 ## Run the absock derived-name unit test natively on the host
 test-absock-names-host: $(BUILD_DIR)/test-absock-names-host
 	$(BUILD_DIR)/test-absock-names-host
+
+## Run the USB descriptor blob walk unit test natively on the host
+test-usb-desc-host: $(BUILD_DIR)/test-usb-desc-host
+	$(BUILD_DIR)/test-usb-desc-host
 
 # Wakeup pipe concurrency unit test. Only a -fsanitize=thread build carries a
 # race detector, so check-sanitizer is where this lane has its full weight.

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -63,6 +63,7 @@
 #include "debug/log.h"
 #include "runtime/procemu.h"
 #include "runtime/procemu-internal.h"
+#include "runtime/usb-sysfs.h"
 #include "core/rosetta.h"
 #include "runtime/thread.h"
 
@@ -1228,6 +1229,23 @@ static int proc_parse_int_write(const void *buf, size_t count, int *out)
 
 int proc_open_dir_fd(const char *path, int linux_flags)
 {
+    /* Linux refuses write access to a directory in open(2) itself: O_WRONLY,
+     * O_RDWR, O_CREAT or O_TRUNC against a directory is EISDIR, decided before
+     * the descriptor exists. Synthesizing the directory does not exempt it -- a
+     * guest opening /dev/bus/usb or /proc/self for write must be told EISDIR
+     * the way a real mount would, not handed a readable descriptor whose first
+     * write then fails with something else.
+     *
+     * O_PATH is the documented exception: it opens the object for name
+     * operations only, and the access mode is ignored rather than checked.
+     */
+    if (!(linux_flags & LINUX_O_PATH) &&
+        ((linux_flags & LINUX_O_ACCMODE) != LINUX_O_RDONLY ||
+         (linux_flags & (LINUX_O_CREAT | LINUX_O_TRUNC)))) {
+        errno = EISDIR;
+        return -1;
+    }
+
     int oflags = O_RDONLY | O_DIRECTORY;
 
     if (linux_flags & LINUX_O_CLOEXEC)
@@ -3048,11 +3066,23 @@ int proc_intercept_open(const guest_t *g,
         }
     }
 
+    /* /dev/bus/usb and /sys/bus/usb: synthetic USB trees from IOKit. */
+    {
+        int ufd = usb_sysfs_intercept_open(path, linux_flags, mode);
+        if (ufd != PROC_NOT_INTERCEPTED)
+            return ufd;
+    }
+
     return PROC_NOT_INTERCEPTED;
 }
 
 
 int proc_intercept_stat(const char *path, struct stat *st)
+{
+    return proc_intercept_stat_at(path, st, false);
+}
+
+int proc_intercept_stat_at(const char *path, struct stat *st, bool follow)
 {
     /* Intercept stat for /proc paths emulated via proc_intercept_open. Without
      * this, runtime libraries that probe a file's existence via stat() before
@@ -3196,7 +3226,7 @@ int proc_intercept_stat(const char *path, struct stat *st)
         if (aliased < 0)
             return -1;
         if (aliased > 0)
-            return proc_intercept_stat(alias, st);
+            return proc_intercept_stat_at(alias, st, follow);
     }
 
     /* /proc/self/task and /proc/self/task/<tid> are directories */
@@ -3340,6 +3370,13 @@ int proc_intercept_stat(const char *path, struct stat *st)
         }
     }
 
+    /* /dev/bus/usb and /sys/bus/usb: synthetic USB trees from IOKit. */
+    {
+        int urc = usb_sysfs_intercept_stat(path, st, follow);
+        if (urc != PROC_NOT_INTERCEPTED)
+            return urc;
+    }
+
     return PROC_NOT_INTERCEPTED;
 }
 
@@ -3433,6 +3470,26 @@ int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz)
             return -1;
         }
 
+        /* Descriptors opened through the synthetic USB trees are backed by
+         * scratch dirs under /tmp; F_GETPATH would leak that host location, and
+         * consumers compare the magic-link target against the guest path they
+         * opened (systemd chase() rejects a syspath that does not start with
+         * /sys). Report the stamped guest spelling instead. Kept narrow (USB
+         * prefixes only) so the pty and shm reporting stays as it was.
+         */
+        {
+            fd_entry_t fd_snap;
+            if (fd_snapshot((int) n, &fd_snap) && fd_snap.proc_path[0] == '/' &&
+                (path_prefix_match(fd_snap.proc_path, "/sys", 4) ||
+                 path_prefix_match(fd_snap.proc_path, "/dev/bus", 8))) {
+                size_t plen = strlen(fd_snap.proc_path);
+                if (plen > bufsiz)
+                    plen = bufsiz;
+                memcpy(buf, fd_snap.proc_path, plen);
+                return (int) plen;
+            }
+        }
+
         char fdpath[MAXPATHLEN];
         if (fcntl(host_fd, F_GETPATH, fdpath) < 0) {
             errno = ENOENT;
@@ -3460,6 +3517,16 @@ int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz)
             len = bufsiz;
         memcpy(buf, report, len);
         return (int) len;
+    }
+
+    /* /dev/bus/usb and /sys/bus/usb entries are real dirs/files, never
+     * symlinks; answer EINVAL for existing paths rather than falling through to
+     * the host (where /sys does not exist and the error would be ENOENT).
+     */
+    {
+        int urc = usb_sysfs_intercept_readlink(path, buf, bufsiz);
+        if (urc != PROC_NOT_INTERCEPTED)
+            return urc;
     }
 
     return PROC_NOT_INTERCEPTED;

--- a/src/runtime/procemu.h
+++ b/src/runtime/procemu.h
@@ -42,7 +42,15 @@ int proc_intercept_readlink(const char *path, char *buf, size_t bufsiz);
 /* Intercept stat/fstatat for /proc paths.
  * Returns 0 if stat was synthesized (mac_st filled), or -2 if not intercepted
  * (fall through to real fstatat).
+ *
+ * `follow` selects stat() vs lstat() semantics for a synthetic symlink leaf.
+ * The synthetic trees carry real symlinks (the USB `subsystem` links), and
+ * Linux reports the target's identity for a following stat, so a caller that is
+ * serving stat()/fstatat() without AT_SYMLINK_NOFOLLOW must pass true.
+ * proc_intercept_stat keeps the nofollow spelling for callers that name a
+ * specific object (an already-opened fd's stamp, a readlink probe).
  */
+int proc_intercept_stat_at(const char *path, struct stat *mac_st, bool follow);
 int proc_intercept_stat(const char *path, struct stat *mac_st);
 
 /* True when PATH names a live Unix98 pty slave (/dev/pts/N whose master is

--- a/src/runtime/usb-desc.c
+++ b/src/runtime/usb-desc.c
@@ -1,0 +1,191 @@
+/*
+ * Bounded walks over raw USB descriptor blobs
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See runtime/usb-desc.h for why these walks treat their input as untrusted.
+ */
+
+#include <stdio.h>
+
+#include "runtime/usb-desc.h"
+
+static uint16_t desc_le16(const uint8_t *p)
+{
+    return (uint16_t) (p[0] | (p[1] << 8));
+}
+
+void usb_desc_iter_init(usb_desc_iter_t *it, const uint8_t *buf, size_t len)
+{
+    it->buf = buf;
+    it->len = buf ? len : 0;
+    it->off = 0;
+    it->truncated = false;
+}
+
+const uint8_t *usb_desc_iter_next(usb_desc_iter_t *it, uint8_t *len_out)
+{
+    size_t left = it->len - it->off; /* off <= len holds on entry and exit */
+    if (left < USB_DESC_MIN_LEN) {
+        it->truncated = left != 0;
+        return NULL;
+    }
+    const uint8_t *d = it->buf + it->off;
+    uint8_t blen = d[0];
+
+    /* The comparison is done in the remaining-bytes domain, never by forming
+     * it->buf + it->off + blen first: a bLength longer than the blob would make
+     * that pointer itself out of bounds.
+     */
+    if (blen < USB_DESC_MIN_LEN || blen > left) {
+        it->truncated = true;
+        return NULL;
+    }
+    it->off += blen;
+    if (len_out)
+        *len_out = blen;
+    return d;
+}
+
+size_t usb_desc_interfaces(const uint8_t *cfg,
+                           size_t cfg_len,
+                           const uint8_t **out,
+                           size_t outcap,
+                           bool *truncated_out,
+                           size_t *stop_off_out)
+{
+    if (truncated_out)
+        *truncated_out = false;
+    if (stop_off_out)
+        *stop_off_out = 0;
+    if (!cfg || !out || outcap == 0)
+        return 0;
+
+    /* One bit per bInterfaceNumber value: the field is a byte, so 256 bits
+     * cover every number a descriptor can carry and the dedup can never be the
+     * reason an interface goes missing.
+     */
+    uint8_t seen[USB_DESC_INTERFACES_MAX / 8] = {0};
+    size_t n = 0;
+
+    usb_desc_iter_t it;
+    usb_desc_iter_init(&it, cfg, cfg_len);
+    const uint8_t *d;
+    uint8_t dlen;
+    while ((d = usb_desc_iter_next(&it, &dlen)) && n < outcap) {
+        if (d[1] != USB_DT_INTERFACE || dlen < USB_INTERFACE_DESC_LEN)
+            continue;
+        if (d[3] != 0) /* bAlternateSetting */
+            continue;
+        unsigned ifnum = d[2];
+        if (seen[ifnum >> 3] & (uint8_t) (1u << (ifnum & 7)))
+            continue;
+        seen[ifnum >> 3] |= (uint8_t) (1u << (ifnum & 7));
+        out[n++] = d;
+    }
+    if (truncated_out)
+        *truncated_out = it.truncated;
+    if (stop_off_out)
+        *stop_off_out = it.off;
+    return n;
+}
+
+const uint8_t *usb_desc_active_config(const uint8_t *blob,
+                                      size_t blob_len,
+                                      unsigned cfg_value,
+                                      size_t *len_out)
+{
+    if (!blob || blob_len < USB_DEVICE_DESC_LEN + USB_CONFIG_DESC_LEN)
+        return NULL;
+
+    size_t off = USB_DEVICE_DESC_LEN;
+    const uint8_t *first = NULL;
+    size_t first_len = 0;
+    while (blob_len - off >= USB_CONFIG_DESC_LEN) {
+        const uint8_t *p = blob + off;
+        size_t left = blob_len - off;
+
+        /* bLength and bDescriptorType are what identify this record as a
+         * configuration header, and they are checked before any field past them
+         * is read. Without this a device that under-reports wTotalLength walks
+         * the cursor into the middle of its own configuration, and the next
+         * record -- an interface descriptor, whose byte 5 is bInterfaceProtocol
+         * rather than bConfigurationValue -- gets matched and returned as the
+         * active configuration.
+         */
+        if (p[0] != USB_CONFIG_DESC_LEN || p[1] != USB_DT_CONFIG)
+            break; /* not a configuration header; the walk ends here */
+
+        size_t total = desc_le16(p + 2); /* wTotalLength */
+        if (total < USB_CONFIG_DESC_LEN)
+            break; /* not a locatable configuration; the walk ends here */
+        /* A device that under-reports the trailing configuration still has a
+         * usable header, so clamp rather than discard -- but clamping is also
+         * what keeps the step below inside the blob.
+         */
+        if (total > left)
+            total = left;
+        if (!first) {
+            first = p;
+            first_len = total;
+        }
+        if (p[5] == (uint8_t) cfg_value) { /* bConfigurationValue */
+            *len_out = total;
+            return p;
+        }
+        off += total;
+    }
+    if (first) {
+        *len_out = first_len;
+        return first;
+    }
+    return NULL;
+}
+
+void usb_desc_actconfig_attrs(const uint8_t *cfg,
+                              size_t cfg_len,
+                              unsigned max_power_unit,
+                              const char *cfg_string,
+                              usb_actconfig_attrs_t *out)
+{
+    /* Empty first, so every early return still leaves four defined -- and
+     * therefore four emitted -- attributes behind.
+     */
+    out->num_interfaces[0] = '\0';
+    out->bm_attributes[0] = '\0';
+    out->max_power[0] = '\0';
+    out->configuration[0] = '\0';
+
+    /* No active configuration is the kernel's actconfig == NULL: four files
+     * that read empty, not four files that are missing.
+     */
+    if (!cfg || cfg_len < USB_CONFIG_DESC_LEN)
+        return;
+
+    /* Widths are the kernel's own format strings (sysfs.c:49-50, 65). */
+    snprintf(out->num_interfaces, sizeof(out->num_interfaces), "%2d\n", cfg[4]);
+    snprintf(out->bm_attributes, sizeof(out->bm_attributes), "%2x\n", cfg[7]);
+
+    /* cfg[8] * max_power_unit cannot overflow: 255 * 8 == 2040. */
+    snprintf(out->max_power, sizeof(out->max_power), "%umA\n",
+             (unsigned) cfg[8] * max_power_unit);
+
+    /* cfg[6] is iConfiguration. Index 0 short-circuits usb_cache_string before
+     * any transfer, so a string handed in for such a configuration is not a
+     * string Linux would ever have cached -- it is dropped rather than shown.
+     */
+    if (cfg[6] == 0 || !cfg_string || cfg_string[0] == '\0')
+        return;
+
+    /* Truncate the string, never the newline. usb_string() caps a cached string
+     * at MAX_USB_STRING_SIZE bytes including its terminator, so anything Linux
+     * could have cached is at most USB_MAX_STRING_SIZE - 1 characters and
+     * "%s\n" fits exactly. A caller that hands over a longer one loses the tail
+     * here as it would there, but the attribute still ends in the newline
+     * sysfs_emit always writes: bounding "%s" alone would let snprintf trim the
+     * newline instead and emit a last line Linux never produces.
+     */
+    snprintf(out->configuration, sizeof(out->configuration), "%.*s\n",
+             (int) (sizeof(out->configuration) - 2), cfg_string);
+}

--- a/src/runtime/usb-desc.h
+++ b/src/runtime/usb-desc.h
@@ -1,0 +1,160 @@
+/*
+ * Bounded walks over raw USB descriptor blobs
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A configuration blob is device-supplied: bLength and wTotalLength are bytes
+ * the peripheral chose, not lengths the host derived, so a walk over them is a
+ * walk over untrusted input. Every step here is expressed as an offset into the
+ * buffer and advances only by what the buffer still holds; the cursor is never
+ * moved past the end, which keeps both the loads and the pointer arithmetic
+ * itself inside the object.
+ *
+ * Pure byte bookkeeping with no I/O and no IOKit, so the malformed-blob cases
+ * are unit-testable without hardware (tests/test-usb-desc-host.c).
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Standard descriptor type codes this layer names. */
+#define USB_DT_DEVICE 1
+#define USB_DT_CONFIG 2
+#define USB_DT_INTERFACE 4
+
+/* Shortest descriptor that can carry a type: bLength + bDescriptorType. */
+#define USB_DESC_MIN_LEN 2
+
+/* Fixed sizes of the descriptors this layer reads fields out of. */
+#define USB_DEVICE_DESC_LEN 18
+#define USB_CONFIG_DESC_LEN 9
+#define USB_INTERFACE_DESC_LEN 9
+
+typedef struct {
+    const uint8_t *buf;
+    size_t len;
+    size_t off;     /* cursor; the invariant is off <= len, always */
+    bool truncated; /* a descriptor claimed more bytes than remained */
+} usb_desc_iter_t;
+
+void usb_desc_iter_init(usb_desc_iter_t *it, const uint8_t *buf, size_t len);
+
+/* Next descriptor, or NULL once the blob is exhausted or malformed.
+ *
+ * Stops (and sets it->truncated) on a bLength below USB_DESC_MIN_LEN or a
+ * bLength larger than the bytes that remain, because either means the rest of
+ * the blob can no longer be located -- descriptors are self-delimiting, so a
+ * bad length is the end of what can be read, not a record to skip. On stop the
+ * cursor stays where the bad record began, so it->off still satisfies off <=
+ * len and names how much of the blob was understood.
+ *
+ * *len_out receives the descriptor's bLength when non-NULL.
+ */
+const uint8_t *usb_desc_iter_next(usb_desc_iter_t *it, uint8_t *len_out);
+
+/* Locate the configuration descriptor whose bConfigurationValue is cfg_value,
+ * else the first well-formed one, inside a blob laid out as a device descriptor
+ * followed by raw configuration descriptors (the usbfs read() view).
+ *
+ * A configuration spans wTotalLength bytes, so the search steps by that rather
+ * than by bLength, and clamps it to the bytes that remain.
+ *
+ * Every candidate is checked to be a configuration header -- bLength exactly
+ * USB_CONFIG_DESC_LEN and bDescriptorType USB_DT_CONFIG -- before any later
+ * field is read from it, and the walk stops at the first record that is not
+ * one. wTotalLength alone cannot be trusted to land the cursor on the next
+ * configuration: a device that under-reports it would otherwise have an
+ * interface descriptor matched on byte 5 and returned as its active config.
+ *
+ * Returns the descriptor with *len_out set to its usable span, or NULL when the
+ * blob carries no configuration.
+ */
+const uint8_t *usb_desc_active_config(const uint8_t *blob,
+                                      size_t blob_len,
+                                      unsigned cfg_value,
+                                      size_t *len_out);
+
+/* Every distinct interface of a configuration, at alternate setting 0.
+ *
+ * `out` receives one pointer per bInterfaceNumber, in the order the numbers
+ * first appear, pointing at that number's alternate-setting-0 descriptor inside
+ * cfg. Later alternate settings and repeats of a number already seen are
+ * skipped, which is the set sysfs turns into <dev>:<cfg>.<if> directories.
+ *
+ * USB_DESC_INTERFACES_MAX is the whole domain, not a policy: bInterfaceNumber
+ * is a __u8 (linux/usb/ch9.h), so a configuration cannot name more distinct
+ * interfaces than there are byte values, and a caller sized that way can never
+ * lose one. A smaller table would not bound the walk -- cfg_len already does --
+ * it would silently drop every interface numbered above it.
+ *
+ * *truncated_out, when non-NULL, reports whether the walk stopped on a
+ * malformed record rather than at the end of the configuration, so the caller
+ * can say so about a blob it only partly understood.
+ *
+ * Returns the count written, which is at most USB_DESC_INTERFACES_MAX.
+ */
+#define USB_DESC_INTERFACES_MAX 256
+
+size_t usb_desc_interfaces(const uint8_t *cfg,
+                           size_t cfg_len,
+                           const uint8_t **out,
+                           size_t outcap,
+                           bool *truncated_out,
+                           size_t *stop_off_out);
+
+/* Longest configuration string this layer will render, matching the kernel's
+ * MAX_USB_STRING_SIZE (message.c:1067): 127 UTF-16 code units at up to three
+ * UTF-8 bytes each, plus the terminator. A string the device reports longer
+ * than that is truncated by usb_string() on Linux too.
+ */
+#define USB_MAX_STRING_SIZE (127 * 3 + 1)
+
+/* The four sysfs attributes Linux derives from the active configuration.
+ *
+ * Each member holds the file's exact contents including the trailing newline,
+ * or an empty string when the value behind it is unavailable. Empty means an
+ * empty file, never an absent one -- see usb_desc_actconfig_attrs.
+ */
+typedef struct {
+    char num_interfaces[8]; /* bNumInterfaces */
+    char bm_attributes[8];  /* bmAttributes   */
+    char max_power[16];     /* bMaxPower      */
+    char configuration[USB_MAX_STRING_SIZE + 1];
+} usb_actconfig_attrs_t;
+
+/* Render bNumInterfaces, bmAttributes, bMaxPower and configuration for the
+ * active configuration descriptor cfg (cfg_len bytes usable, NULL when the blob
+ * carried none), exactly as drivers/usb/core/sysfs.c renders them.
+ *
+ * All four live in the kernel's dev_attr_grp (sysfs.c:782-786), an attribute
+ * group with no .is_visible hook (sysfs.c:815-817), so every USB device
+ * directory carries all four files unconditionally. What varies is their
+ * contents, not their presence: usb_actconfig_show (sysfs.c:29-43) leaves its
+ * return value at the 0 that usb_lock_device_interruptible gave it when
+ * udev->actconfig is NULL, which is a zero-length read rather than an error.
+ * Emitting a file only when its value is known is therefore not the cautious
+ * choice -- it turns a zero-length read into ENOENT, which is a different
+ * answer to a reader that checks for the attribute's existence. That is why
+ * this fills all four members on every call and the caller writes all four.
+ *
+ * configuration follows configuration_show (sysfs.c:71-87), which emits
+ * "<string>\n" only when actconfig->string is non-NULL and nothing at all
+ * otherwise. That string is usb_cache_string's result (message.c:1077-1100),
+ * documented to be "NULL if the index is 0 or the string could not be read" --
+ * so an empty configuration on Linux means "no cached string", which is a
+ * strictly weaker statement than "iConfiguration is 0". Pass cfg_string NULL or
+ * empty for the could-not-be-read case; it is ignored when iConfiguration is 0,
+ * because index 0 makes usb_cache_string return NULL before it reads anything.
+ *
+ * max_power_unit is the mA per bMaxPower count that usb_get_max_power applies:
+ * 8 at SuperSpeed and above, 2 below it. The caller owns the speed mapping.
+ */
+void usb_desc_actconfig_attrs(const uint8_t *cfg,
+                              size_t cfg_len,
+                              unsigned max_power_unit,
+                              const char *cfg_string,
+                              usb_actconfig_attrs_t *out);

--- a/src/runtime/usb-sysfs.c
+++ b/src/runtime/usb-sysfs.c
@@ -1,0 +1,2014 @@
+/*
+ * Synthetic /dev/bus/usb + /sys/bus/usb built from the IOKit registry
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Stage 1 of the usbdevfs emulation. Enumerates IOUSBHostDevice registry
+ * entries without opening any device (device properties come from
+ * IORegistryEntryCreateCFProperty; raw configuration descriptors come from
+ * GetConfigurationDescriptorPtr, which is documented to need no open) and
+ * materializes:
+ *
+ *   /sys/bus/usb/devices/<bus>-<ports>          device attr dirs
+ *   /sys/bus/usb/devices/<bus>-<ports>:<c>.<i>  interface attr dirs
+ *   /dev/bus/usb/BBB/DDD                        char-device nodes
+ *
+ * as scratch directories of real host files (the ensure_syscpu_dir pattern,
+ * procemu.c). The /dev nodes are 0444 regular placeholder files on disk; the
+ * stat intercept reports them as char major 189 minor (bus-1)*128+(dev-1), and
+ * the open intercept diverts them (the /dev/pts placeholder trick).
+ *
+ * Layout deviation from Linux, by design: the /sys/bus/usb/devices entries are
+ * directories, not symlinks into /sys/devices/... . realpath() of an entry
+ * canonicalizes to itself, which libusb (opens attrs relative to the entry) and
+ * nusb (canonicalize() of the entry path) both tolerate.
+ *
+ * Stage-1 open contract for /dev/bus/usb/BBB/DDD: O_RDONLY returns a synthetic
+ * host fd holding the descriptors blob (matching the usbfs read() view,
+ * devio.c:311-390); O_RDWR/O_WRONLY fails with EACCES. TEMPORARY: stage 2
+ * replaces this constructor with a typed FD_USBDEV fd whose read() serves the
+ * same blob via usb_sysfs_descriptors_dup and whose ioctl set talks to IOKit.
+ */
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOCFPlugIn.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/usb/IOUSBLib.h>
+
+#include "debug/log.h"
+#include "runtime/procemu-internal.h"
+#include "runtime/procemu.h"
+#include "runtime/usb-desc.h"
+#include "runtime/usb-sysfs.h"
+#include "syscall/internal.h"
+#include "syscall/linux-wire.h"
+#include "syscall/path.h"
+#include "utils.h"
+
+#define USB_MAJOR 189
+#define USB_MAX_PORTS 6 /* locationID has six port nibbles below the bus */
+
+/* First usb_devs[] allocation; it doubles from here as the registry is walked.
+ * Not a ceiling: usbfs itself caps only at 127 devices per bus, and a chain of
+ * hubs can put more than any fixed guess on one machine. A truncated model
+ * would silently lose devices from both the /dev/bus/usb and the /sys views.
+ */
+#define USB_DEVS_INIT_CAP 16
+
+typedef struct {
+    int busnum;
+    int devnum;
+    uint32_t location_id;
+    char name[40];    /* "2-1.4" */
+    char devpath[32]; /* "1.4" */
+    unsigned vid, pid, bcd_device, bcd_usb;
+    unsigned dev_class, dev_subclass, dev_protocol;
+    unsigned num_configs, max_packet0, cfg_value, speed_code;
+    unsigned i_manufacturer, i_product, i_serial;
+    char manufacturer[128], product[128], serial[128];
+    uint8_t *blob; /* device descriptor + raw config descriptors */
+    size_t blob_len;
+} usb_dev_t;
+
+static pthread_mutex_t usb_lock = PTHREAD_MUTEX_INITIALIZER;
+static bool usb_tree_ok;
+static char usb_sys_dir[64]; /* scratch root == /sys */
+/* usb_sys_dir with every symlink resolved (/tmp itself is one on macOS). The
+ * containment test below compares against this, never against the unresolved
+ * spelling, or /tmp -> /private/tmp alone would fail it.
+ */
+static char usb_sys_real[PATH_MAX];
+static char usb_dev_dir[64]; /* scratch root == /dev/bus     */
+static usb_dev_t *usb_devs;  /* grown on demand; see USB_DEVS_INIT_CAP */
+static int usb_ndevs;
+static int usb_devs_cap;
+static pid_t usb_owner_pid;
+
+/* IOKit property helpers */
+
+static long ioreg_num(io_service_t s, const char *key)
+{
+    CFStringRef k = CFStringCreateWithCString(kCFAllocatorDefault, key,
+                                              kCFStringEncodingUTF8);
+    if (!k)
+        return -1;
+    CFTypeRef v = IORegistryEntryCreateCFProperty(s, k, kCFAllocatorDefault, 0);
+    CFRelease(k);
+    long n = -1;
+    if (v && CFGetTypeID(v) == CFNumberGetTypeID())
+        CFNumberGetValue((CFNumberRef) v, kCFNumberLongType, &n);
+    if (v)
+        CFRelease(v);
+    return n;
+}
+
+static bool ioreg_str(io_service_t s, const char *key, char *out, size_t n)
+{
+    CFStringRef k = CFStringCreateWithCString(kCFAllocatorDefault, key,
+                                              kCFStringEncodingUTF8);
+    if (!k)
+        return false;
+    CFTypeRef v = IORegistryEntryCreateCFProperty(s, k, kCFAllocatorDefault, 0);
+    CFRelease(k);
+    out[0] = '\0';
+    bool ok = false;
+    if (v && CFGetTypeID(v) == CFStringGetTypeID())
+        ok = CFStringGetCString((CFStringRef) v, out, (CFIndex) n,
+                                kCFStringEncodingUTF8) &&
+             out[0] != '\0';
+    if (v)
+        CFRelease(v);
+    return ok;
+}
+
+/* Port path from locationID nibbles below the top (bus) byte; empty for a root
+ * hub (nusb parse_location_id).
+ *
+ * Returns the number of ports written.
+ */
+static int location_ports(uint32_t loc, unsigned ports[USB_MAX_PORTS])
+{
+    int n = 0;
+    for (int shift = 20; shift >= 0 && n < USB_MAX_PORTS; shift -= 4) {
+        unsigned nib = (loc >> shift) & 0xf;
+        if (nib == 0)
+            break;
+        ports[n++] = nib;
+    }
+    return n;
+}
+
+static uint16_t get_le16(const uint8_t *p)
+{
+    return (uint16_t) (p[0] | (p[1] << 8));
+}
+
+/* Append every raw configuration descriptor (bus order, wTotalLength each) to
+ * the device-descriptor blob. Uses the device user-client plug-in, which does
+ * NOT open the device: GetConfigurationDescriptorPtr is explicitly documented
+ * as not requiring an open (IOUSBLib.h "no open needed").
+ */
+static int append_config_descriptors(io_service_t svc, usb_dev_t *d)
+{
+    IOCFPlugInInterface **plug = NULL;
+    SInt32 score = 0;
+    IOReturn kr = IOCreatePlugInInterfaceForService(
+        svc, kIOUSBDeviceUserClientTypeID, kIOCFPlugInInterfaceID, &plug,
+        &score);
+    if (kr != kIOReturnSuccess || !plug) {
+        log_warn(
+            "usb-sysfs: device plug-in failed for %s (0x%x); "
+            "descriptors blob has device descriptor only",
+            d->name, kr);
+        return -1;
+    }
+    IOUSBDeviceInterface650 **dev = NULL;
+    HRESULT hr = (*plug)->QueryInterface(
+        plug, CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID650), (LPVOID *) &dev);
+    IODestroyPlugInInterface(plug);
+    if (hr || !dev) {
+        log_warn("usb-sysfs: QueryInterface(650) failed for %s", d->name);
+        return -1;
+    }
+
+    int rc = 0;
+    for (unsigned i = 0; i < d->num_configs; i++) {
+        IOUSBConfigurationDescriptorPtr cfg = NULL;
+        kr = (*dev)->GetConfigurationDescriptorPtr(dev, (UInt8) i, &cfg);
+        if (kr != kIOReturnSuccess || !cfg) {
+            log_warn(
+                "usb-sysfs: GetConfigurationDescriptorPtr(%u) failed "
+                "for %s (0x%x)",
+                i, d->name, kr);
+            rc = -1;
+            continue;
+        }
+        const uint8_t *raw = (const uint8_t *) cfg;
+        uint16_t total = get_le16(raw + 2); /* wTotalLength, bus order */
+        if (total < 9)
+            continue;
+        uint8_t *nb = realloc(d->blob, d->blob_len + total);
+        if (!nb) {
+            rc = -1;
+            break;
+        }
+        memcpy(nb + d->blob_len, raw, total);
+        d->blob = nb;
+        d->blob_len += total;
+    }
+    (*dev)->Release(dev);
+    return rc;
+}
+
+/* Synthesize the 18-byte little-endian device descriptor from registry
+ * properties (macOS exposes no raw device descriptor; usbfs read() fixes
+ * multibyte fields to host endianness, which on LE hosts is the wire image:
+ * devio.c:331-353).
+ */
+static void build_device_descriptor(const usb_dev_t *d, uint8_t out[18])
+{
+    out[0] = 18;
+    out[1] = 1; /* DEVICE */
+    out[2] = (uint8_t) (d->bcd_usb & 0xff);
+    out[3] = (uint8_t) (d->bcd_usb >> 8);
+    out[4] = (uint8_t) d->dev_class;
+    out[5] = (uint8_t) d->dev_subclass;
+    out[6] = (uint8_t) d->dev_protocol;
+    out[7] = (uint8_t) d->max_packet0;
+    out[8] = (uint8_t) (d->vid & 0xff);
+    out[9] = (uint8_t) (d->vid >> 8);
+    out[10] = (uint8_t) (d->pid & 0xff);
+    out[11] = (uint8_t) (d->pid >> 8);
+    out[12] = (uint8_t) (d->bcd_device & 0xff);
+    out[13] = (uint8_t) (d->bcd_device >> 8);
+    out[14] = (uint8_t) d->i_manufacturer;
+    out[15] = (uint8_t) d->i_product;
+    out[16] = (uint8_t) d->i_serial;
+    out[17] = (uint8_t) d->num_configs;
+}
+
+/* Make room for one more entry, doubling the table when it is full.
+ *
+ * The new tail is zeroed because model_build fills an entry field by field and
+ * relies on the rest (blob, blob_len, the string buffers) starting empty, the
+ * way the file-static array used to give it for free.
+ *
+ * Returns false only when the allocation fails; the caller stops the walk and
+ * says so rather than dropping devices quietly.
+ */
+static bool usb_devs_reserve(void)
+{
+    if (usb_ndevs < usb_devs_cap)
+        return true;
+    int cap = usb_devs_cap ? usb_devs_cap * 2 : USB_DEVS_INIT_CAP;
+    usb_dev_t *grown = realloc(usb_devs, (size_t) cap * sizeof(*grown));
+    if (!grown)
+        return false;
+    memset(grown + usb_devs_cap, 0,
+           (size_t) (cap - usb_devs_cap) * sizeof(*grown));
+    usb_devs = grown;
+    usb_devs_cap = cap;
+    return true;
+}
+
+static void model_clear(void)
+{
+    for (int i = 0; i < usb_ndevs; i++) {
+        free(usb_devs[i].blob);
+        usb_devs[i].blob = NULL;
+    }
+    usb_ndevs = 0;
+}
+
+/* model_clear plus the table itself, for the teardown paths: a rescan keeps the
+ * allocation and refills it, but process exit must not leave it held.
+ */
+static void model_release(void)
+{
+    model_clear();
+    free(usb_devs);
+    usb_devs = NULL;
+    usb_devs_cap = 0;
+}
+
+/* One fixture device before it is emitted: the scalar parameters model_build
+ * turns into a usb_dev_t. Kept as plain data so the allocation that backs the
+ * device stays lexically inside model_build, next to the compaction free, the
+ * way the IOKit branch already carries its malloc.
+ */
+typedef struct {
+    int busnum;
+    int port;
+    int devnum;
+    unsigned vid;
+    unsigned pid;
+    unsigned nifaces;
+} usb_fixture_spec_t;
+
+/* The number of interface descriptors is the only thing that varies the blob
+ * length: an 18-byte device descriptor, one configuration header, then one
+ * interface descriptor per interface.
+ */
+static size_t usb_fixture_blob_len(unsigned nifaces)
+{
+    return USB_DEVICE_DESC_LEN + USB_CONFIG_DESC_LEN +
+           (size_t) nifaces * USB_INTERFACE_DESC_LEN;
+}
+
+/* Fill @d from @s, writing the device, configuration and interface descriptors
+ * into @d->blob, which the caller has already allocated to
+ * usb_fixture_blob_len(@s->nifaces). No allocation happens here, so ownership
+ * of the blob stays with the caller.
+ */
+static void usb_fixture_fill(usb_dev_t *d, const usb_fixture_spec_t *s)
+{
+    size_t blob_len = d->blob_len;
+    uint8_t *blob = d->blob;
+    memset(d, 0, sizeof(*d));
+    d->blob = blob;
+    d->blob_len = blob_len;
+    d->busnum = s->busnum;
+    d->devnum = s->devnum;
+    d->location_id =
+        ((uint32_t) (s->busnum - 1) << 24) | ((uint32_t) s->port << 4);
+    d->vid = s->vid;
+    d->pid = s->pid;
+    d->bcd_usb = 0x0200;
+    d->bcd_device = 0x0100;
+    d->max_packet0 = 64;
+    d->num_configs = 1;
+    d->speed_code = 1;
+    d->cfg_value = 1;
+    snprintf(d->devpath, sizeof(d->devpath), "%d", s->port);
+    snprintf(d->name, sizeof(d->name), "%d-%d", s->busnum, s->port);
+
+    size_t cfg_total =
+        USB_CONFIG_DESC_LEN + (size_t) s->nifaces * USB_INTERFACE_DESC_LEN;
+    build_device_descriptor(d, blob);
+    uint8_t *c = blob + USB_DEVICE_DESC_LEN;
+    c[0] = USB_CONFIG_DESC_LEN;
+    c[1] = USB_DT_CONFIG;
+    c[2] = (uint8_t) (cfg_total & 0xff);
+    c[3] = (uint8_t) (cfg_total >> 8);
+    c[4] = (uint8_t) s->nifaces; /* bNumInterfaces */
+    c[5] = 1;                    /* bConfigurationValue */
+    c[6] = 0;                    /* iConfiguration */
+    c[7] = 0x80;                 /* bmAttributes: bus powered */
+    c[8] = 50;                   /* bMaxPower: 100 mA */
+    for (unsigned i = 0; i < s->nifaces; i++) {
+        uint8_t *q =
+            c + USB_CONFIG_DESC_LEN + (size_t) i * USB_INTERFACE_DESC_LEN;
+        q[0] = USB_INTERFACE_DESC_LEN;
+        q[1] = USB_DT_INTERFACE;
+        q[2] = (uint8_t) i; /* bInterfaceNumber */
+        q[3] = 0;           /* bAlternateSetting */
+        q[4] = 1;           /* bNumEndpoints */
+        q[5] = 0xff;        /* bInterfaceClass: vendor-specific */
+        q[6] = 0x00;
+        q[7] = 0x00;
+        q[8] = 0;
+    }
+}
+
+/* Fill @specs (capacity @cap) with the canned device set behind
+ * ELFUSE_USB_FIXTURE and return how many were written, so the device-half
+ * assertions (descriptor byte-identity, dev/rdev/minor, bNumInterfaces vs the
+ * emitted interface-dir count, subsystem-link resolution) run on a host with no
+ * USB device attached.
+ *
+ * Default: bus1/dev1 with two interfaces, bus2/dev1 with one, exercising the
+ * per-bus minor arithmetic across two buses.
+ *
+ * ELFUSE_USB_FIXTURE=overflow: 129 address-less devices on bus 1 plus one on
+ * bus 2, all routed through the fallback devnum assignment. It is the
+ * regression fixture for the devnum cap -- without the cap bus1's 129th device
+ * takes devnum 129 and shares minor 128 with bus2's first, so the cap must drop
+ * everything past devnum 127.
+ */
+static int usb_fixture_specs(usb_fixture_spec_t *specs, int cap)
+{
+    const char *mode = getenv("ELFUSE_USB_FIXTURE");
+    int n = 0;
+    if (mode && !strcmp(mode, "overflow")) {
+        for (int port = 1; port <= 129 && n < cap; port++)
+            specs[n++] = (usb_fixture_spec_t) {1, port, 0, 0x1d6b, 0x0002, 1};
+        if (n < cap)
+            specs[n++] = (usb_fixture_spec_t) {2, 1, 0, 0x2109, 0x0100, 1};
+        return n;
+    }
+    if (n < cap)
+        specs[n++] = (usb_fixture_spec_t) {1, 1, 1, 0x1d6b, 0x0002, 2};
+    if (n < cap)
+        specs[n++] = (usb_fixture_spec_t) {2, 1, 1, 0x2109, 0x0100, 1};
+    return n;
+}
+
+#define USB_FIXTURE_MAX 130
+
+/* Enumerate the IOKit registry into usb_devs[].
+ *
+ * Known boundary -- no usbN root-hub entries. macOS does not publish root hubs
+ * as USB devices: the IOUSBDevice/IOUSBHostDevice match returns only downstream
+ * devices, and the controllers are IOUSBHostController objects that carry no
+ * device descriptor to synthesize one from. The tree therefore has no
+ * /sys/bus/usb/devices/usbN entries and no parent link from a device to its
+ * bus. libusb enumerates each device independently and leaves parent_dev NULL,
+ * and nusb skips names without a port path, so both still list every device;
+ * what is lost is topology, so `lsusb -t` prints each device without the bus
+ * row above it. The nports == 0 skip below is the matching guard: such an entry
+ * could only be named "<bus>-" with an empty port path.
+ */
+static void model_build(void)
+{
+    model_clear();
+
+    /* Test seam: a canned model, host-independent, so the device-half coverage
+     * runs without hardware. Off in every normal run (the env var is unset), so
+     * production still enumerates only the real IOKit registry.
+     */
+    if (getenv("ELFUSE_USB_FIXTURE")) {
+        usb_fixture_spec_t specs[USB_FIXTURE_MAX];
+        int n = usb_fixture_specs(specs, USB_FIXTURE_MAX);
+        for (int k = 0; k < n; k++) {
+            if (!usb_devs_reserve())
+                break;
+            usb_dev_t *d = &usb_devs[usb_ndevs];
+
+            /* Allocate here, in the same procedure as the compaction free
+             * below, so the blob's ownership is the registry branch's: a
+             * canned-model allocation stashed in a callee would read to the
+             * leak analyzer as unowned once it escaped into usb_devs[].
+             */
+            d->blob = malloc(usb_fixture_blob_len(specs[k].nifaces));
+            if (!d->blob)
+                continue;
+            d->blob_len = usb_fixture_blob_len(specs[k].nifaces);
+            usb_fixture_fill(d, &specs[k]);
+            usb_ndevs++;
+        }
+        goto assign_devnums; /* run the same fallback+cap the registry path does
+                              */
+    }
+
+    CFMutableDictionaryRef match = IOServiceMatching("IOUSBDevice");
+    if (!match)
+        return;
+    io_iterator_t it = IO_OBJECT_NULL;
+    if (IOServiceGetMatchingServices(kIOMainPortDefault, match, &it) !=
+        kIOReturnSuccess)
+        return;
+
+    io_service_t svc;
+    while ((svc = IOIteratorNext(it))) {
+        /* Reserve before the entry pointer below is taken, so the growth can
+         * never move the table out from under it mid-iteration.
+         */
+        if (!usb_devs_reserve()) {
+            log_warn(
+                "usb: cannot grow the device table past %d entries; "
+                "the USB tree is truncated",
+                usb_ndevs);
+            IOObjectRelease(svc);
+            break;
+        }
+        long loc = ioreg_num(svc, "locationID");
+        long vid = ioreg_num(svc, "idVendor");
+        long pid = ioreg_num(svc, "idProduct");
+        if (loc < 0 || vid < 0 || pid < 0) {
+            IOObjectRelease(svc);
+            continue;
+        }
+        unsigned ports[USB_MAX_PORTS];
+        int nports = location_ports((uint32_t) loc, ports);
+        if (nports == 0) { /* unnameable: no port path (see above) */
+            IOObjectRelease(svc);
+            continue;
+        }
+        bool dup = false;
+        for (int i = 0; i < usb_ndevs; i++)
+            if (usb_devs[i].location_id == (uint32_t) loc)
+                dup = true;
+        if (dup) {
+            IOObjectRelease(svc);
+            continue;
+        }
+
+        usb_dev_t *d = &usb_devs[usb_ndevs];
+        memset(d, 0, sizeof(*d));
+        d->location_id = (uint32_t) loc;
+
+        /* macOS bus indices (locationID top byte) start at 0; Linux busnums are
+         * 1-based (minor arithmetic and BBB names break at bus 0), so shift by
+         * one. Deviation from a literal locationID>>24 is deliberate and
+         * stable: the top byte is constant per controller.
+         */
+        d->busnum = (int) ((uint32_t) loc >> 24) + 1;
+        long addr = ioreg_num(svc, "USB Address");
+        if (addr < 0)
+            addr = ioreg_num(svc, "kUSBAddress");
+        d->devnum = addr > 0 && addr < 128 ? (int) addr : 0;
+        d->vid = (unsigned) vid & 0xffff;
+        d->pid = (unsigned) pid & 0xffff;
+
+        long v;
+        d->bcd_device =
+            (v = ioreg_num(svc, "bcdDevice")) >= 0 ? (unsigned) v : 0;
+        d->bcd_usb =
+            (v = ioreg_num(svc, "bcdUSB")) >= 0 ? (unsigned) v : 0x0200;
+        d->dev_class =
+            (v = ioreg_num(svc, "bDeviceClass")) >= 0 ? (unsigned) v : 0;
+        d->dev_subclass =
+            (v = ioreg_num(svc, "bDeviceSubClass")) >= 0 ? (unsigned) v : 0;
+        d->dev_protocol =
+            (v = ioreg_num(svc, "bDeviceProtocol")) >= 0 ? (unsigned) v : 0;
+        d->num_configs =
+            (v = ioreg_num(svc, "bNumConfigurations")) > 0 ? (unsigned) v : 1;
+        d->max_packet0 =
+            (v = ioreg_num(svc, "bMaxPacketSize0")) > 0 ? (unsigned) v : 64;
+        d->speed_code =
+            (v = ioreg_num(svc, "Device Speed")) >= 0 ? (unsigned) v : 1;
+        d->i_manufacturer =
+            (v = ioreg_num(svc, "iManufacturer")) > 0 ? (unsigned) v : 0;
+        d->i_product = (v = ioreg_num(svc, "iProduct")) > 0 ? (unsigned) v : 0;
+        d->i_serial =
+            (v = ioreg_num(svc, "iSerialNumber")) > 0 ? (unsigned) v : 0;
+        d->cfg_value = (v = ioreg_num(svc, "kUSBCurrentConfiguration")) > 0
+                           ? (unsigned) v
+                           : 0;
+
+        if (!ioreg_str(svc, "kUSBVendorString", d->manufacturer,
+                       sizeof(d->manufacturer)))
+            ioreg_str(svc, "USB Vendor Name", d->manufacturer,
+                      sizeof(d->manufacturer));
+        if (!ioreg_str(svc, "kUSBProductString", d->product,
+                       sizeof(d->product)))
+            ioreg_str(svc, "USB Product Name", d->product, sizeof(d->product));
+        if (!ioreg_str(svc, "kUSBSerialNumberString", d->serial,
+                       sizeof(d->serial)))
+            ioreg_str(svc, "USB Serial Number", d->serial, sizeof(d->serial));
+
+        /* "<bus>-<port[.port]*>" (usb.c:704-726) and devpath */
+        size_t off = 0;
+        for (int i = 0; i < nports; i++)
+            off += (size_t) snprintf(d->devpath + off, sizeof(d->devpath) - off,
+                                     "%s%u", i ? "." : "", ports[i]);
+        snprintf(d->name, sizeof(d->name), "%d-%s", d->busnum, d->devpath);
+
+        d->blob = malloc(18);
+        if (!d->blob) {
+            IOObjectRelease(svc);
+            continue;
+        }
+        d->blob_len = 18;
+        append_config_descriptors(svc, d);
+        build_device_descriptor(d, d->blob);
+
+        /* Fall back to the first config's bConfigurationValue when the registry
+         * has no current-configuration key. Byte 5 is bConfigurationValue only
+         * once the record is known to be a configuration header, so the same
+         * two-field check the descriptor walk applies is applied here rather
+         * than reading the field out of whatever the device happened to send.
+         */
+        if (d->cfg_value == 0 &&
+            d->blob_len >= USB_DEVICE_DESC_LEN + USB_CONFIG_DESC_LEN &&
+            d->blob[USB_DEVICE_DESC_LEN] == USB_CONFIG_DESC_LEN &&
+            d->blob[USB_DEVICE_DESC_LEN + 1] == USB_DT_CONFIG)
+            d->cfg_value = d->blob[USB_DEVICE_DESC_LEN + 5];
+        if (d->cfg_value == 0)
+            d->cfg_value = 1;
+
+        usb_ndevs++;
+        IOObjectRelease(svc);
+    }
+    IOObjectRelease(it);
+
+assign_devnums:
+    /* Fallback devnum assignment: stable 1..n per bus in locationID order for
+     * devices without a 'USB Address' property, avoiding taken numbers.
+     */
+    for (int pass = 0; pass < usb_ndevs; pass++) {
+        int best = -1;
+        for (int i = 0; i < usb_ndevs; i++) {
+            if (usb_devs[i].devnum != 0)
+                continue;
+            if (best < 0 ||
+                usb_devs[i].location_id < usb_devs[best].location_id)
+                best = i;
+        }
+        if (best < 0)
+            break;
+        int devnum = 1;
+        for (int again = 1; again;) {
+            again = 0;
+            for (int i = 0; i < usb_ndevs; i++)
+                if (i != best && usb_devs[i].busnum == usb_devs[best].busnum &&
+                    usb_devs[i].devnum == devnum) {
+                    devnum++;
+                    again = 1;
+                }
+        }
+        if (devnum > 127) {
+            /* usbfs numbers devices 1..127 per bus: devnum-1 is the low 7 bits
+             * of the minor (usb_minor()), so a 128th device on one bus would
+             * take the first minor of the next bus (bus1 devnum129 and bus2
+             * devnum1 both map to minor 128). The registry-address path already
+             * clamps to <128; cap the fallback the same way and drop the
+             * overflow rather than alias a node onto another bus's range.
+             */
+            log_warn(
+                "usb: bus %d already holds 127 devices; dropping the device at "
+                "locationID 0x%08x (usbfs caps devnum at 127)",
+                usb_devs[best].busnum, (unsigned) usb_devs[best].location_id);
+            usb_devs[best].devnum = -1; /* tombstone; compacted out below */
+            continue;
+        }
+        usb_devs[best].devnum = devnum;
+    }
+
+    /* Compact the tombstones the cap left behind so no later pass, emit, or
+     * lookup sees a devnum < 1.
+     */
+    int kept = 0;
+    for (int i = 0; i < usb_ndevs; i++) {
+        if (usb_devs[i].devnum >= 1) {
+            if (kept != i)
+                usb_devs[kept] = usb_devs[i];
+            kept++;
+        } else {
+            free(usb_devs[i].blob);
+            usb_devs[i].blob = NULL;
+        }
+    }
+    usb_ndevs = kept;
+}
+
+/* scratch tree construction */
+
+static int usb_write_file(const char *dir,
+                          const char *name,
+                          const void *data,
+                          size_t len)
+{
+    char path[256];
+    if (snprintf(path, sizeof(path), "%s/%s", dir, name) >=
+        (int) sizeof(path)) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0444);
+    if (fd < 0)
+        return -1;
+    const uint8_t *p = data;
+    size_t left = len;
+    while (left > 0) {
+        ssize_t n = write(fd, p, left);
+        if (n < 0 && errno == EINTR)
+            continue; /* retry like syscpu_write_file: a stray signal must
+                       * not abort a one-shot tree build
+                       */
+        if (n <= 0) {
+            close(fd);
+            return -1;
+        }
+        p += n;
+        left -= (size_t) n;
+    }
+    close(fd);
+    return 0;
+}
+
+__attribute__((format(printf, 3, 4))) static int usb_write_fmt(const char *dir,
+                                                               const char *name,
+                                                               const char *fmt,
+                                                               ...)
+{
+    char buf[512];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    if (n < 0)
+        n = 0;
+    if ((size_t) n >= sizeof(buf))
+        n = (int) sizeof(buf) - 1;
+    return usb_write_file(dir, name, buf, (size_t) n);
+}
+
+/* sysfs speed strings (sysfs.c:145-178) keyed by the registry's Device Speed
+ * code (USB.h: 0 Low, 1 Full, 2 High, 3 Super, 4 Super+, 5 Super+x2).
+ */
+static const char *speed_string(unsigned code)
+{
+    switch (code) {
+    case 0:
+        return "1.5";
+    case 1:
+        return "12";
+    case 2:
+        return "480";
+    case 3:
+        return "5000";
+    case 4:
+        return "10000";
+    case 5:
+        return "20000";
+    default:
+        return "12";
+    }
+}
+
+static int usb_minor(const usb_dev_t *d)
+{
+    return (d->busnum - 1) * 128 + (d->devnum - 1);
+}
+
+/* Locate the active configuration descriptor inside the blob: the one whose
+ * bConfigurationValue matches cfg_value, else the first. Every "current
+ * configuration's attributes" reader (bNumInterfaces, bmAttributes, bMaxPower,
+ * the interface dirs) must go through this, or the attribute files and the
+ * emitted :c.i directories can describe two different configurations.
+ *
+ * Returns the descriptor with *len_out set, or NULL when the blob carries none.
+ */
+static const uint8_t *active_config(const usb_dev_t *d, size_t *len_out)
+{
+    return usb_desc_active_config(d->blob, d->blob_len, d->cfg_value, len_out);
+}
+
+/* Emit one interface dir <name>:<cfg>.<if> per bInterfaceNumber (alternate
+ * setting 0) of the active configuration, parsed from the raw config descriptor
+ * already in the blob -- registry children vanish under capture, so they are
+ * deliberately not consulted.
+ */
+static void emit_interface_dirs(const char *devices_dir, const usb_dev_t *d)
+{
+    size_t cfg_len = 0;
+    const uint8_t *cfg = active_config(d, &cfg_len);
+    if (!cfg)
+        return;
+
+    /* The blob is device-supplied, so the walk is a bounded iteration that can
+     * only ever stop early (usb-desc.h), never step off the end of cfg_len.
+     * usb_desc_interfaces owns the selection -- alternate setting 0, first
+     * appearance of each bInterfaceNumber -- and is sized to the whole byte
+     * range the field can hold, so no number is dropped for being large.
+     */
+    const uint8_t *ifaces[USB_DESC_INTERFACES_MAX];
+    bool truncated = false;
+    size_t stop_off = 0;
+    size_t nif = usb_desc_interfaces(cfg, cfg_len, ifaces, ARRAY_SIZE(ifaces),
+                                     &truncated, &stop_off);
+    if (truncated)
+        log_warn(
+            "usb-sysfs: %s: config descriptor truncated after %zu of %zu bytes",
+            d->name, stop_off, cfg_len);
+
+    for (size_t i = 0; i < nif; i++) {
+        const uint8_t *q = ifaces[i];
+        unsigned ifnum = q[2], alt = q[3], neps = q[4];
+        unsigned icls = q[5], isub = q[6], ipro = q[7];
+        char idir[256];
+        if (snprintf(idir, sizeof(idir), "%s/%s:%u.%u", devices_dir, d->name,
+                     d->cfg_value, ifnum) >= (int) sizeof(idir) ||
+            mkdir(idir, 0755) != 0)
+            continue;
+        usb_write_fmt(idir, "bInterfaceNumber", "%02x\n", ifnum);
+        usb_write_fmt(idir, "bAlternateSetting", "%2d\n", alt);
+        usb_write_fmt(idir, "bNumEndpoints", "%02x\n", neps);
+        usb_write_fmt(idir, "bInterfaceClass", "%02x\n", icls);
+        usb_write_fmt(idir, "bInterfaceSubClass", "%02x\n", isub);
+        usb_write_fmt(idir, "bInterfaceProtocol", "%02x\n", ipro);
+        char ilink[300];
+        if (snprintf(ilink, sizeof(ilink), "%s/subsystem", idir) <
+            (int) sizeof(ilink))
+            symlink("../../../usb", ilink);
+        usb_write_fmt(idir, "uevent",
+                      "DEVTYPE=usb_interface\n"
+                      "PRODUCT=%x/%x/%x\n"
+                      "TYPE=%u/%u/%u\n"
+                      "INTERFACE=%u/%u/%u\n"
+                      "MODALIAS=usb:v%04Xp%04Xd%04Xdc%02Xdsc%02Xdp%02X"
+                      "ic%02Xisc%02Xip%02Xin%02X\n",
+                      d->vid, d->pid, d->bcd_device, d->dev_class,
+                      d->dev_subclass, d->dev_protocol, icls, isub, ipro,
+                      d->vid, d->pid, d->bcd_device, d->dev_class,
+                      d->dev_subclass, d->dev_protocol, icls, isub, ipro,
+                      ifnum);
+    }
+}
+
+static void emit_device_dir(const char *devices_dir, const usb_dev_t *d)
+{
+    char dir[256];
+    if (snprintf(dir, sizeof(dir), "%s/%s", devices_dir, d->name) >=
+        (int) sizeof(dir))
+        return;
+    if (mkdir(dir, 0755) < 0)
+        return;
+
+    usb_write_fmt(dir, "busnum", "%d\n", d->busnum);
+    usb_write_fmt(dir, "devnum", "%d\n", d->devnum);
+    usb_write_fmt(dir, "devpath", "%s\n", d->devpath);
+    usb_write_fmt(dir, "idVendor", "%04x\n", d->vid);
+    usb_write_fmt(dir, "idProduct", "%04x\n", d->pid);
+    usb_write_fmt(dir, "bcdDevice", "%04x\n", d->bcd_device);
+    usb_write_fmt(dir, "bDeviceClass", "%02x\n", d->dev_class);
+    usb_write_fmt(dir, "bDeviceSubClass", "%02x\n", d->dev_subclass);
+    usb_write_fmt(dir, "bDeviceProtocol", "%02x\n", d->dev_protocol);
+    usb_write_fmt(dir, "bNumConfigurations", "%u\n", d->num_configs);
+    usb_write_fmt(dir, "bMaxPacketSize0", "%u\n", d->max_packet0);
+    usb_write_fmt(dir, "bConfigurationValue", "%u\n", d->cfg_value);
+    usb_write_fmt(dir, "version", "%2x.%02x\n", d->bcd_usb >> 8,
+                  d->bcd_usb & 0xff);
+    usb_write_fmt(dir, "speed", "%s\n", speed_string(d->speed_code));
+    usb_write_fmt(dir, "dev", "%d:%d\n", USB_MAJOR, usb_minor(d));
+
+    /* Current configuration's attributes (sysfs.c:29-88, 782-786), read from
+     * the same descriptor emit_interface_dirs walks.
+     *
+     * All four are written on every device, including when the blob carried no
+     * usable configuration at all. Linux's dev_attr_grp has no .is_visible
+     * (sysfs.c:815-817), so these files exist on every USB device directory and
+     * a value the kernel cannot supply shows up as a zero-length read; writing
+     * only the ones whose value is known would answer ENOENT where Linux
+     * answers "nothing", which is a different fact about the device. See
+     * usb_desc_actconfig_attrs for the rest of the rule.
+     *
+     * cfg_string is NULL here, and that is the whole of what this stage can
+     * say. iConfiguration names a string descriptor, and a string descriptor is
+     * fetched over an ep0 control transfer on an open device -- which this
+     * layer deliberately does not do. IOKit offers no way around it: an
+     * IOUSBHostDevice registry entry publishes iManufacturer, iProduct and
+     * iSerialNumber together with the three strings the family caches for them
+     * ("USB Vendor Name", "USB Product Name", kUSBSerialNumberString), but it
+     * publishes neither an iConfiguration index nor any configuration string,
+     * and IOUSBDeviceInterface has no cached-string call to stand in for the
+     * transfer the way GetConfigurationDescriptorPtr stands in for fetching a
+     * configuration descriptor.
+     *
+     * A NULL cfg_string is not a lie about the device, and this is why the file
+     * stays present and empty rather than being left out: usb_cache_string
+     * returns NULL "if the index is 0 or the string could not be read", so
+     * every device here takes the second of Linux's own two paths to an empty
+     * configuration. Known deviation, and a fidelity gap rather than a
+     * correctness one: a device whose iConfiguration is non-zero and whose
+     * string descriptor is readable shows that string on Linux and shows
+     * nothing here. Closing it needs the ep0 path.
+     */
+    size_t cfg_len = 0;
+    const uint8_t *cfg = active_config(d, &cfg_len);
+    usb_actconfig_attrs_t actcfg;
+
+    /* bMaxPower is in 2 mA units below SuperSpeed and 8 mA at and above it
+     * (usb_get_max_power); speed_code is IOKit's "Device Speed", whose 3 is
+     * SuperSpeed.
+     */
+    usb_desc_actconfig_attrs(cfg, cfg_len, d->speed_code >= 3 ? 8 : 2, NULL,
+                             &actcfg);
+    usb_write_file(dir, "bNumInterfaces", actcfg.num_interfaces,
+                   strlen(actcfg.num_interfaces));
+    usb_write_file(dir, "bmAttributes", actcfg.bm_attributes,
+                   strlen(actcfg.bm_attributes));
+    usb_write_file(dir, "bMaxPower", actcfg.max_power,
+                   strlen(actcfg.max_power));
+    usb_write_file(dir, "configuration", actcfg.configuration,
+                   strlen(actcfg.configuration));
+
+    /* Downstream port count. Hub descriptors need a control transfer on an open
+     * device, which stage 1 deliberately does not do, so every device reports
+     * the non-hub value. Known deviation: a hub's real port count is not
+     * modeled, and neither is the parent/child topology that would use it.
+     */
+    usb_write_fmt(dir, "maxchild", "%d\n", 0);
+
+    /* Lane counts (hub.c:3036-3041): SuperSpeed+ Gen 2x2 -- the registry's
+     * Device Speed 5 -- runs two lanes each way, everything else one.
+     */
+    unsigned lanes = d->speed_code == 5 ? 2 : 1;
+    usb_write_fmt(dir, "rx_lanes", "%u\n", lanes);
+    usb_write_fmt(dir, "tx_lanes", "%u\n", lanes);
+    if (d->manufacturer[0])
+        usb_write_fmt(dir, "manufacturer", "%s\n", d->manufacturer);
+    if (d->product[0])
+        usb_write_fmt(dir, "product", "%s\n", d->product);
+    if (d->serial[0])
+        usb_write_fmt(dir, "serial", "%s\n", d->serial);
+    usb_write_fmt(dir, "uevent",
+                  "MAJOR=%d\n"
+                  "MINOR=%d\n"
+                  "DEVNAME=bus/usb/%03d/%03d\n"
+                  "DEVTYPE=usb_device\n"
+                  "DRIVER=usb\n"
+                  "PRODUCT=%x/%x/%x\n"
+                  "TYPE=%u/%u/%u\n"
+                  "BUSNUM=%03d\n"
+                  "DEVNUM=%03d\n",
+                  USB_MAJOR, usb_minor(d), d->busnum, d->devnum, d->vid, d->pid,
+                  d->bcd_device, d->dev_class, d->dev_subclass, d->dev_protocol,
+                  d->busnum, d->devnum);
+    usb_write_file(dir, "descriptors", d->blob, d->blob_len);
+
+    /* libudev derives the subsystem from readlink(<dev>/subsystem) and keeps
+     * only its basename; the relative target also resolves inside the scratch
+     * tree (devices/<name>/../../../usb == bus/usb).
+     */
+    char linkpath[300];
+    if (snprintf(linkpath, sizeof(linkpath), "%s/subsystem", dir) <
+        (int) sizeof(linkpath))
+        symlink("../../../usb", linkpath);
+
+    emit_interface_dirs(devices_dir, d);
+}
+
+static void usb_remove_tree(const char *dir, int depth)
+{
+    if (depth > 6)
+        return;
+    DIR *dp = opendir(dir);
+    if (dp) {
+        struct dirent *ent;
+        while ((ent = readdir(dp))) {
+            if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
+                continue;
+            char path[512];
+            if (snprintf(path, sizeof(path), "%s/%s", dir, ent->d_name) >=
+                (int) sizeof(path))
+                continue;
+            struct stat st;
+            if (lstat(path, &st) == 0 && S_ISDIR(st.st_mode))
+                usb_remove_tree(path, depth + 1);
+            else
+                unlink(path);
+        }
+        closedir(dp);
+    }
+    rmdir(dir);
+}
+
+static void usb_tree_cleanup(void)
+{
+    pthread_mutex_lock(&usb_lock);
+    if (usb_tree_ok && usb_owner_pid == getpid()) {
+        usb_remove_tree(usb_sys_dir, 0);
+        usb_remove_tree(usb_dev_dir, 0);
+    }
+    usb_tree_ok = false;
+    model_release();
+    pthread_mutex_unlock(&usb_lock);
+}
+
+/* One-shot build under usb_lock (the ensure_syscpu_dir pattern). The model is a
+ * boot-time snapshot: hotplug support would clear usb_tree_ok here so the next
+ * call re-enumerates, once something (the uevent layer) can observe
+ * attach/detach and call in.
+ * Returns 0 with both scratch roots valid, or -1 with errno set.
+ */
+static int ensure_usb_tree(void)
+{
+    if (usb_tree_ok)
+        return 0;
+
+    str_copy_trunc(usb_sys_dir, "/tmp/elfuse-usbsys-XXXXXX",
+                   sizeof(usb_sys_dir));
+    if (!mkdtemp(usb_sys_dir)) {
+        usb_sys_dir[0] = '\0';
+        return -1;
+    }
+    if (!realpath(usb_sys_dir, usb_sys_real)) {
+        int saved = errno;
+        usb_remove_tree(usb_sys_dir, 0);
+        usb_sys_dir[0] = usb_sys_real[0] = '\0';
+        errno = saved;
+        return -1;
+    }
+    str_copy_trunc(usb_dev_dir, "/tmp/elfuse-usbdev-XXXXXX",
+                   sizeof(usb_dev_dir));
+    if (!mkdtemp(usb_dev_dir)) {
+        usb_remove_tree(usb_sys_dir, 0);
+        usb_sys_dir[0] = usb_dev_dir[0] = usb_sys_real[0] = '\0';
+        return -1;
+    }
+
+    model_build();
+
+    char devices_dir[128];
+    {
+        char sub[128];
+        snprintf(sub, sizeof(sub), "%s/bus", usb_sys_dir);
+        if (mkdir(sub, 0755) < 0)
+            goto fail;
+        snprintf(sub, sizeof(sub), "%s/bus/usb", usb_sys_dir);
+        if (mkdir(sub, 0755) < 0)
+            goto fail;
+    }
+    snprintf(devices_dir, sizeof(devices_dir), "%s/bus/usb/devices",
+             usb_sys_dir);
+    if (mkdir(devices_dir, 0755) < 0)
+        goto fail;
+    char usbdir[128];
+    snprintf(usbdir, sizeof(usbdir), "%s/usb", usb_dev_dir);
+    if (mkdir(usbdir, 0755) < 0)
+        goto fail;
+
+    for (int i = 0; i < usb_ndevs; i++) {
+        const usb_dev_t *d = &usb_devs[i];
+        emit_device_dir(devices_dir, d);
+
+        char busdir[160];
+        if (snprintf(busdir, sizeof(busdir), "%s/%03d", usbdir, d->busnum) >=
+            (int) sizeof(busdir))
+            continue;
+        if (mkdir(busdir, 0755) < 0 && errno != EEXIST)
+            continue;
+        char node[8];
+        snprintf(node, sizeof(node), "%03d", d->devnum);
+        /* Placeholder: 0444 empty regular file; open/stat divert it. */
+        usb_write_file(busdir, node, "", 0);
+    }
+
+    static bool atexit_armed;
+    if (!atexit_armed) {
+        atexit(usb_tree_cleanup);
+        atexit_armed = true;
+    }
+    usb_owner_pid = getpid();
+    usb_tree_ok = true;
+    return 0;
+
+fail:;
+    int saved = errno;
+    usb_remove_tree(usb_sys_dir, 0);
+    usb_remove_tree(usb_dev_dir, 0);
+    usb_sys_dir[0] = usb_dev_dir[0] = usb_sys_real[0] = '\0';
+    model_release();
+    errno = saved;
+    return -1;
+}
+
+/* path classification */
+
+typedef enum {
+    USB_PATH_NONE,
+    USB_PATH_DEV_BUS,      /* /dev/bus            */
+    USB_PATH_DEV_USB,      /* /dev/bus/usb        */
+    USB_PATH_DEV_BUSNUM,   /* /dev/bus/usb/BBB    */
+    USB_PATH_DEV_NODE,     /* /dev/bus/usb/BBB/DDD */
+    USB_PATH_DEV_NODE_SUB, /* the node used as a directory: BBB/DDD/ or /x */
+    USB_PATH_DEV_ABSENT,   /* under /dev/bus but nothing we model */
+    USB_PATH_SYS,          /* /sys[/suffix] (whole sysfs view) */
+} usb_path_kind_t;
+
+/* Parse exactly three decimal digits followed by '\0' or '/'. */
+static int parse_ddd(const char *s, const char **rest)
+{
+    if (!isdigit((unsigned char) s[0]) || !isdigit((unsigned char) s[1]) ||
+        !isdigit((unsigned char) s[2]))
+        return -1;
+    if (s[3] != '\0' && s[3] != '/')
+        return -1;
+    *rest = s + 3;
+    return (s[0] - '0') * 100 + (s[1] - '0') * 10 + (s[2] - '0');
+}
+
+/* Skip one or more '/' and report whether anything follows. */
+static const char *skip_slashes(const char *s)
+{
+    while (*s == '/')
+        s++;
+    return s;
+}
+
+static usb_path_kind_t classify_path(const char *path,
+                                     int *bus_out,
+                                     int *dev_out,
+                                     const char **sys_suffix_out)
+{
+    if (path_prefix_match(path, "/sys", 4)) {
+        /* /sys/devices/system/cpu stays with the syscpu stub, which the procemu
+         * dispatchers consult before this layer.
+         */
+        if (path_prefix_match(path, "/sys/devices/system/cpu", 23))
+            return USB_PATH_NONE;
+        const char *sfx = skip_slashes(path + 4);
+        *sys_suffix_out = sfx;
+        return USB_PATH_SYS;
+    }
+    if (!path_prefix_match(path, "/dev/bus", 8))
+        return USB_PATH_NONE;
+
+    const char *p = skip_slashes(path + 8);
+    if (!*p)
+        return USB_PATH_DEV_BUS;
+    if (strncmp(p, "usb", 3) != 0 || (p[3] != '\0' && p[3] != '/'))
+        return USB_PATH_DEV_ABSENT;
+    p = skip_slashes(p + 3);
+    if (!*p)
+        return USB_PATH_DEV_USB;
+    const char *rest;
+    int bus = parse_ddd(p, &rest);
+    if (bus < 0)
+        return USB_PATH_DEV_ABSENT;
+    rest = skip_slashes(rest);
+    if (!*rest) {
+        *bus_out = bus;
+        return USB_PATH_DEV_BUSNUM;
+    }
+    const char *rest2;
+    int dev = parse_ddd(rest, &rest2);
+    if (dev < 0)
+        return USB_PATH_DEV_ABSENT;
+    *bus_out = bus;
+    *dev_out = dev;
+
+    /* Any separator after the node -- a bare trailing slash included, which is
+     * why this tests rest2 itself rather than what survives skip_slashes -- is
+     * the node being used as a directory. Linux answers ENOTDIR for that, but
+     * only once the node exists; a missing node still reports ENOENT, so the
+     * decision is deferred to the lookup rather than made here.
+     */
+    if (rest2[0] != '\0')
+        return USB_PATH_DEV_NODE_SUB;
+    return USB_PATH_DEV_NODE;
+}
+
+/* True when a folded /sys-relative suffix names something under the one subtree
+ * this layer synthesizes, /sys/bus/usb. It gates a single decision: what to do
+ * when a /sys name resolves to nothing in the scratch tree. Under /sys/bus/usb
+ * an absence is authoritative -- a missing device is ENOENT, the way a real
+ * sysfs answers -- so this returns true and the caller keeps the ENOENT.
+ * Anywhere else under /sys (/sys/class, /sys/devices, /sys/kernel, a bus other
+ * than usb) we model nothing, so a miss must not be reported as ENOENT: that
+ * would shadow a populated sysroot /sys. This returns false there and the
+ * caller reports PROC_NOT_INTERCEPTED so the sysroot backing answers.
+ *
+ * The /sys root and its /sys/bus parent are not "owned" by this test, but they
+ * exist as real directories in the scratch tree, so they resolve and are served
+ * before this test is ever consulted; only the resolve-failure path asks it.
+ * The @suffix arrives with '.'/'..' folded, so "bus/usb/../class" is "class"
+ * and correctly disowned, while "bus/usb/devices/1-1" stays ours.
+ */
+static bool usb_sys_suffix_owned(const char *suffix)
+{
+    /* Exactly the bus/usb directory, or a name that continues it past a '/'.
+     * Spelled with whole-string compares rather than a suffix[7] index so the
+     * boundary byte is never read on its own -- the folded builder output that
+     * reaches here is NUL-terminated, but an explicit index past the compared
+     * prefix reads to the analyzer as a maybe-uninitialized byte.
+     */
+    return !strcmp(suffix, "bus/usb") || !strncmp(suffix, "bus/usb/", 8);
+}
+
+static usb_dev_t *find_dev(int busnum, int devnum)
+{
+    for (int i = 0; i < usb_ndevs; i++)
+        if (usb_devs[i].busnum == busnum && usb_devs[i].devnum == devnum)
+            return &usb_devs[i];
+    return NULL;
+}
+
+static bool bus_exists(int busnum)
+{
+    for (int i = 0; i < usb_ndevs; i++)
+        if (usb_devs[i].busnum == busnum)
+            return true;
+    return false;
+}
+
+/* Fold '.' and '..' in a /sys-relative suffix, lexically.
+ *
+ * This is the ours/not-ours gate and nothing more: a suffix that folds away
+ * above /sys is not a name this layer serves, and the caller reports
+ * PROC_NOT_INTERCEPTED for it. Rejecting '..' outright (the syscpu_suffix_safe
+ * contract) answered EACCES for /sys/bus/usb/devices/../devices/2-1, which
+ * Linux resolves without complaint, so this folds instead.
+ *
+ * The fold is NOT how the served path is built. An earlier version claimed the
+ * lexical fold was exact because `subsystem` links are always the last
+ * component -- that is false, `<dev>/subsystem/..` puts one in the middle, and
+ * Linux applies '..' to what the link resolved to (/sys/bus) rather than to the
+ * directory the link sits in. usb_sys_resolve_suffix does the real resolution;
+ * see it for how '..' and symlinks are ordered.
+ *
+ * A trailing slash survives the fold: it is what makes an attribute file used
+ * as a directory report ENOTDIR.
+ *
+ * Returns 1 with out filled, 0 when the walk climbs above /sys (no longer ours;
+ * the caller reports PROC_NOT_INTERCEPTED), -1 when the result does not fit.
+ */
+static int usb_suffix_normalize(const char *suffix, char *out, size_t outsz)
+{
+    size_t len = 0;
+    size_t marks[64];
+    size_t depth = 0;
+
+    out[0] = '\0';
+    for (const char *p = suffix; *p;) {
+        const char *seg = p;
+        while (*p && *p != '/')
+            p++;
+        size_t seglen = (size_t) (p - seg);
+        while (*p == '/')
+            p++;
+        if (seglen == 0 || (seglen == 1 && seg[0] == '.'))
+            continue;
+        if (seglen == 2 && seg[0] == '.' && seg[1] == '.') {
+            if (depth == 0)
+                return 0; /* above /sys */
+            len = marks[--depth];
+            out[len] = '\0';
+            continue;
+        }
+        if (depth >= ARRAY_SIZE(marks))
+            return -1;
+        marks[depth++] = len;
+        if (len + (len ? 1 : 0) + seglen + 1 > outsz)
+            return -1;
+        if (len)
+            out[len++] = '/';
+        memcpy(out + len, seg, seglen);
+        len += seglen;
+        out[len] = '\0';
+    }
+
+    /* Preserve a trailing slash only when something remains to apply it to;
+     * "/sys/bus/.." folds to /sys itself, which is a directory either way.
+     */
+    if (len > 0 && suffix[0] && suffix[strlen(suffix) - 1] == '/') {
+        if (len + 2 > outsz)
+            return -1;
+        out[len++] = '/';
+        out[len] = '\0';
+    }
+    return 1;
+}
+
+/* Synthetic stat identities, mirroring procemu.c's PROC_SYNTH_DEV scheme with a
+ * distinct device so /sys/bus/usb nodes never collide with /proc ones.
+ */
+#define USB_SYNTH_DEV ((dev_t) 0x5553)
+
+/* st_ino identifies the object, not the spelling that reached it: hashing the
+ * caller's path handed /sys/bus/usb/devices and /sys/bus/usb/devices/../devices
+ * two different inodes for one directory, which is a thing no filesystem does
+ * and which every (st_dev, st_ino) same-file test -- realpath loop detection,
+ * find -L, hardlink accounting -- would believe. Callers pass the canonical
+ * spelling built by usb_canon_path.
+ */
+static ino_t usb_synth_ino(const char *canon)
+{
+    uint64_t h = fnv1a64(canon, strlen(canon));
+    h &= 0x7fffffffffffffffULL;
+    return (ino_t) (h ? h : 1);
+}
+
+/* One spelling per object: the guest-visible path with '.'/'..' already folded
+ * (the suffix arrives normalized) and any trailing slash dropped.
+ */
+static void usb_canon_path(usb_path_kind_t kind,
+                           const char *sfx,
+                           int bus,
+                           int dev,
+                           char *out,
+                           size_t outsz)
+{
+    switch (kind) {
+    case USB_PATH_SYS:
+        if (*sfx)
+            snprintf(out, outsz, "/sys/%s", sfx);
+        else
+            str_copy_trunc(out, "/sys", outsz);
+        break;
+    case USB_PATH_DEV_BUS:
+        str_copy_trunc(out, "/dev/bus", outsz);
+        break;
+    case USB_PATH_DEV_USB:
+        str_copy_trunc(out, "/dev/bus/usb", outsz);
+        break;
+    case USB_PATH_DEV_BUSNUM:
+        snprintf(out, outsz, "/dev/bus/usb/%03d", bus);
+        break;
+    case USB_PATH_DEV_NODE:
+    case USB_PATH_DEV_NODE_SUB:
+        snprintf(out, outsz, "/dev/bus/usb/%03d/%03d", bus, dev);
+        break;
+    case USB_PATH_DEV_ABSENT:
+    case USB_PATH_NONE:
+        str_copy_trunc(out, "/dev/bus", outsz);
+        break;
+    }
+    size_t n = strlen(out);
+    while (n > 1 && out[n - 1] == '/')
+        out[--n] = '\0';
+}
+
+static void fill_synth_dir(struct stat *st, const char *canon)
+{
+    memset(st, 0, sizeof(*st));
+    st->st_mode = S_IFDIR | 0755;
+    st->st_nlink = 2;
+    st->st_dev = USB_SYNTH_DEV;
+    st->st_ino = usb_synth_ino(canon);
+    st->st_uid = getuid();
+    st->st_gid = getgid();
+    st->st_blksize = 4096;
+}
+
+static void fill_synth_file(struct stat *st, const char *canon)
+{
+    memset(st, 0, sizeof(*st));
+    st->st_mode = S_IFREG | 0444;
+    st->st_nlink = 1;
+    st->st_dev = USB_SYNTH_DEV;
+    st->st_ino = usb_synth_ino(canon);
+    st->st_uid = getuid();
+    st->st_gid = getgid();
+    st->st_blksize = 4096;
+}
+
+static void fill_synth_chardev(struct stat *st,
+                               const char *canon,
+                               const usb_dev_t *d)
+{
+    memset(st, 0, sizeof(*st));
+
+    /* 0664 rather than udev's root:root 0660 policy: the single-user guest must
+     * be able to open its own device nodes.
+     */
+    st->st_mode = S_IFCHR | 0664;
+    st->st_nlink = 1;
+    st->st_dev = USB_SYNTH_DEV;
+    st->st_ino = usb_synth_ino(canon);
+    st->st_uid = getuid();
+    st->st_gid = getgid();
+
+    /* macOS dev_t encoding (major<<24 | minor); translate_stat converts.
+     * Composed in uint32_t: dev_t is a signed 32-bit int here, so shifting
+     * major 189 left by 24 lands in the sign bit and is undefined -- the SDK's
+     * own makedev() has the same defect, which is why the encoding is spelled
+     * out rather than borrowed.
+     */
+    st->st_rdev =
+        (dev_t) (((uint32_t) USB_MAJOR << 24) | (uint32_t) usb_minor(d));
+    st->st_blksize = 4096;
+    st->st_size = (off_t) d->blob_len;
+}
+
+/* Synthetic descriptor-blob fd (the proc_synthetic_fd pattern): unlinked temp
+ * file so lseek/pread work.
+ */
+static int usb_blob_fd(const usb_dev_t *d)
+{
+    char template[] = "/tmp/elfuse-usbnode-XXXXXX";
+    int fd = mkstemp(template);
+    if (fd < 0)
+        return -1;
+    unlink(template);
+    const uint8_t *p = d->blob;
+    size_t left = d->blob_len;
+    while (left > 0) {
+        ssize_t n = write(fd, p, left);
+        if (n < 0 && errno == EINTR)
+            continue; /* retry like syscpu_write_file: a stray signal must
+                       * not abort a one-shot tree build
+                       */
+        if (n <= 0) {
+            close(fd);
+            return -1;
+        }
+        p += n;
+        left -= (size_t) n;
+    }
+    lseek(fd, 0, SEEK_SET);
+    return fd;
+}
+
+/* intercept entry points */
+
+/* Shared entry-point preamble: classify, and for the /sys view apply the
+ * ours/not-ours fold before any lock is taken.
+ *
+ * *sfx_out receives the suffix as the guest spelled it -- unfolded, because
+ * usb_sys_resolve_suffix has to see the '..' in their original positions to
+ * order them against the symlinks they follow. `norm` holds the folded
+ * spelling, which is used only to decide whether the name is ours at all.
+ *
+ * Returns the kind, or USB_PATH_NONE when the folded path is not ours; *err_out
+ * non-zero means classify itself failed (ENAMETOOLONG) and the caller must
+ * report it rather than pass the path on.
+ */
+static usb_path_kind_t classify_and_normalize(const char *path,
+                                              int *bus_out,
+                                              int *dev_out,
+                                              const char **sfx_out,
+                                              char *norm,
+                                              size_t normsz,
+                                              int *err_out)
+{
+    *err_out = 0;
+    usb_path_kind_t kind = classify_path(path, bus_out, dev_out, sfx_out);
+    if (kind != USB_PATH_SYS)
+        return kind;
+    int rc = usb_suffix_normalize(*sfx_out, norm, normsz);
+    if (rc < 0) {
+        *err_out = ENAMETOOLONG;
+        return USB_PATH_NONE;
+    }
+    if (rc == 0)
+        return USB_PATH_NONE; /* climbed above /sys; not ours */
+    return USB_PATH_SYS;
+}
+
+/* Resolve a host path inside the sysfs scratch tree and prove the result is
+ * still inside it, so the caller can open it with symlinks followed.
+ *
+ * Why following is safe here, and why O_NOFOLLOW was the wrong belt: the links
+ * this tree carries are ours, written by emit_* with fixed relative targets,
+ * and the tree is read-only to the guest (every mutating open under /sys is
+ * refused before this point, and no mkdir/symlink/rename intercept reaches it),
+ * so the procemu.c rationale "do not follow symlinks the guest created inside
+ * the scratch dir" has nothing to bite on. What replaces it is a positive check
+ * rather than a blanket refusal.
+ *
+ * The escape guarantee, unchanged: the suffix reaching us has already had '.'
+ * and '..' folded lexically by usb_suffix_normalize, so host_path is
+ * usb_sys_dir followed by plain components and cannot climb out on its own; a
+ * symlink is therefore the only way out, and realpath() resolves every one of
+ * them -- in the leaf and in each intermediate component alike -- before we
+ * test the fully canonical result against the canonical root. A path that
+ * resolved outside is reported as absent instead of opened. The open then still
+ * passes O_NOFOLLOW: the resolved leaf is by construction not a symlink, so the
+ * flag changes nothing on the intended path and closes the swap window on the
+ * final component only -- open(2) re-walks by the resolved path string, not
+ * against a root fd retained from realpath(), so a symlink spun into an
+ * intermediate directory between the resolve and the open would still be
+ * followed. That residual TOCTOU is not reachable here: a sysrooted guest
+ * cannot name the host scratch tree to plant such a link, and a sysroot-less
+ * guest already has the host filesystem. Closing it for real would mean an
+ * fd-relative reopen the read-only tree does not justify.
+ *
+ * Returns 0 with `out` filled, or -1 with errno set (realpath's errno, or
+ * ENOENT for a path that resolved outside the tree).
+ */
+static bool usb_sys_contained(const char *canonical)
+{
+    size_t rootlen = strlen(usb_sys_real);
+    return rootlen != 0 && !strncmp(canonical, usb_sys_real, rootlen) &&
+           (canonical[rootlen] == '\0' || canonical[rootlen] == '/');
+}
+
+static int usb_sys_resolve(const char *host_path, char *out, size_t outsz)
+{
+    char resolved[PATH_MAX];
+    if (!realpath(host_path, resolved))
+        return -1;
+    if (!usb_sys_contained(resolved)) {
+        log_warn("usb-sysfs: %s resolves outside the tree; refusing",
+                 host_path);
+        errno = ENOENT;
+        return -1;
+    }
+    if (str_copy_trunc(out, resolved, outsz) >= outsz) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    return 0;
+}
+
+/* Resolve a /sys-relative suffix to a host path inside the scratch tree, the
+ * way the kernel resolves it: each component is applied to what the previous
+ * one resolved to, so a '..' after a symlink pops the *target's* parent.
+ *
+ * This is what makes <dev>/subsystem/.. name /sys/bus, the way Linux does,
+ * rather than the device directory a lexical fold would have kept it in. The
+ * lexical fold in usb_suffix_normalize decides only whether the name is ours.
+ *
+ * realpath() performs the whole walk -- symlinks in the leaf and in every
+ * intermediate component, and '..' in kernel order -- and its canonical result
+ * is then tested against the canonical root. That containment test is the sole
+ * escape authority: nothing above it is trusted to have kept the path inside,
+ * which is why the raw, unfolded suffix can be handed to it safely.
+ *
+ * `nofollow` keeps the semantics O_NOFOLLOW and lstat need: everything up to
+ * the final component is resolved and contained as above, and the leaf is then
+ * appended without being followed, so a symlink leaf stays a symlink -- and
+ * contained again afterwards, because the append is the one step that happens
+ * after a containment test. A '.' or '..' leaf is not held back at all: it
+ * cannot be a symlink, so nothing is protected by withholding it, and it is the
+ * one leaf whose reattachment can move the name (see below).
+ *
+ * *canon_out receives the resolved location as a /sys-relative suffix, so the
+ * synthetic identity is keyed on the object rather than on the spelling.
+ *
+ * Returns 0, or -1 with errno set (realpath's errno, or ENOENT for a path that
+ * resolved outside the tree).
+ */
+static int usb_sys_resolve_suffix(const char *raw_sfx,
+                                  bool nofollow,
+                                  char *host_out,
+                                  size_t host_sz,
+                                  char *canon_out,
+                                  size_t canon_sz)
+{
+    char joined[PATH_MAX];
+    int n = *raw_sfx ? snprintf(joined, sizeof(joined), "%s/%s", usb_sys_dir,
+                                raw_sfx)
+                     : snprintf(joined, sizeof(joined), "%s", usb_sys_dir);
+    if (n < 0 || (size_t) n >= sizeof(joined)) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    char resolved[PATH_MAX];
+    char leaf[NAME_MAX + 1];
+    leaf[0] = '\0';
+
+    if (nofollow && *raw_sfx) {
+        /* Split off the final component, resolve the rest, reattach it. A
+         * trailing slash means the caller is using the name as a directory, so
+         * there is no unfollowed leaf to protect and the whole path resolves.
+         */
+        size_t jlen = strlen(joined);
+        if (joined[jlen - 1] != '/') {
+            char *slash = strrchr(joined, '/');
+            if (!slash) {
+                errno = EINVAL;
+                return -1;
+            }
+            if (strlen(slash + 1) >= sizeof(leaf)) {
+                errno = ENAMETOOLONG;
+                return -1;
+            }
+
+            /* '.' and '..' are never symlinks, so there is nothing for
+             * O_NOFOLLOW to protect -- and holding one back turns the walk
+             * inside out: the prefix is contained, the dot-dot is reattached to
+             * the *canonical* result afterwards, and one applied to the tree
+             * root then names the host directory the root sits in. The
+             * containment test has already run and does not run again, so that
+             * spelling leaves the tree. Let the whole path go to
+             * usb_sys_resolve, which resolves the dot-dot in kernel order and
+             * tests what it actually reached.
+             */
+            const char *last = slash + 1;
+            bool dots = !strcmp(last, ".") || !strcmp(last, "..");
+            if (!dots) {
+                str_copy_trunc(leaf, last, sizeof(leaf));
+                *slash = '\0';
+            }
+        }
+    }
+
+    if (usb_sys_resolve(joined, resolved, sizeof(resolved)) < 0)
+        return -1;
+
+    if (leaf[0]) {
+        size_t rl = strlen(resolved);
+        if (rl + 1 + strlen(leaf) + 1 > sizeof(resolved)) {
+            errno = ENAMETOOLONG;
+            return -1;
+        }
+        resolved[rl] = '/';
+        str_copy_trunc(resolved + rl + 1, leaf, sizeof(resolved) - rl - 1);
+
+        /* Reattaching is the one step that can move the name after the
+         * containment test ran, so the test is applied to what the caller will
+         * actually be handed rather than to the prefix it was derived from. It
+         * stays the single authority: no spelling reaches a caller without
+         * having passed it last.
+         */
+        if (!usb_sys_contained(resolved)) {
+            log_warn("usb-sysfs: %s resolves outside the tree; refusing",
+                     resolved);
+            errno = ENOENT;
+            return -1;
+        }
+    }
+
+    if (str_copy_trunc(host_out, resolved, host_sz) >= host_sz) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    /* usb_sys_resolve proved `resolved` is usb_sys_real or below it, so the
+     * remainder after the root is exactly the /sys-relative spelling.
+     */
+    const char *rel = resolved + strlen(usb_sys_real);
+    while (*rel == '/')
+        rel++;
+    if (str_copy_trunc(canon_out, rel, canon_sz) >= canon_sz) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    return 0;
+}
+
+int usb_sysfs_guest_path_for_fd(int host_fd, char *out, size_t outsz)
+{
+    char host_path[PATH_MAX];
+    if (fcntl(host_fd, F_GETPATH, host_path) < 0)
+        return 0;
+
+    pthread_mutex_lock(&usb_lock);
+    int rc = 0;
+    if (usb_sys_real[0] && usb_sys_contained(host_path)) {
+        /* usb_sys_contained proved the remainder after the root is either empty
+         * or starts with '/', so "/sys" plus it is the guest spelling.
+         */
+        const char *rel = host_path + strlen(usb_sys_real);
+        int n = snprintf(out, outsz, "/sys%s", rel);
+        rc = (n > 0 && (size_t) n < outsz) ? 1 : 0;
+    }
+    pthread_mutex_unlock(&usb_lock);
+    return rc;
+}
+
+int usb_sysfs_intercept_open(const char *path, int linux_flags, int mode)
+{
+    int bus = 0, dev = 0, cerr = 0;
+    const char *sfx = NULL;
+    char norm[LINUX_PATH_MAX];
+    usb_path_kind_t kind = classify_and_normalize(path, &bus, &dev, &sfx, norm,
+                                                  sizeof(norm), &cerr);
+    if (kind == USB_PATH_NONE) {
+        if (cerr) {
+            errno = cerr;
+            return -1;
+        }
+        return PROC_NOT_INTERCEPTED;
+    }
+
+    pthread_mutex_lock(&usb_lock);
+    int rc = -1;
+    int err = 0;
+    if (ensure_usb_tree() < 0) {
+        err = errno;
+        goto out;
+    }
+
+    switch (kind) {
+    case USB_PATH_SYS: {
+        bool nofollow = (linux_flags & LINUX_O_NOFOLLOW) != 0;
+        int accmode = translate_open_flags(linux_flags) & O_ACCMODE;
+        bool mutating = accmode != O_RDONLY ||
+                        (linux_flags & (LINUX_O_CREAT | LINUX_O_TRUNC));
+        char host_path[PATH_MAX], canon_sfx[PATH_MAX];
+
+        /* Resolve in kernel order first: '..' after a symlink has to pop the
+         * target's parent before anything is decided about the name.
+         */
+        if (usb_sys_resolve_suffix(sfx, nofollow, host_path, sizeof(host_path),
+                                   canon_sfx, sizeof(canon_sfx)) < 0) {
+            int reserr = errno;
+
+            /* A /sys name we do not synthesize resolved to nothing here: hand
+             * it back to the sysroot backing instead of shadowing it with
+             * ENOENT. Only the /sys/bus/usb subtree we own answers for its own
+             * absences.
+             */
+            if (reserr == ENOENT && !usb_sys_suffix_owned(norm)) {
+                pthread_mutex_unlock(&usb_lock);
+                return PROC_NOT_INTERCEPTED;
+            }
+
+            /* A create names something that does not exist yet, so the resolve
+             * failing is expected there and says nothing about the request. It
+             * is still a mutating open of a read-only tree, which is what the
+             * guest has to be told -- not the ENOENT of the name it picked.
+             */
+            err = mutating ? EACCES : reserr;
+            goto out;
+        }
+
+        /* O_NOFOLLOW on a symlink is ELOOP, and Linux decides that before it
+         * looks at the access mode: open("<dev>/subsystem", O_WRONLY |
+         * O_NOFOLLOW) is ELOOP on a real sysfs, not the EISDIR the link's
+         * target would earn (measured on /sys/class/net/lo/subsystem, 6.19).
+         * Deciding the read-only refusal first would answer for the target of a
+         * link the caller explicitly asked not to follow. O_PATH is the
+         * documented exception: O_PATH|O_NOFOLLOW names the link itself.
+         */
+        if (nofollow && !(linux_flags & LINUX_O_PATH)) {
+            struct stat lst;
+            if (lstat(host_path, &lst) == 0 && S_ISLNK(lst.st_mode)) {
+                err = ELOOP;
+                goto out;
+            }
+        }
+
+        /* Read-only tree, syscpu contract: reject mutating opens -- with the
+         * errno Linux gives, which depends on what the name resolves to. A
+         * sysfs directory answers EISDIR, because open(2) refuses write access
+         * to a directory before it ever consults permissions; a sysfs attribute
+         * is a mode 0444 regular file, so it answers EACCES.
+         */
+        if (mutating) {
+            struct stat wst;
+            err = (stat(host_path, &wst) == 0 && S_ISDIR(wst.st_mode)) ? EISDIR
+                                                                       : EACCES;
+            goto out;
+        }
+
+        /* In the follow case the leaf is already resolved and by construction
+         * not a symlink, so O_NOFOLLOW changes nothing on the intended path and
+         * closes the swap window on that final component only: open(2) re-walks
+         * the resolved path string, so a symlink spun into an intermediate
+         * directory after the resolve would still be followed. That residual
+         * window is unreachable (a sysrooted guest cannot name the scratch tree
+         * to plant one; see usb_sys_resolve above).
+         *
+         * In the nofollow case the flags are passed through untouched: the
+         * guest's intent is already encoded there, and O_PATH|O_NOFOLLOW maps
+         * to macOS O_SYMLINK -- "open the link itself" -- which OR-ing
+         * O_NOFOLLOW back in would turn into an ELOOP.
+         */
+        int oflags = translate_open_flags(linux_flags);
+        if (!nofollow)
+            oflags |= O_NOFOLLOW;
+        rc = open(host_path, oflags, mode);
+        if (rc < 0)
+            err = errno;
+        goto out;
+    }
+    case USB_PATH_DEV_BUS:
+        rc = proc_open_dir_fd(usb_dev_dir, linux_flags);
+        if (rc < 0)
+            err = errno;
+        goto out;
+    case USB_PATH_DEV_USB:
+    case USB_PATH_DEV_BUSNUM: {
+        char host_path[256];
+        int n;
+        if (kind == USB_PATH_DEV_USB)
+            n = snprintf(host_path, sizeof(host_path), "%s/usb", usb_dev_dir);
+        else {
+            if (!bus_exists(bus)) {
+                err = ENOENT;
+                goto out;
+            }
+            n = snprintf(host_path, sizeof(host_path), "%s/usb/%03d",
+                         usb_dev_dir, bus);
+        }
+        if (n < 0 || (size_t) n >= sizeof(host_path)) {
+            err = ENAMETOOLONG;
+            goto out;
+        }
+        rc = proc_open_dir_fd(host_path, linux_flags);
+        if (rc < 0)
+            err = errno;
+        goto out;
+    }
+    case USB_PATH_DEV_NODE_SUB:
+        err = find_dev(bus, dev) ? ENOTDIR : ENOENT;
+        goto out;
+    case USB_PATH_DEV_NODE: {
+        usb_dev_t *d = find_dev(bus, dev);
+        if (!d) {
+            err = ENOENT;
+            goto out;
+        }
+        if (linux_flags & LINUX_O_DIRECTORY) {
+            err = ENOTDIR;
+            goto out;
+        }
+        int accmode = translate_open_flags(linux_flags) & O_ACCMODE;
+        if (accmode != O_RDONLY) {
+            /* TEMPORARY (stage 1): writable opens are what stage 2's FD_USBDEV
+             * constructor will serve; until then they fail.
+             */
+            log_warn(
+                "usb-sysfs: O_RDWR open of %s not implemented yet "
+                "(stage 2)",
+                path);
+            err = EACCES;
+            goto out;
+        }
+        rc = usb_blob_fd(d);
+        if (rc < 0)
+            err = errno;
+        goto out;
+    }
+    case USB_PATH_DEV_ABSENT:
+        err = ENOENT;
+        goto out;
+    case USB_PATH_NONE:
+        break;
+    }
+
+out:
+    pthread_mutex_unlock(&usb_lock);
+    if (rc < 0)
+        errno = err ? err : EIO;
+    return rc;
+}
+
+int usb_sysfs_intercept_stat(const char *path, struct stat *st, bool follow)
+{
+    int bus = 0, dev = 0, cerr = 0;
+    const char *sfx = NULL;
+    char norm[LINUX_PATH_MAX];
+    usb_path_kind_t kind = classify_and_normalize(path, &bus, &dev, &sfx, norm,
+                                                  sizeof(norm), &cerr);
+    if (kind == USB_PATH_NONE) {
+        if (cerr) {
+            errno = cerr;
+            return -1;
+        }
+        return PROC_NOT_INTERCEPTED;
+    }
+
+    pthread_mutex_lock(&usb_lock);
+    int rc = -1;
+    int err = 0;
+    if (ensure_usb_tree() < 0) {
+        err = errno;
+        goto out;
+    }
+
+    char canon[LINUX_PATH_MAX];
+    usb_canon_path(kind, sfx ? sfx : "", bus, dev, canon, sizeof(canon));
+
+    switch (kind) {
+    case USB_PATH_SYS: {
+        if (!*sfx) {
+            fill_synth_dir(st, canon);
+            rc = 0;
+            goto out;
+        }
+
+        /* Resolve in kernel order, and only then decide what was named: with
+         * `follow` the leaf symlink is resolved too, so stat() of a subsystem
+         * link reports the directory it points at, the way it does on Linux.
+         * lstat() (follow == false) still reports the link itself.
+         */
+        char host_path[PATH_MAX], canon_sfx[PATH_MAX];
+        if (usb_sys_resolve_suffix(sfx, !follow, host_path, sizeof(host_path),
+                                   canon_sfx, sizeof(canon_sfx)) < 0) {
+            int reserr = errno;
+
+            /* A /sys name we do not synthesize resolved to nothing: let the
+             * sysroot backing answer rather than shadow it with ENOENT, so stat
+             * and open agree on it (see usb_sysfs_intercept_open). Only the
+             * /sys/bus/usb subtree we own reports its own absences.
+             */
+            if (reserr == ENOENT && !usb_sys_suffix_owned(norm)) {
+                pthread_mutex_unlock(&usb_lock);
+                return PROC_NOT_INTERCEPTED;
+            }
+            err = reserr;
+            goto out;
+        }
+        usb_canon_path(kind, canon_sfx, bus, dev, canon, sizeof(canon));
+
+        struct stat host_st;
+        if (lstat(host_path, &host_st) < 0) {
+            err = errno;
+            goto out;
+        }
+        if (S_ISDIR(host_st.st_mode))
+            fill_synth_dir(st, canon);
+        else if (S_ISLNK(host_st.st_mode)) {
+            /* Only reachable with follow == false; the follow case resolved the
+             * link away above.
+             */
+            fill_synth_file(st, canon);
+            st->st_mode = S_IFLNK | 0777;
+            st->st_size = host_st.st_size;
+        } else {
+            fill_synth_file(st, canon);
+            st->st_size = host_st.st_size; /* attrs read as sized files */
+        }
+        rc = 0;
+        goto out;
+    }
+    case USB_PATH_DEV_BUS:
+    case USB_PATH_DEV_USB:
+        fill_synth_dir(st, canon);
+        rc = 0;
+        goto out;
+    case USB_PATH_DEV_BUSNUM:
+        if (!bus_exists(bus)) {
+            err = ENOENT;
+            goto out;
+        }
+        fill_synth_dir(st, canon);
+        rc = 0;
+        goto out;
+    case USB_PATH_DEV_NODE_SUB:
+        err = find_dev(bus, dev) ? ENOTDIR : ENOENT;
+        goto out;
+    case USB_PATH_DEV_NODE: {
+        usb_dev_t *d = find_dev(bus, dev);
+        if (!d) {
+            err = ENOENT;
+            goto out;
+        }
+        fill_synth_chardev(st, canon, d);
+        rc = 0;
+        goto out;
+    }
+    case USB_PATH_DEV_ABSENT:
+        err = ENOENT;
+        goto out;
+    case USB_PATH_NONE:
+        break;
+    }
+
+out:
+    pthread_mutex_unlock(&usb_lock);
+    if (rc < 0)
+        errno = err ? err : EIO;
+    return rc;
+}
+
+int usb_sysfs_intercept_readlink(const char *path, char *buf, size_t bufsiz)
+{
+    int bus = 0, dev = 0, cerr = 0;
+    const char *sfx = NULL;
+    char norm[LINUX_PATH_MAX];
+    usb_path_kind_t kind = classify_and_normalize(path, &bus, &dev, &sfx, norm,
+                                                  sizeof(norm), &cerr);
+    if (kind == USB_PATH_NONE) {
+        if (cerr) {
+            errno = cerr;
+            return -1;
+        }
+        return PROC_NOT_INTERCEPTED;
+    }
+
+    if (kind == USB_PATH_SYS) {
+        /* The scratch tree holds real symlinks for `subsystem` entries;
+         * readlink passes their targets through. Plain dirs/files answer EINVAL
+         * and missing paths ENOENT, exactly as sysfs would.
+         */
+        pthread_mutex_lock(&usb_lock);
+        int rc = -1;
+        int err = 0;
+        if (ensure_usb_tree() < 0) {
+            err = errno;
+        } else if (!*sfx) {
+            err = EINVAL; /* /sys itself is a directory */
+        } else {
+            /* The same resolution the open and stat paths use, for the same two
+             * reasons. The suffix arrives as the guest spelled it, so a '..'
+             * behind a `subsystem` link still has to be applied to what that
+             * link resolved to; and usb_sys_resolve_suffix carries the only
+             * containment check in this layer. Joining the raw suffix onto the
+             * scratch root instead would let a name whose lexical fold stays
+             * inside resolve, through the link, onto a host symlink outside the
+             * tree and report its target to the guest.
+             *
+             * nofollow, because readlink names the link itself and never the
+             * object behind it.
+             */
+            char host_path[PATH_MAX], canon_sfx[PATH_MAX];
+            if (usb_sys_resolve_suffix(sfx, true, host_path, sizeof(host_path),
+                                       canon_sfx, sizeof(canon_sfx)) < 0) {
+                err = errno;
+
+                /* A /sys name we do not synthesize resolved to nothing: fall
+                 * through to the sysroot backing rather than shadow it, as the
+                 * open and stat paths do. Only /sys/bus/usb answers its own
+                 * absences.
+                 */
+                if (err == ENOENT && !usb_sys_suffix_owned(norm)) {
+                    pthread_mutex_unlock(&usb_lock);
+                    return PROC_NOT_INTERCEPTED;
+                }
+            } else {
+                ssize_t n = readlink(host_path, buf, bufsiz);
+                if (n < 0)
+                    err = errno;
+                else
+                    rc = (int) n;
+            }
+        }
+        pthread_mutex_unlock(&usb_lock);
+        if (rc < 0)
+            errno = err ? err : EIO;
+        return rc;
+    }
+
+    struct stat st;
+    int rc = usb_sysfs_intercept_stat(path, &st, false);
+    if (rc == PROC_NOT_INTERCEPTED)
+        return PROC_NOT_INTERCEPTED;
+    if (rc < 0)
+        return -1; /* errno already set (ENOENT etc.) */
+    /* The /dev/bus tree holds real dirs and device nodes, never symlinks. */
+    errno = EINVAL;
+    return -1;
+}
+
+uint8_t *usb_sysfs_descriptors_dup(int busnum, int devnum, size_t *len_out)
+{
+    pthread_mutex_lock(&usb_lock);
+    uint8_t *copy = NULL;
+    if (ensure_usb_tree() == 0) {
+        usb_dev_t *d = find_dev(busnum, devnum);
+        if (d) {
+            copy = malloc(d->blob_len);
+            if (copy) {
+                memcpy(copy, d->blob, d->blob_len);
+                *len_out = d->blob_len;
+            }
+        } else {
+            errno = ENODEV;
+        }
+    }
+    pthread_mutex_unlock(&usb_lock);
+    return copy;
+}

--- a/src/runtime/usb-sysfs.h
+++ b/src/runtime/usb-sysfs.h
@@ -1,0 +1,62 @@
+/*
+ * Synthetic /dev/bus/usb + /sys/bus/usb built from the IOKit registry
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Stage 1 of the usbdevfs emulation: enumeration only. The IOKit registry is
+ * read without opening any device (GetConfigurationDescriptorPtr needs no
+ * open), and the result is materialized as two scratch-dir trees that the
+ * procemu interceptors expose as /sys/bus/usb and /dev/bus/usb.
+ *
+ * The intercept functions follow the procemu contract:
+ *   open:      host fd on match, -1 with errno on error,
+ *              PROC_NOT_INTERCEPTED (-2) when the path is not ours.
+ *   stat:      0 on match (st filled), -1 with errno, -2 not ours.
+ *   readlink:  link length on match, -1 with errno, -2 not ours.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/stat.h>
+
+struct guest;
+
+int usb_sysfs_intercept_open(const char *path, int linux_flags, int mode);
+
+/* `follow` selects stat() vs lstat() semantics for a symlink leaf: with it set,
+ * a `subsystem` link reports the directory it resolves to, as on Linux; without
+ * it the link itself is reported.
+ */
+int usb_sysfs_intercept_stat(const char *path, struct stat *st, bool follow);
+int usb_sysfs_intercept_readlink(const char *path, char *buf, size_t bufsiz);
+
+/* Malloc'd copy of the usbfs descriptors blob (18-byte little-endian device
+ * descriptor followed by every raw configuration descriptor in index order) for
+ * the device at busnum/devnum. This is the exact byte sequence read() returns
+ * on the /dev/bus/usb node and on the sysfs `descriptors` attribute; stage 2's
+ * usbdevfs fd constructor must serve reads from this generator so the two views
+ * stay byte-identical.
+ *
+ * Returns the blob (caller frees) with *len_out set, or NULL with errno set
+ * (ENODEV when no such device).
+ */
+uint8_t *usb_sysfs_descriptors_dup(int busnum, int devnum, size_t *len_out);
+
+/* The guest /sys spelling of the object an open descriptor holds, for stamping
+ * a synthetic identity on it.
+ *
+ * The name the guest opened is not always the name it got: a `subsystem` link
+ * opened for following names the directory it resolves to, and every relative
+ * openat off that descriptor must walk from there. Asking the descriptor
+ * instead of the request is what makes the two agree -- F_GETPATH reports the
+ * link's own path for the O_PATH|O_NOFOLLOW open that deliberately named the
+ * link, and the target's path for every open that followed it.
+ *
+ * Returns 1 with `out` filled, or 0 when the descriptor is not in the sysfs
+ * tree (including when the tree does not exist).
+ */
+int usb_sysfs_guest_path_for_fd(int host_fd, char *out, size_t outsz);

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -246,7 +246,13 @@ static int64_t stat_at_path(guest_t *g,
             }
             dir_ref.fd = snap.host_fd;
             if (snap.type == FD_PATH && snap.proc_path[0] != '\0') {
-                int intercepted = proc_intercept_stat(snap.proc_path, mac_st);
+                /* The descriptor already names one object: an O_PATH open that
+                 * followed refers to the target, one made with O_NOFOLLOW to
+                 * the link itself, so the open's flag is what selects here.
+                 */
+                bool follow = !(snap.linux_flags & LINUX_O_NOFOLLOW);
+                int intercepted =
+                    proc_intercept_stat_at(snap.proc_path, mac_st, follow);
                 if (intercepted == 0)
                     goto done;
                 if (intercepted == -1) {
@@ -266,7 +272,9 @@ static int64_t stat_at_path(guest_t *g,
 
         int intercepted = PROC_NOT_INTERCEPTED;
         if (path_might_use_stat_intercept(tx.intercept_path)) {
-            intercepted = proc_intercept_stat(tx.intercept_path, mac_st);
+            intercepted =
+                proc_intercept_stat_at(tx.intercept_path, mac_st,
+                                       !(flags & LINUX_AT_SYMLINK_NOFOLLOW));
             if (intercepted == -1) {
                 rc = linux_errno();
                 goto done;
@@ -309,7 +317,12 @@ int64_t sys_fstat(guest_t *g, int fd, uint64_t stat_gva)
     fd_entry_t snap;
     if (fd_snapshot(fd, &snap) && snap.type == FD_PATH &&
         snap.proc_path[0] != '\0') {
-        int intercepted = proc_intercept_stat(snap.proc_path, &mac_st);
+        /* As in stat_at_path's AT_EMPTY_PATH branch: the open already chose
+         * between the link and its target, so replay that choice here.
+         */
+        bool follow = !(snap.linux_flags & LINUX_O_NOFOLLOW);
+        int intercepted =
+            proc_intercept_stat_at(snap.proc_path, &mac_st, follow);
         if (intercepted == 0) {
             if (write_linux_stat(g, stat_gva, &mac_st) < 0)
                 return -LINUX_EFAULT;
@@ -449,6 +462,66 @@ static void fill_proc_statfs(linux_statfs_t *lin)
     lin->f_frsize = 4096;
 }
 
+/* Boundary-checked "/sys or under it", applied to the folded name, which is
+ * also published so the caller can act on the same spelling it classified.
+ *
+ * Linux resolves the path before deciding which filesystem answers it, so
+ * statfs("/sys/../etc") reports the filesystem behind /etc and not sysfs. The
+ * intercept path arrives here unnormalized, so testing the "/sys" prefix as
+ * spelled would hand SYSFS_MAGIC to every name that merely starts inside /sys
+ * and then climbs back out of it. Fold '.' and '..' first and test what the
+ * name actually resolves to.
+ *
+ * A relative name resolves the same way, against the cwd -- statfs("sys") from
+ * / is statfs("/sys") to the kernel, and sd-device and libusb both reach sysfs
+ * through relative walks. Refusing every name that did not start with '/' left
+ * those on the pass-through, which on a host with no /sys is ENOENT.
+ *
+ * path_openat2_normalize_in_root clamps '..' at the root, which is what the
+ * kernel does with a leading "/..", and yields a root-relative spelling --
+ * "sys/bus" for /sys/bus, "etc" for /sys/../etc, "." for /.
+ */
+static bool statfs_path_is_sysfs(const char *path, char *abs, size_t abssz)
+{
+    if (!path || path[0] == '\0')
+        return false;
+
+    char joined[LINUX_PATH_MAX];
+    if (path[0] != '/') {
+        proc_cwd_view_t view;
+        if (proc_acquire_cwd_view(&view) < 0)
+            return false;
+        int jn = snprintf(joined, sizeof(joined), "%s/%s", view.path, path);
+        proc_release_cwd_view(&view);
+        if (jn < 0 || (size_t) jn >= sizeof(joined))
+            return false;
+        path = joined;
+    }
+
+    char folded[LINUX_PATH_MAX];
+    if (path_openat2_normalize_in_root(path, folded, sizeof(folded)) < 0)
+        return false;
+    if (strncmp(folded, "sys", 3) != 0 ||
+        (folded[3] != '\0' && folded[3] != '/'))
+        return false;
+    int n = snprintf(abs, abssz, "/%s", folded);
+    return n > 0 && (size_t) n < abssz;
+}
+
+static void fill_sysfs_statfs(linux_statfs_t *lin)
+{
+    memset(lin, 0, sizeof(*lin));
+    lin->f_type = 0x62656572; /* SYSFS_MAGIC */
+    lin->f_bsize = 4096;
+    lin->f_blocks = 0;
+    lin->f_bfree = 0;
+    lin->f_bavail = 0;
+    lin->f_files = 0;
+    lin->f_ffree = 0;
+    lin->f_namelen = 255;
+    lin->f_frsize = 4096;
+}
+
 static int64_t sys_statfs_impl(guest_t *g,
                                const char *path,
                                uint64_t buf_gva,
@@ -475,7 +548,8 @@ static int64_t sys_statfs_impl(guest_t *g,
         }
 
         struct stat mac_st;
-        int intercepted = proc_intercept_stat(tx.intercept_path, &mac_st);
+        int intercepted =
+            proc_intercept_stat_at(tx.intercept_path, &mac_st, true);
         if (intercepted == 0) {
             linux_statfs_t lin_st;
             fill_proc_statfs(&lin_st);
@@ -495,6 +569,47 @@ static int64_t sys_statfs_impl(guest_t *g,
                 return -LINUX_EFAULT;
             return 0;
         }
+    }
+
+    /* /sys is sysfs. libusb refuses to enumerate through the synthetic
+     * /sys/bus/usb tree unless statfs("/sys") reports SYSFS_MAGIC
+     * (linux_usbfs.c:398-408), and passing through to the host either fails (no
+     * /sys on macOS) or leaks the sysroot's filesystem magic. The mount point
+     * itself always answers; paths under it answer when the intercept layer (or
+     * the host/sysroot backing, e.g. an empty /sys skeleton) knows them, and
+     * report the same ENOENT a real Linux kernel would for the rest.
+     */
+    char sys_abs[LINUX_PATH_MAX];
+    if (statfs_path_is_sysfs(tx.intercept_path, sys_abs, sizeof(sys_abs))) {
+        /* Classifying the folded name and then probing the raw one asked two
+         * different questions of two different spellings: "/sys/../sys" is
+         * sysfs, but no intercept and no host backing carries that literal
+         * name, so the probe answered ENOENT for a directory that exists.
+         * Re-enter on the folded spelling so the existence probe, the host
+         * fallback and the answer all describe the same object. Folding is
+         * idempotent, so this recurses at most once.
+         */
+        if (strcmp(sys_abs, tx.intercept_path) != 0)
+            return sys_statfs_impl(g, sys_abs, buf_gva, depth + 1);
+
+        bool exists = sys_abs[4] == '\0'; /* "/sys" itself */
+        if (!exists) {
+            struct stat sys_st;
+            int intercepted = proc_intercept_stat_at(sys_abs, &sys_st, true);
+            if (intercepted == 0)
+                exists = true;
+            else if (intercepted == -1)
+                return linux_errno();
+            else
+                exists = stat(tx.host_path, &sys_st) == 0;
+        }
+        if (!exists)
+            return -LINUX_ENOENT;
+        linux_statfs_t lin_st;
+        fill_sysfs_statfs(&lin_st);
+        if (guest_write_small(g, buf_gva, &lin_st, sizeof(lin_st)) < 0)
+            return -LINUX_EFAULT;
+        return 0;
     }
 
     /* glibc's posix_openpt() opens /dev/ptmx and then confirms devpts is
@@ -574,6 +689,21 @@ int64_t sys_fstatfs(guest_t *g, int fd, uint64_t buf_gva)
         linux_statfs_t proc_st;
         fill_proc_statfs(&proc_st);
         if (guest_write_small(g, buf_gva, &proc_st, sizeof(proc_st)) < 0)
+            return -LINUX_EFAULT;
+        return 0;
+    }
+
+    /* Descriptors opened under /sys are scratch-dir backed; the host fstatfs
+     * would leak the /tmp filesystem's magic. systemd's sd-device gates every
+     * enumerated syspath on fstatfs(fd) == SYSFS_MAGIC, so answer as sysfs
+     * exactly like path statfs("/sys") does.
+     */
+    char fd_sys_abs[LINUX_PATH_MAX];
+    if (snap.proc_path[0] &&
+        statfs_path_is_sysfs(snap.proc_path, fd_sys_abs, sizeof(fd_sys_abs))) {
+        linux_statfs_t sys_st;
+        fill_sysfs_statfs(&sys_st);
+        if (guest_write_small(g, buf_gva, &sys_st, sizeof(sys_st)) < 0)
             return -LINUX_EFAULT;
         return 0;
     }

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -39,6 +39,7 @@ _Static_assert(NAME_MAX == DIRENT64_NAME_MAX,
 #include "core/shim-globals.h" /* shim_globals_mark_urandom_fd */
 
 #include "runtime/procemu.h"
+#include "runtime/usb-sysfs.h"
 
 #include "syscall/linux-wire.h"
 #include "syscall/asyncio.h"
@@ -210,6 +211,20 @@ static bool resolve_virtual_path(const char *path, char *out, size_t out_size)
      */
     if (!strcmp(path, "/dev/pts") || !strcmp(path, "/dev/pts/")) {
         str_copy_trunc(out, "/dev/pts", out_size);
+        return true;
+    }
+
+    /* The synthetic USB trees (usb-sysfs.c) are scratch-dir backed like
+     * /dev/pts, and their consumers walk them with per-component relative
+     * openat (systemd chase()) and then fstatfs the result expecting
+     * SYSFS_MAGIC. Both need the guest spelling on the descriptor: the former
+     * so resolve_proc_dirfd_path keeps the walk on the intercepts, the latter
+     * so sys_fstatfs can answer synthetically instead of leaking the /tmp
+     * filesystem.
+     */
+    if (path_prefix_match(path, "/sys", 4) ||
+        path_prefix_match(path, "/dev/bus", 8)) {
+        str_copy_trunc(out, path, out_size);
         return true;
     }
 
@@ -659,6 +674,32 @@ int64_t sys_openat_path(guest_t *g,
                         int linux_flags,
                         int mode)
 {
+    /* Linux rejects O_DIRECTORY|O_CREAT while it is still building the open
+     * flags, before the path is resolved and before the dirfd is validated:
+     * EINVAL for a name that exists, one that does not, a directory, and a bad
+     * dirfd alike (measured on 6.19; macOS open(2) agrees, so host-backed names
+     * already answered this and only the intercepts did not). Deciding it here
+     * rather than inside each intercept keeps the one answer in the one place
+     * the kernel decides it, and stops a synthetic directory from reporting
+     * EISDIR for a request the kernel never got far enough to look at.
+     *
+     * O_PATH does not reach that test at all: the same function first masks
+     * the flags down to O_DIRECTORY|O_NOFOLLOW|O_PATH, so the creation bit is
+     * gone before the pair is looked at and O_PATH|O_DIRECTORY|O_CREAT opens
+     * the directory and hands back a descriptor, behaving exactly like
+     * O_PATH|O_DIRECTORY on a present name, an absent one and a regular file
+     * alike (measured). Dropping the bit here rather than only skipping the
+     * test is what makes the rest of the path agree: left set, it reads as
+     * write intent, and the read-only sysfs gate answered EISDIR for a
+     * descriptor the kernel hands out.
+     */
+    if (linux_flags & LINUX_O_PATH)
+        linux_flags &= ~LINUX_O_CREAT;
+
+    if ((linux_flags & (LINUX_O_DIRECTORY | LINUX_O_CREAT)) ==
+        (LINUX_O_DIRECTORY | LINUX_O_CREAT))
+        return -LINUX_EINVAL;
+
     path_translation_t tx;
     unsigned int tx_flags =
         (linux_flags & LINUX_O_NOFOLLOW) ? PATH_TR_NOFOLLOW : PATH_TR_NONE;
@@ -742,10 +783,40 @@ int64_t sys_openat_path(guest_t *g,
                  */
                 spec = fd_alias_host_shared(&alias_src);
             }
-            int guest_fd =
-                fd_alloc_opened_host(intercepted, type, linux_flags,
-                                     min_guest_fd, fd_cleanup_for_type(type),
-                                     tx.intercept_path, aliased ? &spec : NULL);
+
+            /* The virtual-path stamp follows the same dup: opening a magic link
+             * reopens the underlying file, so the new descriptor must inherit
+             * the target fd's stamped identity, not the literal magic-link
+             * spelling. fstatfs on a reopened /sys directory has to keep
+             * answering SYSFS_MAGIC (systemd's sd-device reopens every chased
+             * syspath this way and gates on it), and a reopened regular file
+             * must not masquerade as procfs -- so a magic link whose target
+             * carries no virtual identity stamps nothing at all.
+             */
+            const char *stamp = tx.intercept_path;
+
+            /* Under /sys the request and the result can name different objects:
+             * opening <dev>/subsystem without O_NOFOLLOW hands back the
+             * directory the link resolves to, and Linux's fd then reports that
+             * directory -- /proc/self/fd/N names it, and openat(fd, "..") pops
+             * *its* parent. Stamping the guest's spelling made every relative
+             * walk off such a descriptor restart from the link's own directory
+             * instead. Ask the descriptor what it holds; it names the link
+             * itself for the O_PATH|O_NOFOLLOW open that asked for the link,
+             * and the target for every open that followed one.
+             */
+            char sys_stamp[LINUX_PATH_MAX];
+            if (usb_sysfs_guest_path_for_fd(intercepted, sys_stamp,
+                                            sizeof(sys_stamp)) > 0)
+                stamp = sys_stamp;
+
+            if (alias_fd >= 0)
+                stamp = (aliased && alias_src.proc_path[0] != '\0')
+                            ? alias_src.proc_path
+                            : NULL;
+            int guest_fd = fd_alloc_opened_host(
+                intercepted, type, linux_flags, min_guest_fd,
+                fd_cleanup_for_type(type), stamp, aliased ? &spec : NULL);
             if (guest_fd < 0)
                 return linux_errno();
             return guest_fd;
@@ -782,6 +853,26 @@ int64_t sys_openat_path(guest_t *g,
 
     int host_fd =
         open_nonblocking_writer(dir_ref.fd, tx.host_path, flags, mode);
+    if (host_fd < 0 && errno == ENOENT) {
+        /* Relative walkers (systemd chase() opens one component per openat)
+         * step from host-backed directories into synthetic subtrees the host
+         * does not carry -- openat(<sysroot>/sys fd, "bus") is ENOENT on the
+         * host while /sys/bus is served by an intercept. Rebase the relative
+         * path to its guest-absolute spelling and, only when that spelling is
+         * gated for interception, retry through the normal absolute-path flow.
+         * Host semantics for everything else are unchanged: the fallback runs
+         * only after a host ENOENT.
+         */
+        char rebased[LINUX_PATH_MAX];
+        if (path_rebase_hostdirfd(dir_ref.fd, tx.host_path, rebased,
+                                  sizeof(rebased)) > 0 &&
+            path_might_use_open_intercept(rebased)) {
+            host_fd_ref_close(&dir_ref);
+            return sys_openat_path(g, LINUX_AT_FDCWD, rebased, linux_flags,
+                                   mode);
+        }
+        errno = ENOENT;
+    }
     host_fd_ref_close(&dir_ref);
     if (host_fd < 0)
         return linux_errno();
@@ -2121,6 +2212,21 @@ int64_t sys_fchdir(int fd)
      */
     if (!proc_virtual && !strcmp(fd_table[fd].proc_path, "/dev/pts"))
         proc_virtual = "/dev/pts";
+
+    /* The synthetic USB trees are virtual for the same reason as /dev/pts: the
+     * scratch directory behind a /sys or /dev/bus descriptor is not what the
+     * guest named, and its host location is not a name the guest may see. Left
+     * to proc_cwd_refresh() the fd's real cwd would surface through getcwd, and
+     * a relative open resolved against it would land in the scratch tree --
+     * writing into a read-only view and reporting the wrong statfs magic.
+     * Publishing the stamped guest spelling instead keeps the cwd on the
+     * intercepts, exactly as chdir() does for these paths.
+     * resolve_proc_cwd_path knows the same two prefixes.
+     */
+    if (!proc_virtual && fd_table[fd].proc_path[0] &&
+        (path_prefix_match(fd_table[fd].proc_path, "/sys", 4) ||
+         path_prefix_match(fd_table[fd].proc_path, "/dev/bus", 8)))
+        proc_virtual = fd_table[fd].proc_path;
     if (fchdir(host_ref.fd) < 0) {
         host_fd_ref_close(&host_ref);
         return linux_errno();
@@ -2853,7 +2959,8 @@ int64_t sys_faccessat(guest_t *g,
      */
     struct stat intercepted_st;
     if (path_might_use_stat_intercept(tx.intercept_path) &&
-        proc_intercept_stat(tx.intercept_path, &intercepted_st) == 0) {
+        proc_intercept_stat_at(tx.intercept_path, &intercepted_st,
+                               !(flags & LINUX_AT_SYMLINK_NOFOLLOW)) == 0) {
         host_fd_ref_close(&dir_ref);
         if (path_check_intercept_access(&intercepted_st, mode, flags) < 0)
             return linux_errno();

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -125,6 +125,7 @@
  *   removed_overlay_lock (fs.c)      syscpu_dir_lock (procemu.c)
  *                                    sysinfo_lock (sys.c)
  *                                    sysroot_lock (proc-state.c)
+ *                                    usb_lock (runtime/usb-sysfs.c)
  *
  * log_mutex is the one leaf every other entry may hold: a lock anywhere in
  * either list can log while held. It sits below the whole order rather than

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -36,7 +36,14 @@ bool path_prefix_match(const char *path, const char *prefix, size_t plen)
     return path[plen] == '\0' || path[plen] == '/';
 }
 
-#define SYSFS_CPU_PREFIX "/sys/devices/system/cpu"
+/* The whole sysfs view: the USB layer answers /sys, /sys/bus, /sys/class and
+ * everything under them (usb-sysfs.c), with /sys/devices/system/cpu carved out
+ * for the older CPU-topology stub. Every gate below -- open, stat, poll --
+ * reaches the whole view through SYSFS_PREFIX; the carve-out is about which
+ * module answers, not about what the filesystem can do.
+ */
+#define SYSFS_PREFIX "/sys"
+#define DEV_USB_PREFIX "/dev/bus"
 
 bool path_might_use_open_intercept(const char *path)
 {
@@ -49,7 +56,7 @@ bool path_might_use_open_intercept(const char *path)
         return true;
     if (fuse_path_matches_mount(path))
         return true;
-    if (path_prefix_match(path, SYSFS_CPU_PREFIX, sizeof(SYSFS_CPU_PREFIX) - 1))
+    if (path_prefix_match(path, SYSFS_PREFIX, sizeof(SYSFS_PREFIX) - 1))
         return true;
     if (!strcmp(path, "/etc/mtab"))
         return true;
@@ -158,7 +165,16 @@ bool path_intercept_poll_capable(const char *path)
      */
     if (!strncmp(path, "/proc/", 6))
         return true;
-    if (path_prefix_match(path, SYSFS_CPU_PREFIX, sizeof(SYSFS_CPU_PREFIX) - 1))
+
+    /* Every sysfs attribute, not the CPU subtree alone: pollability comes from
+     * kernfs_fop_poll, which sysfs_file_operations installs on all of them, so
+     * a real /sys answers epoll_ctl(ADD) with 0 for net/lo/mtu and for
+     * bus/usb/devices/1-1/idVendor alike (measured on 6.19). Naming one subtree
+     * made every attribute the USB layer added report EPERM, which is the
+     * answer for a file that cannot be polled at all -- and udev-style readers
+     * arm `uevent` before they read it.
+     */
+    if (path_prefix_match(path, SYSFS_PREFIX, sizeof(SYSFS_PREFIX) - 1))
         return true;
     if (!strcmp(path, "/dev/random"))
         return true;
@@ -186,7 +202,9 @@ bool path_might_use_stat_intercept(const char *path)
         return true;
     if (fuse_path_matches_mount(path))
         return true;
-    if (path_prefix_match(path, SYSFS_CPU_PREFIX, sizeof(SYSFS_CPU_PREFIX) - 1))
+    if (path_prefix_match(path, SYSFS_PREFIX, sizeof(SYSFS_PREFIX) - 1))
+        return true;
+    if (path_prefix_match(path, DEV_USB_PREFIX, sizeof(DEV_USB_PREFIX) - 1))
         return true;
 
     return false;
@@ -1147,6 +1165,30 @@ static int proc_seed_absolute_path(const char *path,
     return proc_apply_components(path, out, outsz, marks, marks_cap, depth);
 }
 
+/* Does this O_PATH descriptor name a directory?
+ *
+ * The stamped path is the FD_PATH identity: a synthetic entry's host_fd is only
+ * a backing placeholder, so the intercepts are asked first and the host fd is
+ * consulted only for descriptors they do not serve. The open's O_NOFOLLOW
+ * decides whether the descriptor refers to a symlink or to its target, exactly
+ * as it does for fstat.
+ *
+ * Undecidable cases answer true: leaving the walk as it was is the conservative
+ * outcome, whereas inventing an ENOTDIR would break a resolution that works.
+ */
+static bool proc_path_fd_is_dir(const fd_entry_t *snap)
+{
+    struct stat st;
+    bool follow = !(snap->linux_flags & LINUX_O_NOFOLLOW);
+    int intercepted = proc_intercept_stat_at(snap->proc_path, &st, follow);
+    if (intercepted == 0)
+        return S_ISDIR(st.st_mode);
+    if (intercepted == PROC_NOT_INTERCEPTED && snap->host_fd >= 0 &&
+        fstat(snap->host_fd, &st) == 0)
+        return S_ISDIR(st.st_mode);
+    return true;
+}
+
 int resolve_proc_dirfd_path(guest_fd_t dirfd,
                             const char *path,
                             char *out,
@@ -1155,10 +1197,32 @@ int resolve_proc_dirfd_path(guest_fd_t dirfd,
     if (dirfd == LINUX_AT_FDCWD || !path || path[0] == '/')
         return 0;
 
+    /* FD_PATH joins FD_DIR: O_PATH directory descriptors are how systemd's
+     * chase() walks a path one openat per component, and a stamped O_PATH dirfd
+     * must keep resolving through the intercepts or the walk falls off the
+     * synthetic tree onto its host backing (and loses the stamp for every later
+     * component).
+     */
     fd_entry_t snap;
-    if (!fd_snapshot(dirfd, &snap) || snap.type != FD_DIR ||
+    if (!fd_snapshot(dirfd, &snap) ||
+        (snap.type != FD_DIR && snap.type != FD_PATH) ||
         snap.proc_path[0] == '\0')
         return 0;
+
+    /* Linux resolves a relative name against a dirfd only when the dirfd is a
+     * directory: openat() with an O_PATH descriptor on a regular file or on a
+     * symlink is ENOTDIR, decided before the name is looked up. FD_DIR is a
+     * directory by construction, so only FD_PATH has to be asked.
+     *
+     * The empty path is deliberately excluded: it is AT_EMPTY_PATH territory,
+     * where the descriptor names itself rather than a child, and fstatat() on
+     * an O_PATH fd of a regular file has to keep working.
+     */
+    if (snap.type == FD_PATH && path[0] != '\0' &&
+        !proc_path_fd_is_dir(&snap)) {
+        errno = ENOTDIR;
+        return -1;
+    }
 
     size_t marks[PROC_PATH_COMPONENTS_MAX];
     size_t depth;
@@ -1182,13 +1246,17 @@ static int resolve_proc_cwd_path(const char *path, char *out, size_t outsz)
     if (proc_acquire_cwd_view(&view) < 0)
         return 0;
 
-    /* /dev/pts joins /proc here: both are served from host directories whose
-     * contents are not what the guest names, so a relative path measured
-     * against one has to be rebuilt as a guest path and re-offered to the
-     * intercepts. The component walk below is base-agnostic.
+    /* /dev/pts and the synthetic USB trees join /proc here: all are served from
+     * host directories whose contents are not what the guest names, so a
+     * relative path measured against one has to be rebuilt as a guest path and
+     * re-offered to the intercepts. Without the /sys and /dev/bus arms a cwd
+     * set by fchdir() onto a synthetic USB directory would resolve relative
+     * names straight against the scratch tree. The component walk below is
+     * base-agnostic.
      */
     int rc = 0;
-    if (!strncmp(view.path, "/proc", 5) || !strncmp(view.path, "/dev/pts", 8)) {
+    if (!strncmp(view.path, "/proc", 5) || !strncmp(view.path, "/dev/pts", 8) ||
+        !strncmp(view.path, "/sys", 4) || !strncmp(view.path, "/dev/bus", 8)) {
         size_t marks[PROC_PATH_COMPONENTS_MAX];
         size_t depth;
         if (proc_seed_absolute_path(view.path, out, outsz, marks,
@@ -1219,6 +1287,62 @@ int resolve_proc_at_path(guest_fd_t dirfd,
         return rc;
 
     return resolve_proc_cwd_path(path, out, outsz);
+}
+
+/* Rebase a relative path against the host directory a descriptor points at,
+ * producing the guest-visible absolute spelling: F_GETPATH names where the
+ * directory lives on the host, path_host_to_guest strips the sysroot, and the
+ * component walk folds "." and "..".
+ *
+ * This exists for relative walkers (systemd's chase() opens "/", then "sys",
+ * then "bus", one openat per component) stepping from a host-backed directory
+ * into a synthetic subtree the host does not carry: the host openat fails
+ * ENOENT even though the guest path is served by an intercept. Callers rebase
+ * on that failure and re-offer the absolute path to the intercept gates.
+ *
+ * Returns 1 with out filled, 0 when the descriptor's path cannot be mapped (not
+ * an error: the caller keeps the host result).
+ */
+int path_rebase_hostdirfd(int host_dirfd,
+                          const char *rel,
+                          char *out,
+                          size_t outsz)
+{
+    if (!rel || rel[0] == '/' || rel[0] == '\0')
+        return 0;
+    char host_dir[LINUX_PATH_MAX];
+    if (fcntl(host_dirfd, F_GETPATH, host_dir) < 0)
+        return 0;
+
+    /* Only a descriptor inside the sysroot has a guest spelling. With a sysroot
+     * configured, path_host_to_guest passes a host path that is not under it
+     * through unchanged, so a dirfd on the host's /dev -- reachable through any
+     * sysroot symlink pointing out of the tree -- rebased to the guest-absolute
+     * "/dev", and the retry then handed the walk to the /dev/bus/usb intercept.
+     * The name the guest asked for lives outside the namespace the intercepts
+     * describe, so the ENOENT the host already gave is the answer; without a
+     * sysroot the guest root is the host root and every host path does have a
+     * guest spelling.
+     */
+    char sysroot[LINUX_PATH_MAX];
+    if (proc_sysroot_snapshot(sysroot, sizeof(sysroot))) {
+        size_t sl = strlen(sysroot);
+        if (strncmp(host_dir, sysroot, sl) != 0 ||
+            (host_dir[sl] != '\0' && host_dir[sl] != '/'))
+            return 0;
+    }
+
+    char guest_dir[LINUX_PATH_MAX];
+    if (path_host_to_guest(host_dir, guest_dir, sizeof(guest_dir)) < 0)
+        return 0;
+    size_t marks[PROC_PATH_COMPONENTS_MAX];
+    size_t depth;
+    if (proc_seed_absolute_path(guest_dir, out, outsz, marks, ARRAY_SIZE(marks),
+                                &depth) < 0 ||
+        proc_apply_components(rel, out, outsz, marks, ARRAY_SIZE(marks),
+                              &depth) < 0)
+        return 0;
+    return 1;
 }
 
 bool path_openat2_stays_beneath(const char *path, bool clamp_at_root)

--- a/src/syscall/path.h
+++ b/src/syscall/path.h
@@ -261,6 +261,18 @@ int path_translate_dirent_name(bool dir_holds_escapes,
                                const char *host_name,
                                char *guest_name,
                                size_t guest_name_sz);
+
+/* Rebase a relative path against a host directory fd into the guest-visible
+ * absolute spelling (F_GETPATH + sysroot strip + dot-folding).
+ *
+ * Returns 1 with out filled, 0 when no mapping exists. See path.c for the
+ * chase() rationale.
+ */
+int path_rebase_hostdirfd(int host_dirfd,
+                          const char *rel,
+                          char *out,
+                          size_t outsz);
+
 int resolve_proc_at_path(guest_fd_t dirfd,
                          const char *path,
                          char *out,

--- a/src/syscall/proc-state.c
+++ b/src/syscall/proc-state.c
@@ -916,10 +916,15 @@ static casefold_verdict_t resolve_through_links(const char *sr,
  * finally named. Reports whether a link was actually crossed, because the
  * host-fallback decision downstream is different for a path the guest typed and
  * one a link handed it; shared by both resolvers so the two cannot drift.
+ *
+ * An empty spelling means the walk reported none, and the caller keeps the path
+ * it already had. Callers seed the buffer empty for that reason: the return
+ * value is read on every verdict, so a walk that exits without publishing a
+ * spelling must not leave the decision reading uninitialized stack.
  */
 static bool rebase_after_link(const char **path, const char *followed)
 {
-    if (!strcmp(*path, followed))
+    if (followed[0] == '\0' || !strcmp(*path, followed))
         return false;
     *path = followed;
     return true;
@@ -949,6 +954,17 @@ static casefold_verdict_t resolve_byte_exact_through_links(
         size_t guest_len = 0;
         bool found_link = false;
 
+        /* Publish the spelling this iteration resolves before resolving it. The
+         * caller reads it on every verdict, and the two absent returns in the
+         * component loop below exit without reaching the fall-through that used
+         * to be the only writer -- an absent intermediate component left them
+         * reporting whatever the caller's stack happened to hold, which rebased
+         * resolution onto a path the guest never named.
+         */
+        if (str_copy_trunc(guest_out, cur, guest_outsz) >= guest_outsz) {
+            errno = ENAMETOOLONG;
+            return CASEFOLD_ERROR;
+        }
         if (snprintf(buf, bufsz, "%s%s", sr, cur) >= (int) bufsz) {
             errno = ENAMETOOLONG;
             return CASEFOLD_ERROR;
@@ -1024,10 +1040,6 @@ static casefold_verdict_t resolve_byte_exact_through_links(
         if (found_link)
             continue;
 
-        if (str_copy_trunc(guest_out, cur, guest_outsz) >= guest_outsz) {
-            errno = ENAMETOOLONG;
-            return CASEFOLD_ERROR;
-        }
         if (snprintf(buf, bufsz, "%s%s", sr, cur) >= (int) bufsz) {
             errno = ENAMETOOLONG;
             return CASEFOLD_ERROR;
@@ -1073,7 +1085,12 @@ static const char *proc_resolve_sysroot_path_flags(const char *path,
     bool followed_link = false;
     bool followed_relative_link = false;
     bool walk_typed_all = false;
+
+    /* One byte, not a 4 KiB zero-fill: only the leading NUL is read, and these
+     * resolvers run on every absolute path the guest names.
+     */
     char followed[LINUX_PATH_MAX];
+    followed[0] = '\0';
     if (casefold_active()) {
         casefold_walk_t walk;
         casefold_verdict_t verdict = resolve_through_links(
@@ -1269,7 +1286,12 @@ const char *proc_resolve_sysroot_create_path(const char *path,
      */
     bool followed_link = false;
     bool followed_relative_link = false;
+
+    /* One byte, not a 4 KiB zero-fill: only the leading NUL is read, and these
+     * resolvers run on every absolute path the guest names.
+     */
     char followed[LINUX_PATH_MAX];
+    followed[0] = '\0';
     if (casefold_active()) {
         casefold_walk_t walk;
 

--- a/tests/test-sysroot-name-relative.c
+++ b/tests/test-sysroot-name-relative.c
@@ -15,12 +15,13 @@
  * trees with openat(dirfd, name) throughout, and never build an absolute path
  * at all.
  *
- * Code under test: src/syscall/casefold-walk.c reached from
- * src/syscall/path.c's path_translate_at, for the case where the guest path
- * does not begin with '/'. A regression shows up as the same guest name
- * resolving to two different files depending on how it was spelled, so a create
- * through one spelling is invisible through the other, and an O_EXCL create of
- * a name that already exists succeeds instead of reporting EEXIST.
+ * Code under test: src/syscall/casefold-walk.c and the byte-exact resolver
+ * beside it in src/syscall/proc-state.c, both reached from src/syscall/path.c's
+ * path_translate_at, for the case where the guest path does not begin with '/'.
+ * A regression shows up as the same guest name resolving to two different files
+ * depending on how it was spelled, so a create through one spelling is
+ * invisible through the other, and an O_EXCL create of a name that already
+ * exists succeeds instead of reporting EEXIST.
  *
  * Run under --sysroot.
  */
@@ -274,6 +275,8 @@ static void section_trailing_slash(void)
  * because the two take different spellings on disk and the rule has to survive
  * either.
  */
+static void section_below_non_directory_at(void);
+
 static void section_below_non_directory(void)
 {
     char path[PATH_MAX];
@@ -309,10 +312,102 @@ static void section_below_non_directory(void)
     EXPECT_ERRNO(stat(path, &st), ENOTDIR, "should be ENOTDIR");
 
     /* The rule must not swallow a plain absent path, which still owes ENOENT.
+     * The two answers come from different findings -- ENOTDIR from a component
+     * that exists and is not a directory, ENOENT from one that does not exist
+     * at all -- so a resolver that cannot report which of the two it stopped on
+     * gives one answer for the other. Every case below was measured on Linux
+     * 6.19 (docker gcc:14) rather than reasoned from the rule.
+     *
+     * The absent arm is the one that fails dangerously, because the wrong errno
+     * is not the whole of it. A walk that gives up on an absent component and
+     * reports no spelling for where it stopped leaves the caller deciding from
+     * an unset one, and the syscall then answers for a path the guest never
+     * named: this suite caught it succeeding, and describing the sysroot root,
+     * for a name nothing holds. errno is cleared first for that reason -- a
+     * call that returns 0 leaves the previous assertion's errno behind, and the
+     * failure then reads as the wrong errno rather than as no failure at all.
      */
     TEST("an absent path below a real directory is still ENOENT");
     snprintf(path, sizeof(path), "%s/absent-dir/below", DIR_V);
+    errno = 0;
     EXPECT_ERRNO(stat(path, &st), ENOENT, "should be ENOENT");
+
+    TEST("open of an absent path below a real directory is ENOENT");
+    errno = 0;
+    EXPECT_ERRNO(open(path, O_RDONLY), ENOENT, "should be ENOENT");
+
+    TEST("the absent component named on its own is ENOENT");
+    snprintf(path, sizeof(path), "%s/absent-dir", DIR_V);
+    errno = 0;
+    EXPECT_ERRNO(stat(path, &st), ENOENT, "should be ENOENT");
+
+    /* A trailing slash turns the leaf into a directory reference, which is what
+     * flips the answer to ENOTDIR when the leaf exists as a file. It must not
+     * flip anything when nothing on the path exists.
+     */
+    TEST("an absent path with a trailing slash is ENOENT");
+    snprintf(path, sizeof(path), "%s/absent-dir/below/", DIR_V);
+    errno = 0;
+    EXPECT_ERRNO(stat(path, &st), ENOENT, "should be ENOENT");
+
+    TEST("two absent components deep is still ENOENT");
+    snprintf(path, sizeof(path), "%s/absent-dir/absent-two/below", DIR_V);
+    errno = 0;
+    EXPECT_ERRNO(stat(path, &st), ENOENT, "should be ENOENT");
+
+    section_below_non_directory_at();
+}
+
+/* The same split addressed through a descriptor rather than a path. Linux
+ * refuses a relative name against an O_PATH descriptor on a regular file with
+ * ENOTDIR before it looks the name up, while a descriptor on a real directory
+ * still owes ENOENT for a name that directory does not hold -- so neither
+ * answer can be derived from the other, and a rule that decides the first one
+ * early must not reach the second. Measured on Linux 6.19 alongside the path
+ * cases above.
+ */
+static void section_below_non_directory_at(void)
+{
+    struct stat st;
+    int filefd, dirfd;
+
+    TEST("O_PATH opens the regular file itself");
+    filefd = open(DIR_V "/notdirfile", O_PATH);
+    EXPECT_TRUE(filefd >= 0, "O_PATH open");
+
+    TEST("openat below an O_PATH regular file is ENOTDIR");
+    errno = 0;
+    EXPECT_ERRNO(openat(filefd, "below", O_RDONLY), ENOTDIR,
+                 "should be ENOTDIR");
+
+    TEST("fstatat below an O_PATH regular file is ENOTDIR");
+    errno = 0;
+    EXPECT_ERRNO(fstatat(filefd, "below", &st, 0), ENOTDIR,
+                 "should be ENOTDIR");
+
+    /* AT_EMPTY_PATH names the descriptor itself, not a child, so the rule above
+     * must not reach it.
+     */
+    TEST("fstatat of the O_PATH file itself still reports the file");
+    EXPECT_TRUE(
+        fstatat(filefd, "", &st, AT_EMPTY_PATH) == 0 && S_ISREG(st.st_mode),
+        "AT_EMPTY_PATH");
+    close(filefd);
+
+    TEST("O_PATH opens the real directory");
+    dirfd = open(DIR_V, O_PATH);
+    EXPECT_TRUE(dirfd >= 0, "O_PATH open");
+
+    TEST("an absent name under an O_PATH directory is ENOENT");
+    errno = 0;
+    EXPECT_ERRNO(fstatat(dirfd, "absent-dir/below", &st, 0), ENOENT,
+                 "should be ENOENT");
+
+    TEST("openat an absent name under an O_PATH directory is ENOENT");
+    errno = 0;
+    EXPECT_ERRNO(openat(dirfd, "absent-dir/below", O_RDONLY), ENOENT,
+                 "should be ENOENT");
+    close(dirfd);
 }
 
 int main(int argc, char **argv)

--- a/tests/test-sysroot-symlink-escape.c
+++ b/tests/test-sysroot-symlink-escape.c
@@ -83,6 +83,44 @@ int main(void)
         }
     }
 
+    /* A bridge to a host *directory* outside the sysroot, walked relatively.
+     *
+     * The host openat fails -- macOS has no /dev/bus and no /dev/shm -- and the
+     * ENOENT fallback that exists for systemd's chase() then rebuilds a
+     * guest-absolute spelling from the descriptor. path_host_to_guest passes a
+     * host path that is not under the sysroot through unchanged, so the
+     * descriptor on the host's /dev rebased to the guest-absolute "/dev" and
+     * the retry handed the walk to the /dev/bus/usb and /dev/shm intercepts: a
+     * name resolved outside the guest namespace came back answered from inside
+     * it. Both names must stay ENOENT, which is what the host already said.
+     */
+    int devfd = openat(dirfd, "dev-bridge", O_RDONLY | O_DIRECTORY);
+    TEST("a bridge to a host directory outside the sysroot opens");
+    if (devfd < 0) {
+        FAIL("openat(dirfd, dev-bridge) failed");
+    } else {
+        PASS();
+        static const char *const names[] = {"bus/usb", "shm", "bus"};
+        for (unsigned i = 0; i < sizeof(names) / sizeof(names[0]); i++) {
+            TEST(
+                "a relative walk off it is not retargeted into the intercepts");
+            errno = 0;
+            int fd = openat(devfd, names[i], O_RDONLY);
+            if (fd >= 0) {
+                close(fd);
+                printf("      %s answered from the intercept namespace\n",
+                       names[i]);
+                FAIL("openat off the host bridge was retargeted");
+            } else if (errno != ENOENT) {
+                printf("      %s: errno=%d\n", names[i], errno);
+                FAIL("openat off the host bridge answered the wrong errno");
+            } else {
+                PASS();
+            }
+        }
+        close(devfd);
+    }
+
     close(dirfd);
 
     TEST("AT_FDCWD relative escape is blocked after chdir");

--- a/tests/test-usb-desc-host.c
+++ b/tests/test-usb-desc-host.c
@@ -1,0 +1,628 @@
+/*
+ * Native-host unit tests for the raw USB descriptor walks
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Configuration blobs arrive from the peripheral, so bLength and wTotalLength
+ * are attacker-shaped numbers. These cases feed the walker (runtime/usb-desc.c)
+ * the three malformed shapes a real device can produce -- a bLength longer than
+ * the bytes that remain, a zero-length descriptor, and a header truncated
+ * mid-record -- and assert the two things that must hold for every one of them:
+ * the walk terminates, and its cursor never leaves the buffer. The cursor bound
+ * is asserted directly rather than inferred, because a walk that steps past the
+ * end and only then re-tests its guard still yields the right interface list
+ * while having formed an out-of-bounds pointer; nothing but the cursor itself
+ * distinguishes the two.
+ *
+ * Interfaces read before the malformed record must still be reported: a device
+ * with a trailing junk descriptor is common, and dropping its whole
+ * configuration would lose the interface dirs libusb enumerates.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "runtime/usb-desc.h"
+
+/* Collect the bInterfaceNumbers of alternate setting 0, exactly as
+ * emit_interface_dirs does, and report where the walk stopped.
+ */
+static int walk_interfaces(const unsigned char *buf,
+                           size_t len,
+                           unsigned char *out,
+                           size_t *stop_off,
+                           int *truncated)
+{
+    usb_desc_iter_t it;
+    usb_desc_iter_init(&it, buf, len);
+    int n = 0;
+    const unsigned char *d;
+    unsigned char dlen;
+    while ((d = usb_desc_iter_next(&it, &dlen))) {
+        /* The invariant, checked on every single step and not just at the end:
+         * a cursor past the end means an out-of-bounds pointer was formed.
+         */
+        assert(it.off <= it.len);
+        if (d[1] == USB_DT_INTERFACE && dlen >= USB_INTERFACE_DESC_LEN &&
+            d[3] == 0)
+            out[n++] = d[2];
+    }
+    assert(it.off <= it.len);
+    *stop_off = it.off;
+    *truncated = it.truncated;
+    return n;
+}
+
+/* config descriptor header, then `nif` nine-byte interface descriptors */
+static size_t build_config(unsigned char *buf,
+                           unsigned cfg_value,
+                           unsigned nif,
+                           size_t total_override)
+{
+    size_t off = 0;
+    size_t total = USB_CONFIG_DESC_LEN + nif * USB_INTERFACE_DESC_LEN;
+    size_t declared = total_override ? total_override : total;
+    buf[off++] = USB_CONFIG_DESC_LEN;
+    buf[off++] = USB_DT_CONFIG;
+    buf[off++] = (unsigned char) (declared & 0xff);
+    buf[off++] = (unsigned char) (declared >> 8);
+    buf[off++] = (unsigned char) nif; /* bNumInterfaces */
+    buf[off++] = (unsigned char) cfg_value;
+    buf[off++] = 0; /* iConfiguration */
+    buf[off++] = 0xa0;
+    buf[off++] = 50;
+    for (unsigned i = 0; i < nif; i++) {
+        buf[off++] = USB_INTERFACE_DESC_LEN;
+        buf[off++] = USB_DT_INTERFACE;
+        buf[off++] = (unsigned char) i; /* bInterfaceNumber */
+        buf[off++] = 0;                 /* bAlternateSetting */
+        buf[off++] = 1;                 /* bNumEndpoints */
+        buf[off++] = 0xff;
+        buf[off++] = 0;
+        buf[off++] = 0;
+        buf[off++] = 0;
+    }
+    return off;
+}
+
+static void test_well_formed_blob_is_fully_consumed(void)
+{
+    unsigned char buf[64], ifs[8];
+    size_t len = build_config(buf, 1, 2, 0);
+    size_t stop = 0;
+    int trunc = 1;
+    int n = walk_interfaces(buf, len, ifs, &stop, &trunc);
+    assert(n == 2 && ifs[0] == 0 && ifs[1] == 1);
+    assert(stop == len);
+    assert(!trunc);
+}
+
+/* bLength claims more than the buffer still holds: the pre-fix walk advanced
+ * the cursor by that claim and left the buffer behind.
+ */
+static void test_blength_past_the_end_stops_in_bounds(void)
+{
+    unsigned char buf[64], ifs[8];
+    size_t len = build_config(buf, 1, 1, 0);
+    size_t before = len;
+    buf[len++] = 200; /* bLength far beyond the four bytes that follow */
+    buf[len++] = USB_DT_INTERFACE;
+    buf[len++] = 7;
+    buf[len++] = 0;
+    size_t stop = 0;
+    int trunc = 0;
+    int n = walk_interfaces(buf, len, ifs, &stop, &trunc);
+    assert(n == 1 && ifs[0] == 0); /* the readable interface survives */
+    assert(stop == before);        /* stopped at the bad record, not past it */
+    assert(trunc);
+}
+
+static void test_zero_length_descriptor_stops(void)
+{
+    unsigned char buf[64], ifs[8];
+    size_t len = build_config(buf, 1, 1, 0);
+    size_t before = len;
+    buf[len++] = 0; /* bLength 0: advancing by it would never terminate */
+    buf[len++] = USB_DT_INTERFACE;
+    buf[len++] = 9;
+    buf[len++] = 0;
+    size_t stop = 0;
+    int trunc = 0;
+    int n = walk_interfaces(buf, len, ifs, &stop, &trunc);
+    assert(n == 1 && stop == before && trunc);
+}
+
+/* A nine-byte interface descriptor with only five bytes left behind it. */
+static void test_truncated_interface_descriptor_stops(void)
+{
+    unsigned char buf[64], ifs[8];
+    size_t len = build_config(buf, 1, 1, 0);
+    size_t before = len;
+    buf[len++] = USB_INTERFACE_DESC_LEN;
+    buf[len++] = USB_DT_INTERFACE;
+    buf[len++] = 1;
+    buf[len++] = 0;
+    buf[len++] = 1;
+    size_t stop = 0;
+    int trunc = 0;
+    int n = walk_interfaces(buf, len, ifs, &stop, &trunc);
+    assert(n == 1 && ifs[0] == 0);
+    assert(stop == before && trunc);
+}
+
+/* One trailing byte cannot even carry bLength + bDescriptorType. */
+static void test_single_trailing_byte_stops(void)
+{
+    unsigned char buf[64], ifs[8];
+    size_t len = build_config(buf, 1, 1, 0);
+    size_t before = len;
+    buf[len++] = USB_INTERFACE_DESC_LEN;
+    size_t stop = 0;
+    int trunc = 0;
+    int n = walk_interfaces(buf, len, ifs, &stop, &trunc);
+    assert(n == 1 && stop == before && trunc);
+}
+
+static void test_empty_and_null_buffers(void)
+{
+    usb_desc_iter_t it;
+    usb_desc_iter_init(&it, NULL, 99);
+    assert(usb_desc_iter_next(&it, NULL) == NULL && it.off == 0);
+    unsigned char buf[4] = {0};
+    usb_desc_iter_init(&it, buf, 0);
+    assert(usb_desc_iter_next(&it, NULL) == NULL && it.off == 0 &&
+           !it.truncated);
+}
+
+/* device descriptor + two configurations, the second one selected */
+static size_t build_blob(unsigned char *buf, size_t total_override)
+{
+    memset(buf, 0, USB_DEVICE_DESC_LEN);
+    buf[0] = USB_DEVICE_DESC_LEN;
+    buf[1] = USB_DT_DEVICE;
+    size_t off = USB_DEVICE_DESC_LEN;
+    off += build_config(buf + off, 1, 1, 0);
+    off += build_config(buf + off, 2, 2, total_override);
+    return off;
+}
+
+static void test_active_config_selects_by_value(void)
+{
+    unsigned char buf[128];
+    size_t len = build_blob(buf, 0);
+    size_t clen = 0;
+    const unsigned char *cfg = usb_desc_active_config(buf, len, 2, &clen);
+    assert(cfg && cfg[5] == 2 && clen == USB_CONFIG_DESC_LEN + 2 * 9);
+
+    /* No such value: the first configuration, not a NULL and not the last. */
+    cfg = usb_desc_active_config(buf, len, 7, &clen);
+    assert(cfg && cfg[5] == 1 && clen == USB_CONFIG_DESC_LEN + 9);
+}
+
+/* wTotalLength larger than the blob: the step must clamp, not run off. */
+static void test_active_config_clamps_overlong_total(void)
+{
+    unsigned char buf[128];
+    size_t len = build_blob(buf, 60000);
+    size_t clen = 0;
+    const unsigned char *cfg = usb_desc_active_config(buf, len, 2, &clen);
+    assert(cfg && cfg[5] == 2);
+    assert(clen == len - (size_t) (cfg - buf)); /* clamped to what remains */
+
+    /* And the walk that would have to step over it still terminates. */
+    cfg = usb_desc_active_config(buf, len, 9, &clen);
+    assert(cfg && cfg[5] == 1);
+}
+
+/* wTotalLength under-reported: the header is a real configuration, but the span
+ * it names stops short of the interface behind it, so the cursor lands on that
+ * interface descriptor. An interface descriptor's bytes 2-3 are
+ * bInterfaceNumber/bAlternateSetting, which the pre-fix walk read as
+ * wTotalLength, and its byte 5 is bInterfaceClass, which the pre-fix walk
+ * compared against bConfigurationValue -- so the interface was returned as the
+ * device's active configuration.
+ */
+static void test_active_config_ignores_non_config_records(void)
+{
+    unsigned char buf[64];
+    memset(buf, 0, sizeof(buf));
+    buf[0] = USB_DEVICE_DESC_LEN;
+    buf[1] = USB_DT_DEVICE;
+    size_t off = USB_DEVICE_DESC_LEN;
+
+    /* Configuration value 1, under-reporting wTotalLength as the header alone
+     */
+    buf[off++] = USB_CONFIG_DESC_LEN;
+    buf[off++] = USB_DT_CONFIG;
+    buf[off++] = USB_CONFIG_DESC_LEN; /* wTotalLength lo: the header only */
+    buf[off++] = 0;                   /* wTotalLength hi */
+    buf[off++] = 1;                   /* bNumInterfaces */
+    buf[off++] = 1;                   /* bConfigurationValue */
+    buf[off++] = 0;                   /* iConfiguration */
+    buf[off++] = 0xa0;                /* bmAttributes */
+    buf[off++] = 50;                  /* bMaxPower */
+
+    /* The interface the configuration failed to cover. bInterfaceNumber is 32
+     * so bytes 2-3 read as a wTotalLength of 32 -- past the header minimum, so
+     * the pre-fix walk accepted the record and stepped by it.
+     */
+    buf[off++] = USB_INTERFACE_DESC_LEN;
+    buf[off++] = USB_DT_INTERFACE;
+    buf[off++] = 32;   /* bInterfaceNumber (pre-fix: wTotalLength lo) */
+    buf[off++] = 0;    /* bAlternateSetting (pre-fix: wTotalLength hi) */
+    buf[off++] = 1;    /* bNumEndpoints */
+    buf[off++] = 0x07; /* bInterfaceClass (pre-fix: bConfigurationValue) */
+    buf[off++] = 0;
+    buf[off++] = 0;
+    buf[off++] = 0;
+    size_t len = off;
+
+    /* Ask for the interface's bInterfaceClass as if it were a configuration
+     * value: nothing in the blob has bConfigurationValue 7, so the only way to
+     * return a match is to have matched the interface descriptor.
+     */
+    size_t clen = 0;
+    const unsigned char *cfg = usb_desc_active_config(buf, len, 0x07, &clen);
+    assert(cfg != NULL);
+    assert(cfg[1] == USB_DT_CONFIG); /* never an interface descriptor */
+    assert(cfg[0] == USB_CONFIG_DESC_LEN);
+    assert(cfg[5] == 1);                 /* the real config, via fallback */
+    assert(clen == USB_CONFIG_DESC_LEN); /* the span its header declared */
+
+    /* The same blob asked for its real value still answers with the header. */
+    cfg = usb_desc_active_config(buf, len, 1, &clen);
+    assert(cfg && cfg[1] == USB_DT_CONFIG && cfg[5] == 1);
+}
+
+/* A configuration header whose bLength is not USB_CONFIG_DESC_LEN is not a
+ * configuration header, even when bDescriptorType and wTotalLength agree.
+ */
+static void test_active_config_rejects_bad_header_length(void)
+{
+    unsigned char buf[128];
+    size_t len = build_blob(buf, 0);
+
+    buf[USB_DEVICE_DESC_LEN] = 0; /* bLength 0 */
+    size_t clen = 0;
+    assert(usb_desc_active_config(buf, len, 1, &clen) == NULL);
+
+    buf[USB_DEVICE_DESC_LEN] = USB_CONFIG_DESC_LEN + 1; /* merely wrong */
+    assert(usb_desc_active_config(buf, len, 1, &clen) == NULL);
+}
+
+/* bDescriptorType wrong: the record is well-formed and long enough, and its
+ * byte 5 would match, but it is not a configuration.
+ */
+static void test_active_config_rejects_bad_header_type(void)
+{
+    unsigned char buf[128];
+    size_t len = build_blob(buf, 0);
+
+    buf[USB_DEVICE_DESC_LEN + 1] = USB_DT_INTERFACE;
+    size_t clen = 0;
+    assert(usb_desc_active_config(buf, len, 1, &clen) == NULL);
+
+    buf[USB_DEVICE_DESC_LEN + 1] = USB_DT_DEVICE;
+    assert(usb_desc_active_config(buf, len, 1, &clen) == NULL);
+}
+
+/* A malformed leading configuration must not hide a well-formed one behind it
+ * -- but it does end the walk, because the bad record's span cannot be trusted
+ * to say where the next one starts. The first config stays authoritative.
+ */
+static void test_active_config_stops_at_first_bad_record(void)
+{
+    unsigned char buf[128];
+    size_t len = build_blob(buf, 0);
+
+    /* Corrupt the *second* configuration's type; the first is still returned
+     * for its own value, and the second is no longer reachable at all.
+     */
+    size_t second = USB_DEVICE_DESC_LEN + USB_CONFIG_DESC_LEN + 9;
+    assert(buf[second] == USB_CONFIG_DESC_LEN &&
+           buf[second + 1] == USB_DT_CONFIG);
+    buf[second + 1] = 0x21; /* HID descriptor type */
+
+    size_t clen = 0;
+    const unsigned char *cfg = usb_desc_active_config(buf, len, 1, &clen);
+    assert(cfg && cfg[5] == 1 && clen == USB_CONFIG_DESC_LEN + 9);
+
+    /* Value 2 lives only in the corrupted record, so the fallback answers. */
+    cfg = usb_desc_active_config(buf, len, 2, &clen);
+    assert(cfg && cfg[5] == 1);
+    assert(cfg[1] == USB_DT_CONFIG);
+}
+
+static void test_active_config_rejects_short_blobs(void)
+{
+    unsigned char buf[128];
+    size_t clen = 0;
+    size_t len = build_blob(buf, 0);
+    assert(usb_desc_active_config(buf, USB_DEVICE_DESC_LEN, 1, &clen) == NULL);
+    assert(usb_desc_active_config(NULL, len, 1, &clen) == NULL);
+
+    /* wTotalLength below the header size names no locatable configuration. */
+    buf[USB_DEVICE_DESC_LEN + 2] = 3;
+    buf[USB_DEVICE_DESC_LEN + 3] = 0;
+    assert(usb_desc_active_config(buf, len, 1, &clen) == NULL);
+}
+
+
+/* The active-configuration attribute set.
+ *
+ * These are the cases the attached hardware cannot reach. Both devices on the
+ * development board report iConfiguration 0, so nothing local exercises the
+ * branch where a configuration names a string -- and the branch where the blob
+ * carries no configuration at all needs a device that does not enumerate.
+ * Feeding usb_desc_actconfig_attrs a synthesized descriptor runs every branch
+ * on any host, with no bus involved.
+ */
+
+/* offsets inside a configuration descriptor */
+#define CFG_I_CONFIGURATION 6
+#define CFG_BMATTRIBUTES 7
+#define CFG_BMAXPOWER 8
+
+static void test_actconfig_no_configuration_is_four_empty_files(void)
+{
+    usb_actconfig_attrs_t a;
+
+    /* actconfig == NULL on Linux: usb_actconfig_show and configuration_show
+     * both return the 0 the lock gave them, so all four attributes read empty.
+     * They are still present -- dev_attr_grp has no .is_visible -- which is
+     * what the caller relies on when it writes all four unconditionally.
+     */
+    memset(&a, 0xaa, sizeof(a));
+    usb_desc_actconfig_attrs(NULL, 0, 2, "ignored", &a);
+    assert(a.num_interfaces[0] == '\0');
+    assert(a.bm_attributes[0] == '\0');
+    assert(a.max_power[0] == '\0');
+    assert(a.configuration[0] == '\0');
+
+    /* A cfg_len below the header size is the same situation: nothing can be
+     * read out of it, so nothing is claimed about it.
+     */
+    unsigned char buf[64];
+    build_config(buf, 1, 1, 0);
+    memset(&a, 0xaa, sizeof(a));
+    usb_desc_actconfig_attrs(buf, USB_CONFIG_DESC_LEN - 1, 2, "ignored", &a);
+    assert(a.num_interfaces[0] == '\0');
+    assert(a.bm_attributes[0] == '\0');
+    assert(a.max_power[0] == '\0');
+    assert(a.configuration[0] == '\0');
+}
+
+static void test_actconfig_fields_use_the_kernel_formats(void)
+{
+    unsigned char buf[64];
+    usb_actconfig_attrs_t a;
+    size_t len = build_config(buf, 1, 2, 0);
+
+    buf[CFG_BMATTRIBUTES] = 0xe0;
+    buf[CFG_BMAXPOWER] = 50;
+    usb_desc_actconfig_attrs(buf, len, 2, NULL, &a);
+    assert(!strcmp(a.num_interfaces, " 2\n")); /* "%2d\n" */
+    assert(!strcmp(a.bm_attributes, "e0\n"));  /* "%2x\n" */
+    assert(!strcmp(a.max_power, "100mA\n"));   /* 50 * 2 */
+
+    /* SuperSpeed counts in 8 mA units, and the widest value still fits. */
+    buf[CFG_BMAXPOWER] = 0xff;
+    usb_desc_actconfig_attrs(buf, len, 8, NULL, &a);
+    assert(!strcmp(a.max_power, "2040mA\n"));
+}
+
+static void test_actconfig_configuration_string_branches(void)
+{
+    unsigned char buf[64];
+    usb_actconfig_attrs_t a;
+    size_t len = build_config(buf, 1, 1, 0);
+
+    /* iConfiguration 0, no string: empty, and the three siblings are not. This
+     * is the only shape the development board can produce.
+     */
+    buf[CFG_I_CONFIGURATION] = 0;
+    usb_desc_actconfig_attrs(buf, len, 2, NULL, &a);
+    assert(a.configuration[0] == '\0');
+    assert(a.num_interfaces[0] != '\0');
+
+    /* iConfiguration 0 with a string handed in anyway: still empty.
+     * usb_cache_string returns NULL for index <= 0 before it reads anything, so
+     * there is no path on Linux by which such a configuration has a string, and
+     * a caller that produced one from somewhere else must not be believed.
+     */
+    usb_desc_actconfig_attrs(buf, len, 2, "Bus Powered Config", &a);
+    assert(a.configuration[0] == '\0');
+
+    /* iConfiguration non-zero with the string unreadable -- NULL and empty
+     * alike. This is Linux's second route to an empty configuration, and the
+     * one every device on this platform takes today, so it must stay empty
+     * rather than become an absent file.
+     */
+    buf[CFG_I_CONFIGURATION] = 4;
+    usb_desc_actconfig_attrs(buf, len, 2, NULL, &a);
+    assert(a.configuration[0] == '\0');
+    usb_desc_actconfig_attrs(buf, len, 2, "", &a);
+    assert(a.configuration[0] == '\0');
+
+    /* iConfiguration non-zero and the string readable: sysfs_emit("%s\n"). The
+     * branch the board has no device for.
+     */
+    usb_desc_actconfig_attrs(buf, len, 2, "Bus Powered Config", &a);
+    assert(!strcmp(a.configuration, "Bus Powered Config\n"));
+}
+
+static void test_actconfig_string_is_bounded(void)
+{
+    unsigned char buf[64];
+    usb_actconfig_attrs_t a;
+    char huge[USB_MAX_STRING_SIZE * 2];
+    size_t len = build_config(buf, 1, 1, 0);
+
+    /* A device can report a string longer than the kernel's own cache bound;
+     * usb_string() truncates it there, and so does this. The assertion is on
+     * the buffer, not on the result: a rendering that ran past USB_MAX_STRING
+     * _SIZE would have smashed the struct before anything could compare it.
+     */
+    memset(huge, 'x', sizeof(huge) - 1);
+    huge[sizeof(huge) - 1] = '\0';
+    buf[CFG_I_CONFIGURATION] = 1;
+    usb_desc_actconfig_attrs(buf, len, 2, huge, &a);
+    assert(strlen(a.configuration) < sizeof(a.configuration));
+    assert(a.configuration[0] == 'x');
+
+    /* What gets truncated is the string, never the trailing newline. Every
+     * sysfs attribute Linux emits through sysfs_emit("%s\n", ...) ends in one,
+     * whatever the string did, so a rendering that dropped it to make room
+     * would be emitting a last line the kernel never writes.
+     */
+    assert(a.configuration[strlen(a.configuration) - 1] == '\n');
+
+    /* The longest string Linux itself could have cached -- usb_string() stops
+     * at MAX_USB_STRING_SIZE counting the terminator -- still round-trips
+     * whole, so the bound above only ever trims input the kernel could not have
+     * produced.
+     */
+    char longest[USB_MAX_STRING_SIZE];
+    memset(longest, 'y', sizeof(longest) - 1);
+    longest[sizeof(longest) - 1] = '\0';
+    usb_desc_actconfig_attrs(buf, len, 2, longest, &a);
+    assert(strlen(a.configuration) == sizeof(longest));
+    assert(!strncmp(a.configuration, longest, sizeof(longest) - 1));
+    assert(a.configuration[strlen(a.configuration) - 1] == '\n');
+}
+
+static void test_actconfig_reads_the_selected_configuration(void)
+{
+    /* End to end with the locator: two configurations whose iConfiguration
+     * differs, so picking the wrong one shows up as the wrong string. Byte 5
+     * (bConfigurationValue) selects; byte 6 (iConfiguration) is what is read.
+     */
+    unsigned char blob[256];
+    usb_actconfig_attrs_t a;
+    size_t off = USB_DEVICE_DESC_LEN;
+    memset(blob, 0, sizeof(blob));
+    blob[0] = USB_DEVICE_DESC_LEN;
+    blob[1] = USB_DT_DEVICE;
+
+    size_t c1 = build_config(blob + off, 1, 1, 0);
+    blob[off + CFG_I_CONFIGURATION] = 0;
+    off += c1;
+    size_t c2 = build_config(blob + off, 2, 3, 0);
+    blob[off + CFG_I_CONFIGURATION] = 7;
+    off += c2;
+
+    size_t clen = 0;
+    const unsigned char *cfg = usb_desc_active_config(blob, off, 2, &clen);
+    assert(cfg && cfg[5] == 2);
+    usb_desc_actconfig_attrs(cfg, clen, 2, "High Power", &a);
+    assert(!strcmp(a.configuration, "High Power\n"));
+    assert(!strcmp(a.num_interfaces, " 3\n"));
+
+    cfg = usb_desc_active_config(blob, off, 1, &clen);
+    assert(cfg && cfg[5] == 1);
+    usb_desc_actconfig_attrs(cfg, clen, 2, "High Power", &a);
+    assert(a.configuration[0] == '\0');
+    assert(!strcmp(a.num_interfaces, " 1\n"));
+}
+
+/* The interface set sysfs turns into directories.
+ *
+ * bInterfaceNumber is a __u8, so 200 is as ordinary a number as 3; a device is
+ * free to pick it. Selecting into a 32-entry table dropped every interface at
+ * or above 32 -- silently, since the walk itself was still bounded and still
+ * terminated, and the only visible symptom was a missing :c.i directory. These
+ * numbers are chosen around that edge: 0 below it, 31 at the last value the old
+ * table held, 32 at the first it dropped, and 200 well past it.
+ */
+static void test_interfaces_cover_the_whole_byte_range(void)
+{
+    static const unsigned char nums[] = {0, 31, 32, 200};
+    unsigned char buf[128];
+    size_t len = build_config(buf, 1, 4, 0);
+    for (unsigned i = 0; i < 4; i++)
+        buf[USB_CONFIG_DESC_LEN + i * USB_INTERFACE_DESC_LEN + 2] = nums[i];
+
+    const unsigned char *ifs[USB_DESC_INTERFACES_MAX];
+    bool trunc = true;
+    size_t stop = 0;
+    size_t n = usb_desc_interfaces(buf, len, ifs, USB_DESC_INTERFACES_MAX,
+                                   &trunc, &stop);
+    assert(n == 4);
+    for (unsigned i = 0; i < 4; i++)
+        assert(ifs[i][2] == nums[i]);
+    assert(!trunc && stop == len);
+}
+
+/* Alternate settings are not interfaces: only setting 0 gets a directory, and a
+ * number already emitted is not emitted twice however many times it recurs.
+ */
+static void test_interfaces_dedup_by_number_at_alt_zero(void)
+{
+    unsigned char buf[128];
+    size_t len = build_config(buf, 1, 4, 0);
+    unsigned char *p0 = buf + USB_CONFIG_DESC_LEN;
+    p0[2] = 200;                          /* if 200, alt 0  */
+    p0[USB_INTERFACE_DESC_LEN + 2] = 200; /* if 200, alt 1  */
+    p0[USB_INTERFACE_DESC_LEN + 3] = 1;
+    p0[2 * USB_INTERFACE_DESC_LEN + 2] = 200; /* if 200, alt 0 again */
+    p0[3 * USB_INTERFACE_DESC_LEN + 2] = 5;   /* if 5,   alt 0  */
+
+    const unsigned char *ifs[USB_DESC_INTERFACES_MAX];
+    size_t n =
+        usb_desc_interfaces(buf, len, ifs, USB_DESC_INTERFACES_MAX, NULL, NULL);
+    assert(n == 2);
+    assert(ifs[0][2] == 200 && ifs[0][3] == 0);
+    assert(ifs[1][2] == 5 && ifs[1][3] == 0);
+}
+
+/* The malformed-blob contract holds through the selector too: what was read
+ * before the bad record is reported, and the truncation is not hidden.
+ */
+static void test_interfaces_report_truncation(void)
+{
+    unsigned char buf[128];
+    size_t len = build_config(buf, 1, 1, 0);
+    size_t before = len;
+    buf[len++] = 200; /* bLength far beyond the bytes that follow */
+    buf[len++] = USB_DT_INTERFACE;
+    buf[len++] = 7;
+    buf[len++] = 0;
+
+    const unsigned char *ifs[USB_DESC_INTERFACES_MAX];
+    bool trunc = false;
+    size_t stop = 0;
+    size_t n = usb_desc_interfaces(buf, len, ifs, USB_DESC_INTERFACES_MAX,
+                                   &trunc, &stop);
+    assert(n == 1 && ifs[0][2] == 0);
+    assert(trunc && stop == before);
+}
+
+int main(void)
+{
+    test_well_formed_blob_is_fully_consumed();
+    test_blength_past_the_end_stops_in_bounds();
+    test_zero_length_descriptor_stops();
+    test_truncated_interface_descriptor_stops();
+    test_single_trailing_byte_stops();
+    test_empty_and_null_buffers();
+    test_active_config_selects_by_value();
+    test_active_config_clamps_overlong_total();
+    test_active_config_rejects_short_blobs();
+    test_active_config_ignores_non_config_records();
+    test_active_config_rejects_bad_header_length();
+    test_active_config_rejects_bad_header_type();
+    test_active_config_stops_at_first_bad_record();
+    test_actconfig_no_configuration_is_four_empty_files();
+    test_actconfig_fields_use_the_kernel_formats();
+    test_actconfig_configuration_string_branches();
+    test_actconfig_string_is_bounded();
+    test_actconfig_reads_the_selected_configuration();
+    test_interfaces_cover_the_whole_byte_range();
+    test_interfaces_dedup_by_number_at_alt_zero();
+    test_interfaces_report_truncation();
+    printf("test-usb-desc-host: all tests passed\n");
+    return 0;
+}

--- a/tests/test-usb-sysfs-overflow.c
+++ b/tests/test-usb-sysfs-overflow.c
@@ -1,0 +1,128 @@
+/*
+ * The per-bus devnum cap keeps minors from crossing bus ranges
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Code under test: the fallback devnum assignment and its 127 cap in
+ * src/runtime/usb-sysfs.c (usb_minor() encodes devnum-1 as the low 7 bits of
+ * the minor, so a 128th device on a bus would land on the next bus's range).
+ *
+ * Run with ELFUSE_USB_FIXTURE=overflow, which routes 129 address-less devices
+ * on bus 1 plus one on bus 2 through the fallback path. Without the cap bus1's
+ * 129th device takes devnum 129 and shares minor 128 with bus2's first device;
+ * with it, everything past devnum 127 is dropped. The assertions: every device
+ * directory has a devnum in 1..127, no two share a (major, minor), and bus 1
+ * kept exactly 127 of its 129 while bus 2 kept its one.
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define DEVICES_DIR "/sys/bus/usb/devices"
+
+static int read_attr_int(const char *dev, const char *attr)
+{
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s/%s", DEVICES_DIR, dev, attr);
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return -1;
+    char buf[64];
+    ssize_t n = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (n <= 0)
+        return -1;
+    buf[n] = '\0';
+    return (int) strtol(buf, NULL, 10);
+}
+
+/* Read the minor from the device's "dev" attribute ("189:MINOR\n"). */
+static int read_minor(const char *dev)
+{
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s/dev", DEVICES_DIR, dev);
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return -1;
+    char buf[64];
+    ssize_t n = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (n <= 0)
+        return -1;
+    buf[n] = '\0';
+    const char *colon = strchr(buf, ':');
+    return colon ? (int) strtol(colon + 1, NULL, 10) : -1;
+}
+
+int main(void)
+{
+    printf("test-usb-sysfs-overflow: the per-bus devnum cap\n");
+
+    DIR *d = opendir(DEVICES_DIR);
+    if (!d) {
+        printf("  cannot open %s\n", DEVICES_DIR);
+        printf("\ntest-usb-sysfs-overflow: 0 passed, 1 failed - FAIL\n");
+        return 1;
+    }
+
+    int minors[512];
+    int nminors = 0;
+    int bus1 = 0, bus2 = 0;
+    bool devnum_ok = true, minor_ok = true, name_ok = true;
+    struct dirent *e;
+    while ((e = readdir(d))) {
+        if (e->d_name[0] == '.')
+            continue;
+        /* Device directories only; interface directories carry a ':'. */
+        if (strchr(e->d_name, ':'))
+            continue;
+        int busnum = read_attr_int(e->d_name, "busnum");
+        int devnum = read_attr_int(e->d_name, "devnum");
+        int minor = read_minor(e->d_name);
+        if (busnum == 1)
+            bus1++;
+        else if (busnum == 2)
+            bus2++;
+        if (devnum < 1 || devnum > 127)
+            devnum_ok = false;
+
+        /* Every kept device must expose a readable dev minor to compare. */
+        if (minor < 0)
+            name_ok = false;
+        for (int i = 0; i < nminors; i++)
+            if (minors[i] == minor)
+                minor_ok = false;
+        if (nminors < (int) (sizeof(minors) / sizeof(minors[0])))
+            minors[nminors++] = minor;
+    }
+    closedir(d);
+
+    TEST("every device has a devnum in 1..127");
+    EXPECT_TRUE(devnum_ok, "a device kept a devnum outside 1..127");
+
+    TEST("no two devices share a minor");
+    EXPECT_TRUE(minor_ok, "two devices collided on one minor");
+
+    TEST("every device exposes a dev attribute");
+    EXPECT_TRUE(name_ok, "a device had no readable dev minor");
+
+    TEST("bus 1 kept exactly 127 of its 129 devices");
+    EXPECT_EQ(bus1, 127, "bus 1 device count wrong");
+
+    TEST("bus 2 kept its single device");
+    EXPECT_EQ(bus2, 1, "bus 2 device count wrong");
+
+    SUMMARY("test-usb-sysfs-overflow");
+    return fails ? 1 : 0;
+}

--- a/tests/test-usb-sysfs-sysroot.c
+++ b/tests/test-usb-sysfs-sysroot.c
@@ -1,0 +1,233 @@
+/*
+ * The synthetic USB /sys view sharing /sys with a populated sysroot
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Code under test: the /sys ours/not-ours split in src/runtime/usb-sysfs.c and
+ * the /sys + /dev/bus arms of sys_fchdir (src/syscall/fs.c) and
+ * resolve_proc_cwd_path (src/syscall/path.c).
+ *
+ * Run under --sysroot over a tree that carries a real /sys skeleton
+ * (/sys/class/net/eth0/address, /sys/kernel/mm/transparent_hugepage/enabled,
+ * /sys/devices/system/node/online) and with ELFUSE_USB_FIXTURE set so the USB
+ * tree carries two deterministic devices with no hardware attached.
+ *
+ * Two regressions are pinned here.
+ *
+ * F1: the USB layer synthesizes only /sys/bus/usb. A name it does not model
+ * (everything under /sys/class, /sys/kernel, /sys/devices) must fall through to
+ * the sysroot rather than be answered ENOENT, which would shadow the backing
+ * /sys and leave the layer self-contradicting -- access() reading the sysroot
+ * file as present while open() reports it absent. The cubic behavior that must
+ * survive: /sys/bus/usb still serves the synthetic tree, and its attributes are
+ * still epoll-addable (a real sysfs attribute is pollable through kernfs).
+ *
+ * F2: a descriptor opened on a synthetic /sys or /dev/bus directory is stamped
+ * with the guest spelling. fchdir() onto it must publish that spelling as the
+ * virtual cwd, or getcwd leaks the /tmp scratch location, a relative create
+ * lands in the read-only tree, and fstatfs reports the /tmp filesystem instead
+ * of sysfs. The cubic behavior that must survive: a relative walk resolved
+ * against that cwd still reaches the synthetic attributes.
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define SYSFS_MAGIC 0x62656572
+
+/* Read a whole small file; returns bytes read or -1. */
+static ssize_t read_file(const char *path, char *buf, size_t bufsz)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return -1;
+    ssize_t n = read(fd, buf, bufsz - 1);
+    close(fd);
+    if (n >= 0)
+        buf[n] = '\0';
+    return n;
+}
+
+static bool dir_has_entry(const char *dir, const char *name)
+{
+    DIR *d = opendir(dir);
+    if (!d)
+        return false;
+    bool found = false;
+    struct dirent *e;
+    while ((e = readdir(d))) {
+        if (!strcmp(e->d_name, name)) {
+            found = true;
+            break;
+        }
+    }
+    closedir(d);
+    return found;
+}
+
+int main(void)
+{
+    char buf[256];
+
+    printf(
+        "test-usb-sysfs-sysroot: /sys fall-through and fchdir containment\n");
+
+    /* F1: sysroot-backed /sys names reach the sysroot again */
+
+    TEST("a /sys attribute we do not model opens from the sysroot");
+    {
+        ssize_t n = read_file("/sys/class/net/eth0/address", buf, sizeof(buf));
+        if (n < 0)
+            FAIL("open/read /sys/class/net/eth0/address");
+        else if (strcmp(buf, "02:42:ac:11:00:02\n") != 0)
+            FAIL("wrong /sys/class/net/eth0/address content");
+        else
+            PASS();
+    }
+
+    TEST("access() and open() agree on the sysroot /sys file");
+    {
+        int a = access("/sys/class/net/eth0/address", R_OK);
+        int fd = open("/sys/class/net/eth0/address", O_RDONLY);
+        if (a == 0 && fd >= 0)
+            PASS();
+        else
+            FAIL("access/open disagree (readable but unopenable)");
+        if (fd >= 0)
+            close(fd);
+    }
+
+    TEST("readdir(/sys/class) lists the sysroot's entries");
+    EXPECT_TRUE(dir_has_entry("/sys/class", "net"),
+                "/sys/class did not list net");
+
+    TEST("/sys/kernel attribute reaches the sysroot");
+    EXPECT_TRUE(read_file("/sys/kernel/mm/transparent_hugepage/enabled", buf,
+                          sizeof(buf)) > 0,
+                "open /sys/kernel/mm/transparent_hugepage/enabled");
+
+    TEST("/sys/devices attribute reaches the sysroot");
+    EXPECT_TRUE(
+        read_file("/sys/devices/system/node/online", buf, sizeof(buf)) > 0,
+        "open /sys/devices/system/node/online");
+
+    /* F1 cubic: /sys/bus/usb is still ours and still pollable */
+
+    TEST("/sys/bus/usb/devices still serves the synthetic tree");
+    {
+        struct stat st;
+        if (stat("/sys/bus/usb/devices", &st) == 0 && S_ISDIR(st.st_mode))
+            PASS();
+        else
+            FAIL("stat /sys/bus/usb/devices");
+    }
+
+    TEST("a synthetic USB attribute reads its value");
+    {
+        ssize_t n =
+            read_file("/sys/bus/usb/devices/1-1/idVendor", buf, sizeof(buf));
+        if (n < 0)
+            FAIL("open /sys/bus/usb/devices/1-1/idVendor");
+        else if (strcmp(buf, "1d6b\n") != 0)
+            FAIL("wrong idVendor");
+        else
+            PASS();
+    }
+
+    TEST("a synthetic USB attribute is still epoll-addable");
+    {
+        int afd = open("/sys/bus/usb/devices/1-1/idVendor", O_RDONLY);
+        int ep = epoll_create1(0);
+        struct epoll_event ev = {.events = EPOLLIN};
+        int rc = -1;
+        if (afd >= 0 && ep >= 0)
+            rc = epoll_ctl(ep, EPOLL_CTL_ADD, afd, &ev);
+        if (rc == 0)
+            PASS();
+        else
+            FAIL("epoll_ctl ADD on a sysfs attribute (cubic 3862484162)");
+        if (afd >= 0)
+            close(afd);
+        if (ep >= 0)
+            close(ep);
+    }
+
+    /* A missing name under the subtree we own stays ENOENT, not a fall-through
+     * (nothing in the sysroot carries it either, but the answer is ours).
+     */
+    TEST("a missing device under /sys/bus/usb is ENOENT");
+    EXPECT_ERRNO(open("/sys/bus/usb/devices/9-9/idVendor", O_RDONLY), ENOENT,
+                 "missing owned name should be ENOENT");
+
+    /* F2: fchdir onto a synthetic /sys directory is contained */
+
+    TEST("fchdir onto /sys/bus/usb/devices keeps the guest cwd");
+    {
+        int fd = open("/sys/bus/usb/devices", O_RDONLY | O_DIRECTORY);
+        char cwd[256];
+        if (fd < 0) {
+            FAIL("open /sys/bus/usb/devices O_DIRECTORY");
+        } else if (fchdir(fd) < 0) {
+            FAIL("fchdir onto /sys/bus/usb/devices");
+            close(fd);
+        } else if (!getcwd(cwd, sizeof(cwd))) {
+            FAIL("getcwd after fchdir");
+            close(fd);
+        } else if (strcmp(cwd, "/sys/bus/usb/devices") != 0) {
+            FAIL("getcwd leaked the scratch tree location");
+            close(fd);
+        } else {
+            PASS();
+            close(fd);
+        }
+    }
+
+    /* cwd is /sys/bus/usb/devices from here on. */
+
+    TEST("a relative create against the /sys cwd cannot write the tree");
+    EXPECT_ERRNO(open("intruder", O_WRONLY | O_CREAT, 0644), EACCES,
+                 "relative O_CREAT should be refused, not land in the tree");
+
+    TEST("fstatfs of a fd opened at the /sys cwd reports sysfs");
+    {
+        int fd = open(".", O_RDONLY | O_DIRECTORY);
+        struct statfs sfs;
+        if (fd < 0) {
+            FAIL("open . at /sys cwd");
+        } else if (fstatfs(fd, &sfs) < 0) {
+            FAIL("fstatfs");
+            close(fd);
+        } else if ((unsigned) sfs.f_type != SYSFS_MAGIC) {
+            FAIL("fstatfs did not report SYSFS_MAGIC (leaked /tmp fs)");
+            close(fd);
+        } else {
+            PASS();
+            close(fd);
+        }
+    }
+
+    TEST("a relative walk against the /sys cwd reaches the attribute");
+    {
+        ssize_t n = read_file("1-1/idVendor", buf, sizeof(buf));
+        if (n > 0 && strcmp(buf, "1d6b\n") == 0)
+            PASS();
+        else
+            FAIL("relative 1-1/idVendor against the /sys cwd");
+    }
+
+    SUMMARY("test-usb-sysfs-sysroot");
+    return fails ? 1 : 0;
+}

--- a/tests/test-usb-sysfs.c
+++ b/tests/test-usb-sysfs.c
@@ -1,0 +1,1134 @@
+/*
+ * The synthetic USB tree's contract, and the two views that must agree
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Code under test: src/runtime/usb-sysfs.c, plus the sysfs statfs arms in
+ * src/syscall/fs-stat.c.
+ *
+ * Two halves. The first asserts what holds with no USB device attached at all:
+ * SYSFS_MAGIC from statfs and fstatfs alike, the read-only open contract, and
+ * the ENOENT/EINVAL/ENOTDIR answers for paths the tree does not carry. Those
+ * run everywhere, so a machine with an empty bus still regression-tests the
+ * path layer.
+ *
+ * The second half walks whatever devices are present and asserts the identities
+ * that can only be checked against a real one -- above all that the
+ * `descriptors` attribute and a read() of the matching /dev/bus/usb node return
+ * the same bytes, which is the invariant Linux keeps between sysfs and usbfs
+ * and the one a second blob generator would silently break, and that the
+ * `subsystem` links the tree emits are reachable the way Linux makes them
+ * reachable: followed on a plain open, ELOOP only when the caller asked for
+ * O_NOFOLLOW, and readable as a target either way.
+ *
+ * A run with no devices is not a pass by default: the device count is printed,
+ * so a lane that quietly stopped covering the second half is visible rather
+ * than merely green.
+ *
+ * What the second half cannot cover, whatever is plugged in: an attribute value
+ * this layer never produces. `configuration` is the case in point -- it needs a
+ * configuration whose iConfiguration is non-zero *and* a string descriptor read
+ * over ep0, and no device can supply the second half of that to a layer that
+ * opens nothing. Asserting the value here would only ever assert the empty
+ * case, so the rule itself is asserted in test-usb-desc-host.c against
+ * synthesized descriptors, which runs both branches on any host, and what stays
+ * here are the two facts a real device can falsify: that the attribute exists,
+ * and that it is empty whenever iConfiguration is 0.
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define SYSFS_MAGIC 0x62656572
+#define USB_MAJOR 189
+#define DEVICES_DIR "/sys/bus/usb/devices"
+
+/* Read a whole file into a fresh buffer; *out is set on success and the caller
+ * frees it.
+ *
+ * Returns the byte count, or -1 with the buffer untouched.
+ *
+ * The buffer grows instead of stopping at a fixed cap. A fixed one had to
+ * answer "the file was this long" and "the read stopped here" with the same
+ * number, and the two-view compare below reads that number as a length: two
+ * blobs whose difference lies past the cap compared equal and the assertion
+ * passed on a prefix. A descriptors blob is bounded by the device, not by us --
+ * wTotalLength is 16-bit and bNumConfigurations is a byte -- so there is no
+ * honest constant to pick, and the compare must see whatever the file holds.
+ */
+static ssize_t slurp(const char *path, unsigned char **out)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return -1;
+
+    size_t cap = 4096, off = 0;
+    unsigned char *buf = malloc(cap);
+    if (!buf) {
+        close(fd);
+        return -1;
+    }
+    for (;;) {
+        if (off == cap) {
+            unsigned char *grown = realloc(buf, cap * 2);
+            if (!grown) {
+                free(buf);
+                close(fd);
+                return -1;
+            }
+            buf = grown;
+            cap *= 2;
+        }
+        ssize_t n = read(fd, buf + off, cap - off);
+        if (n < 0 && errno == EINTR)
+            continue;
+        if (n < 0) {
+            free(buf);
+            close(fd);
+            return -1;
+        }
+        if (n == 0)
+            break;
+        off += (size_t) n;
+    }
+    close(fd);
+    *out = buf;
+    return (ssize_t) off;
+}
+
+/* Read a small text attribute, trimming the trailing newline. A value that does
+ * not fit is an error, not a prefix: every attribute this reads is a short
+ * fixed-shape string, so one that overflowed is a fact worth failing on.
+ */
+static int attr_str(const char *dir, const char *name, char *out, size_t cap)
+{
+    char path[512];
+    if (snprintf(path, sizeof(path), "%s/%s", dir, name) >= (int) sizeof(path))
+        return -1;
+    unsigned char *raw = NULL;
+    ssize_t n = slurp(path, &raw);
+    if (n < 0)
+        return -1;
+    if ((size_t) n >= cap) {
+        free(raw);
+        return -1;
+    }
+    memcpy(out, raw, (size_t) n);
+    free(raw);
+    out[n] = '\0';
+    if (n > 0 && out[n - 1] == '\n')
+        out[n - 1] = '\0';
+    return 0;
+}
+
+/* EXPECT_TRUE for an assertion that compares two values it already holds.
+ *
+ * FAIL prints the global errno, which is only meaningful when the assertion
+ * just made a failing syscall. For a value comparison it prints whatever the
+ * last failure anywhere left behind: this file's CI log once reported a
+ * configuration mismatch as "(errno=13)", the EACCES from the writable-open
+ * check several assertions earlier, which reads as an attribute that could not
+ * be opened rather than one that held the wrong bytes. Clearing errno first
+ * makes such a report say errno=0 -- and still lets a syscall inside cond set
+ * it, so a genuine failure is not hidden.
+ */
+#define EXPECT_VALUE(cond, msg) \
+    do {                        \
+        errno = 0;              \
+        EXPECT_TRUE(cond, msg); \
+    } while (0)
+
+static void check_tree_contract(void)
+{
+    struct statfs sfs;
+    struct stat st;
+    int fd;
+
+    /* libusb gates its whole sysfs path on this, and a wrong answer sends it
+     * down the usbfs directory scan instead.
+     */
+    TEST("statfs(/sys) reports SYSFS_MAGIC");
+    EXPECT_TRUE(
+        statfs("/sys", &sfs) == 0 && (unsigned) sfs.f_type == SYSFS_MAGIC,
+        "statfs /sys f_type");
+
+    /* Same fact, other entry point: systemd's sd-device reopens a chased
+     * syspath and gates on fstatfs, so the two must not disagree.
+     */
+    TEST("fstatfs of a /sys fd agrees with statfs");
+    fd = open("/sys", O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        FAIL("open /sys");
+    } else {
+        EXPECT_TRUE(
+            fstatfs(fd, &sfs) == 0 && (unsigned) sfs.f_type == SYSFS_MAGIC,
+            "fstatfs /sys f_type");
+        close(fd);
+    }
+
+    TEST("statfs of an absent /sys path is ENOENT");
+    EXPECT_TRUE(statfs("/sys/elfuse-no-such-node", &sfs) < 0 && errno == ENOENT,
+                "statfs absent /sys path");
+
+    TEST("/sys/bus/usb/devices is a directory");
+    EXPECT_TRUE(stat(DEVICES_DIR, &st) == 0 && S_ISDIR(st.st_mode),
+                "stat " DEVICES_DIR);
+
+    /* The tree is read-only; a mutating open must say so rather than land on
+     * the scratch directory backing it.
+     */
+    TEST("a writable open under /sys is EACCES");
+    fd = open(DEVICES_DIR "/elfuse-probe", O_WRONLY | O_CREAT, 0644);
+    if (fd >= 0) {
+        close(fd);
+        FAIL("a create under /sys succeeded");
+    } else {
+        EXPECT_TRUE(errno == EACCES, "EACCES for a create under /sys");
+    }
+
+    TEST("readlink of a /sys directory is EINVAL");
+    char lbuf[256];
+    EXPECT_TRUE(
+        readlink(DEVICES_DIR, lbuf, sizeof(lbuf)) < 0 && errno == EINVAL,
+        "readlink a directory");
+
+    /* '..' is a legal sysfs component. Rejecting it outright answered EACCES
+     * for a path Linux resolves, so the fold has to land back on the same
+     * directory rather than on an error.
+     */
+    TEST("'..' inside a /sys path folds");
+    struct stat plain, dotted;
+    EXPECT_TRUE(stat(DEVICES_DIR, &plain) == 0 &&
+                    stat("/sys/bus/usb/devices/../devices", &dotted) == 0 &&
+                    plain.st_ino == dotted.st_ino,
+                "folded path is the same directory");
+
+    TEST("an absurd bus number is ENOENT");
+    EXPECT_TRUE(open("/dev/bus/usb/999/001", O_RDONLY) < 0 && errno == ENOENT,
+                "open bus 999");
+
+    /* usbfs names are always three digits; a shorter spelling is not the same
+     * file with leading zeros stripped, it is a path that does not exist.
+     */
+    TEST("a non-3-digit node name is ENOENT");
+    EXPECT_TRUE(open("/dev/bus/usb/2/1", O_RDONLY) < 0 && errno == ENOENT,
+                "open /dev/bus/usb/2/1");
+
+    TEST("/dev/bus/usb is a directory");
+    EXPECT_TRUE(stat("/dev/bus/usb", &st) == 0 && S_ISDIR(st.st_mode),
+                "stat /dev/bus/usb");
+
+    /* Which filesystem answers is decided by what the name resolves to, not by
+     * how it was spelled. "/sys/../sys" is /sys once the kernel has folded it,
+     * and Linux reports SYSFS_MAGIC for it (measured, 6.19: f_type 0x62656572).
+     * Classifying the folded name and then probing the raw one asked two
+     * questions of two spellings and answered ENOENT for a directory that
+     * exists. systemd and libusb both reach sysfs through paths they assembled,
+     * so the unfolded spelling is not a curiosity.
+     */
+    TEST("statfs of an unfolded /sys spelling still reports SYSFS_MAGIC");
+    EXPECT_TRUE(statfs("/sys/../sys", &sfs) == 0 &&
+                    (unsigned) sfs.f_type == SYSFS_MAGIC,
+                "statfs /sys/../sys");
+
+    TEST("statfs of a /sys path through '.' reports SYSFS_MAGIC");
+    EXPECT_TRUE(statfs("/sys/./bus/usb/../usb", &sfs) == 0 &&
+                    (unsigned) sfs.f_type == SYSFS_MAGIC,
+                "statfs /sys/./bus/usb/../usb");
+
+    /* Same rule for a relative name: it resolves against the cwd before the
+     * filesystem is chosen, so statfs("sys") from / is statfs("/sys"). A gate
+     * that required a leading '/' sent every relative walker to the host, which
+     * has no /sys at all.
+     */
+    TEST("statfs of a relative sysfs name resolves against the cwd");
+    {
+        char saved[512];
+        const char *cwd = getcwd(saved, sizeof(saved));
+        if (chdir("/") < 0) {
+            FAIL("chdir /");
+        } else {
+            errno = 0;
+            EXPECT_TRUE(statfs("sys", &sfs) == 0 &&
+                            (unsigned) sfs.f_type == SYSFS_MAGIC,
+                        "statfs sys from /");
+        }
+
+        /* Only the cwd-is-/ case is asserted: chdir into the synthetic tree is
+         * not served at all here (chdir("/sys") is ENOENT), which is a
+         * different gap and not this one.
+         */
+        if (cwd)
+            (void) !chdir(cwd);
+    }
+
+    /* O_DIRECTORY|O_CREAT is rejected in build_open_flags(), before the path is
+     * resolved: EINVAL for an existing directory, an absent name and a
+     * synthetic directory alike (measured on 6.19; macOS open(2) agrees, so
+     * only the intercepts answered otherwise). A synthetic directory reporting
+     * EISDIR describes a lookup the kernel never performed.
+     */
+    static const char *const dircreate[] = {
+        "/sys",         "/sys/bus/usb/devices", "/sys/bus/usb/devices/absent",
+        "/dev/bus/usb", "/proc/self",
+    };
+    for (size_t i = 0; i < sizeof(dircreate) / sizeof(dircreate[0]); i++) {
+        TEST("O_DIRECTORY|O_CREAT is EINVAL, not EISDIR");
+        errno = 0;
+        fd = open(dircreate[i], O_RDONLY | O_DIRECTORY | O_CREAT, 0644);
+        if (fd >= 0) {
+            close(fd);
+            printf("      %s opened\n", dircreate[i]);
+            FAIL("O_DIRECTORY|O_CREAT succeeded");
+        } else {
+            int got = errno;
+            char why[600];
+            snprintf(why, sizeof(why), "%s answered errno=%d", dircreate[i],
+                     got);
+            EXPECT_VALUE(got == EINVAL, why);
+        }
+
+        /* O_PATH is the exception, and the reason the pair cannot simply be
+         * refused: under O_PATH the kernel masks the flags down to
+         * O_DIRECTORY|O_NOFOLLOW|O_PATH, so the creation bit is gone before the
+         * pair is tested and the open succeeds on a directory (measured on
+         * 6.19). Refusing it too would break a descriptor systemd's chase()
+         * takes on every directory it walks.
+         */
+        TEST("O_PATH|O_DIRECTORY|O_CREAT still opens a directory");
+        errno = 0;
+        int pfd = open(dircreate[i], O_RDONLY | O_PATH | O_DIRECTORY | O_CREAT);
+        bool absent = strstr(dircreate[i], "absent") != NULL;
+        if (pfd >= 0) {
+            close(pfd);
+            char why[600];
+            snprintf(why, sizeof(why), "%s opened", dircreate[i]);
+            EXPECT_VALUE(!absent, why);
+        } else {
+            int got = errno;
+            char why[600];
+            snprintf(why, sizeof(why), "%s answered errno=%d, wanted %s",
+                     dircreate[i], got, absent ? "ENOENT" : "success");
+            EXPECT_VALUE(absent && got == ENOENT, why);
+        }
+    }
+}
+
+/* The reader this file's two-view compare rests on.
+ *
+ * A descriptors blob is bounded by the device -- wTotalLength is 16-bit and
+ * bNumConfigurations is a byte -- so a reader with a fixed cap has to answer
+ * "the file was this long" and "I stopped here" with the same number. It did,
+ * and the compare read that number as a length: two blobs differing only past
+ * the cap reported equal lengths and an equal prefix, and the assertion passed
+ * without ever seeing the tail. Asserted on files this test writes, because no
+ * attached device produces a blob that large and the property must hold
+ * whatever is plugged in.
+ */
+static void check_slurp_reads_whole_files(void)
+{
+    const size_t len = 70000; /* past the 65536 the fixed cap stopped at */
+    char pa[] = "/tmp/elfuse-usb-slurp-a-XXXXXX";
+    char pb[] = "/tmp/elfuse-usb-slurp-b-XXXXXX";
+    unsigned char *a = NULL, *b = NULL;
+
+    TEST("slurp fixtures are writable");
+    int fa = mkstemp(pa), fb = mkstemp(pb);
+    if (fa < 0 || fb < 0) {
+        FAIL("mkstemp");
+        goto out;
+    }
+    PASS();
+
+    for (size_t off = 0; off < len; off++) {
+        unsigned char byte = (unsigned char) (off & 0xff);
+        /* The two files differ in exactly one byte, and it is the last one. */
+        unsigned char bbyte =
+            (off == len - 1) ? (unsigned char) (byte ^ 0xff) : byte;
+        if (write(fa, &byte, 1) != 1 || write(fb, &bbyte, 1) != 1)
+            break;
+    }
+    close(fa);
+    close(fb);
+    fa = fb = -1;
+
+    ssize_t na = slurp(pa, &a), nb = slurp(pb, &b);
+    char why[128];
+    snprintf(why, sizeof(why), "read %zd and %zd of %zu bytes", na, nb, len);
+    TEST("slurp reports the whole file, not the prefix it stopped at");
+    EXPECT_VALUE(na == (ssize_t) len && nb == (ssize_t) len, why);
+
+    TEST("two blobs differing only past 64 KiB do not compare equal");
+    EXPECT_VALUE(
+        !(na > 0 && na == nb && a && b && memcmp(a, b, (size_t) na) == 0),
+        "the tail difference is seen");
+
+out:
+    if (fa >= 0)
+        close(fa);
+    if (fb >= 0)
+        close(fb);
+    free(a);
+    free(b);
+    unlink(pa);
+    unlink(pb);
+}
+
+/* The `subsystem` link is how libudev and pyserial's list_ports_linux prove a
+ * node is USB-backed: they readlink it, or walk through it, and keep the
+ * basename. Linux opens it as the directory it points at, so a tree that
+ * refuses to follow its own links is unreachable to exactly the consumers this
+ * layer exists for. `what` names the entry kind in the failure line, because
+ * the device and interface dirs sit at different depths and only one of them
+ * being wrong is the interesting outcome.
+ */
+static void check_subsystem_link(const char *dir, const char *what)
+{
+    char path[600];
+    if (snprintf(path, sizeof(path), "%s/subsystem", dir) >=
+        (int) sizeof(path)) {
+        TEST("subsystem path fits");
+        FAIL("path too long");
+        return;
+    }
+
+    TEST("open follows the subsystem link to a directory");
+    struct stat st;
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        printf("      %s: open %s: %s\n", what, path, strerror(errno));
+        FAIL("open subsystem");
+    } else {
+        EXPECT_TRUE(fstat(fd, &st) == 0 && S_ISDIR(st.st_mode),
+                    "subsystem opens as a directory");
+        close(fd);
+    }
+
+    /* The guest asking for O_NOFOLLOW is the one case where refusing is right,
+     * and it is what tells the two behaviors apart: before the fix every open
+     * answered this way.
+     */
+    TEST("O_NOFOLLOW on the subsystem link is ELOOP");
+    fd = open(path, O_RDONLY | O_NOFOLLOW);
+    if (fd >= 0) {
+        close(fd);
+        FAIL("O_NOFOLLOW followed the link");
+    } else {
+        EXPECT_TRUE(errno == ELOOP, "ELOOP for O_NOFOLLOW");
+    }
+
+    /* Same flag, write side. O_NOFOLLOW on a symlink is ELOOP before the access
+     * mode is looked at -- measured on a real /sys/class/net/lo/ subsystem
+     * under 6.19, where O_WRONLY|O_NOFOLLOW is ELOOP and plain O_WRONLY is
+     * EISDIR. Answering the read-only refusal first describes the directory the
+     * link points at, for a caller that said not to go there.
+     */
+    TEST("a writable O_NOFOLLOW open of the subsystem link is ELOOP");
+    fd = open(path, O_WRONLY | O_NOFOLLOW);
+    if (fd >= 0) {
+        close(fd);
+        FAIL("writable O_NOFOLLOW succeeded");
+    } else {
+        EXPECT_TRUE(errno == ELOOP, "ELOOP before EISDIR");
+    }
+
+    TEST("a writable open that follows the link is EISDIR");
+    fd = open(path, O_WRONLY);
+    if (fd >= 0) {
+        close(fd);
+        FAIL("writable open succeeded");
+    } else {
+        EXPECT_TRUE(errno == EISDIR, "EISDIR for the directory behind it");
+    }
+
+    /* What the descriptor holds, and therefore where a relative walk off it
+     * starts. Linux gives a followed open the target: /proc/self/fd/N names the
+     * directory, and openat(fd, "..") pops the *target's* parent -- which is
+     * how systemd's chase() and libudev step from a device up into /sys/bus. A
+     * descriptor stamped with the link's own spelling restarts every such walk
+     * from the device directory instead.
+     */
+    static const char busdir[] = "/sys/bus/usb";
+
+    for (int opath = 0; opath <= 1; opath++) {
+        int oflags = opath ? O_PATH : (O_RDONLY | O_DIRECTORY);
+        fd = open(path, oflags);
+        TEST(opath ? "an O_PATH fd on the link names the directory it resolves "
+                     "to"
+                   : "a followed fd on the link names the directory it "
+                     "resolves to");
+        if (fd < 0) {
+            FAIL("open subsystem for the identity check");
+            continue;
+        }
+        char fdpath[64], seen[600];
+        snprintf(fdpath, sizeof(fdpath), "/proc/self/fd/%d", fd);
+        ssize_t sn = readlink(fdpath, seen, sizeof(seen) - 1);
+        if (sn < 0) {
+            FAIL("readlink /proc/self/fd");
+        } else {
+            seen[sn] = '\0';
+            char why[1300];
+            snprintf(why, sizeof(why), "fd names \"%s\", wanted \"%s\"", seen,
+                     busdir);
+            EXPECT_VALUE(!strcmp(seen, busdir), why);
+        }
+
+        TEST(opath ? "openat(\"..\") off the O_PATH fd pops the target's parent"
+                   : "openat(\"..\") off the followed fd pops the target's "
+                     "parent");
+        int up = openat(fd, "..", O_RDONLY | O_DIRECTORY);
+        if (up < 0) {
+            FAIL("openat .. off the subsystem fd");
+        } else {
+            /* By name, not by inode: a path stat of this tree reports a
+             * synthesized st_ino while fstat of an opened descriptor reports
+             * the scratch directory's own, so the two never compare equal for
+             * any path. The name is what the walkers act on anyway.
+             */
+            char upfd[64], upname[600];
+            snprintf(upfd, sizeof(upfd), "/proc/self/fd/%d", up);
+            ssize_t un = readlink(upfd, upname, sizeof(upname) - 1);
+            if (un < 0) {
+                FAIL("readlink /proc/self/fd of the parent");
+            } else {
+                upname[un] = '\0';
+                char why[1300];
+                snprintf(why, sizeof(why),
+                         "'..' landed on \"%s\", wanted \"/sys/bus\"", upname);
+                EXPECT_VALUE(!strcmp(upname, "/sys/bus"), why);
+            }
+            close(up);
+        }
+        close(fd);
+    }
+
+    /* The other half of the same rule: O_PATH|O_NOFOLLOW is the spelling that
+     * asks for the link itself, and it must keep naming the link.
+     */
+    TEST("O_PATH|O_NOFOLLOW still names the link, not its target");
+    fd = open(path, O_PATH | O_NOFOLLOW);
+    if (fd < 0) {
+        FAIL("O_PATH|O_NOFOLLOW open");
+    } else {
+        char fdpath[64], seen[600];
+        snprintf(fdpath, sizeof(fdpath), "/proc/self/fd/%d", fd);
+        ssize_t sn = readlink(fdpath, seen, sizeof(seen) - 1);
+        if (sn < 0) {
+            FAIL("readlink /proc/self/fd");
+        } else {
+            seen[sn] = '\0';
+            char why[1300];
+            snprintf(why, sizeof(why), "fd names \"%s\", wanted \"%s\"", seen,
+                     path);
+            EXPECT_VALUE(!strcmp(seen, path), why);
+        }
+        close(fd);
+    }
+
+    /* kernfs installs .poll on every sysfs file (sysfs_file_operations), so
+     * epoll_ctl(ADD) on an attribute is 0 on Linux -- measured for net/lo/mtu,
+     * net/lo/uevent and virtual/net/lo/type alike on 6.19. udev-style readers
+     * arm `uevent` before they read it, and EPERM there reads as "this file can
+     * never be polled".
+     */
+    char attr[620];
+    snprintf(attr, sizeof(attr), "%s/uevent", dir);
+    TEST("a sysfs attribute can be added to an epoll set");
+    int afd = open(attr, O_RDONLY);
+    int epfd = epoll_create1(0);
+    if (afd < 0 || epfd < 0) {
+        FAIL("open the attribute / epoll_create1");
+    } else {
+        struct epoll_event ev = {.events = EPOLLIN, .data = {.fd = afd}};
+        EXPECT_TRUE(epoll_ctl(epfd, EPOLL_CTL_ADD, afd, &ev) == 0,
+                    "epoll_ctl ADD on a sysfs attribute");
+    }
+    if (afd >= 0)
+        close(afd);
+    if (epfd >= 0)
+        close(epfd);
+
+    /* The same link reached the other two ways a path walker reaches it. Both
+     * ran through the forced-O_NOFOLLOW open before the fix, so both answered
+     * ELOOP; libudev opens by dirfd, and O_PATH is how a resolver pins a
+     * component it means to walk through rather than read.
+     */
+    TEST("openat with a dirfd follows the subsystem link");
+    int dfd = open(dir, O_RDONLY | O_DIRECTORY);
+    if (dfd < 0) {
+        FAIL("open the parent dir");
+    } else {
+        fd = openat(dfd, "subsystem", O_RDONLY);
+        if (fd < 0) {
+            printf("      %s: openat subsystem: %s\n", what, strerror(errno));
+            FAIL("openat subsystem");
+        } else {
+            EXPECT_TRUE(fstat(fd, &st) == 0 && S_ISDIR(st.st_mode),
+                        "openat subsystem is a directory");
+            close(fd);
+        }
+        close(dfd);
+    }
+
+    /* Only that the open succeeds: fstat of the resulting descriptor still
+     * answers link-shaped, because the stat intercept takes a path and no
+     * follow flag and so cannot tell stat from lstat (usb-sysfs.c, the S_ISLNK
+     * arm). That is a separate deviation from this one, and asserting a
+     * directory here would be asserting a fix this change does not make.
+     */
+    TEST("O_PATH on the subsystem link is not ELOOP");
+    fd = open(path, O_PATH);
+    if (fd < 0) {
+        printf("      %s: O_PATH subsystem: %s\n", what, strerror(errno));
+        FAIL("O_PATH subsystem");
+    } else {
+        PASS();
+        close(fd);
+    }
+
+    /* Following must not have replaced the link with a directory: libudev reads
+     * the target, never opens it.
+     */
+    TEST("readlink of the subsystem link still reports its target");
+    char lbuf[256];
+    ssize_t n = readlink(path, lbuf, sizeof(lbuf) - 1);
+    if (n < 0) {
+        FAIL("readlink subsystem");
+    } else {
+        lbuf[n] = '\0';
+        EXPECT_TRUE(!strcmp(lbuf, "../../../usb"), "subsystem target");
+    }
+}
+
+/* '..' applied after the `subsystem` link must not walk out of the tree.
+ *
+ * The link resolves to the tree's own /sys/bus/usb, so the '..' chain climbs
+ * /sys/bus, then /sys, and the next one would leave. Every name that resolves
+ * out there has to be refused, on the readlink path as much as on open and
+ * stat: readlink hands a string back without opening anything, which is exactly
+ * why it is the easy one to leave behind, and a target string is still the
+ * guest learning about a host object it was never given.
+ *
+ * Two shapes, and they are not the same test. One appends a component after the
+ * chain, so the whole prefix is resolved and refused before the leaf is ever
+ * consulted. The other ends *at* the '..', which is the shape that escaped: a
+ * resolver that holds the last component back to keep O_NOFOLLOW honest
+ * resolves the prefix, proves it contained, and then reattaches a '..' to it --
+ * and one applied to the tree root names the host directory the root sits in,
+ * with no containment test left to run. The suite passed 68/68 while that was
+ * live, because it only ever asked the first shape.
+ *
+ * A symlink is planted in the directory the escape lands in, under a name
+ * mkstemp reserved, so concurrent lanes cannot collide on it: a fixed name made
+ * three of eight parallel runs fail on the plant rather than on the contract
+ * ("escape probe not planted (File exists)"). A pid suffix does not do it here
+ * -- every guest starts at pid 1, so all eight lanes spell the same name; the
+ * uniqueness has to come from the filesystem that holds the plant. The plant is
+ * what makes the assertions non-vacuous, and it is used two ways: readlink of
+ * it by its own name must succeed, so a plant that never got created cannot be
+ * mistaken for a refusal; and it must not appear in anything the tree hands
+ * back, which is how the escaping shape is caught -- a descriptor opened on the
+ * escape lists the planted name, naming the host directory it reached rather
+ * than merely being "some directory".
+ */
+static void check_link_containment(const char *dir)
+{
+    char probe[] = "/tmp/elfuse-usb-escape-probe-XXXXXX";
+    const char *plantname = probe + 5; /* past "/tmp/" */
+    static const char planted[] = "/elfuse-usb-escape-target";
+
+    TEST("escape probe is plantable");
+    int slot = mkstemp(probe);
+    if (slot < 0) {
+        FAIL("mkstemp");
+        return;
+    }
+    close(slot);
+    unlink(probe);
+    if (symlink(planted, probe) < 0) {
+        FAIL("symlink");
+        return;
+    }
+    PASS();
+
+    /* The plant is live and reachable by its own name. Without this the two
+     * refusals below could both be reporting an absent file.
+     */
+    TEST("escape probe is planted and readable by its own name");
+    char pbuf[256];
+    ssize_t pn = readlink(probe, pbuf, sizeof(pbuf) - 1);
+    if (pn < 0) {
+        FAIL("readlink of the plant");
+        goto done;
+    }
+    pbuf[pn] = '\0';
+    EXPECT_TRUE(!strcmp(pbuf, planted), "plant target");
+
+    /* Shape one: a component after the chain. */
+    char path[700];
+    /* probe + 4 drops the leading "/tmp", which the '..' chain re-enters. */
+    int n =
+        snprintf(path, sizeof(path), "%s/subsystem/../../..%s", dir, probe + 4);
+    if (n < 0 || (size_t) n >= sizeof(path))
+        goto done;
+
+    TEST("'..' after subsystem cannot readlink out of the tree");
+    char lbuf[256];
+    ssize_t rn = readlink(path, lbuf, sizeof(lbuf) - 1);
+    if (rn >= 0) {
+        lbuf[rn] = '\0';
+        printf("      escaped: %s -> %s\n", path, lbuf);
+        FAIL("readlink left the tree");
+    } else {
+        EXPECT_TRUE(errno == ENOENT, "escape answers ENOENT");
+    }
+
+    /* open and stat resolve through the same helper; assert them here too so
+     * one lane covers all three entry points rather than trusting agreement.
+     */
+    TEST("'..' after subsystem cannot open out of the tree");
+    int fd = open(path, O_RDONLY | O_NOFOLLOW);
+    if (fd >= 0) {
+        close(fd);
+        FAIL("open left the tree");
+    } else {
+        EXPECT_TRUE(errno == ENOENT || errno == ELOOP, "escape refused");
+    }
+
+    TEST("'..' after subsystem cannot lstat out of the tree");
+    struct stat est;
+    EXPECT_TRUE(lstat(path, &est) < 0 && errno == ENOENT, "escape is ENOENT");
+
+    /* Shape two: the chain itself, with nothing appended.
+     *
+     * Each depth is pinned to the object Linux resolves it to, by identity
+     * rather than by errno: one '..' after the link is /sys/bus and two is
+     * /sys, both of which the tree carries, and the third leaves the tree
+     * altogether. Asserting only "not an escape" would pass for a resolver that
+     * refused all three, which would break every relative walk through the
+     * link; asserting the identity says the resolution is right as well as
+     * contained.
+     */
+    struct stat sys_st, bus_st;
+    bool have_roots =
+        stat("/sys", &sys_st) == 0 && stat("/sys/bus", &bus_st) == 0;
+    TEST("/sys and /sys/bus are stat-able, so the depths below mean something");
+    EXPECT_TRUE(have_roots, "tree roots");
+
+    for (int depth = 1; depth <= 4 && have_roots; depth++) {
+        char chain[700];
+        int cn = snprintf(chain, sizeof(chain), "%s/subsystem", dir);
+        for (int i = 0; i < depth && cn > 0 && (size_t) cn < sizeof(chain); i++)
+            cn += snprintf(chain + cn, sizeof(chain) - (size_t) cn, "/..");
+        if (cn < 0 || (size_t) cn >= sizeof(chain))
+            break;
+
+        const struct stat *want = depth == 1   ? &bus_st
+                                  : depth == 2 ? &sys_st
+                                               : NULL;
+        char why[800];
+        struct stat cst;
+        snprintf(why, sizeof(why), "%s resolves to %s", chain,
+                 want ? (depth == 1 ? "/sys/bus" : "/sys") : "nothing");
+
+        TEST("a trailing '..' chain resolves inside the tree or not at all");
+        errno = 0;
+        int src = stat(chain, &cst);
+        if (want)
+            EXPECT_TRUE(src == 0 && cst.st_dev == want->st_dev &&
+                            cst.st_ino == want->st_ino,
+                        why);
+        else
+            EXPECT_TRUE(src < 0 && errno == ENOENT, why);
+
+        /* The loud half: if it opened, say which directory it opened by looking
+         * for the plant in it.
+         */
+        TEST("a trailing '..' chain cannot open a host directory");
+        int cfd = open(chain, O_RDONLY | O_NOFOLLOW);
+        if (cfd < 0) {
+            EXPECT_TRUE(!want, why);
+            continue;
+        }
+        bool found = false;
+        DIR *cd = fdopendir(cfd);
+        if (!cd) {
+            close(cfd);
+            FAIL("fdopendir on the opened chain");
+            continue;
+        }
+        struct dirent *e;
+        while ((e = readdir(cd))) {
+            if (!strcmp(e->d_name, plantname))
+                found = true;
+        }
+        closedir(cd);
+        if (found) {
+            printf("      escaped: %s lists the planted %s\n", chain,
+                   plantname);
+            FAIL("the opened directory is the host's, not the tree's");
+        } else {
+            EXPECT_TRUE(want != NULL, why);
+        }
+    }
+
+done:
+    unlink(probe);
+}
+
+/* Locate the active configuration inside a raw `descriptors` blob.
+ *
+ * Deliberately a second implementation rather than a call into
+ * runtime/usb-desc.c: a test that reuses the code under test cannot catch that
+ * code agreeing with itself. Walks configuration headers only -- bLength 9 and
+ * bDescriptorType 2 -- and steps by wTotalLength, so a blob whose config
+ * under-reports its span ends the walk instead of matching an interface
+ * descriptor's bytes.
+ *
+ * Returns a pointer into blob, or NULL.
+ */
+static const unsigned char *active_cfg(const unsigned char *blob,
+                                       size_t len,
+                                       unsigned want_value)
+{
+    const unsigned char *first = NULL;
+    size_t off = 18; /* past the device descriptor */
+    while (len - off >= 9 && off < len) {
+        const unsigned char *p = blob + off;
+        if (p[0] != 9 || p[1] != 2)
+            break;
+        size_t total = (size_t) (p[2] | (p[3] << 8));
+        if (total < 9)
+            break;
+        if (total > len - off)
+            total = len - off;
+        if (!first)
+            first = p;
+        if (p[5] == (unsigned char) want_value)
+            return p;
+        off += total;
+    }
+    return first;
+}
+
+/* sysfs `speed` string -> the bMaxPower unit Linux scales by (usb_get_max_power
+ * uses 8 mA at SuperSpeed and above, 2 mA below it).
+ */
+static unsigned max_power_unit(const char *speed)
+{
+    return atoi(speed) >= 5000 ? 8 : 2;
+}
+
+/* Assertions that need a device. Returns the number examined. */
+static int check_devices(void)
+{
+    DIR *dp = opendir(DEVICES_DIR);
+    if (!dp)
+        return 0;
+
+    int ndev = 0;
+    struct dirent *ent;
+    while ((ent = readdir(dp))) {
+        /* Device entries only: interfaces carry a ':' and are checked through
+         * the bNumInterfaces count below.
+         */
+        if (ent->d_name[0] == '.' || strchr(ent->d_name, ':'))
+            continue;
+        char dir[512];
+        if (snprintf(dir, sizeof(dir), "%s/%s", DEVICES_DIR, ent->d_name) >=
+            (int) sizeof(dir))
+            continue;
+        ndev++;
+
+        char busbuf[64], devbuf[64], val[128];
+        if (attr_str(dir, "busnum", busbuf, sizeof(busbuf)) < 0 ||
+            attr_str(dir, "devnum", devbuf, sizeof(devbuf)) < 0) {
+            TEST("device carries busnum and devnum");
+            FAIL("missing busnum/devnum");
+            continue;
+        }
+        int busnum = atoi(busbuf), devnum = atoi(devbuf);
+
+        /* The five attributes lsusb -t reads. Their absence is not a crash, it
+         * is a warning per device and a topology listing with holes in it.
+         *
+         * bmAttributes, bMaxPower and configuration are checked against the
+         * device's own `descriptors` blob rather than merely for being present:
+         * each is a field copied out of the active configuration descriptor, so
+         * the blob is the only thing that can say whether the right byte was
+         * copied. Asserting shape alone -- "parses as hex", "is present" --
+         * passes for a wrong value and for a garbage string alike.
+         */
+        unsigned char *blob = NULL;
+        char cfgpath[600];
+        ssize_t blen = -1;
+        if (snprintf(cfgpath, sizeof(cfgpath), "%s/descriptors", dir) <
+            (int) sizeof(cfgpath))
+            blen = slurp(cfgpath, &blob);
+
+        char cfgvalbuf[64], speedbuf[64];
+        const unsigned char *cfg = NULL;
+        if (blen > 0 && attr_str(dir, "bConfigurationValue", cfgvalbuf,
+                                 sizeof(cfgvalbuf)) == 0)
+            cfg = active_cfg(blob, (size_t) blen, (unsigned) atoi(cfgvalbuf));
+
+        TEST("bmAttributes equals the active config descriptor's byte");
+        if (!cfg) {
+            FAIL("no active configuration in descriptors");
+        } else {
+            char *end = NULL;
+            long got = attr_str(dir, "bmAttributes", val, sizeof(val)) == 0
+                           ? strtol(val, &end, 16)
+                           : -1;
+
+            /* endptr, not just the value: strtol returns 0 for a string with no
+             * digits at all, which is what made the old check unfalsifiable.
+             */
+            EXPECT_VALUE(
+                end && end != val && *end == '\0' && got == (long) cfg[7],
+                "bmAttributes matches descriptor");
+        }
+
+        TEST("bMaxPower equals the descriptor field scaled by the speed unit");
+        if (!cfg || attr_str(dir, "speed", speedbuf, sizeof(speedbuf)) != 0) {
+            FAIL("no active configuration or speed");
+        } else if (attr_str(dir, "bMaxPower", val, sizeof(val)) != 0) {
+            FAIL("bMaxPower missing");
+        } else {
+            char expect[64];
+            snprintf(expect, sizeof(expect), "%umA",
+                     (unsigned) cfg[8] * max_power_unit(speedbuf));
+            EXPECT_VALUE(!strcmp(val, expect), "bMaxPower matches descriptor");
+        }
+
+        /* configuration against iConfiguration, in the one direction Linux
+         * actually guarantees.
+         *
+         * An earlier version of this asserted the biconditional -- empty
+         * exactly when iConfiguration is 0 -- and that is not Linux's rule.
+         * configuration_show emits nothing whenever actconfig->string is NULL
+         * (sysfs.c:83-84), and usb_cache_string returns NULL "if the index is 0
+         * or the string could not be read" (message.c:1074-1075). An empty
+         * configuration therefore means "no cached string", which a non-zero
+         * iConfiguration does not rule out: a device that NAKs its own string
+         * descriptor reads empty on real sysfs too, so the biconditional fails
+         * against Linux itself. It failed here for the same reason -- this
+         * layer has no ep0 and so never has a string -- and that made it look
+         * like an implementation bug when the assertion was the wrong one.
+         *
+         * What does hold in both directions is the index-0 half: index 0
+         * short-circuits usb_cache_string before any transfer, so a non-empty
+         * configuration on a configuration with no string index is a value this
+         * layer invented. That is the falsifiable claim, and it is what stays.
+         *
+         * The other branch -- a non-zero index whose string was read -- has no
+         * device here to produce it (both attached devices report
+         * iConfiguration 0) and no code path to produce it either. It is
+         * covered against a synthesized descriptor in test-usb-desc-host.c.
+         */
+        TEST("configuration is empty when iConfiguration is 0");
+        if (!cfg) {
+            FAIL("no active configuration in descriptors");
+        } else if (attr_str(dir, "configuration", val, sizeof(val)) != 0) {
+            FAIL("configuration missing");
+        } else {
+            char why[256];
+            snprintf(why, sizeof(why),
+                     "iConfiguration=%u but configuration reads \"%s\"",
+                     (unsigned) cfg[6], val);
+            EXPECT_VALUE(cfg[6] != 0 || val[0] == '\0', why);
+        }
+
+        /* Presence, separately from contents. Linux keeps these four in
+         * dev_attr_grp (sysfs.c:782-786), an attribute group with no
+         * .is_visible (sysfs.c:815-817), so they exist on every USB device
+         * directory whether or not the kernel has a value to put in them -- a
+         * value it lacks is a zero-length read, never an ENOENT. Emitting them
+         * only when the descriptor parsed, or leaving `configuration` out
+         * because no string could be fetched, would both be caught here.
+         */
+        TEST("the four active-config attributes are all present");
+        {
+            static const char *const names[] = {
+                "bNumInterfaces", "bmAttributes", "bMaxPower", "configuration"};
+            const char *absent = NULL;
+            for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++)
+                if (attr_str(dir, names[i], val, sizeof(val)) != 0)
+                    absent = names[i];
+            char why[128];
+            snprintf(why, sizeof(why), "%s is absent, not empty",
+                     absent ? absent : "?");
+            EXPECT_TRUE(!absent, why);
+        }
+
+        /* An attribute this tree really does not carry answers ENOENT, the way
+         * sysfs answers for a name that is not an attribute. The read path has
+         * no business reporting EACCES for an absent file: the tree's EACCES is
+         * the read-only refusal of a *mutating* open, and the two must not be
+         * confusable -- a reader probing for an optional attribute takes ENOENT
+         * as "not supported" and EACCES as "supported but denied".
+         */
+        TEST("an absent device attribute is ENOENT, not EACCES");
+        {
+            char probe[600];
+            snprintf(probe, sizeof(probe), "%s/elfuse-no-such-attribute", dir);
+            EXPECT_ERRNO(open(probe, O_RDONLY), ENOENT, "absent attr errno");
+        }
+
+        TEST("maxchild is present and numeric");
+        EXPECT_TRUE(attr_str(dir, "maxchild", val, sizeof(val)) == 0 &&
+                        val[0] >= '0' && val[0] <= '9',
+                    "maxchild");
+
+        TEST("rx_lanes is at least one");
+        EXPECT_TRUE(
+            attr_str(dir, "rx_lanes", val, sizeof(val)) == 0 && atoi(val) >= 1,
+            "rx_lanes");
+
+        TEST("tx_lanes is at least one");
+        EXPECT_TRUE(
+            attr_str(dir, "tx_lanes", val, sizeof(val)) == 0 && atoi(val) >= 1,
+            "tx_lanes");
+
+        /* bNumInterfaces and the emitted :c.i directories describe the same
+         * configuration, so they have to count the same. Reading the attribute
+         * off the first config while the directories came from the active one
+         * would show up right here.
+         */
+        TEST("bNumInterfaces matches the interface dirs");
+        int declared = -1;
+        if (attr_str(dir, "bNumInterfaces", val, sizeof(val)) == 0)
+            declared = atoi(val);
+        int seen = 0;
+        char ifdir[600];
+        ifdir[0] = '\0';
+        DIR *idp = opendir(DEVICES_DIR);
+        if (idp) {
+            size_t nlen = strlen(ent->d_name);
+            struct dirent *ient;
+            while ((ient = readdir(idp))) {
+                if (!strncmp(ient->d_name, ent->d_name, nlen) &&
+                    ient->d_name[nlen] == ':') {
+                    seen++;
+                    if (!ifdir[0])
+                        snprintf(ifdir, sizeof(ifdir), "%s/%s", DEVICES_DIR,
+                                 ient->d_name);
+                }
+            }
+            closedir(idp);
+        }
+        EXPECT_EQ(seen, declared, "interface dir count");
+
+        /* Both depths carry a `subsystem` link, and both are walked in the
+         * field: libudev from the interface, pyserial from the device.
+         */
+        check_subsystem_link(dir, "device");
+        if (ifdir[0])
+            check_subsystem_link(ifdir, "interface");
+        check_link_containment(dir);
+
+        /* The dev attribute, the node's name, and the node's own st_rdev are
+         * three spellings of one identity.
+         */
+        TEST("dev attribute matches the node's rdev");
+        char node[64];
+        snprintf(node, sizeof(node), "/dev/bus/usb/%03d/%03d", busnum, devnum);
+        struct stat nst;
+        int want_minor = (busnum - 1) * 128 + (devnum - 1);
+        char want_dev[64];
+        snprintf(want_dev, sizeof(want_dev), "%d:%d", USB_MAJOR, want_minor);
+        EXPECT_TRUE(attr_str(dir, "dev", val, sizeof(val)) == 0 &&
+                        !strcmp(val, want_dev) && stat(node, &nst) == 0 &&
+                        S_ISCHR(nst.st_mode) &&
+                        (int) major(nst.st_rdev) == USB_MAJOR &&
+                        (int) minor(nst.st_rdev) == want_minor,
+                    "dev / node / rdev agree");
+
+        /* The invariant this whole layer rests on: one blob, two views. */
+        TEST("descriptors and the node read the same bytes");
+        unsigned char *a = NULL, *b = NULL;
+        char dpath[600];
+        snprintf(dpath, sizeof(dpath), "%s/descriptors", dir);
+        ssize_t na = slurp(dpath, &a);
+        ssize_t nb = slurp(node, &b);
+        EXPECT_TRUE(
+            na > 0 && na == nb && a && b && memcmp(a, b, (size_t) na) == 0,
+            "byte-identical descriptor blobs");
+
+        /* The device descriptor is the first 18 bytes of that blob, and its
+         * idVendor/idProduct have to be the ones sysfs advertises.
+         */
+        TEST("the blob's device descriptor matches idVendor/idProduct");
+        unsigned vid = 0, pid = 0;
+        if (attr_str(dir, "idVendor", val, sizeof(val)) == 0)
+            vid = (unsigned) strtoul(val, NULL, 16);
+        if (attr_str(dir, "idProduct", val, sizeof(val)) == 0)
+            pid = (unsigned) strtoul(val, NULL, 16);
+        EXPECT_TRUE(a && na >= 18 && a[0] == 18 && a[1] == 1 &&
+                        (unsigned) (a[8] | (a[9] << 8)) == vid &&
+                        (unsigned) (a[10] | (a[11] << 8)) == pid,
+                    "device descriptor header");
+
+        /* A char device used as a directory is ENOTDIR on Linux, whichever way
+         * the extra component is spelled. Answering ENOENT, or worse handing
+         * back the blob, tells a path walker the wrong thing about the node.
+         */
+        TEST("a trailing slash on the node is ENOTDIR");
+        char trail[80];
+        snprintf(trail, sizeof(trail), "%s/", node);
+        EXPECT_TRUE(open(trail, O_RDONLY) < 0 && errno == ENOTDIR,
+                    "open node with a trailing slash");
+
+        TEST("a component below the node is ENOTDIR");
+        snprintf(trail, sizeof(trail), "%s/anything", node);
+        EXPECT_TRUE(open(trail, O_RDONLY) < 0 && errno == ENOTDIR,
+                    "open below the node");
+
+        TEST("O_DIRECTORY on the node is ENOTDIR");
+        EXPECT_TRUE(open(node, O_RDONLY | O_DIRECTORY) < 0 && errno == ENOTDIR,
+                    "O_DIRECTORY on a char device");
+
+        TEST("a writable open of the node is EACCES");
+        EXPECT_TRUE(open(node, O_RDWR) < 0 && errno == EACCES,
+                    "O_RDWR on the node");
+
+        free(a);
+        free(b);
+        free(blob);
+    }
+    closedir(dp);
+    return ndev;
+}
+
+int main(void)
+{
+    printf("test-usb-sysfs: synthetic USB tree contract\n");
+
+    check_tree_contract();
+    check_slurp_reads_whole_files();
+    int ndev = check_devices();
+
+    /* Stated, not implied: the second half is only as strong as the bus it ran
+     * against, and a zero here means those assertions did not execute.
+     */
+    printf("  devices examined: %d\n", ndev);
+
+    SUMMARY("test-usb-sysfs");
+    return fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
> [!NOTE]
> Second piece of the general USB translation layer discussed in #319, sitting on top of the netlink piece merged as #325. With #325 alone a libusb guest reaches `libusb_init = 0` but `get_device_list` still returns 0; this piece is what puts devices in that list. It is read-only enumeration, so it stands alone and does not depend on the pieces that follow.

## Summary

libusb and nusb do not discover devices through a syscall. They read Linux sysfs directly: `/sys/bus/usb/devices/<bus>-<port>` for the attribute files, and `/dev/bus/usb/BBB/DDD` for the raw descriptor blob. A guest running on elfuse has neither tree, so enumeration came back empty no matter how far init got.

This change synthesizes both trees from an IOKit registry walk. No device is opened to build them: registry properties supply the 18-byte device descriptor, and `GetConfigurationDescriptorPtr` supplies the raw configuration descriptors without an open. An unmodified guest binary now enumerates the attached hardware.

## What

New `src/runtime/usb-sysfs.c` materializes both trees as scratch directories of real host files, following the `ensure_syscpu_dir` pattern already in `procemu.c`:

```
/sys/bus/usb/devices/<bus>-<ports>          device attribute dirs
/sys/bus/usb/devices/<bus>-<ports>:<c>.<i>  interface attribute dirs
/dev/bus/usb/BBB/DDD                        char 189:(bus-1)*128+(dev-1)
```

Design decisions that are worth a reviewer's attention:

**Bus numbering.** `busnum` is the top byte of the IOKit `locationID` plus one. macOS controller indices start at 0 while Linux busnums start at 1, so a literal `locationID >> 24` would produce a bus 0 that no Linux tool expects. The port path below it comes from the remaining `locationID` nibbles, six at most, which is the same `<bus>-<port>.<port>` spelling `linux_usbfs.c` parses.

**devnum.** Taken from the `USB Address` property. Devices without that property get a stable per-bus fallback, numbered 1..n in `locationID` order and skipping numbers already taken, so a device never silently collides with another and the numbering does not shuffle between reads within a run.

**Root hubs are absent, on purpose.** macOS publishes no root hub as a USB device, verified with `ioreg`: there is no `IOUSBDevice` entry to name. So the tree carries no `usbN` entry and no parent link from a device up to its bus. Enumeration is unaffected, because libusb derives topology from the `<bus>-<port>` names alone and nusb drops root hubs outright. The `nports == 0` branch in the code is not a filter for root hubs, it is the guard for an entry with no port path to name it by, and the comment says so. The one visible consequence is `lsusb -t`, covered below.

**One descriptor blob, two readers.** The `descriptors` sysfs attribute and a `read()` of the matching `/dev/bus/usb` node are served from the same buffer, so the two views cannot drift. `usb_sysfs_descriptors_dup` exports it for the usbdevfs fd that comes next. The test asserts the two reads are byte-identical rather than merely both parseable.

**One view of the active configuration.** `bNumInterfaces`, `bmAttributes`, `bMaxPower`, `configuration`, and the emitted `:c.i` interface directories all read the current configuration through a single `active_config()` helper. An earlier revision read `bNumInterfaces` from the first configuration in the blob while the interface directories came from the active one, which disagreed on any device whose active configuration is not the first. That class of bug is now structurally impossible, and the test pins `bNumInterfaces` against the actual directory count.

**All four attributes exist on every device, whatever the blob held.** Linux keeps `configuration`, `bNumInterfaces`, `bmAttributes` and `bMaxPower` in `dev_attr_grp` (`sysfs.c:782-786`), an attribute group with **no** `.is_visible` hook (`sysfs.c:815-817`), so every USB device directory carries all four files. When `udev->actconfig` is NULL, `usb_actconfig_show` returns the `0` its lock handed it (`sysfs.c:29-43`) -- a **zero-length read, not an error**. Emitting an attribute only when its value was known would turn that into `ENOENT`, and the two are different answers to a reader probing for an optional attribute: absent means unsupported, empty means supported with nothing to say. libudev makes the distinction observable -- `udev_device_get_sysattr_value()` returns a pointer to `""` for an empty attribute and `NULL` for an absent one. So all four now render through one pure leaf, `usb_desc_actconfig_attrs`, and the caller writes all four unconditionally; presence is structural rather than repeated per line. (Contrast `manufacturer`/`product`/`serial`, which *are* gated by `dev_string_attrs_are_visible` and which this tree correctly omits when absent.)

**`SYSFS_MAGIC`.** `statfs` and `fstatfs` report `0x62656572` for `/sys` paths and for `descriptors` fds. libudev checks this before it will trust the tree, so without it the whole tree reads as untrustworthy to a udev-backed consumer.

**Path handling.** `.` and `..` inside a `/sys` path are resolved rather than refused, so `/sys/bus/usb/devices/../devices` resolves the way it does on Linux instead of reporting `EACCES`; a suffix that climbs above `/sys` is handed back to the normal path flow. The lexical fold decides only whether a name is this layer's at all. The name that is actually served is resolved component by component, so a `..` behind a symlink pops the *target's* parent the way the kernel does: `<dev>/subsystem/..` is `/sys/bus`, which makes `<dev>/subsystem/../usb/devices` resolve and `<dev>/subsystem/../idVendor` `ENOENT` -- the reverse of what folding the name first produces. `st_ino` is derived from the resolved spelling, so two ways of naming one directory agree on their identity and an `(st_dev, st_ino)` same-file test tells the truth. A node addressed as a directory, a bare trailing slash included, reports `ENOTDIR` once the node exists and `ENOENT` when it does not. Symlinks inside the tree are followed the way Linux follows them, so `open()` of a `subsystem` link reaches the target directory and libudev's and pyserial's USB-backed checks resolve. Every link in the tree is written by this code with a fixed target and the tree is read-only to the guest, so following is safe; containment is proved rather than assumed, in that the resolved path is canonicalized and tested against the canonical scratch root and anything landing outside reports `ENOENT` instead of being opened. `open`, `stat`, `lstat` and `readlink` all resolve through that one helper, so the entry points cannot disagree about what the tree holds -- `readlink` opens nothing, but a target string is still the guest learning about a host object it was never handed. That property did not hold on the first revision and the review caught it: `O_NOFOLLOW` split the final component off, contained the prefix, then reattached the leaf, so a `..` leaf reattached to the canonical root named the host directory the tree sits in. `open("<dev>/subsystem/../../..", O_NOFOLLOW)` returned a descriptor on the host temp parent while `stat`, `lstat` and `readlink` of the same name refused it and logged the refusal. A `.` or `..` leaf is no longer held back, since neither can be a symlink and O_NOFOLLOW has nothing to protect there, and containment is now factored into one `usb_sys_contained()` applied last on every path, including after the reattach. A probe that plants a file in the backing directory and asks 16 names through open, O_NOFOLLOW open, stat, lstat, readlink and openat reports 4 escapes against the first revision and 0 now, with all entry points agreeing on every name. `O_NOFOLLOW` on a symlink reports `ELOOP` before the access mode is consulted, which is the order Linux uses (`open(subsystem, O_WRONLY|O_NOFOLLOW)` is ELOOP, plain `O_WRONLY` is EISDIR, measured on 6.19), and `O_PATH | O_NOFOLLOW` yields an fd on the link itself.

**Descriptor identity, and the errnos around it.** A descriptor on a followed `subsystem` link names the directory it resolves to, not the spelling the guest opened, so `openat(fd, "..")` pops the target's parent. That is what Linux does (`open("/sys/class/net/lo/subsystem", O_PATH)` names `/sys/class/net` and `..` off it names `/sys/class`, measured on 6.19) and the stamp now comes from `F_GETPATH` on the descriptor rather than from the request, which needs no special case because F_GETPATH already reports the target for a followed open and the link for an `O_SYMLINK` one. `O_DIRECTORY|O_CREAT` is `EINVAL`, decided while the open flags are built and therefore ahead of path resolution and of the dirfd check, with O_PATH excluded because the kernel masks the creation bit off there and `O_PATH|O_DIRECTORY|O_CREAT` opens the directory. Every sysfs attribute is poll-capable, not just the CPU subtree, because `kernfs_fop_poll` is installed by `sysfs_file_operations` on all of them, so `epoll_ctl(ADD)` on `<dev>/uevent` answers 0 rather than `EPERM`; udev-style readers arm `uevent` before they read it. `statfs` decides which filesystem answers from what the name resolves to, so `/sys/../sys` and a relative `sys` from a cwd of `/` both report `SYSFS_MAGIC`. `st_rdev` is composed in `uint32_t` before it becomes a `dev_t`: `dev_t` is a signed 32-bit int on macOS and shifting major 189 left by 24 lands in the sign bit, which UBSAN reports as undefined. The ENOENT rebase fallback that lets `chase()` step from a host directory into a synthetic subtree now requires the descriptor to be inside the sysroot, so a sysroot symlink pointing out of the tree cannot hand a host `/dev` dirfd to the `/dev/bus/usb` intercept.

**Interface numbers are a whole byte.** `bInterfaceNumber` is a `__u8`, so the selection is sized to all 256 values rather than 32; the earlier bound silently dropped interfaces numbered 32 and above and left `bNumInterfaces` disagreeing with the directories on disk. The walk itself is bounded by `cfg_len`, so the table size was never what kept it in bounds.

**Read-only for now.** `O_RDONLY` on a node serves the descriptor blob; `O_RDWR` and `O_WRONLY` report `EACCES` with a one-line warning. Write access to a *directory* is refused the way `open(2)` refuses it, with `EISDIR` rather than a readable descriptor or an `EACCES`: `/dev/bus/usb`, the per-bus directories and `/sys/bus/usb/devices` all answer alike, while a create under the read-only `/sys` tree still answers `EACCES`. The directory opener is shared with `/proc`, which had the same gap, so that spelling is corrected too. The typed usbdevfs fd and its ioctls are the next piece; this one deliberately carries no transfer path.

**Layout deviations that are deliberate, and their cost.** The `/sys/bus/usb/devices` entries are real directories rather than symlinks into `/sys/devices/...`, so `realpath()` of an entry canonicalizes to itself. libusb opens attributes relative to the entry and nusb canonicalizes the entry path, so both tolerate it. Two smaller ones are accepted rather than hidden, and both are recorded in `docs/internals.md`:

- the `/dev/bus/usb` device nodes are placeholder files, so `getdents64` reports them with `d_type` `DT_REG` where Linux reports `DT_CHR`. `stat()` is correct -- the intercept fills `S_IFCHR` with major 189 and the right minor, which is what libusb, nusb and `lsusb` consult -- so only a scanner that filters on `d_type` alone and never calls `stat` would skip them. No such consumer is known, and creating real character devices needs privileges elfuse does not ask for.
- `statfs` on `/dev/bus` agrees with `fstatfs` but reports the scratch filesystem's magic instead of `DEVTMPFS_MAGIC`.
- `configuration` is always empty, and this is the one deviation that is one-directional rather than cosmetic. The attribute holds the string named by the active configuration's `iConfiguration`, and a string descriptor is fetched over an ep0 control transfer on an open device -- which this piece deliberately does not do. IOKit offers no way around it, and that was checked against the live registry rather than assumed: an `IOUSBHostDevice` entry publishes `iManufacturer`, `iProduct` and `iSerialNumber` together with the three strings the family caches for them (`USB Vendor Name`, `USB Product Name`, `kUSBSerialNumberString`), but no `iConfiguration` index and no configuration string. An empty file is nevertheless the honest answer rather than a missing one, because it is the answer Linux gives from the same position: `configuration_show` emits nothing whenever `actconfig->string` is NULL (`sysfs.c:83-84`), and `usb_cache_string` is documented to return NULL "if the index is 0 **or the string could not be read**" (`message.c:1074-1075`). An empty `configuration` on Linux therefore means "no cached string", which is strictly weaker than "`iConfiguration` is 0" -- a device that NAKs its own string descriptor reads empty on real sysfs too, and every device here takes that second route. The residual gap: a configuration whose `iConfiguration` is non-zero and whose string is readable shows that string on Linux and shows nothing here, until an ep0 path exists to fetch it.

Nothing in scope reads either, and I would rather name them than have them found. A third one is gone rather than documented: `stat()` of a `subsystem` link now reports the directory it resolves to and `lstat()` reports the link, because the stat intercept takes the follow flag its callers already had.

**Snapshot.** The tree is built once per run, so a replug is not visible within a run until the uevent layer can invalidate it. Documented, not papered over.

**No device ceiling.** The device table grows on demand rather than stopping at a fixed 64. usbfs itself caps only at 127 devices per bus, and a chain of hubs can put more than any fixed guess on one machine; a truncated model would lose devices from both the `/dev/bus/usb` and the `/sys` view at once. Only a failed allocation stops the walk, and it says so.

**`O_PATH` dirfds.** An `O_PATH` descriptor on a non-directory answers `ENOTDIR` for a relative name resolved against it, as `openat(2)` does. The empty path is excluded from that rule, so `fstat()` of such a descriptor still reports the object it names.

**Link and plumbing.** The Makefile adds `-framework IOKit -framework CoreFoundation` and the new source. `path.c` gates claim `/sys` (minus the existing syscpu stub) and `/dev/bus` for the open and stat intercepts; `openat`/`fstatat`/`readlinkat` on synthetic paths resolve through `path_rebase_hostdirfd` and are re-offered to the intercepts, which is what keeps systemd `chase()`'s per-component walk on the synthetic tree. `usb_lock` is documented as a leaf.

**Tests.** New `tests/test-usb-sysfs.c` with its own `make check` lane, in two halves. The first needs no device at all (`SYSFS_MAGIC` from `statfs` and `fstatfs` alike, the read-only open contract, the `..` fold, the `ENOENT`/`EINVAL`/`ENOTDIR` answers), so a machine with an empty bus still covers the path layer. The second walks whatever is attached and asserts the identities that need a device. It prints the device count, so a run that covered only the first half says so instead of reading as full cover. Writing it found two bugs before review did: the bare trailing slash returning a descriptors fd, and the unfolded `st_ino`. The descriptor blob is device-supplied, so the walks over it live in a pure leaf unit, `src/runtime/usb-desc.c`, with `tests/test-usb-desc-host.c` covering the malformed cases natively on the host: a `bLength` past the end of the buffer, a zero `bLength`, a truncated trailing descriptor, a `wTotalLength` longer than the blob, and a `wTotalLength` *shorter* than the configuration it names -- which without a header check lands the cursor on an interface descriptor and returns it as the active configuration, since an interface's byte 5 sits where `bConfigurationValue` does. The iterator compares in the remaining-bytes domain, so a bad length stops the walk in bounds instead of stepping the cursor off the end.

The same unit covers the active-configuration attribute set, which is where the interesting branches are hardware-inaccessible: no active configuration at all; a `cfg_len` below the header size; `iConfiguration` 0 with and without a string offered (one offered at index 0 is dropped, because `usb_cache_string` short-circuits before any transfer); `iConfiguration` non-zero with the string unreadable (NULL and `""` alike); `iConfiguration` non-zero with the string readable, which is the branch no attached device can reach; a string longer than the kernel's `MAX_USB_STRING_SIZE`, which is truncated in its own tail and never in the trailing newline `sysfs_emit` always writes; and a two-configuration blob where selecting the wrong one shows the wrong string. That leaves only the emit-to-file step hardware-conditional, and `test-usb-sysfs.c` covers that against whatever is attached.

Three of the device-half assertions were rewritten because they could not fail. `bmAttributes`, `bMaxPower` and `configuration` are now checked against the device's own `descriptors` blob -- `strtol`'s endptr against `cfg[7]`, the power string against `cfg[8]` scaled by the speed's unit, and `configuration` empty **whenever** `iConfiguration` is 0 -- through a second, deliberately independent walk of the blob inside the test, so the test cannot pass by agreeing with the code under test. A mutant that emits the wrong `bmAttributes` byte, swaps the power unit and writes a non-empty `configuration` passes the old assertions 56/0 and fails the new ones in 5 places. A containment assertion was added for the same reason, and the review found that it too could not fail: the probe path dropped the `tmp` component the `..` chain re-entered, so it never named the plant and passed on ENOENT while the resolver was leaking. It now asserts the chain with nothing appended, pins each depth by `st_dev`/`st_ino` against `/sys/bus` and `/sys` rather than by errno (refusing every depth would satisfy "not an escape" while breaking every relative walk through the link), takes the plant appearing in the opened directory's `getdents` listing as the oracle, and reads the plant back by its own name first so the refusals cannot both be reporting an absent file. Against the first revision it reports 100 passed, 33 failed, naming the escaped path and the planted file. The probe name comes from `mkstemp`, because the guest pid is always 1 and a pid suffix separates no lanes; eight concurrent lanes now pass 8/8 where the fixed name gave 3/8. The blob reader grows its buffer instead of capping: a fixed cap answered "the file was this long" and "the read stopped here" with one number, and the two-view compare read it as a length, so two blobs differing past the cap compared equal.

## Evidence

Clean rebuild at this tip, ESP32-S3 (303a:1001) attached behind a Fresco Logic hub.

`lsusb-lite`, a static guest binary that walks sysfs exactly the way `linux_usbfs.c` does and then byte-compares the sysfs blob against the `/dev/bus/usb` node:

```
STEP statfs_/sys = 0 (0 ok) f_type=0x62656572 SYSFS_MAGIC
STEP opendir_/sys/bus/usb/devices = ok (0 ok)
DEVICE 2-1
  realpath = /sys/bus/usb/devices/2-1
  busnum = 2
  devnum = 1
  idVendor = 303a
  idProduct = 1001
  bcdDevice = 0101
  version =  2.00
  bDeviceClass = ef
  bDeviceSubClass = 02
  bDeviceProtocol = 01
  speed = 12
  bConfigurationValue = 1
  manufacturer = Espressif
  product = USB JTAG/serial debug unit
  serial = 34:85:18:42:6C:98
  descriptors = 116 bytes
  IFACE 2-1:1.1: bInterfaceNumber=01 bInterfaceClass=0a bInterfaceSubClass=02 bInterfaceProtocol=00
  IFACE 2-1:1.0: bInterfaceNumber=00 bInterfaceClass=02 bInterfaceSubClass=02 bInterfaceProtocol=00
  IFACE 2-1:1.2: bInterfaceNumber=02 bInterfaceClass=ff bInterfaceSubClass=ff bInterfaceProtocol=01
  node /dev/bus/usb/002/001 = 116 bytes -> MATCH
  PARSE OK
RESULT devices_ok=2 sysfs_ok=1
```

The hub enumerates too (`1-1`, Fresco Logic 1d5c:5801, `MATCH`), trimmed here for length.

The five attributes `lsusb -t` warns about, plus `bMaxPower`, read back on both devices:

```
== /sys/bus/usb/devices/1-1 ==        == /sys/bus/usb/devices/2-1 ==
  bmAttributes   = [e0]                 bmAttributes   = [c0]
  bMaxPower      = [0mA]                bMaxPower      = [500mA]
  configuration  = []                   configuration  = []
  maxchild       = [0]                  maxchild       = [0]
  rx_lanes       = [1]                  rx_lanes       = [1]
  tx_lanes       = [1]                  tx_lanes       = [1]
```

Those are not free-standing values; they are the configuration descriptor decoded. Bytes 18..26 of `2-1/descriptors` are the configuration descriptor itself:

```
09 02 62 00 03 01 00 c0 fa
                  ^^ ^^ ^^
                  |  |  bMaxPower 0xfa = 250 units = 500mA
                  |  bmAttributes 0xc0 = bus-reserved | self-powered
                  iConfiguration 0, so no string is named and the
                  configuration file is empty -- as it is on Linux
```

`bNumInterfaces` is the `03` in that same descriptor, and three `:1.N` directories exist. `configuration` being empty is the Linux behavior for a configuration whose string was not cached, not a stub -- see the deviation note above for why the file is present and empty rather than omitted. `maxchild` is 0 for both, including the hub, because the hub class descriptor needs an open device; the code says so at the write site.

The one-blob invariant, and the node's identity:

```
$ cmp /sys/bus/usb/devices/2-1/descriptors /dev/bus/usb/002/001 && echo IDENTICAL
IDENTICAL
$ cat /sys/bus/usb/devices/2-1/dev
189:128
```

189:128 is `(bus-1)*128 + (dev-1)` for bus 2 device 1, and `uevent` agrees (`MAJOR=189 MINOR=128 DEVNAME=bus/usb/002/001 PRODUCT=303a/1001/101 TYPE=239/2/1`).

Test lane and full suite on a clean rebuild:

```
test-usb-sysfs: 138 passed, 0 failed - PASS
  devices examined: 2
test-usb-desc-host: all tests passed
test-sysroot-symlink-escape: 9 passed, 0 failed - PASS
make check BAREMETAL_CROSS=aarch64-elf- exit=0
  All 89 tests passed
  Results: 7 passed, 0 failed, 0 skipped (of 7)
  Results: 81 passed, 0 failed, 3 skipped (of 84)
  Results: 27 passed, 0 failed, 0 skipped (of 27)
  Results: 4 passed, 0 failed, 0 skipped (of 4)
make check-ubsan exit=0   0 runtime errors, test-usb-sysfs 138/0
make check-asan  exit=0   0 sanitizer reports, test-usb-sysfs 138/0
```

`test-usb-sysfs` moved onto the sanitizer lane through `CHECK_SHARED_LANES` rather than `tests/manifest.txt`: `.ci/check-matrix-lists.sh` rejects a manifest binary the matrix never runs, confirmed by adding it and watching the gate fail. It belongs there because this layer composes a `dev_t` by shifting a major number, which is exactly the arithmetic UBSAN is there to adjudicate, and nothing else on the lane builds the tree.

Run against the previous revision of this branch, the same test reports:

```
test-usb-sysfs: 100 passed, 33 failed - FAIL
escaped: /sys/bus/usb/devices/2-1/subsystem/../../.. lists the planted elfuse-usb-escape-probe-shftDx
```

(The three skips are environment-driven and identical on `main`: two musl fixtures absent, one busybox applet not in this build.)

On the self-hosted runner, which has four devices where this board has two, and at least one whose active configuration carries a non-zero `iConfiguration`:

```
  configuration is empty when iConfiguration is 0            OK   (x4)
  the four active-config attributes are all present          OK   (x4)
  an absent device attribute is ENOENT, not EACCES           OK   (x4)
  devices examined: 4
test-usb-sysfs: 126 passed, 0 failed - PASS
```

**What does not work yet, stated plainly.** Real Debian `lsusb` (usbutils 018 over libusb-1.0.28, the udev-backed build) still does not reach this tree:

```
$ elfuse --sysroot ./sysroot-libusb /usr/bin/lsusb
WARN unimplemented syscall 264 (...)
unable to initialize libusb: -99
```

Syscall 264 is `name_to_handle_at`, which libudev uses to decide whether `/sys` is a genuine sysfs mount. That is a separate change and not in this PR, so the evidence above comes from a static guest binary that walks the same sysfs paths libusb walks, not from `lsusb` itself. Transfers are also not here: this piece is enumeration only, and reading or writing an endpoint needs the usbdevfs fd that follows.

## Known boundary: `lsusb -t`

`lsusb -t` lists devices without the bus rows above them. The README feature line now says so, and no longer claims the tree is enough for `lsusb` at all: a udev-backed `lsusb` needs `name_to_handle_at` as well, which is not implemented yet, so the bullet promises libusb-style enumeration and names both gaps. `lsusb -t` no longer prints the per-device warnings either: the five missing-attribute warnings per device are gone, and it exits 0 silently. That is the improvement this PR makes to tree mode, and it is the whole of it.

The empty tree itself is structural and recorded in [#319 (comment)](https://github.com/sysprog21/elfuse/issues/319#issuecomment-5374102738). Tree mode does not enumerate through libusb; it walks `/sys/bus/usb/devices` itself and roots the tree at the `usbN` root-hub entries, which macOS gives us nothing to build from. Making the tree render is a coherent chunk of work rather than a missing attribute: `usbN` entries occupy `Device 001` on each bus on Linux, so real devices would renumber to 002 and up, moving their `/dev/bus/usb` paths, and the per-interface `driver` symlinks would then have to agree with what `GETDRIVER` reports. No consumer in scope reads any of it, so it is recorded as a known boundary rather than planned work. If a real workflow needs tree mode, it can become its own issue then.
