### PR TITLE
Introduce conformance test harness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ on:
       - '.editorconfig'
       - '.clang-format'
       - 'frama-c-stubs/**'
+      - '.github/workflows/conformance.yml'
       - '.github/workflows/lint.yml'
       - '.github/workflows/static-analysis.yml'
       - '.github/workflows/verify.yml'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,123 @@
+name: Conformance
+
+on:
+  push:
+    branches: [main]
+  # Required checks must start; classify scope in job conditions.
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: pr subset or the full sweep
+        type: choice
+        options: [pr, full]
+        default: pr
+      update_check:
+        description: report which pins upstream has moved
+        type: boolean
+        default: false
+  merge_group:
+  schedule:
+    # Stagger the nightly run from common hour boundaries.
+    - cron: '17 3 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  CONF_SCOPE: ${{ (github.event_name == 'schedule' || inputs.scope == 'full') && 'full' || 'pr' }}
+
+jobs:
+  # Build shares the Mac runner, while concurrency groups cancel instead of queue.
+  wait-for-runtime:
+    name: Wait for the runtime matrix
+    if: github.repository == 'sysprog21/elfuse'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Poll until Build is idle
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          live() {
+            for status in in_progress queued; do
+              curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/$REPO/actions/workflows/build.yml/runs?status=$status&per_page=1" \
+                | python3 -c 'import json,sys; print(json.load(sys.stdin)["total_count"])'
+            done | awk '{ n += $1 } END { print n + 0 }'
+          }
+          for _ in $(seq 1 110); do
+            n=$(live) || { echo "API error; retrying"; sleep 30; continue; }
+            echo "Build runs live: $n"
+            [ "$n" = 0 ] && exit 0
+            sleep 30
+          done
+          echo "::error::Build has held the Mac for 55 minutes; re-run when it is idle"
+          exit 1
+
+  harness:
+    name: Harness selftests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Gate consistency
+        run: |
+          python3 scripts/workflow-jobs.py --self-test
+          python3 scripts/workflow-jobs.py .github/workflows/conformance.yml "(make test-conformance)"
+
+      - name: Selftests
+        run: python3 scripts/conformance selftest
+
+  # Keep this required-check name independent of the lane graph.
+  conformance:
+    name: Conformance (make test-conformance)
+    needs: [wait-for-runtime, harness]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every dependency to have passed
+        run: |
+          set -euo pipefail
+          ok() {
+            [ "$1" = success ] || { [ "$1" = skipped ] && [ '${{ github.repository }}' != sysprog21/elfuse ]; }
+          }
+          ok '${{ needs.wait-for-runtime.result }}' || { echo "::error::the runtime wait did not pass"; exit 1; }
+          ok '${{ needs.harness.result }}' || { echo "::error::harness selftests did not pass"; exit 1; }
+          echo "every dependency accounted for"
+
+  update-check:
+    name: Pin drift
+    if: github.event_name == 'workflow_dispatch' && inputs.update_check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Report which pins upstream has moved
+        # Exit 3 reports drift without rewriting pins.
+        run: |
+          set -uo pipefail
+          out=$(python3 scripts/conformance update --check 2>&1); rc=$?
+          printf '%s\n' "$out"
+          { echo '## Pin drift'; echo; echo '```'; printf '%s\n' "$out"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          case $rc in
+            0) ;;
+            3) echo "::warning title=conformance pins::upstream has moved; run make update-pins" ;;
+            *) exit "$rc" ;;
+          esac

--- a/Makefile
+++ b/Makefile
@@ -590,6 +590,7 @@ $(BUILD_DIR)/probe: tests/fixtures/sharun/probe.c \
 endif
 
 include mk/tests.mk
+include mk/conformance.mk
 include mk/lint.mk
 include mk/verify.mk
 include mk/format.mk

--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ The build signs `build/elfuse` before use. Override the signing identity with
 ## Documentation
 
 - [docs/usage.md](docs/usage.md): command-line options, x86_64 via
-  Rosetta, dynamic linking via `--sysroot`, and attaching `gdb` /
-  `lldb` to the built-in stub.
+  Rosetta, dynamic linking via `--sysroot`, attaching `gdb` / `lldb` to
+  the built-in stub, and running the conformance suites.
 - [docs/testing.md](docs/testing.md): build prerequisites, the
   `make check` flow, the QEMU and Rosetta cross-check matrices, and
   fixture handling.
+- [docs/conformance.md](docs/conformance.md): the conformance harness,
+  expectations, payloads, and CI workflow.
 - [docs/filenames.md](docs/filenames.md): how a guest filename becomes a
   name on disk and back: case folding and normalization on the sysroot
   volume, the escape encoding, and the length limits both systems impose.
@@ -173,6 +175,9 @@ rules in [CONTRIBUTING.md](CONTRIBUTING.md). A missing local formatter warns
 rather than blocks, and a hook you already wrote is never replaced.
 `make uninstall-hooks` removes them, `make install-hooks` puts them back. They
 do not replace `make check`.
+
+`make test-conformance` judges each suite's pull-request subset against
+checked-in expectations. See [docs/usage.md](docs/usage.md#conformance-testing).
 
 ## Limitations
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,204 @@
+# Conformance testing
+
+The harness under `tests/conformance/` runs suites against `elfuse` and a
+Linux reference in QEMU. It judges each case against checked-in expectations.
+Providers adapt suites; backends execute commands; selection, retries,
+judgment, reporting, payloads, and the CLI are shared.
+
+## Quick start
+
+```sh
+make elfuse
+bash tests/fetch-fixtures.sh
+make conformance-payloads
+make test-conformance
+make test-conformance-full BACKEND=all
+make test-conformance TEST='<suite>:<group>/*' BACKEND=qemu
+```
+
+`BACKEND` accepts `elfuse` (default), `qemu`, `all` (QEMU first), or `host`
+for the fake selftest suite. `TEST` accepts canonical ids or globs. See
+[usage.md](usage.md#conformance-testing) for setup and maintenance commands.
+
+## Interface
+
+`scripts/conformance` is the entry point; the make targets are aliases.
+
+```
+scripts/conformance [--backend elfuse|qemu|all|host] [--results DIR] [--jobs N]
+                    [--bootstrap] [--require] [--no-retry] [--dry-run] [-v]
+                    <suite> pr | full | test ID [ID...]
+scripts/conformance <suite> list [--scope pr|full] [--json]
+scripts/conformance <suite> seed RESULTS_DIR [--reason TEXT] [--write]
+scripts/conformance <suite> fingerprint | verify | payload | audit | regen
+scripts/conformance <suite> update [--check] [--ref REF]
+scripts/conformance lint | gate RESULTS_DIR | report DIR | selftest | update
+```
+
+Exit codes are:
+
+- `0`: green.
+- `1`: a red verdict, backend failure, bad verified payload, or selection
+  drift.
+- `2`: invalid input or configuration, including malformed data, lint errors,
+  stale expectations, and manifest mismatches.
+- `3`: `update --check` found pin drift.
+- `77`: a prerequisite is absent. `--require` or `CONF_REQUIRE=1` promotes
+  this to `2`; make prints an unpromoted `77` as `SKIP`.
+
+`gate DIR` re-derives the exit code from `results.json`. `report DIR` renders
+all results below a directory as a Markdown table.
+
+## Test ids and results
+
+Every case has one id:
+
+```
+<suite>:<group>
+<suite>:<group>/<case>[/<parameter>...]
+```
+
+The group is part of the id because different launch units may define the
+same case name. Expectation matchers use the same grammar plus shell globs;
+`*` spans `/`.
+
+Each attempt records an execution class (`normal`, `timeout`, `signal`, or
+`transport`), host wall time, and an exit code or signal when applicable. A
+case has a suite status and a judge verdict. Keeping them separate shows both
+what happened and whether it was expected.
+
+Statuses are `PASS`, `FAIL`, `SKIP`, `CONF`, `WARN`, `BROK`, `TIMEOUT`,
+`CRASH`, `INCONSISTENT`, and harness `ERROR`. Verdicts are `as_expected`,
+`unexpected_failure`, `unexpected_pass`, `flaked`, `filtered`, and `error`.
+`CONF` remains distinct from pass and fail. Timeouts, crashes, inconsistent
+reports, and harness errors satisfy no expectation.
+
+`results.json` is authoritative. Loading it rejects stored gates or counts
+that disagree with the cases, and an empty case set is red. `junit.xml` and
+`summary.txt` are derived views.
+
+## Selection
+
+A suite selection accounts for every upstream launch group at the pin. An
+enabled group has scope `pr` or `full`, and may set a positive `timeout_s` or
+an `only` list of case globs. A declined group requires a reason. `pr` groups
+run in both scopes; `full` groups run only in the full sweep.
+
+Loading rejects unknown keys, duplicate groups, and groups that are both
+enabled and declined. `<suite> audit` compares the selection with upstream.
+Decline groups only when the guest cannot provide their prerequisite or they
+have no Linux contract; record elfuse failures as expectations.
+
+`test ID...` resolves ids against the full selection and rejects unmatched
+names with nearby ids, so a typo cannot produce an empty green run.
+
+## Expectations
+
+Expectation files are JSONC with trailing commas. A suite has a shared base,
+one backend leaf that includes it, and `flaky.jsonc`. Files contain ordered
+actions; the last matching action wins. The first effective action is
+`expect_pass` for `*`, so new upstream cases fail until triaged.
+
+```jsonc
+{
+  "actions": [
+    { "include": "ltp.jsonc" },
+    { "type": "expect_failure",
+      "reason": "chmod through a /proc fd follows the symlink chain",
+      "tracking": "#123",
+      "matchers": ["ltp:chmod09"] },
+    { "type": "skip",
+      "reason": "wedges the VM before the test framework starts",
+      "matchers": ["ltp:ptrace06"] },
+  ],
+}
+```
+
+Actions are `expect_pass`, `expect_failure`, `expect_conf`, `skip`, and
+`quarantine`. Non-pass actions require a reason and may carry `since` and
+`tracking`. Quarantine is legal only in `flaky.jsonc`; it permits retries
+without changing the expected status. Loading enforces sorted,
+suite-namespaced matchers. A full run rejects stale matchers.
+
+The judge is red for regressions and unexpected passes. A gated run does not
+launch skipped cases; `--bootstrap` launches them. A suite-reported `SKIP` is
+`filtered`. Only quarantined cases retry, up to three attempts. A later
+expected result after a red attempt is `flaked`.
+
+## Seeding
+
+`<suite> seed RESULTS_DIR` proposes expectation actions. Bootstrap results
+seed non-passing statuses; gated results seed only red verdicts. Harness
+errors are refused because the case did not run.
+
+Complete multi-case groups with one outcome collapse to
+`<suite>:<group>/*`. Named test runs never collapse groups. Every proposal
+uses `--reason` or a provisional `seeded from` reason that lint rejects until
+triage. `--write` appends to the backend leaf, preserves its leading comment
+block, and lints the directory.
+
+## Providers and backends
+
+A provider enumerates cases and maps suite outcomes to statuses. It does not
+retry, judge, or load expectations. `run_batch` handles cases with one batch
+key. The runner isolates unresolved cases through `run_single`, so a batch
+crash is attributed to its cause.
+
+A backend executes one argv and returns an invocation. Both backends use an
+isolated scratch directory and fixed environment.
+
+The elfuse backend starts one `build/elfuse --timeout 0` process per case,
+disables core dumps, sets an 8 MiB stack, and reaps orphaned fork children.
+Timeouts kill the process group and perform one bounded wait. A session lock
+covers start through stop because guest `/dev/shm` is shared by elfuse
+processes for the same user.
+
+The QEMU backend holds one VM under `build/conformance/qemu.lock`. It starts
+the VM through `tests/qemu-runner.sh --state-file` and uses a fresh SSH
+connection for each command. A sentinel distinguishes the remote exit from
+transport loss; a local SSH deadline is a timeout. Artifacts return through
+`ssh cat` because the guest has no SFTP server. The VM sees the repository on
+read-only 9p, so payloads remain below the repository root.
+
+## Payloads and pins
+
+Payloads are pinned upstream artifacts staged under
+`externals/payloads/<suite>/` and never committed. Pins live in
+`tests/conformance/<suite>/pins.json` and are schema-checked on load.
+
+A payload fingerprint hashes its pins and builder inputs. It does not use
+mtimes, so a recipe edit invalidates the cache even with one-second make
+timestamps. `manifest.json` records the fingerprint, staged files, symlinks,
+and writable directory prefixes. A lane reports missing or stale payloads as
+`77`, then verifies the entire tree before starting a backend.
+
+Payloads survive `make clean` and `make distclean`; `make clean-payloads`
+removes them. `<suite> update` fetches, validates, and atomically replaces
+pins. `--check` reports without writing, and fetch failures return `2` rather
+than claiming drift.
+
+## CI and pin updates
+
+`.github/workflows/conformance.yml` owns the schedule and the stable required
+check `Conformance (make test-conformance)`. The workflow reader verifies that
+the gate reaches every macOS job. Pull requests have no path filter because a
+required workflow that never starts remains pending.
+
+One Mac serves Build and the conformance lanes. A wait job polls Build because
+a shared concurrency group would cancel instead of queue. Nightly and
+`scope=full` dispatches set `CONF_SCOPE=full`; other runs use `pr`.
+`update_check` reports pin drift without writing.
+
+To update a suite:
+
+1. Run `make update-pins`, or use `UPDATE_CHECK=1` to report only.
+2. Rebuild with `make conformance-payloads`.
+3. Run `<suite> audit` and `<suite> regen` for upstream selection changes.
+4. Bootstrap, seed, triage, and rerun each backend under the gate.
+5. Fold the pin, selection, and expectation changes into the suite commit.
+
+## Selftests
+
+`make test-conformance-harness` runs the hermetic fake suite, selection and
+expectation lint, runner tests, and CLI tests. It needs neither a payload nor
+a VM and is part of `make check`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -423,6 +423,8 @@ The repository contains several layers of validation:
 - shell integration suites such as BusyBox, coreutils, and dynamic-loader tests
 - debugger integration tests for the GDB stub
 - native macOS HVF checks such as multi-vCPU and RWX validation
+- conformance lanes that judge test suites against elfuse and a QEMU
+  reference; see `docs/conformance.md`
 
 The quick suite is driven by `tests/driver.sh`, which supports:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -299,3 +299,62 @@ That has a few direct implications:
   work entirely inside the VM. Programs that link against `libfuse`
   (sshfs, ntfs-3g, AppImage runtimes) run without macFUSE, FUSE-T, or
   FSKit on the host.
+
+## Conformance testing
+
+`scripts/conformance` runs upstream suites on elfuse and a Linux reference in
+QEMU, then judges each case against checked-in expectations. See
+[conformance.md](conformance.md) for the data model and file formats.
+
+Prepare a checkout with:
+
+```sh
+make elfuse
+bash tests/fetch-fixtures.sh
+brew install qemu
+make conformance-payloads
+```
+
+Common runs are:
+
+```sh
+make test-conformance-harness
+make test-conformance
+make test-conformance BACKEND=qemu
+make test-conformance-full BACKEND=all
+make test-conformance TEST='<id> ...'
+```
+
+`BACKEND` accepts `elfuse` (default), `qemu`, or `all`; `host` is for the
+fake selftest suite. `CONF_JOBS` controls elfuse batch parallelism and
+`CONF_RESULTS` moves the results root. Each lane writes below
+`build/conformance/<suite>/<backend>/` and updates a `latest` symlink.
+
+The make targets wrap these CLI operations:
+
+```sh
+scripts/conformance <suite> list --scope pr
+scripts/conformance <suite> pr --dry-run
+scripts/conformance <suite> full -v --no-retry
+scripts/conformance gate <results-dir>
+scripts/conformance report build/conformance
+scripts/conformance <suite> pr --bootstrap
+scripts/conformance <suite> seed <results-dir> --reason '<why>' --write
+scripts/conformance lint
+scripts/conformance <suite> audit
+scripts/conformance <suite> verify
+scripts/conformance <suite> payload --force
+make update-pins UPDATE_CHECK=1
+make update-pins CONF_REF_<suite>=<ref>
+make clean-payloads
+```
+
+The CLI defaults to elfuse, one job, and `build/conformance`. The reference
+serializes cases. Exit codes are documented in
+[conformance.md](conformance.md#interface). Suites register through
+`mk/conformance.mk` and `tests/conformance/providers/`; if none register, the
+suite targets print `SKIP`.
+
+CI gates on `Conformance (make test-conformance)`. Nightly runs and dispatches
+with `scope=full` use the full selection; `update_check` reports pin drift
+without writing.

--- a/mk/conformance.mk
+++ b/mk/conformance.mk
@@ -1,0 +1,47 @@
+.PHONY: test-conformance-harness test-conformance test-conformance-full \
+        conformance-payloads clean-payloads update-pins
+
+CONFORMANCE := python3 scripts/conformance
+CONF_SUITES :=
+BACKEND ?= elfuse
+TEST ?=
+CONF_JOBS ?= 4
+CONF_RESULTS ?= $(BUILD_DIR)/conformance
+CONF_RUN = $(CONFORMANCE) --backend $(BACKEND) --jobs $(CONF_JOBS) --results $(CONF_RESULTS)
+CONF_SCOPE ?= pr
+CONF_RUN_SCOPE = $(if $(TEST),test $(TEST),$(CONF_SCOPE))
+# foreach inserts spaces, but RUN_OPTIONAL_SKIP77 expands as a recipe line.
+define conf-newline
+
+
+endef
+
+## Run the conformance harness selftests (hermetic)
+test-conformance-harness:
+	@$(CONFORMANCE) selftest
+
+## Run every suite's CONF_SCOPE (pr) subset, or TEST=ID... (BACKEND=elfuse|qemu|all|host)
+test-conformance:
+	$(if $(CONF_SUITES),,@printf "$(YELLOW)SKIP$(RESET) no conformance suites registered\n")
+	$(foreach s,$(CONF_SUITES),$(call RUN_OPTIONAL_SKIP77,$(CONF_RUN) $(s) $(CONF_RUN_SCOPE),test-$(s))$(conf-newline))
+
+## Run every suite in full, the nightly shape
+test-conformance-full:
+	$(if $(CONF_SUITES),,@printf "$(YELLOW)SKIP$(RESET) no conformance suites registered\n")
+	$(foreach s,$(CONF_SUITES),$(call RUN_OPTIONAL_SKIP77,$(CONF_RUN) $(s) full,test-$(s)-full)$(conf-newline))
+
+## Build every conformance payload under externals/payloads/
+conformance-payloads:
+	$(if $(CONF_SUITES),,@printf "$(YELLOW)SKIP$(RESET) no conformance suites registered\n")
+	$(foreach s,$(CONF_SUITES),$(CONFORMANCE) $(s) payload &&) true
+
+## Remove the conformance payloads (they survive clean and distclean)
+clean-payloads:
+	rm -rf externals/payloads
+
+UPDATE_CHECK ?=
+
+## Refresh the conformance pins from upstream (UPDATE_CHECK=1 to report only)
+update-pins:
+	$(if $(CONF_SUITES),,@printf "$(YELLOW)SKIP$(RESET) no conformance suites registered\n")
+	$(foreach s,$(CONF_SUITES),$(CONFORMANCE) $(s) update $(if $(UPDATE_CHECK),--check) $(if $(CONF_REF_$(s)),--ref $(CONF_REF_$(s))) &&) true

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -275,6 +275,7 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-eintr-contract ch
 	$(call run-lane,test-rosetta-cli,rosetta CLI gating)
 	$(call run-lane,test-bench-guardrail,hot-syscall guardrail)
 	$(call run-lane,test-sharun,sharun launcher and probe)
+	$(call run-lane,test-conformance-harness,conformance harness selftests)
 
 ## Hot-syscall performance guardrail: ensure getpid, libc clock_gettime,
 ## and 1-byte /dev/urandom reads stay under their TODO ns/op ceilings.

--- a/scripts/check-proof-targets.py
+++ b/scripts/check-proof-targets.py
@@ -25,6 +25,7 @@ Usage:
     check-proof-targets.py
 """
 
+import importlib.util
 import pathlib
 import re
 import subprocess
@@ -33,20 +34,16 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
-# scripts/ filenames are kebab-case per CLAUDE.md, which no plain "import"
-# statement can name, so the shared reader is loaded by path. The alternative
-# was an underscore in the filename, which the tree does not use anywhere.
-def _load_verify_mk():
-    import importlib.util
-
-    path = pathlib.Path(__file__).resolve().parent / "verify-mk.py"
-    spec = importlib.util.spec_from_file_location("verify_mk", path)
+# Kebab-case script names require path-based imports.
+def _load_sibling(name):
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_").replace(".py", ""),
+                                                  pathlib.Path(__file__).with_name(name))
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-verify_mk = _load_verify_mk()
+verify_mk = _load_sibling("verify-mk.py")
 
 
 PROVED_DIR = ROOT / "src" / "proved"
@@ -145,71 +142,11 @@ def verdict_covers_every_prover_job():
     macOS job in the workflow does prover work, so each must be reachable from
     that job's needs, or the name goes green without it.
     """
-    # Regex rather than a YAML parser, matching what this file already does
-    # above and keeping the lint job free of a PyYAML dependency it does not
-    # otherwise need. The shapes read here are the ones this workflow uses:
-    # a two-space job key, and needs as either a scalar or a flow list.
-    #
-    # Split the "jobs:" section rather than the whole file, and accept any
-    # leading identifier character rather than a lower-case letter. A key class
-    # of [a-z] silently drops a job named "Verify-extra" or "_probe" from BOTH
-    # sides of the comparison below, so a macOS job the check name does not
-    # reach reads as no job at all -- the exact miss this function exists to
-    # make loud. Splitting the whole file also read the sub-keys of "on:",
-    # "concurrency:" and "permissions:" as jobs.
     text = (ROOT / ".github" / "workflows" / "verify.yml").read_text()
-    section = re.split(r"^jobs:[ \t]*$", text, maxsplit=1, flags=re.M)
-    if len(section) != 2:
-        print(
-            "  no top-level 'jobs:' key in .github/workflows/verify.yml",
-            file=sys.stderr,
-        )
-        return False
-    blocks = re.split(r"^  (?=[A-Za-z_])", section[1], flags=re.M)[1:]
-    jobs = {}
-    for block in blocks:
-        job = block.split(":", 1)[0]
-        needs = re.search(r"^    needs:\s*(.+)$", block, re.M)
-        jobs[job] = {
-            "name": (re.search(r"^    name:\s*(.+)$", block, re.M) or [None, ""])[1],
-            "runs-on": (re.search(r"^    runs-on:\s*(.+)$", block, re.M) or [None, ""])[
-                1
-            ],
-            "needs": re.findall(r"[A-Za-z][\w-]*", needs.group(1)) if needs else [],
-        }
-    verdict = [j for j, v in jobs.items() if v["name"].endswith("(make verify)")]
-    if len(verdict) != 1:
-        print(
-            "  expected exactly one job named '... (make verify)' in "
-            f".github/workflows/verify.yml, found {verdict}",
-            file=sys.stderr,
-        )
-        return False
-
-    seen, stack = set(), list(jobs[verdict[0]]["needs"])
-    while stack:
-        job = stack.pop()
-        if job in seen or job not in jobs:
-            continue
-        seen.add(job)
-        stack.extend(jobs[job]["needs"])
-    # Substring, case-folded, rather than a prefix on "macos". The hosted
-    # runner is "macos-15", but the self-hosted one build.yml already uses is
-    # the flow list "[self-hosted, macOS, arm64]", which a prefix test reads as
-    # a non-macOS job and stops enforcing on the day this workflow moves there.
-    # Over-matching only demands one more "needs" edge; under-matching drops a
-    # prover job out from under the required check with nothing said.
-    prover_jobs = {j for j, v in jobs.items() if "macos" in v["runs-on"].lower()}
-    missing = sorted(prover_jobs - seen)
-    if missing:
-        print(
-            f"  {missing} run on macOS but the '{jobs[verdict[0]]['name']}' check "
-            "does not reach them through needs, so requiring that check would "
-            "not enforce them",
-            file=sys.stderr,
-        )
-        return False
-    return True
+    problems = _load_sibling("workflow-jobs.py").check(text, "(make verify)")
+    for p in problems:
+        print("  .github/workflows/verify.yml: %s" % p, file=sys.stderr)
+    return not problems
 
 
 def main():

--- a/scripts/conformance
+++ b/scripts/conformance
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "tests"))
+
+from conformance.cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/proof-scope.py
+++ b/scripts/proof-scope.py
@@ -349,6 +349,7 @@ MAKEFILE_PROOF_INCLUDES = {
 MAKEFILE_INERT_INCLUDES = {
     "mk/shim.mk",
     "mk/tests.mk",
+    "mk/conformance.mk",
     "mk/lint.mk",
     "mk/format.mk",
     "mk/help.mk",

--- a/scripts/workflow-jobs.py
+++ b/scripts/workflow-jobs.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Read workflow jobs without adding a YAML dependency.
+
+The named gate must reach every macOS job through needs.
+"""
+
+import re
+import sys
+
+_VALUE = r"[ \t]*(\[[^\]]*\]|[^\n]*(?:\n[ \t]+-[ \t]*[^\n]*)*)"
+
+
+def _uncomment(value):
+    # A YAML comment starts at a "#" that begins the line or follows a blank.
+    return re.sub(r"(?m)(^|[ \t])#.*$", r"\1", value)
+
+
+def _scalar(block, key):
+    m = re.search(r"^    %s:[ \t]*(.*)$" % key, block, re.M)
+    if not m:
+        return ""
+    value = m.group(1).strip()
+    quoted = re.match(r"""(["'])(.*?)\1""", value)
+    return quoted.group(2) if quoted else _uncomment(value).strip()
+
+
+def _names(block, key):
+    m = re.search(r"^    %s:%s" % (key, _VALUE), block, re.M)
+    return re.findall(r"[A-Za-z][\w-]*", _uncomment(m.group(1))) if m else []
+
+
+def jobs_of(text):
+    section = re.split(r"^jobs:[ \t]*(?:#.*)?$", text, maxsplit=1, flags=re.M)
+    if len(section) != 2:
+        return None
+    jobs = {}
+    for block in re.split(r"^  (?=[A-Za-z_])", section[1], flags=re.M)[1:]:
+        jobs[block.split(":", 1)[0]] = {
+            "name": _scalar(block, "name"),
+            "runs-on": " ".join(_names(block, "runs-on")),
+            "needs": _names(block, "needs"),
+        }
+    return jobs
+
+
+def reachable(jobs, start):
+    seen, stack = set(), list(jobs[start]["needs"])
+    while stack:
+        job = stack.pop()
+        if job in seen or job not in jobs:
+            continue
+        seen.add(job)
+        stack.extend(jobs[job]["needs"])
+    return seen
+
+
+def check(text, suffix):
+    """Report macOS jobs unreachable from the named gate."""
+    jobs = jobs_of(text)
+    if jobs is None:
+        return ["no top-level 'jobs:' key"]
+    gates = [j for j, v in jobs.items() if v["name"].endswith(suffix)]
+    if len(gates) != 1:
+        return ["expected exactly one job named '... %s', found %s" % (suffix, gates)]
+    # Both macos-15 and [self-hosted, macOS, arm64] contain macos.
+    macos = {j for j, v in jobs.items() if "macos" in v["runs-on"].lower()}
+    missing = sorted(macos - reachable(jobs, gates[0]))
+    if missing:
+        return ["%s run on macOS but '%s' does not reach them through needs"
+                % (missing, jobs[gates[0]]["name"])]
+    return []
+
+
+SAMPLE = """
+on: [push]
+jobs:  # inline comment
+  a:
+    runs-on: [self-hosted, macOS, arm64]
+  b:
+    needs: a
+    runs-on: macos-15
+  gate:
+    name: "Gate (make x)"  # quoted, commented
+    needs: [b]
+    runs-on: ubuntu-latest
+  stray:
+    runs-on: macos-15
+  listed:
+    needs:
+      - b
+      - stray
+    runs-on: ubuntu-latest
+  block:
+    runs-on:
+      - self-hosted
+      - macOS
+      - arm64
+"""
+
+
+def self_test():
+    problems = check(SAMPLE, "(make x)")
+    assert problems and "['block', 'stray']" in problems[0], problems
+    assert check(SAMPLE.replace("needs: [b]", "needs: [b, stray, block]"), "(make x)") == []
+    assert check(SAMPLE.replace("needs: [b]", "needs: [b, listed, block]"), "(make x)") == []
+    assert check(SAMPLE.replace("needs: [b]", "needs: [\n      b,\n      listed, block\n    ]"),
+                 "(make x)") == []
+    assert check(SAMPLE.replace("needs: [b]", "needs: [b]  # stray, block"), "(make x)") != []
+    assert check(SAMPLE.replace('"Gate (make x)"', '"Gate #2 (make x)"')
+                 .replace("needs: [b]", "needs: [b, stray, block]"), "(make x)") == []
+    assert check("on: [push]\n", "(make x)") == ["no top-level 'jobs:' key"]
+    return 0
+
+
+def main(argv):
+    if argv == ["--self-test"]:
+        return self_test()
+    if len(argv) != 2:
+        print("usage: workflow-jobs.py WORKFLOW GATE_NAME_SUFFIX | --self-test", file=sys.stderr)
+        return 2
+    problems = check(open(argv[0]).read(), argv[1])
+    for p in problems:
+        print("  %s: %s" % (argv[0], p), file=sys.stderr)
+    if not problems:
+        print("%s: the '%s' gate reaches every macOS job" % (argv[0], argv[1]))
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/conformance/__init__.py
+++ b/tests/conformance/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/conformance/backends/__init__.py
+++ b/tests/conformance/backends/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from conformance.backends.base import Backend, BackendError
+
+def make(name: str, repo_root: Path, **options: Any) -> Backend:
+    if name == "elfuse":
+        from conformance.backends.elfuse import ElfuseBackend
+
+        return ElfuseBackend(repo_root, **options)
+    if name == "qemu":
+        from conformance.backends.qemu import QemuBackend
+
+        return QemuBackend(repo_root, **options)
+    if name == "host":
+        from conformance.backends.host import HostBackend
+
+        if options:
+            raise BackendError("host backend takes no options, got %s" % sorted(options))
+        return HostBackend(repo_root)
+    raise BackendError("unknown backend %r" % (name,))

--- a/tests/conformance/backends/base.py
+++ b/tests/conformance/backends/base.py
@@ -1,0 +1,73 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional
+
+from conformance.model import Invocation
+
+
+class BackendError(RuntimeError):
+    pass
+
+
+FIXED_ENV = {"PATH": "/usr/bin:/bin", "LC_ALL": "C", "TZ": "UTC"}
+SCRATCH_NAMES = ("HOME", "TMPDIR", "TEST_TMPDIR")
+
+
+def guest_environment(scratch: str, env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    scratch = os.path.abspath(scratch)
+    return {**FIXED_ENV, **{name: scratch for name in SCRATCH_NAMES}, **(env or {})}
+
+
+class Backend:
+    name = ""
+    max_jobs = 0  # 0: no cap on --jobs
+    lock_file: Optional[Path] = None  # held by serialize() when set
+
+    def prerequisites(self) -> Optional[str]:
+        """Return an exit-77 reason when the backend cannot run."""
+        return None
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def run(
+        self,
+        argv: List[str],
+        timeout_s: int,
+        scratch: Path,
+        env: Optional[Dict[str, str]] = None,
+        fetch: Iterable[str] = (),
+    ) -> Invocation:
+        """Run argv in a fresh guest cwd and return artifacts in scratch."""
+        raise NotImplementedError
+
+    def guest_path(self, host_path: Path) -> str:
+        return str(host_path)
+
+    @contextlib.contextmanager
+    def serialize(self) -> Iterator[None]:
+        """Take a non-blocking flock when lock_file is set."""
+        if self.lock_file is None:
+            yield
+            return
+        self.lock_file.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self.lock_file, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                raise BackendError("another %s conformance session holds %s"
+                                   % (self.name, self.lock_file)) from None
+            yield
+        finally:
+            os.close(fd)

--- a/tests/conformance/backends/elfuse.py
+++ b/tests/conformance/backends/elfuse.py
@@ -1,0 +1,80 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import fcntl
+import os
+import signal
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from conformance.backends import base, proc
+from conformance.model import Invocation
+
+
+# Linux programs expect an 8 MiB initial stack.
+WRAPPER = ["/bin/sh", "-c", 'ulimit -c 0; ulimit -s 8192; exec "$@"', "--"]
+
+
+def orphan_pids(ps_output: str, binary: str, session: int) -> list:
+    """Limit orphan cleanup to fork children from one case session."""
+    out = []
+    for line in ps_output.splitlines():
+        fields = line.split(None, 3)
+        if len(fields) < 4:
+            continue
+        pid, ppid, sess, command = fields
+        if (ppid == "1" and sess == str(session) and command.startswith(binary + " ")
+                and "--fork-child" in command):
+            out.append(int(pid))
+    return out
+
+
+class ElfuseBackend(base.Backend):
+    name = "elfuse"
+
+    def __init__(self, repo_root: Path, sysroot: Optional[Path] = None,
+                 binary: Optional[Path] = None):
+        self.repo_root = repo_root
+        self.binary = binary or repo_root / "build" / "elfuse"
+        self.sysroot = sysroot
+        # One session per user: guest /dev/shm is a per-uid host directory.
+        self.lock_file = Path("/tmp/elfuse-conformance-%d.lock" % os.getuid())
+
+    def prerequisites(self) -> Optional[str]:
+        if not os.access(self.binary, os.X_OK):
+            return "%s is absent; run: make" % self.binary
+        if self.sysroot is not None and not self.sysroot.is_dir():
+            return "sysroot %s is absent" % self.sysroot
+        return None
+
+    def argv(self, guest_argv: List[str]) -> List[str]:
+        out = [str(self.binary), "--timeout", "0"]
+        if self.sysroot is not None:
+            out += ["--sysroot", str(self.sysroot)]
+        return out + list(guest_argv)
+
+    def run(
+        self,
+        argv: List[str],
+        timeout_s: int,
+        scratch: Path,
+        env: Optional[Dict[str, str]] = None,
+        fetch: Iterable[str] = (),
+    ) -> Invocation:
+        full = base.guest_environment(str(scratch), env)
+        inv = proc.run_local(WRAPPER + self.argv(argv), timeout_s, scratch, env=full)
+        if inv.pid is not None:
+            self.reap_orphans(inv.pid)
+        return inv
+
+    def reap_orphans(self, session: int) -> None:
+        """Release VMs held by fork children that outlived their case."""
+        listing = subprocess.run(["ps", "-eo", "pid=,ppid=,sess=,command="], capture_output=True, text=True)
+        for pid in orphan_pids(listing.stdout, str(self.binary), session):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass

--- a/tests/conformance/backends/host.py
+++ b/tests/conformance/backends/host.py
@@ -1,0 +1,27 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from conformance.backends import base, proc
+from conformance.model import Invocation
+
+
+class HostBackend(base.Backend):
+    name = "host"
+
+    def __init__(self, repo_root: Path):
+        self.repo_root = repo_root
+
+    def run(
+        self,
+        argv: List[str],
+        timeout_s: int,
+        scratch: Path,
+        env: Optional[Dict[str, str]] = None,
+        fetch: Iterable[str] = (),
+    ) -> Invocation:
+        return proc.run_local(argv, timeout_s, scratch, env=base.guest_environment(str(scratch), env))

--- a/tests/conformance/backends/proc.py
+++ b/tests/conformance/backends/proc.py
@@ -1,0 +1,67 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from conformance.model import Invocation
+
+KILL_WAIT_S = 30
+
+
+def classify(rc: int, timed_out: bool, wall_us: int, stdout: str, stderr: str) -> Invocation:
+    """Interpret negative Popen return codes as signal deaths."""
+    if timed_out:
+        return Invocation(execution="timeout", wall_us=wall_us, stdout=stdout, stderr=stderr)
+    if rc < 0:
+        return Invocation(execution="signal", wall_us=wall_us, signal=-rc, stdout=stdout, stderr=stderr)
+    return Invocation(execution="normal", wall_us=wall_us, exit_code=rc, stdout=stdout, stderr=stderr)
+
+
+def _kill_and_reap(proc: subprocess.Popen) -> int:
+    """Bound the wait for a guest stuck in an uninterruptible state."""
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    try:
+        return proc.wait(timeout=KILL_WAIT_S)
+    except subprocess.TimeoutExpired:
+        return -signal.SIGKILL
+
+
+def run_local(
+    argv: List[str],
+    timeout_s: int,
+    scratch: Path,
+    env: Optional[Dict[str, str]] = None,
+    stdout_name: str = "stdout",
+) -> Invocation:
+    """Run argv in a new session so timeout cleanup reaches its group."""
+    scratch.mkdir(parents=True, exist_ok=True)
+    out_path, err_path = scratch / stdout_name, scratch / "stderr"
+    started = time.monotonic()
+    with open(out_path, "wb") as out, open(err_path, "wb") as err, \
+            open(os.devnull, "rb") as feed:
+        try:
+            proc = subprocess.Popen(argv, cwd=str(scratch), env=env, stdin=feed,
+                                    stdout=out, stderr=err, start_new_session=True)
+        except OSError as e:
+            err.write(("cannot spawn %s: %s\n" % (argv[0], e)).encode())
+            return Invocation(execution="transport", wall_us=int((time.monotonic() - started) * 1_000_000),
+                              stdout=str(out_path), stderr=str(err_path))
+        timed_out = False
+        try:
+            rc = proc.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            rc = _kill_and_reap(proc)
+    inv = classify(rc, timed_out, int((time.monotonic() - started) * 1_000_000), str(out_path), str(err_path))
+    inv.pid = proc.pid  # start_new_session makes pid the process-group id
+    return inv

--- a/tests/conformance/backends/qemu.py
+++ b/tests/conformance/backends/qemu.py
@@ -1,0 +1,117 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from conformance.backends import base
+from conformance.backends.ssh import SshSession
+from conformance.model import Invocation
+
+FIXTURES = ("kernel/vmlinuz-virt", "initramfs.cpio.gz", "keys/ssh_key")
+
+RUNNER_TIMEOUT_S = 600
+KILL_WAIT_S = 30
+# Match the environment passed to qemu-runner.sh.
+RUNNER_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+
+def parse_state(text: str) -> Dict[str, str]:
+    out = {}
+    for line in text.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            out[key.strip()] = value.strip()
+    return out
+
+
+class QemuBackend(base.Backend):
+    name = "qemu"
+    max_jobs = 1  # the reference takes one case at a time
+
+    def __init__(self, repo_root: Path, mem_mib: int = 2048,
+                 runner: Optional[Path] = None, state_dir: Optional[Path] = None):
+        self.repo_root = repo_root
+        self.mem_mib = mem_mib
+        self.runner = runner or repo_root / "tests" / "qemu-runner.sh"
+        self.state_file = (state_dir or repo_root / "build" / "conformance") / "qemu.state"
+        # One session per checkout: start() reaps whatever the state file names.
+        self.lock_file = self.state_file.with_suffix(".lock")
+        self.session: Optional[SshSession] = None
+
+    def prerequisites(self) -> Optional[str]:
+        fixtures = self.repo_root / "externals" / "test-fixtures"
+        missing = [f for f in FIXTURES if not (fixtures / f).is_file()]
+        if missing:
+            return "QEMU fixtures missing (%s); run: bash tests/fetch-fixtures.sh" % ", ".join(missing)
+        if shutil.which("qemu-system-aarch64", path=RUNNER_PATH) is None:
+            return ("qemu-system-aarch64 is not on the runner PATH (%s); "
+                    "run: brew install qemu" % RUNNER_PATH)
+        return None
+
+    def _runner(self, verb: str) -> subprocess.CompletedProcess:
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        with subprocess.Popen(
+            ["bash", str(self.runner), verb, "--state-file", str(self.state_file)],
+            cwd=str(self.repo_root),
+            env={**{k: v for k, v in os.environ.items() if k.startswith("QEMU_") or k == "TMPDIR"},
+                 "PATH": RUNNER_PATH, "QEMU_MEM": str(self.mem_mib), "HOME": str(Path.home())},
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        ) as run:
+            try:
+                out, _ = run.communicate(timeout=RUNNER_TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                # SIGTERM, not SIGKILL, so the runner's EXIT trap reaps the VM.
+                run.terminate()
+                run.communicate(timeout=KILL_WAIT_S)
+                raise base.BackendError("qemu-runner %s did not return in %ds" % (verb, RUNNER_TIMEOUT_S)) from None
+        return subprocess.CompletedProcess(run.args, run.returncode, out)
+
+    def start(self) -> None:
+        # A state file from an interrupted run names a VM still up; reap it
+        # first or this start would overwrite the only record of it.
+        self.stop()
+        done = self._runner("start")
+        if done.returncode != 0:
+            raise base.BackendError("qemu-runner start failed:\n%s" % done.stdout)
+        try:
+            state = parse_state(self.state_file.read_text()) if self.state_file.exists() else {}
+            if "port" not in state or "key" not in state:
+                raise base.BackendError("qemu-runner wrote no port/key to %s" % self.state_file)
+            self.session = SshSession(int(state["port"]), Path(state["key"]))
+        except (base.BackendError, ValueError, OSError) as e:
+            self.stop()
+            raise base.BackendError(str(e)) from None
+
+    def stop(self) -> None:
+        if self.session is not None or self.state_file.exists():
+            done = self._runner("stop")
+            if done.returncode != 0:
+                raise base.BackendError("qemu-runner stop failed:\n%s" % done.stdout)
+            self.session = None
+
+    def guest_path(self, host_path: Path) -> str:
+        try:
+            rel = Path(host_path).resolve().relative_to(self.repo_root.resolve())
+        except ValueError:
+            raise base.BackendError(
+                "%s is outside the repo root, unreachable over the 9p share" % host_path
+            ) from None
+        return "/mnt/host/%s" % rel.as_posix()
+
+    def run(
+        self,
+        argv: List[str],
+        timeout_s: int,
+        scratch: Path,
+        env: Optional[Dict[str, str]] = None,
+        fetch: Iterable[str] = (),
+    ) -> Invocation:
+        if self.session is None:
+            raise base.BackendError("qemu backend is not started")
+        return self.session.run(argv, timeout_s, scratch, env=env, fetch=fetch)

--- a/tests/conformance/backends/ssh.py
+++ b/tests/conformance/backends/ssh.py
@@ -1,0 +1,105 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+# Alpine's initramfs has no sftp-server, so files return through ssh cat.
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from conformance.backends import base, proc
+from conformance.model import Invocation
+
+SENTINEL = "__CONF_RC="
+DIR_MARK = " __CONF_DIR="
+TRANSPORT_SLACK_S = 15
+
+
+class SshSession:
+    def __init__(self, port: int, key: Path, host: str = "127.0.0.1", user: str = "root",
+                 ssh: str = "ssh"):
+        self.port, self.key, self.host, self.user = port, key, host, user
+        self.ssh = ssh
+
+    def options(self) -> List[str]:
+        return [
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "LogLevel=ERROR",
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=10",
+            "-o", "ServerAliveInterval=10",
+            "-o", "ServerAliveCountMax=6",
+            "-i", str(self.key),
+        ]
+
+    def ssh_argv(self, script: str) -> List[str]:
+        return [self.ssh] + self.options() + ["-p", str(self.port),
+                                              "%s@%s" % (self.user, self.host), script]
+
+    @staticmethod
+    def remote_script(argv: List[str], timeout_s: int, env: Dict[str, str],
+                      cwd: Optional[str], cleanup: bool = False) -> str:
+        """Build the guest command with an isolated cwd and fixed environment."""
+        exports = "export %s;" % " ".join('%s="$PWD"' % n for n in base.SCRATCH_NAMES) + "".join(
+            " export %s=%s;" % (k, shlex.quote(v)) for k, v in sorted({**base.FIXED_ENV, **env}.items()))
+        enter = "cd %s" % shlex.quote(cwd) if cwd else 'd=$(mktemp -d /tmp/conf.XXXXXX) && cd "$d"'
+        if cleanup:
+            enter += " && trap 'cd / && rm -rf \"$d\"' EXIT"
+        return (
+            "%s && { %s /usr/bin/timeout -s KILL %d %s; rc=$?; "
+            'printf "\\n%s%%s%s%%s\\n" "$rc" "$PWD"; }'
+            % (enter, exports, timeout_s, shlex.join(argv), SENTINEL, DIR_MARK)
+        )
+
+    @staticmethod
+    def parse_sentinel(text: str) -> Optional[tuple]:
+        # DIR_MARK terminates rc and detects a partial sentinel write.
+        for line in reversed(text.splitlines()):
+            if line.startswith(SENTINEL):
+                head, mark, tail = line.partition(DIR_MARK)
+                field = head[len(SENTINEL):].split()
+                if not mark or not field or not field[0].lstrip("-").isdigit():
+                    return None
+                return int(field[0]), tail
+        return None
+
+    def run(self, argv: List[str], timeout_s: int, scratch: Path,
+            env: Optional[Dict[str, str]] = None, cwd: Optional[str] = None,
+            fetch: Iterable[str] = ()) -> Invocation:
+        cleanup = not cwd and not fetch
+        script = self.remote_script(argv, timeout_s, env or {}, cwd, cleanup)
+        inv = proc.run_local(self.ssh_argv(script), timeout_s + TRANSPORT_SLACK_S, scratch,
+                             stdout_name="stdout.raw")
+        raw_path, out_path = Path(inv.stdout), scratch / "stdout"
+        raw = raw_path.read_bytes()
+        parsed = self.parse_sentinel(raw.decode("utf-8", "replace"))
+        if parsed is None:
+            raw_path.replace(out_path)
+            # An uninterruptible guest can outlive both timeout and SIGKILL.
+            return Invocation(execution="timeout" if inv.execution == "timeout" else "transport",
+                              wall_us=inv.wall_us,
+                              stdout=str(out_path), stderr=inv.stderr)
+        rc, guest_dir = parsed
+        os.truncate(raw_path, max(raw.rfind(SENTINEL.encode()) - 1, 0))
+        raw_path.replace(out_path)
+        if guest_dir:
+            for name in fetch:
+                self.copy_from("%s/%s" % (guest_dir, name), scratch / name)
+            if not cwd and fetch:
+                proc.run_local(self.ssh_argv("rm -rf %s" % shlex.quote(guest_dir)), 30,
+                               scratch / ".cleanup")
+        timed_out = rc == 137 and inv.wall_us >= timeout_s * 1_000_000
+        # timeout encodes signal death as 128+n, which is ambiguous with a
+        # plain exit above 128. No registered suite uses the latter.
+        return proc.classify(128 - rc if rc > 128 else rc, timed_out, inv.wall_us, str(out_path), inv.stderr)
+
+    def copy_from(self, remote: str, local: Path) -> bool:
+        inv = proc.run_local(self.ssh_argv("cat %s" % shlex.quote(remote)), 120,
+                             local.parent / ".fetch", stdout_name=local.name + ".part")
+        if inv.exit_code != 0:
+            return False
+        Path(inv.stdout).replace(local)
+        return True

--- a/tests/conformance/cli.py
+++ b/tests/conformance/cli.py
@@ -1,0 +1,411 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime
+import json
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+from typing import Callable, Iterator, List, Optional
+
+from conformance import backends, expectations, jsonc, payload, providers, report, runner, seed
+from conformance import selection as selection_mod
+from conformance import update as update_mod
+from conformance.backends.base import BackendError
+from conformance.model import Status
+from conformance.providers.base import ProviderError
+
+EXIT_OK, EXIT_RED, EXIT_USAGE, EXIT_SKIP = 0, 1, 2, 77
+_SEVERITY = {EXIT_RED: 3, EXIT_USAGE: 2, EXIT_SKIP: 1, EXIT_OK: 0}
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKENDS = ("elfuse", "qemu", "all", "host")
+
+
+def worst_of(codes) -> int:
+    return max(codes, key=lambda c: _SEVERITY.get(c, 3), default=EXIT_OK)
+
+
+class _Exit(Exception):
+    def __init__(self, code: int):
+        super().__init__(code)
+        self.code = code
+
+
+class Cli:
+    def __init__(self, repo_root: Path, out: Callable[[str], None] = print):
+        self.repo_root = repo_root
+        self.out = out
+
+    def skip(self, args: argparse.Namespace, message: str) -> int:
+        self.out(message)
+        required = args.require or os.environ.get("CONF_REQUIRE") == "1"
+        return EXIT_USAGE if required else EXIT_SKIP
+
+    def provider(self, name: str) -> providers.Provider:
+        return providers.make(name, self.repo_root)
+
+    @staticmethod
+    def backend_names(args: argparse.Namespace) -> List[str]:
+        return ["qemu", "elfuse"] if args.backend == "all" else [args.backend]
+
+    def run(self, args: argparse.Namespace) -> int:
+        provider = self.provider(args.suite)
+        return worst_of(self.run_one(args, provider, name) for name in self.backend_names(args))
+
+    def make_backend(self, args: argparse.Namespace, provider: providers.Provider, name: str,
+                     verify_payload: bool = False) -> backends.Backend:
+        absent = provider.prerequisites(name)
+        if absent:
+            raise _Exit(self.skip(args, absent))
+        if verify_payload:
+            try:
+                payload.verify(provider.payload_root(), provider.fingerprint())
+            except NotImplementedError:
+                pass
+            except payload.PayloadError as e:
+                # Manifest corruption is an error, not an absent prerequisite.
+                self.out("conformance: %s" % e)
+                raise _Exit(EXIT_USAGE) from None
+        try:
+            backend = backends.make(name, self.repo_root, **provider.backend_options(name))
+        except BackendError as e:
+            self.out("conformance: %s" % e)
+            raise _Exit(EXIT_USAGE) from None
+        absent = backend.prerequisites()
+        if absent:
+            raise _Exit(self.skip(args, "conformance: " + absent))
+        return backend
+
+    @contextlib.contextmanager
+    def started(self, args: argparse.Namespace, backend: backends.Backend) -> Iterator[None]:
+        """Hold backend serialization across start, use, and stop."""
+        with backend.serialize():
+            try:
+                backend.start()
+            except BackendError as e:
+                raise _Exit(self.skip(args, "conformance: %s" % e)) from None
+            try:
+                yield
+            finally:
+                backend.stop()
+
+    def run_one(self, args: argparse.Namespace, provider: providers.Provider, name: str) -> int:
+        try:
+            backend = self.make_backend(args, provider, name, verify_payload=True)
+        except _Exit as e:
+            return e.code
+        try:
+            exps = expectations.load(provider.name, name, provider.expectations_dir)
+        except ValueError as e:  # ExpectationError included
+            self.out("conformance: %s" % e)
+            return EXIT_USAGE
+        scope = "full" if args.scope == "test" else args.scope
+        entries = provider.selection.groups(scope)
+        results_dir = self.results_dir(args, provider.name, name)
+        started = time.monotonic()
+        try:
+            with self.started(args, backend):
+                cases = provider.enumerate(backend, entries)
+                if args.scope == "test":
+                    chosen, errors = selection_mod.resolve_ids(args.ids, [c.id for c in cases], provider.name)
+                    for e in errors:
+                        self.out("conformance: " + e)
+                    if errors:
+                        return EXIT_USAGE
+                    wanted = set(chosen)
+                    cases = [c for c in cases if c.id in wanted]
+                if args.dry_run:
+                    for c in cases:
+                        self.out(c.id)
+                    return EXIT_OK
+                log = self.out if args.verbose else (lambda _: None)
+                results = runner.run_lane(provider, backend, cases, exps, results_dir,
+                                          args.jobs, not args.no_retry, args.bootstrap, log)
+            meta = {
+                "suite": provider.name, "backend": name, "scope": args.scope,
+                "ids": list(args.ids),
+                "started": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+                "elapsed_s": round(time.monotonic() - started, 3),
+                "bootstrap": args.bootstrap, "argv": sys.argv[1:],
+            }
+            report.write(results_dir, meta, results)
+            self.link_latest(results_dir)
+            for line in report.summary_lines(meta, results, results_dir):
+                self.out(line)
+        except _Exit as e:
+            return e.code
+        except BackendError as e:
+            self.out("conformance: backend error: %s" % e)
+            return EXIT_RED
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            for c in results:
+                if c.verdict.is_red:
+                    self.out("::error title=conformance::%s"
+                             % report.red_line(c).splitlines()[0])
+        if args.scope == "full" and not args.bootstrap:
+            stale = exps.stale([c.id for c in cases])
+            for s in stale:
+                self.out("conformance: stale expectation, " + s)
+            if stale:
+                return EXIT_USAGE
+        if args.bootstrap:
+            return EXIT_RED if any(c.status is Status.ERROR for c in results) else EXIT_OK
+        return EXIT_OK if report.gate(results) == "green" else EXIT_RED
+
+    def results_dir(self, args: argparse.Namespace, suite: str, backend: str) -> Path:
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        return Path(args.results) / suite / backend / ("%s-%d" % (stamp, os.getpid()))
+
+    @staticmethod
+    def link_latest(results_dir: Path) -> None:
+        link = results_dir.parent / "latest"
+        try:
+            if link.is_symlink() or link.exists():
+                link.unlink()
+            link.symlink_to(results_dir.name)
+        except OSError:
+            pass
+
+    def list_ids(self, args: argparse.Namespace) -> int:
+        provider = self.provider(args.suite)
+        # Listing through "all" uses elfuse and never boots QEMU.
+        try:
+            backend = self.make_backend(args, provider, self.backend_names(args)[-1])
+            with self.started(args, backend):
+                cases = provider.enumerate(backend, provider.selection.groups(args.scope))
+        except _Exit as e:
+            return e.code
+        except BackendError as e:
+            self.out("conformance: backend error: %s" % e)
+            return EXIT_RED
+        if args.json:
+            self.out(json.dumps([{"id": c.id, "group": c.group, "scope": c.scope,
+                                  "timeout_s": c.timeout_s} for c in cases], indent=1))
+        else:
+            for c in cases:
+                self.out(c.id)
+        return EXIT_OK
+
+    def seed(self, args: argparse.Namespace) -> int:
+        provider = self.provider(args.suite)
+        try:
+            meta, cases = report.load(Path(args.results_dir))
+        except (ValueError, KeyError) as e:  # ReportError included
+            self.out("conformance: %s" % e)
+            return EXIT_USAGE
+        if meta.get("suite") != provider.name:
+            self.out("conformance: %s holds %s results, not %s" % (args.results_dir, meta.get("suite"), provider.name))
+            return EXIT_USAGE
+        reason = args.reason or seed.default_reason(Path(args.results_dir), str(meta.get("started", ""))[:10])
+        try:
+            # Named ids do not prove that the run covered a complete group.
+            actions = seed.propose(cases, reason, bool(meta.get("bootstrap")),
+                                   whole_groups=meta.get("scope") != "test")
+        except ValueError as e:
+            self.out("conformance: %s" % e)
+            return EXIT_USAGE
+        if not actions:
+            self.out("conformance: nothing to seed; every case is as expected")
+            return EXIT_OK
+        if args.write:
+            if not meta.get("backend"):
+                self.out("conformance: %s names no backend" % args.results_dir)
+                return EXIT_USAGE
+            leaf = expectations.leaf_path(provider.expectations_dir, provider.name, meta["backend"])
+            seed.append(leaf, actions)
+            problems = expectations.lint(provider.expectations_dir, seeded_ok=True)
+            for p in problems:
+                self.out("conformance: " + p)
+            self.out("%s: %d action(s) appended" % (leaf, len(actions)))
+            return EXIT_USAGE if problems else EXIT_OK
+        self.out(seed.format_actions(actions).rstrip("\n"))
+        return EXIT_OK
+
+    def lint(self, args: argparse.Namespace) -> int:
+        problems: List[str] = []
+        for name in sorted(providers.REGISTRY):
+            provider = self.provider(name)
+            if provider.expectations_dir.is_dir():
+                problems += expectations.lint(provider.expectations_dir)
+        for p in problems:
+            self.out("conformance: " + p)
+        self.out("conformance: lint %s" % ("clean" if not problems else "found %d problem(s)" % len(problems)))
+        return EXIT_USAGE if problems else EXIT_OK
+
+    def gate(self, args: argparse.Namespace) -> int:
+        try:
+            meta, cases = report.load(Path(args.results_dir))
+        except (ValueError, KeyError) as e:  # ReportError included
+            self.out("conformance: %s" % e)
+            return EXIT_USAGE
+        for line in report.summary_lines(meta, cases, Path(args.results_dir)):
+            self.out(line)
+        return EXIT_OK if report.gate(cases) == "green" else EXIT_RED
+
+    def report(self, args: argparse.Namespace) -> int:
+        self.out(report.markdown(Path(args.results_dir)).rstrip("\n"))
+        return EXIT_OK
+
+    def selftest(self, args: argparse.Namespace) -> int:
+        suite = unittest.defaultTestLoader.discover(
+            str(self.repo_root / "tests" / "conformance" / "selftest"),
+            top_level_dir=str(self.repo_root / "tests"))
+        result = unittest.TextTestRunner(verbosity=1).run(suite)
+        return EXIT_OK if result.wasSuccessful() else EXIT_RED
+
+    def fingerprint(self, args: argparse.Namespace) -> int:
+        self.out(self.provider(args.suite).fingerprint())
+        return EXIT_OK
+
+    def verify(self, args: argparse.Namespace) -> int:
+        provider = self.provider(args.suite)
+        try:
+            payload.verify(provider.payload_root(), args.fingerprint or provider.fingerprint())
+        except payload.PayloadError as e:
+            self.out("conformance: %s" % e)
+            return EXIT_RED
+        self.out("%s: verified" % provider.payload_root())
+        return EXIT_OK
+
+    def build_payload(self, args: argparse.Namespace) -> int:
+        try:
+            self.provider(args.suite).build_payload(force=args.force)
+        except (payload.PayloadError, ProviderError) as e:
+            self.out("conformance: %s" % e)
+            return EXIT_RED if isinstance(e, payload.PayloadError) and e.kind != "config" else EXIT_USAGE
+        return EXIT_OK
+
+    def audit(self, args: argparse.Namespace) -> int:
+        provider = self.provider(args.suite)
+        problems = provider.audit()
+        for p in problems:
+            self.out("conformance: " + p)
+        if not problems:
+            self.out("conformance: %s selection is consistent with upstream at the pin" % provider.name)
+        return EXIT_RED if problems else EXIT_OK
+
+    def regen(self, args: argparse.Namespace) -> int:
+        provider = self.provider(args.suite)
+        lines = provider.regen_selection(check=False)
+        for line in lines:
+            self.out("conformance: " + line)
+        if not lines:
+            self.out("conformance: %s generated selection is current" % provider.name)
+        return EXIT_OK
+
+    def update(self, args: argparse.Namespace) -> int:
+        names = [args.suite] if getattr(args, "suite", None) else [
+            n for n in sorted(providers.REGISTRY) if n != "fake"]
+        codes = [update_mod.refresh(self.provider(name), getattr(args, "ref", None),
+                                    args.check, self.out) for name in names]
+        # An error outranks drift: an unreachable upstream has no answer.
+        for rc in (update_mod.EXIT_ERROR, update_mod.EXIT_DRIFT):
+            if rc in codes:
+                return rc
+        return EXIT_OK
+
+
+def _common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--backend", choices=BACKENDS, default=argparse.SUPPRESS,
+                        help="elfuse (default), qemu, all (qemu first), or host")
+    parser.add_argument("--results", default=argparse.SUPPRESS, help="results root (build/conformance)")
+    parser.add_argument("--jobs", type=int, default=argparse.SUPPRESS, help="parallel batches (the reference takes one at a time)")
+    parser.add_argument("--bootstrap", action="store_true", default=argparse.SUPPRESS,
+                        help="record without judging; the input to seed")
+    parser.add_argument("--require", action="store_true", default=argparse.SUPPRESS,
+                        help="an absent prerequisite is an error, not a skip")
+    parser.add_argument("--no-retry", action="store_true", default=argparse.SUPPRESS)
+    parser.add_argument("--dry-run", action="store_true", default=argparse.SUPPRESS,
+                        help="print the selected ids and exit")
+    parser.add_argument("-v", "--verbose", action="store_true", default=argparse.SUPPRESS)
+
+
+_DEFAULTS = {"backend": "elfuse", "results": "build/conformance", "jobs": 1, "bootstrap": False,
+             "require": False, "no_retry": False, "dry_run": False, "verbose": False}
+
+
+def build_parser(suites: List[str]) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="conformance",
+        description="Run upstream Linux test suites against elfuse and the QEMU reference.")
+    _common(parser)
+    top = parser.add_subparsers(dest="target", metavar="<suite>|lint|gate|report|selftest|update")
+    top.required = True
+    for name in suites:
+        sp = top.add_parser(name, help="the %s suite" % name)
+        sub = sp.add_subparsers(dest="command", metavar="pr|full|test|list|seed|...")
+        sub.required = True
+        for scope, text in (("pr", "the pull-request subset"), ("full", "everything enabled")):
+            p = sub.add_parser(scope, help=text)
+            _common(p)
+            p.set_defaults(handler="run", scope=scope, ids=[])
+        p = sub.add_parser("test", help="named tests or globs")
+        p.add_argument("ids", nargs="+", metavar="ID")
+        _common(p)
+        p.set_defaults(handler="run", scope="test")
+        p = sub.add_parser("list", help="enumerate ids")
+        p.add_argument("--scope", choices=selection_mod.SCOPES, default="full")
+        p.add_argument("--json", action="store_true")
+        _common(p)
+        p.set_defaults(handler="list_ids")
+        p = sub.add_parser("seed", help="propose expectation actions from a results directory")
+        p.add_argument("results_dir")
+        p.add_argument("--reason")
+        p.add_argument("--write", action="store_true", help="append them to the backend leaf")
+        p.set_defaults(handler="seed")
+        p = sub.add_parser("fingerprint", help="print the payload fingerprint")
+        p.set_defaults(handler="fingerprint")
+        p = sub.add_parser("verify", help="verify the staged payload")
+        p.add_argument("--fingerprint")
+        p.set_defaults(handler="verify")
+        p = sub.add_parser("payload", help="build the payload")
+        p.add_argument("--force", action="store_true")
+        p.set_defaults(handler="build_payload")
+        p = sub.add_parser("audit", help="check the selection against upstream at the pin")
+        p.set_defaults(handler="audit")
+        p = sub.add_parser("regen", help="rewrite the generated selection from the pin")
+        p.set_defaults(handler="regen")
+        p = sub.add_parser("update", help="refresh this suite's pins")
+        p.add_argument("--check", action="store_true")
+        p.add_argument("--ref", help="an upstream ref or tag instead of the latest")
+        p.set_defaults(handler="update")
+    p = top.add_parser("lint", help="lint every selection and expectation file")
+    p.set_defaults(handler="lint")
+    p = top.add_parser("gate", help="re-derive the exit code from a results directory")
+    p.add_argument("results_dir")
+    p.set_defaults(handler="gate")
+    p = top.add_parser("report", help="markdown table over every results.json under a root")
+    p.add_argument("results_dir")
+    p.set_defaults(handler="report")
+    p = top.add_parser("selftest", help="run the hermetic selftests")
+    p.set_defaults(handler="selftest")
+    p = top.add_parser("update", help="refresh every suite's pins")
+    p.add_argument("--check", action="store_true")
+    p.set_defaults(handler="update")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None, repo_root: Path = REPO_ROOT,
+         out: Callable[[str], None] = print) -> int:
+    parser = build_parser(sorted(providers.REGISTRY))
+    args = parser.parse_args(argv)
+    for key, value in _DEFAULTS.items():
+        if not hasattr(args, key):
+            setattr(args, key, value)
+    if args.target in providers.REGISTRY:
+        args.suite = args.target
+    cli = Cli(repo_root, out)
+    try:
+        return getattr(cli, args.handler)(args)
+    except (ProviderError, selection_mod.SelectionError, payload.PinError, jsonc.JsoncError) as e:
+        out("conformance: %s" % e)
+        return EXIT_USAGE
+    except NotImplementedError as e:
+        out("conformance: %s" % (str(e) or "the %s suite does not support %s" % (getattr(args, "suite", "?"), args.handler)))
+        return EXIT_USAGE

--- a/tests/conformance/data/fake.jsonc
+++ b/tests/conformance/data/fake.jsonc
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "enabled": [
+    { "group": "basic", "scope": "pr" },
+    { "group": "slow", "scope": "full", "timeout_s": 1 },
+    { "group": "narrow", "scope": "full", "only": ["keep*"] },
+    { "group": "recorded", "scope": "full" },
+  ],
+  "declined": [
+    { "reason": "needs a kernel facility the host does not have",
+      "groups": ["kernel"] },
+  ],
+  "cases": {
+    "basic": {
+      "pass": "exit 0",
+      "fail": "exit 1",
+      "conf": "exit 32",
+      "warn": "exit 4",
+      "skipped": "exit 0",
+      "flaky": "flaky",
+    },
+    "slow": {
+      "timeout": "sleep 30",
+      "crash": "kill -SEGV $$",
+      "unresolved": "unresolved",
+    },
+    "recorded": {
+      "passes": "exit 0",
+    },
+    "narrow": {
+      "keep": "exit 0",
+      "drop": "exit 1",
+    },
+  },
+}

--- a/tests/conformance/elfcheck.py
+++ b/tests/conformance/elfcheck.py
@@ -1,0 +1,90 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+EM_AARCH64 = 183
+PT_LOAD, PT_DYNAMIC, PT_INTERP = 1, 2, 3
+DT_NULL, DT_NEEDED, DT_STRTAB = 0, 1, 5
+
+
+class ElfError(ValueError):
+    pass
+
+
+@dataclass
+class DynamicInfo:
+    machine: int
+    interp: Optional[str] = None
+    needed: List[str] = field(default_factory=list)
+    has_load: bool = False
+
+
+def _headers(data: bytes, path: Path) -> Tuple[int, list]:
+    if len(data) < 64 or data[:4] != b"\x7fELF":
+        raise ElfError("%s: not an ELF file" % path)
+    if data[4] != 2 or data[5] != 1:
+        raise ElfError("%s: not ELF64 little-endian" % path)
+    machine = struct.unpack_from("<H", data, 18)[0]
+    phoff = struct.unpack_from("<Q", data, 32)[0]
+    phentsize, phnum = struct.unpack_from("<HH", data, 54)
+    if phentsize != 56 or phoff + phnum * 56 > len(data):
+        raise ElfError("%s: program header table out of range" % path)
+    phdrs = [struct.unpack_from("<IIQQQQQQ", data, phoff + i * 56) for i in range(phnum)]
+    return machine, phdrs
+
+
+def _vaddr_to_offset(phdrs: list, vaddr: int) -> Optional[int]:
+    for p_type, _, p_offset, p_vaddr, _, p_filesz, _, _ in phdrs:
+        if p_type == PT_LOAD and p_vaddr <= vaddr < p_vaddr + p_filesz:
+            return p_offset + (vaddr - p_vaddr)
+    return None
+
+
+def _cstring(data: bytes, offset: int, path: Path) -> str:
+    end = data.find(b"\0", offset)
+    if end < 0:
+        raise ElfError("%s: string out of range" % path)
+    return data[offset:end].decode("ascii", "replace")
+
+
+def read_dynamic(path: Path) -> DynamicInfo:
+    data = path.read_bytes()
+    machine, phdrs = _headers(data, path)
+    info = DynamicInfo(machine)
+    for p_type, _, p_offset, _, _, p_filesz, _, _ in phdrs:
+        if p_type == PT_LOAD:
+            info.has_load = True
+        elif p_type == PT_INTERP:
+            info.interp = _cstring(data, p_offset, path)
+        elif p_type == PT_DYNAMIC:
+            if p_offset + p_filesz > len(data):
+                raise ElfError("%s: dynamic segment out of range" % path)
+            entries = [struct.unpack_from("<qQ", data, p_offset + i * 16) for i in range(p_filesz // 16)]
+            strtab = next((v for t, v in entries if t == DT_STRTAB), None)
+            needed = [v for t, v in entries if t == DT_NEEDED]
+            if needed:
+                if strtab is None:
+                    raise ElfError("%s: DT_NEEDED without DT_STRTAB" % path)
+                base = _vaddr_to_offset(phdrs, strtab)
+                if base is None:
+                    raise ElfError("%s: DT_STRTAB outside any PT_LOAD" % path)
+                info.needed = [_cstring(data, base + off, path) for off in needed]
+    return info
+
+
+def validate_static_aarch64(path: Path) -> None:
+    info = read_dynamic(path)
+    if info.machine != EM_AARCH64:
+        raise ElfError("%s: machine %d is not AArch64" % (path, info.machine))
+    if not info.has_load:
+        raise ElfError("%s: no PT_LOAD segment" % path)
+    if info.interp is not None:
+        raise ElfError("%s: has PT_INTERP %s, not static" % (path, info.interp))
+    if info.needed:
+        raise ElfError("%s: needs %s, not static" % (path, ", ".join(info.needed)))

--- a/tests/conformance/expectations.py
+++ b/tests/conformance/expectations.py
@@ -1,0 +1,221 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from conformance import ids, jsonc
+
+ACTION_TYPES = ("expect_pass", "expect_failure", "expect_conf", "skip", "quarantine")
+_ACTION_KEYS = {"type", "matchers", "reason", "since", "tracking"}
+_TRACKING_RE = re.compile(r"^(#\d+|https?://\S+)$")
+_SINCE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+SEEDED_PREFIX = "seeded from "
+FLAKY = "flaky.jsonc"
+
+
+class ExpectationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Action:
+    type: str
+    matchers: tuple
+    reason: str
+    source: str
+    since: str = ""
+    tracking: str = ""
+
+
+@dataclass(frozen=True)
+class Resolution:
+    type: str
+    reason: str
+    source: str
+    matcher: str
+    quarantined: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "reason": self.reason,
+            "source": self.source,
+            "matcher": self.matcher,
+            "quarantined": self.quarantined,
+        }
+
+
+class Expectations:
+    def __init__(self, suite: str, actions: List[Action]):
+        self.suite = suite
+        self.actions = list(actions)
+        first = next((a for a in actions if a.type != "quarantine"), None)
+        if first is None or first.type != "expect_pass" or first.matchers != ("*",):
+            raise ExpectationError(
+                'the first effective action must be expect_pass on "*"'
+            )
+
+    def resolve(self, test_id: str) -> Resolution:
+        chosen: Optional[Action] = None
+        chosen_matcher = ""
+        quarantined = False
+        for action in self.actions:
+            for m in action.matchers:
+                if ids.matches(m, test_id):
+                    if action.type == "quarantine":
+                        quarantined = True
+                    else:
+                        chosen, chosen_matcher = action, m
+        assert chosen is not None
+        return Resolution(
+            type=chosen.type,
+            reason=chosen.reason,
+            source=chosen.source,
+            matcher=chosen_matcher,
+            quarantined=quarantined,
+        )
+
+    def stale(self, known: Iterable[str]) -> List[str]:
+        universe = list(known)
+        out = []
+        for action in self.actions:
+            for m in action.matchers:
+                if m == "*" or ids.suite_of(m) != self.suite:
+                    continue
+                if not any(ids.matches(m, i) for i in universe):
+                    out.append("%s: %r matches no test" % (action.source, m))
+        return out
+
+
+def _check_text(text: str, where: str) -> None:
+    if "\u2014" in text:
+        raise ExpectationError("%s: em dash in text" % where)
+
+
+def _parse_action(doc: Any, where: str, suite: str) -> Action:
+    if not isinstance(doc, dict):
+        raise ExpectationError("%s: action is not an object" % where)
+    unknown = set(doc) - _ACTION_KEYS
+    if unknown:
+        raise ExpectationError("%s: unknown keys %s" % (where, sorted(unknown)))
+    kind = doc.get("type")
+    if kind not in ACTION_TYPES:
+        raise ExpectationError("%s: unknown action type %r" % (where, kind))
+    matchers = doc.get("matchers")
+    if not isinstance(matchers, list) or not matchers:
+        raise ExpectationError("%s: matchers must be a non-empty list" % where)
+    if any(not isinstance(m, str) for m in matchers):
+        raise ExpectationError("%s: matchers must be strings" % where)
+    if matchers != sorted(matchers):
+        raise ExpectationError("%s: matchers are not sorted" % where)
+    if len(set(matchers)) != len(matchers):
+        raise ExpectationError("%s: duplicate matcher" % where)
+    for m in matchers:
+        if m == "*":
+            if kind != "expect_pass":
+                raise ExpectationError('%s: "*" is legal only on expect_pass' % where)
+            continue
+        if ids.suite_of(m) != suite:
+            raise ExpectationError("%s: matcher %r is not in suite %s" % (where, m, suite))
+        if not ids.is_valid(m.replace("*", "x").replace("?", "x")):
+            raise ExpectationError("%s: matcher %r is not an id pattern" % (where, m))
+    reason = doc.get("reason", "")
+    if not isinstance(reason, str):
+        raise ExpectationError("%s: reason must be a string" % where)
+    if kind != "expect_pass" and not reason.strip():
+        raise ExpectationError("%s: %s needs a reason" % (where, kind))
+    _check_text(reason, where)
+    since = doc.get("since", "")
+    if since and not (isinstance(since, str) and _SINCE_RE.match(since)):
+        raise ExpectationError("%s: since must be YYYY-MM-DD" % where)
+    tracking = doc.get("tracking", "")
+    if tracking and not (isinstance(tracking, str) and _TRACKING_RE.match(tracking)):
+        raise ExpectationError("%s: tracking must be #N or a URL" % where)
+    return Action(kind, tuple(matchers), reason, where, since, tracking)
+
+
+def read_file(path: Path, suite: str, seen: Optional[List[Path]] = None) -> List[Action]:
+    seen = list(seen or [])
+    if path in seen:
+        raise ExpectationError("%s: include cycle" % path)
+    if len(seen) > 8:
+        raise ExpectationError("%s: include chain too deep" % path)
+    seen.append(path)
+    out: List[Action] = []
+    for where, entry in _entries(path):
+        if isinstance(entry, dict) and "include" in entry:
+            if set(entry) != {"include"} or not isinstance(entry["include"], str):
+                raise ExpectationError("%s: include takes only a file name" % where)
+            out.extend(read_file(path.parent / entry["include"], suite, seen))
+            continue
+        action = _parse_action(entry, where, suite)
+        if action.type == "quarantine" and path.name != FLAKY:
+            raise ExpectationError("%s: quarantine is legal only in %s" % (where, FLAKY))
+        if path.name == FLAKY and action.type != "quarantine":
+            raise ExpectationError("%s: %s holds only quarantine actions" % (where, FLAKY))
+        out.append(action)
+    return out
+
+
+def _entries(path: Path) -> List[Tuple[str, Any]]:
+    if not path.exists():
+        raise ExpectationError("%s: no such file" % path)
+    doc = jsonc.load(path)
+    if not isinstance(doc, dict) or set(doc) != {"actions"}:
+        raise ExpectationError('%s: expected an object with only "actions"' % path)
+    if not isinstance(doc["actions"], list):
+        raise ExpectationError("%s: actions must be a list" % path)
+    return [("%s:%d" % (path.name, index), entry) for index, entry in enumerate(doc["actions"])]
+
+
+def leaf_path(root: Path, suite: str, backend: str) -> Path:
+    return root / ("%s_%s.jsonc" % (suite, backend))
+
+
+def load(suite: str, backend: str, root: Path) -> Expectations:
+    actions = read_file(leaf_path(root, suite, backend), suite)
+    flaky = root / FLAKY
+    if flaky.exists():
+        actions.extend(a for a in read_flaky(flaky) if ids.suite_of(a.matchers[0]) == suite)
+    return Expectations(suite, actions)
+
+
+def read_flaky(path: Path) -> List[Action]:
+    out = []
+    for where, entry in _entries(path):
+        matchers = entry.get("matchers") if isinstance(entry, dict) else None
+        first = matchers[0] if isinstance(matchers, list) and matchers else ""
+        suite = ids.suite_of(first) if isinstance(first, str) else ""
+        action = _parse_action(entry, where, suite)
+        if action.type != "quarantine":
+            raise ExpectationError("%s: %s holds only quarantine actions" % (where, FLAKY))
+        if any(ids.suite_of(m) != suite for m in action.matchers):
+            raise ExpectationError("%s: matchers span suites" % where)
+        out.append(action)
+    return out
+
+
+def lint(root: Path, seeded_ok: bool = False) -> List[str]:
+    problems: List[str] = []
+    seeded: List[str] = []
+    for path in sorted(root.glob("*.jsonc")):
+        try:
+            if path.name == FLAKY:
+                actions = read_flaky(path)
+            else:
+                suite = path.stem.split("_", 1)[0]
+                actions = read_file(path, suite)
+                if "_" in path.stem:
+                    Expectations(suite, actions)
+        except (ExpectationError, jsonc.JsoncError) as e:
+            problems.append(str(e))
+            continue
+        seeded.extend(a.source for a in actions if a.reason.startswith(SEEDED_PREFIX))
+    for source in () if seeded_ok else seeded:
+        problems.append("%s: still carries a seeded reason; triage it" % source)
+    return problems

--- a/tests/conformance/expectations/fake.jsonc
+++ b/tests/conformance/expectations/fake.jsonc
@@ -1,0 +1,5 @@
+{
+  "actions": [
+    { "type": "expect_pass", "matchers": ["*"] },
+  ],
+}

--- a/tests/conformance/expectations/fake_host.jsonc
+++ b/tests/conformance/expectations/fake_host.jsonc
@@ -1,0 +1,18 @@
+// Host expectations used by selftests.
+{
+  "actions": [
+    { "include": "fake.jsonc" },
+    { "type": "expect_failure",
+      "reason": "the script exits 1 by design",
+      "matchers": ["fake:basic/fail"] },
+    { "type": "expect_failure",
+      "reason": "recorded as failing while the script exits 0; the unexpected_pass fixture",
+      "matchers": ["fake:recorded/passes"] },
+    { "type": "expect_conf",
+      "reason": "the script exits 32, LTP's TCONF",
+      "matchers": ["fake:basic/conf"] },
+    { "type": "skip",
+      "reason": "never launched; the filtered fixture",
+      "matchers": ["fake:basic/skipped"] },
+  ],
+}

--- a/tests/conformance/expectations/flaky.jsonc
+++ b/tests/conformance/expectations/flaky.jsonc
@@ -1,0 +1,7 @@
+{
+  "actions": [
+    { "type": "quarantine",
+      "reason": "fails on the first attempt by construction; selftest fixture",
+      "matchers": ["fake:basic/flaky"] },
+  ],
+}

--- a/tests/conformance/ids.py
+++ b/tests/conformance/ids.py
@@ -1,0 +1,55 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import re
+from typing import Iterable, List, Optional, Tuple
+
+_ID_RE = re.compile(
+    r"^(?P<suite>[a-z][a-z0-9]*):(?P<group>[A-Za-z0-9_][A-Za-z0-9_.-]*)"
+    r"(?P<case>(/[A-Za-z0-9_.-]+)*)$"
+)
+
+
+class IdError(ValueError):
+    pass
+
+
+def parse(test_id: str) -> Tuple[str, str, Optional[str]]:
+    m = _ID_RE.match(test_id)
+    if not m:
+        raise IdError("not a canonical test id: %r" % (test_id,))
+    case = m.group("case")
+    return m.group("suite"), m.group("group"), case[1:] if case else None
+
+
+def is_valid(test_id: str) -> bool:
+    return _ID_RE.match(test_id) is not None
+
+
+def suite_of(text: str) -> str:
+    head, sep, _ = text.partition(":")
+    return head if sep else ""
+
+
+def group_of(test_id: str) -> str:
+    return parse(test_id)[1]
+
+
+def matches(pattern: str, test_id: str) -> bool:
+    """Match wildcards across the full canonical id, including slashes."""
+    return fnmatch.fnmatchcase(test_id, pattern)
+
+
+def expand(patterns: Iterable[str], ids: Iterable[str]) -> List[str]:
+    pats = list(patterns)
+    return [i for i in ids if any(matches(p, i) for p in pats)]
+
+
+def slug(test_id: str) -> str:
+    """Keep sanitized ids distinct with a digest suffix."""
+    digest = hashlib.sha256(test_id.encode()).hexdigest()[:8]
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", test_id) + "-" + digest

--- a/tests/conformance/jsonc.py
+++ b/tests/conformance/jsonc.py
@@ -1,0 +1,66 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class JsoncError(ValueError):
+    pass
+
+
+def strip(text: str) -> str:
+    out = []
+    comma = None
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                j += 2 if text[j] == "\\" else 1
+            out.append(text[i : j + 1])
+            comma = None
+            i = j + 1
+        elif text.startswith("//", i):
+            j = text.find("\n", i)
+            i = n if j < 0 else j
+        elif text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            if j < 0:
+                raise JsoncError("unterminated block comment")
+            # Preserve token separation when a block comment is removed.
+            out.append(" " + "\n" * text.count("\n", i, j))
+            i = j + 2
+        else:
+            if c == ",":
+                comma = len(out)
+            elif c in "]}" and comma is not None:
+                out[comma] = ""
+                comma = None
+            elif not c.isspace():
+                comma = None
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def _reject(literal: str) -> Any:
+    raise JsoncError("%s is not JSON" % literal)
+
+
+def loads(text: str) -> Any:
+    try:
+        return json.loads(strip(text), parse_constant=_reject)
+    except json.JSONDecodeError as e:
+        raise JsoncError("line %d: %s" % (e.lineno, e.msg)) from None
+
+
+def load(path: Path) -> Any:
+    try:
+        return loads(path.read_text())
+    except JsoncError as e:
+        raise JsoncError("%s: %s" % (path, e)) from None

--- a/tests/conformance/judge.py
+++ b/tests/conformance/judge.py
@@ -1,0 +1,49 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from conformance.expectations import Resolution
+from conformance.model import Status, Verdict
+
+MAX_ATTEMPTS = 3
+
+_SATISFIES = {
+    "expect_pass": (Status.PASS, Status.WARN),
+    "expect_failure": (Status.FAIL, Status.BROK),
+    "expect_conf": (Status.CONF,),
+}
+
+
+def decide(test_id: str, status: Status, resolution: Resolution) -> Tuple[Verdict, str]:
+    if status is Status.ERROR:
+        return Verdict.ERROR, "%s: HARNESS ERROR, the case did not run" % test_id
+    if status is Status.SKIP:
+        return Verdict.FILTERED, ""
+    if status in (Status.TIMEOUT, Status.CRASH, Status.INCONSISTENT):
+        return (
+            Verdict.UNEXPECTED_FAILURE,
+            "%s: %s, which no expectation can satisfy" % (test_id, status.value),
+        )
+    if status in _SATISFIES[resolution.type]:
+        return Verdict.AS_EXPECTED, ""
+    if status is Status.PASS:
+        return (
+            Verdict.UNEXPECTED_PASS,
+            "%s: passed but %s expects %s (matcher %r); narrow or delete that "
+            "matcher in this same change" % (
+                test_id, resolution.source, resolution.type, resolution.matcher),
+        )
+    return (
+        Verdict.UNEXPECTED_FAILURE,
+        "%s: %s but %s expects %s (matcher %r); fix the regression or record "
+        "the divergence in the backend leaf" % (
+            test_id, status.value, resolution.source, resolution.type,
+            resolution.matcher),
+    )
+
+
+def may_retry(resolution: Resolution, attempts: int) -> bool:
+    return resolution.quarantined and attempts < MAX_ATTEMPTS

--- a/tests/conformance/model.py
+++ b/tests/conformance/model.py
@@ -1,0 +1,136 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class Status(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    SKIP = "SKIP"
+    CONF = "CONF"
+    WARN = "WARN"
+    BROK = "BROK"
+    TIMEOUT = "TIMEOUT"
+    CRASH = "CRASH"
+    INCONSISTENT = "INCONSISTENT"
+    ERROR = "ERROR"
+
+
+class Verdict(str, Enum):
+    AS_EXPECTED = "as_expected"
+    UNEXPECTED_FAILURE = "unexpected_failure"
+    UNEXPECTED_PASS = "unexpected_pass"
+    FLAKED = "flaked"
+    FILTERED = "filtered"
+    ERROR = "error"
+
+    @property
+    def is_red(self) -> bool:
+        return self in (
+            Verdict.UNEXPECTED_FAILURE,
+            Verdict.UNEXPECTED_PASS,
+            Verdict.ERROR,
+        )
+
+
+EXECUTIONS = ("normal", "timeout", "signal", "transport")
+
+
+@dataclass
+class Invocation:
+    execution: str
+    wall_us: int
+    exit_code: Optional[int] = None
+    signal: Optional[int] = None
+    stdout: str = ""
+    stderr: str = ""
+
+    def __post_init__(self) -> None:
+        if self.execution not in EXECUTIONS:
+            raise ValueError("unknown execution %r" % (self.execution,))
+        if self.wall_us < 0:
+            raise ValueError("negative wall_us")
+        carries = {"normal": "exit_code", "signal": "signal"}.get(self.execution)
+        for name in ("exit_code", "signal"):
+            if (getattr(self, name) is None) != (name != carries):
+                raise ValueError("%s execution %s carry %s" % (
+                    self.execution, "must" if name == carries else "cannot", name))
+
+    pid: Optional[int] = dataclasses.field(default=None, compare=False)
+
+    def to_dict(self) -> Dict[str, Any]:
+        doc = dataclasses.asdict(self)
+        del doc["pid"]
+        return doc
+
+    @classmethod
+    def from_dict(cls, doc: Dict[str, Any]) -> "Invocation":
+        return cls(**doc)
+
+
+@dataclass
+class Attempt:
+    status: Status
+    invocation: Invocation
+    detail: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "invocation": self.invocation.to_dict(),
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, doc: Dict[str, Any]) -> "Attempt":
+        return cls(
+            status=Status(doc["status"]),
+            invocation=Invocation.from_dict(doc["invocation"]),
+            detail=doc.get("detail", ""),
+        )
+
+
+@dataclass
+class CaseResult:
+    id: str
+    suite: str
+    backend: str
+    status: Status
+    verdict: Verdict
+    expectation: Dict[str, Any] = field(default_factory=dict)
+    attempts: List[Attempt] = field(default_factory=list)
+    detail: str = ""
+    artifacts: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "suite": self.suite,
+            "backend": self.backend,
+            "status": self.status.value,
+            "verdict": self.verdict.value,
+            "expectation": dict(self.expectation),
+            "attempts": [a.to_dict() for a in self.attempts],
+            "detail": self.detail,
+            "artifacts": dict(self.artifacts),
+        }
+
+    @classmethod
+    def from_dict(cls, doc: Dict[str, Any]) -> "CaseResult":
+        return cls(
+            id=doc["id"],
+            suite=doc["suite"],
+            backend=doc["backend"],
+            status=Status(doc["status"]),
+            verdict=Verdict(doc["verdict"]),
+            expectation=dict(doc.get("expectation", {})),
+            attempts=[Attempt.from_dict(a) for a in doc.get("attempts", [])],
+            detail=doc.get("detail", ""),
+            artifacts=dict(doc.get("artifacts", {})),
+        )

--- a/tests/conformance/payload.py
+++ b/tests/conformance/payload.py
@@ -1,0 +1,175 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+MANIFEST = "manifest.json"
+_HEX = {"hex40": re.compile(r"^[0-9a-f]{40}$"), "hex64": re.compile(r"^[0-9a-f]{64}$")}
+
+
+class PayloadError(Exception):
+    def __init__(self, kind: str, message: str):
+        super().__init__(message)
+        self.kind = kind
+
+
+class PinError(ValueError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fingerprint(pin_section: Dict[str, Any], files: Iterable[Path], flavor: str = "") -> str:
+    h = hashlib.sha256()
+    h.update(json.dumps(pin_section, sort_keys=True).encode())
+    for path in files:
+        h.update(path.name.encode() + b"\0")
+        h.update(sha256_file(path).encode() + b"\0")
+    h.update(flavor.encode())
+    return h.hexdigest()
+
+
+def _walk(root: Path) -> Dict[str, Dict[str, Any]]:
+    out: Dict[str, Dict[str, Any]] = {}
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames.sort()
+        for name in list(dirnames):
+            path = Path(dirpath) / name
+            if path.is_symlink():
+                out[path.relative_to(root).as_posix()] = {"link": os.readlink(path)}
+                dirnames.remove(name)
+        for name in sorted(filenames):
+            path = Path(dirpath) / name
+            rel = path.relative_to(root).as_posix()
+            if rel == MANIFEST:
+                continue
+            if path.is_symlink():
+                out[rel] = {"link": os.readlink(path)}
+            else:
+                st = path.stat()
+                out[rel] = {"sha256": sha256_file(path), "size": st.st_size,
+                            "mode": "%o" % (st.st_mode & 0o777)}
+    return out
+
+
+def write_manifest(root: Path, fp: str, extra: Optional[Dict[str, Any]] = None,
+                   volatile: Iterable[str] = ()) -> Dict[str, Any]:
+    """Permit new files below volatile prefixes during verification."""
+    doc = {"schema_version": 1, "fingerprint": fp, "files": _walk(root), "extra": extra or {},
+           "volatile": sorted(volatile)}
+    atomic_write(root / MANIFEST, json.dumps(doc, indent=1, sort_keys=True) + "\n")
+    return doc
+
+
+def read_manifest(root: Path) -> Dict[str, Any]:
+    path = root / MANIFEST
+    if not path.is_file():
+        raise PayloadError("missing", "no %s under %s" % (MANIFEST, root))
+    try:
+        doc = json.loads(path.read_text())
+    except ValueError as e:
+        raise PayloadError("corrupt", "%s: %s" % (path, e)) from None
+    volatile = doc.get("volatile", []) if isinstance(doc, dict) else []
+    if (not isinstance(doc, dict) or doc.get("schema_version") != 1
+            or not isinstance(doc.get("files"), dict)
+            or not isinstance(volatile, list) or not all(isinstance(v, str) for v in volatile)):
+        raise PayloadError("corrupt", "%s: unexpected shape" % path)
+    return doc
+
+
+def verify(root: Path, expected_fp: Optional[str] = None) -> Dict[str, Any]:
+    doc = read_manifest(root)
+    if expected_fp is not None and doc.get("fingerprint") != expected_fp:
+        raise PayloadError(
+            "stale",
+            "%s was built for fingerprint %s, the tree wants %s"
+            % (root, str(doc.get("fingerprint"))[:12], expected_fp[:12]),
+        )
+    actual = _walk(root)
+    want = doc["files"]
+    # A trailing slash, so a volatile "tmp" does not also absorb "tmplog/".
+    volatile = tuple(v.rstrip("/") + "/" for v in doc.get("volatile", []))
+    missing = sorted(set(want) - set(actual))
+    extra = sorted(k for k in set(actual) - set(want) if not k.startswith(volatile))
+    changed = sorted(k for k in set(want) & set(actual) if want[k] != actual[k])
+    if missing or extra or changed:
+        parts = []
+        for label, items in (("missing", missing), ("extra", extra), ("changed", changed)):
+            if items:
+                parts.append("%s: %s" % (label, ", ".join(items[:5]) + (" ..." if len(items) > 5 else "")))
+        raise PayloadError("corrupt", "%s does not match its manifest (%s)" % (root, "; ".join(parts)))
+    return doc
+
+
+def status(root: Path, expected_fp: str) -> str:
+    try:
+        doc = read_manifest(root)
+    except PayloadError as e:
+        return e.kind
+    return "ok" if doc.get("fingerprint") == expected_fp else "stale"
+
+
+def absent_message(suite: str, root: Path, state: str, build_hint: str) -> str:
+    return ("conformance: %s payload %s (%s); run: %s, see docs/conformance.md"
+            % (suite, state, root, build_hint))
+
+
+def atomic_write(path: Path, text: str) -> None:
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".")
+    try:
+        os.fchmod(fd, 0o644)  # generated files should not retain mkstemp's 0600
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        os.unlink(tmp)
+        raise
+
+
+def check_pins(doc: Any, schema: Dict[str, Dict[str, str]]) -> Dict[str, Any]:
+    if not isinstance(doc, dict) or doc.get("schema_version") != 1:
+        raise PinError("pins: schema_version must be 1")
+    for section, fields in schema.items():
+        body = doc.get(section)
+        if not isinstance(body, dict):
+            raise PinError("pins: missing section %r" % section)
+        for name, kind in fields.items():
+            value = body.get(name)
+            where = "pins: %s.%s" % (section, name)
+            if kind == "int":
+                if not isinstance(value, int) or isinstance(value, bool):
+                    raise PinError("%s must be an integer" % where)
+            elif not isinstance(value, str) or not value:
+                raise PinError("%s must be a non-empty string" % where)
+            elif kind in _HEX and not _HEX[kind].match(value):
+                raise PinError("%s is not a %s digest" % (where, kind))
+            elif kind == "url" and not value.startswith("https://"):
+                raise PinError("%s must be an https URL" % where)
+    return doc
+
+
+def load_pins(path: Path, schema: Dict[str, Dict[str, str]]) -> Dict[str, Any]:
+    try:
+        doc = json.loads(path.read_text())
+    except (OSError, ValueError) as e:
+        raise PinError("%s: %s" % (path, e)) from None
+    return check_pins(doc, schema)
+
+
+def write_pins(path: Path, doc: Dict[str, Any], schema: Dict[str, Dict[str, str]]) -> None:
+    check_pins(doc, schema)
+    atomic_write(path, json.dumps(doc, indent=2, sort_keys=True) + "\n")

--- a/tests/conformance/providers/__init__.py
+++ b/tests/conformance/providers/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Dict
+
+from conformance.providers.base import Provider, ProviderError
+
+REGISTRY: Dict[str, str] = {
+    "fake": "conformance.providers.fake:FakeProvider",
+}
+
+
+def make(name: str, repo_root: Path) -> Provider:
+    if name not in REGISTRY:
+        raise ProviderError("unknown suite %r; registered: %s" % (name, ", ".join(sorted(REGISTRY))))
+    module, _, cls = REGISTRY[name].partition(":")
+    return getattr(importlib.import_module(module), cls)(repo_root)

--- a/tests/conformance/providers/base.py
+++ b/tests/conformance/providers/base.py
@@ -1,0 +1,91 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from conformance.backends.base import Backend
+from conformance.model import Attempt
+from conformance.selection import Entry, Selection
+
+
+class ProviderError(RuntimeError):
+    pass
+
+
+@dataclass
+class Case:
+    id: str
+    group: str
+    scope: str
+    timeout_s: int
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+class Provider:
+    name = ""
+    default_timeout_s = 120
+    pins_schema: Dict[str, Dict[str, str]] = {}
+
+    def __init__(self, repo_root: Path):
+        self.repo_root = repo_root
+        self.suite_dir = repo_root / "tests" / "conformance" / self.name
+
+    @property
+    def pins_path(self) -> Path:
+        return self.suite_dir / "pins.json"
+
+    @property
+    def selection(self) -> Selection:
+        raise NotImplementedError
+
+    @property
+    def expectations_dir(self) -> Path:
+        return self.suite_dir / "expectations"
+
+    def backend_options(self, backend: str) -> Dict[str, Any]:
+        return {}
+
+    def prerequisites(self, backend: str) -> Optional[str]:
+        """Return an exit-77 reason when the suite cannot run."""
+        return None
+
+    def enumerate(self, backend: Backend, entries: List[Entry]) -> List[Case]:
+        raise NotImplementedError
+
+    def batch_key(self, case: Case) -> str:
+        return case.group
+
+    def run_batch(self, backend: Backend, cases: List[Case], scratch: Path) -> Dict[str, Attempt]:
+        """Run cases that share a batch key; ids left out are rerun alone."""
+        raise NotImplementedError
+
+    def run_single(self, backend: Backend, case: Case, scratch: Path) -> Attempt:
+        raise NotImplementedError
+
+    def payload_root(self) -> Path:
+        return self.repo_root / "externals" / "payloads" / self.name
+
+    def fingerprint(self) -> str:
+        raise NotImplementedError
+
+    def build_payload(self, force: bool = False) -> None:
+        raise NotImplementedError
+
+    def build_hint(self) -> str:
+        return "make %s-payload" % self.name
+
+    def latest_pin(self, doc: Dict[str, Any], ref: Optional[str]) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def update_next_steps(self) -> List[str]:
+        return [self.build_hint()]
+
+    def audit(self) -> List[str]:
+        return []
+
+    def regen_selection(self, check: bool = False) -> List[str]:
+        return []

--- a/tests/conformance/providers/fake.py
+++ b/tests/conformance/providers/fake.py
@@ -1,0 +1,76 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from conformance import ids, jsonc, selection
+from conformance.backends.base import Backend
+from conformance.model import Attempt, Status
+from conformance.providers.base import Case, Provider
+
+_EXIT_STATUS = {0: Status.PASS, 1: Status.FAIL, 2: Status.BROK, 4: Status.WARN, 32: Status.CONF}
+
+
+def status_of(inv) -> Status:
+    if inv.execution == "timeout":
+        return Status.TIMEOUT
+    if inv.execution == "signal":
+        return Status.CRASH
+    if inv.execution == "transport":
+        return Status.ERROR
+    return _EXIT_STATUS.get(inv.exit_code, Status.FAIL)
+
+
+def detail_of(inv) -> str:
+    if inv.execution == "signal":
+        return "signal %d" % inv.signal
+    if inv.execution != "normal":
+        return inv.execution
+    return "exit %d" % inv.exit_code
+
+
+class FakeProvider(Provider):
+    name = "fake"
+    default_timeout_s = 5
+
+    def __init__(self, repo_root: Path):
+        super().__init__(repo_root)
+        self.suite_dir = repo_root / "tests" / "conformance"
+        self.data = jsonc.load(self.suite_dir / "data" / "fake.jsonc")
+        self._selection = selection.parse(self.data, "fake.jsonc")
+        self.runs: Dict[str, int] = {}
+
+    @property
+    def selection(self) -> selection.Selection:
+        return self._selection
+
+    def enumerate(self, backend: Backend, entries: List[selection.Entry]) -> List[Case]:
+        out = []
+        for entry in entries:
+            for name, script in self.data["cases"][entry.group].items():
+                cid = "fake:%s/%s" % (entry.group, name)
+                if entry.only and not any(ids.matches(o, name) for o in entry.only):
+                    continue
+                out.append(Case(cid, entry.group, entry.scope,
+                                entry.timeout_s or self.default_timeout_s, {"script": script}))
+        return out
+
+    def _run(self, backend: Backend, case: Case, scratch: Path) -> Attempt:
+        self.runs[case.id] = self.runs.get(case.id, 0) + 1
+        script = case.meta["script"]
+        if script == "flaky":
+            script = "exit 1" if self.runs[case.id] == 1 else "exit 0"
+        inv = backend.run(["sh", "-c", script], case.timeout_s, scratch)
+        return Attempt(status_of(inv), inv, detail_of(inv))
+
+    def run_batch(self, backend: Backend, cases: List[Case], scratch: Path) -> Dict[str, Attempt]:
+        return {c.id: self._run(backend, c, scratch / ids.slug(c.id))
+                for c in cases if c.meta["script"] != "unresolved"}
+
+    def run_single(self, backend: Backend, case: Case, scratch: Path) -> Attempt:
+        if case.meta["script"] == "unresolved":
+            case = Case(case.id, case.group, case.scope, case.timeout_s, {"script": "exit 0"})
+        return self._run(backend, case, scratch)

--- a/tests/conformance/report.py
+++ b/tests/conformance/report.py
@@ -1,0 +1,127 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+from conformance import payload
+from conformance.model import CaseResult, Verdict
+
+RESULTS = "results.json"
+_NOT_XML = re.compile("[^\t\n\r\x20-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]")
+
+
+class ReportError(ValueError):
+    pass
+
+
+def red_line(case: CaseResult) -> str:
+    return case.detail or "%s: %s" % (case.id, case.status.value)
+
+
+def gate(cases: Iterable[CaseResult]) -> str:
+    cases = list(cases)
+    return "red" if not cases or any(c.verdict.is_red for c in cases) else "green"
+
+
+def counts(cases: Iterable[CaseResult]) -> Dict[str, int]:
+    out = {v.value: 0 for v in Verdict}
+    for c in cases:
+        out[c.verdict.value] += 1
+    return out
+
+
+def write(results_dir: Path, meta: Dict[str, Any], cases: List[CaseResult]) -> Dict[str, Any]:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    doc = {"schema_version": 1, "run": dict(meta), "gate": gate(cases),
+           "counts": counts(cases), "cases": [c.to_dict() for c in cases]}
+    payload.atomic_write(results_dir / RESULTS, json.dumps(doc, indent=1, sort_keys=True) + "\n")
+    (results_dir / "junit.xml").write_bytes(junit(meta, cases))
+    (results_dir / "summary.txt").write_text("\n".join(summary_lines(meta, cases, results_dir)) + "\n")
+    return doc
+
+
+def load(results_dir: Path) -> Tuple[Dict[str, Any], List[CaseResult]]:
+    path = results_dir / RESULTS
+    if not path.is_file():
+        raise ReportError("no %s under %s" % (RESULTS, results_dir))
+    doc = json.loads(path.read_text())
+    if (not isinstance(doc, dict) or not isinstance(doc.get("cases"), list)
+            or not isinstance(doc.get("run"), dict)):
+        raise ReportError("%s: unexpected shape" % path)
+    if doc.get("schema_version") != 1:
+        raise ReportError("%s: unknown schema" % path)
+    cases = [CaseResult.from_dict(c) for c in doc["cases"]]
+    if doc.get("gate") != gate(cases) or doc.get("counts") != counts(cases):
+        raise ReportError("%s: stored gate or counts contradict the case records" % path)
+    return doc["run"], cases
+
+
+def _xml_text(text: str) -> str:
+    return _NOT_XML.sub("?", text)
+
+
+def junit(meta: Dict[str, Any], cases: List[CaseResult]) -> bytes:
+    suite = ET.Element("testsuite", name="%s-%s" % (meta.get("suite", ""), meta.get("backend", "")),
+                       tests=str(len(cases)),
+                       failures=str(sum(1 for c in cases if c.verdict.is_red)),
+                       skipped=str(sum(1 for c in cases if c.verdict is Verdict.FILTERED)))
+    for c in cases:
+        tc = ET.SubElement(suite, "testcase", name=c.id, classname=c.backend,
+                           time="%.3f" % (sum(a.invocation.wall_us for a in c.attempts) / 1e6))
+        if c.verdict.is_red:
+            ET.SubElement(tc, "failure", message=c.status.value).text = _xml_text(c.detail)
+        elif c.verdict is Verdict.FILTERED:
+            ET.SubElement(tc, "skipped", message=_xml_text(c.detail))
+    return ET.tostring(suite, encoding="utf-8", xml_declaration=True)
+
+
+def _duration(seconds: float) -> str:
+    seconds = int(seconds)
+    if seconds >= 3600:
+        return "%dh%02dm" % (seconds // 3600, seconds % 3600 // 60)
+    return "%dm%02ds" % (seconds // 60, seconds % 60)
+
+
+def summary_lines(meta: Dict[str, Any], cases: List[CaseResult], results_dir: Path) -> List[str]:
+    n = counts(cases)
+    head = "conformance %s/%s %s: %d cases in %s" % (
+        meta.get("suite", "?"), meta.get("backend", "?"), meta.get("scope", "?"),
+        len(cases), _duration(meta.get("elapsed_s", 0)))
+    lines = [head]
+    if meta.get("bootstrap"):
+        lines.append("  bootstrap: expectations not applied")
+    lines.append("  as_expected %d  flaked %d  filtered %d" % (
+        n["as_expected"], n["flaked"], n["filtered"]))
+    lines.append("  unexpected_failure %d  unexpected_pass %d  error %d" % (
+        n["unexpected_failure"], n["unexpected_pass"], n["error"]))
+    for c in cases:
+        if c.verdict.is_red:
+            lines.append("  RED " + red_line(c))
+    if not cases:
+        lines.append("  RED no cases ran")
+    lines.append("RESULT: %s   (results: %s)" % (gate(cases).upper(), results_dir))
+    return lines
+
+
+def markdown(root: Path) -> str:
+    rows = ["| lane | scope | gate | as_expected | flaked | filtered | red |", "|---|---|---|---|---|---|---|"]
+    found = False
+    for path in sorted(root.rglob(RESULTS)):
+        found = True
+        try:
+            meta, cases = load(path.parent)
+        except (ValueError, KeyError) as e:
+            rows.append("| %s | | error | | | | %s |" % (path.parent, e))
+            continue
+        n = counts(cases)
+        rows.append("| %s/%s | %s | %s | %d | %d | %d | %d |" % (
+            meta.get("suite"), meta.get("backend"), meta.get("scope"), gate(cases),
+            n["as_expected"], n["flaked"], n["filtered"],
+            n["unexpected_failure"] + n["unexpected_pass"] + n["error"]))
+    return "\n".join(rows) + "\n" if found else "no conformance results under %s\n" % root

--- a/tests/conformance/runner.py
+++ b/tests/conformance/runner.py
@@ -1,0 +1,105 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import concurrent.futures
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from conformance import ids, judge
+from conformance.backends.base import Backend
+from conformance.expectations import Expectations, Resolution
+from conformance.model import Attempt, CaseResult, Invocation, Status, Verdict
+from conformance.providers.base import Case, Provider
+
+Log = Callable[[str], None]
+
+
+def _relativize(inv: Invocation, root: Path) -> None:
+    for name in ("stdout", "stderr"):
+        value = getattr(inv, name)
+        if value:
+            try:
+                setattr(inv, name, str(Path(value).relative_to(root)))
+            except ValueError:
+                pass
+
+
+def _finish(case: Case, attempts: List[Attempt], resolution: Resolution,
+            bootstrap: bool, results_dir: Path, backend: str) -> CaseResult:
+    last = attempts[-1]
+    if bootstrap:
+        verdict = Verdict.ERROR if last.status is Status.ERROR else Verdict.AS_EXPECTED
+        message = last.detail if verdict is Verdict.ERROR else ""
+    else:
+        verdict, message = judge.decide(case.id, last.status, resolution)
+        if verdict is Verdict.ERROR and last.detail:
+            message = "%s: %s" % (message, last.detail)
+        if verdict is Verdict.AS_EXPECTED and len(attempts) > 1:
+            verdict = Verdict.FLAKED
+    for a in attempts:
+        _relativize(a.invocation, results_dir)
+    return CaseResult(
+        id=case.id, suite=ids.suite_of(case.id), backend=backend, status=last.status,
+        verdict=verdict, expectation=resolution.to_dict(), attempts=attempts, detail=message,
+    )
+
+
+def run_lane(provider: Provider, backend: Backend, cases: List[Case],
+             expectations: Expectations, results_dir: Path, jobs: int = 1,
+             retry: bool = True, bootstrap: bool = False,
+             log: Optional[Log] = None) -> List[CaseResult]:
+    log = log or (lambda _: None)
+    results: Dict[str, CaseResult] = {}
+    launch: List[Case] = []
+    resolutions: Dict[str, Resolution] = {}
+    for case in cases:
+        resolution = expectations.resolve(case.id)
+        resolutions[case.id] = resolution
+        if resolution.type == "skip" and not bootstrap:
+            results[case.id] = CaseResult(
+                id=case.id, suite=ids.suite_of(case.id), backend=backend.name,
+                status=Status.SKIP, verdict=Verdict.FILTERED, expectation=resolution.to_dict(),
+                detail="skip: " + resolution.reason)
+        else:
+            launch.append(case)
+
+    batches: Dict[str, List[Case]] = {}
+    for case in launch:
+        batches.setdefault(provider.batch_key(case), []).append(case)
+
+    def run_batch(key: str) -> List[CaseResult]:
+        members = batches[key]
+        scratch = results_dir / "cases" / ("batch-" + ids.slug(key))
+        first = provider.run_batch(backend, members, scratch)
+        out = []
+        for case in members:
+            case_dir = results_dir / "cases" / ids.slug(case.id)
+            if case.id in first:
+                attempts = [first[case.id]]
+            else:
+                log("%s: unresolved by the batch, rerunning alone" % case.id)
+                attempts = [provider.run_single(backend, case, case_dir / "attempt-1")]
+            resolution = resolutions[case.id]
+            while (retry and not bootstrap
+                   and judge.decide(case.id, attempts[-1].status, resolution)[0].is_red
+                   and attempts[-1].status is not Status.ERROR
+                   and judge.may_retry(resolution, len(attempts))):
+                n = len(attempts) + 1
+                log("%s: %s on attempt %d, quarantined, retrying" % (case.id, attempts[-1].status.value, n - 1))
+                attempts.append(provider.run_single(backend, case, case_dir / ("attempt-%d" % n)))
+            out.append(_finish(case, attempts, resolution, bootstrap, results_dir, backend.name))
+        return out
+
+    workers = min(jobs, backend.max_jobs or jobs)
+    keys = list(batches)
+    if workers > 1 and len(keys) > 1:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            batched = list(pool.map(run_batch, keys))
+    else:
+        batched = [run_batch(k) for k in keys]
+    for group in batched:
+        for r in group:
+            results[r.id] = r
+    return [results[c.id] for c in cases]

--- a/tests/conformance/seed.py
+++ b/tests/conformance/seed.py
@@ -1,0 +1,101 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from conformance import ids, jsonc, payload
+from conformance.expectations import SEEDED_PREFIX
+from conformance.model import CaseResult, Status, Verdict
+
+_ACTION_FOR = {
+    Status.FAIL: "expect_failure",
+    Status.BROK: "expect_failure",
+    Status.CONF: "expect_conf",
+    Status.TIMEOUT: "skip",
+    Status.CRASH: "skip",
+    Status.INCONSISTENT: "skip",
+}
+_ORDER = ("expect_pass", "expect_failure", "expect_conf", "skip")
+
+
+def default_reason(results_dir: Path, date: str) -> str:
+    return "%s%s on %s; untriaged" % (SEEDED_PREFIX, results_dir, date)
+
+
+def propose(cases: List[CaseResult], reason: str, bootstrap: bool,
+            whole_groups: bool = True) -> List[Dict[str, Any]]:
+    """Collapse complete groups when whole_groups is set."""
+    wanted: Dict[str, str] = {}
+    for c in cases:
+        if c.status is Status.ERROR:
+            raise ValueError("%s is a harness ERROR; seeding refuses it" % c.id)
+        if bootstrap:
+            # What an earlier leaf recorded is not evidence.
+            action = _ACTION_FOR.get(c.status)
+            if action:
+                wanted[c.id] = action
+        elif c.verdict is Verdict.UNEXPECTED_PASS:
+            wanted[c.id] = "expect_pass"
+        elif c.verdict is Verdict.UNEXPECTED_FAILURE:
+            wanted[c.id] = _ACTION_FOR.get(c.status, "expect_failure")
+    by_group: Dict[tuple, List[str]] = {}
+    for c in cases:
+        by_group.setdefault((ids.suite_of(c.id), ids.group_of(c.id)), []).append(c.id)
+    out: Dict[str, List[str]] = {}
+    for (suite, group), members in sorted(by_group.items()):
+        actions = {wanted.get(m) for m in members}
+        if whole_groups and len(actions) == 1 and None not in actions and len(members) > 1:
+            out.setdefault(actions.pop(), []).append("%s:%s/*" % (suite, group))
+            continue
+        for m in members:
+            if m in wanted:
+                out.setdefault(wanted[m], []).append(m)
+    return [{"type": kind, "reason": reason, "matchers": sorted(out[kind])}
+            for kind in _ORDER if kind in out]
+
+
+def format_actions(actions: List[Dict[str, Any]], header: str = "") -> str:
+    lines = [header.rstrip("\n")] if header else []
+    lines += ["{", '  "actions": [']
+    for a in actions:
+        if "include" in a:
+            lines.append('    { "include": %s },' % json.dumps(a["include"]))
+            continue
+        head = '    { "type": %s,' % json.dumps(a["type"])
+        for key in ("reason", "since", "tracking"):
+            if a.get(key):
+                lines.append(head)
+                head = '      "%s": %s,' % (key, json.dumps(a[key]))
+        lines.append(head)
+        matchers = a["matchers"]
+        if len(matchers) == 1:
+            lines.append('      "matchers": [%s] },' % json.dumps(matchers[0]))
+        else:
+            lines.append('      "matchers": [')
+            lines.extend("        %s," % json.dumps(m) for m in matchers)
+            lines.append("      ] },")
+    lines += ["  ],", "}", ""]
+    return "\n".join(lines)
+
+
+def append(leaf: Path, actions: List[Dict[str, Any]]) -> None:
+    """Append actions while preserving the leading comment block."""
+    text = leaf.read_text() if leaf.exists() else ""
+    header_lines = []
+    for line in text.splitlines():
+        if line.startswith("//") or not line.strip():
+            header_lines.append(line)
+        else:
+            break
+    if text.strip():
+        existing = jsonc.loads(text)["actions"]
+    else:
+        # Prefer the shared suite default when present.
+        base = leaf.parent / (leaf.stem.split("_", 1)[0] + ".jsonc")
+        existing = ([{"include": base.name}] if base.exists()
+                    else [{"type": "expect_pass", "matchers": ["*"]}])
+    payload.atomic_write(leaf, format_actions(existing + actions, "\n".join(header_lines)))

--- a/tests/conformance/selection.py
+++ b/tests/conformance/selection.py
@@ -1,0 +1,127 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from conformance import ids, jsonc
+
+SCOPES = ("pr", "full")
+
+
+class SelectionError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Entry:
+    group: str
+    scope: str
+    timeout_s: Optional[int] = None
+    only: Tuple[str, ...] = ()
+
+
+@dataclass
+class Selection:
+    enabled: List[Entry]
+    declined: List[Tuple[str, Tuple[str, ...]]]
+    extra: Dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+
+    def groups(self, scope: str) -> List[Entry]:
+        if scope not in SCOPES:
+            raise SelectionError("unknown scope %r" % (scope,))
+        return [e for e in self.enabled if scope == "full" or e.scope == "pr"]
+
+    def entry(self, group: str) -> Optional[Entry]:
+        return next((e for e in self.enabled if e.group == group), None)
+
+    def lint(self) -> List[str]:
+        problems = []
+        seen: Dict[str, str] = {}
+        for e in self.enabled:
+            if e.group in seen:
+                problems.append("%s: %s is enabled twice" % (self.source, e.group))
+            seen[e.group] = "enabled"
+        for reason, groups in self.declined:
+            for g in groups:
+                if seen.get(g) == "enabled":
+                    problems.append("%s: %s is both enabled and declined" % (self.source, g))
+                elif g in seen:
+                    problems.append("%s: %s is declined twice" % (self.source, g))
+                seen[g] = "declined"
+        return problems
+
+
+def _entry(doc: Any, where: str) -> Entry:
+    if not isinstance(doc, dict) or not isinstance(doc.get("group"), str):
+        raise SelectionError("%s: enabled entry needs a group" % where)
+    unknown = set(doc) - {"group", "scope", "timeout_s", "only"}
+    if unknown:
+        raise SelectionError("%s: unknown keys %s" % (where, sorted(unknown)))
+    scope = doc.get("scope")
+    if scope not in SCOPES:
+        raise SelectionError("%s: %s has scope %r, want pr or full" % (where, doc["group"], scope))
+    timeout = doc.get("timeout_s")
+    if timeout is not None and (isinstance(timeout, bool) or not isinstance(timeout, int)
+                                or timeout <= 0):
+        raise SelectionError("%s: timeout_s must be a positive integer" % where)
+    only = doc.get("only", [])
+    if not isinstance(only, list) or any(not isinstance(o, str) for o in only):
+        raise SelectionError("%s: only must be a list of case globs" % where)
+    return Entry(doc["group"], scope, timeout, tuple(only))
+
+
+def parse(doc: Any, source: str) -> Selection:
+    if not isinstance(doc, dict) or doc.get("schema_version") != 1:
+        raise SelectionError("%s: schema_version must be 1" % source)
+    enabled = doc.get("enabled")
+    if not isinstance(enabled, list):
+        raise SelectionError("%s: enabled must be a list" % source)
+    entries = [_entry(e, "%s:enabled[%d]" % (source, i)) for i, e in enumerate(enabled)]
+    declined = []
+    for i, d in enumerate(doc.get("declined", [])):
+        where = "%s:declined[%d]" % (source, i)
+        if (not isinstance(d, dict) or set(d) != {"reason", "groups"}
+                or not isinstance(d["reason"], str) or not d["reason"].strip()
+                or not isinstance(d["groups"], list) or not d["groups"]
+                or any(not isinstance(g, str) for g in d["groups"])):
+            raise SelectionError("%s: a declined entry is a reason and a group list" % where)
+        declined.append((d["reason"], tuple(d["groups"])))
+    extra = {k: v for k, v in doc.items() if k not in ("schema_version", "enabled", "declined")}
+    sel = Selection(entries, declined, extra, source)
+    problems = sel.lint()
+    if problems:
+        raise SelectionError("; ".join(problems))
+    return sel
+
+
+def load(path: Path) -> Selection:
+    return parse(jsonc.load(path), path.name)
+
+
+def resolve_ids(patterns: Iterable[str], universe: Iterable[str],
+                suite: str) -> Tuple[List[str], List[str]]:
+    """Report unmatched patterns with nearby canonical ids."""
+    known = list(universe)
+    chosen: List[str] = []
+    seen = set()
+    errors: List[str] = []
+    for pattern in patterns:
+        if ids.suite_of(pattern) != suite:
+            errors.append("%s: not a %s id (want %s:<group>[/<case>])" % (pattern, suite, suite))
+            continue
+        # A bare group id also selects its cases.
+        pats = [pattern] if "/" in pattern else [pattern, pattern + "/*"]
+        hits = ids.expand(pats, known)
+        if not hits:
+            near = difflib.get_close_matches(pattern, known, n=3, cutoff=0.6)
+            errors.append("%s: no such test%s" % (
+                pattern, ("; near: " + ", ".join(near)) if near else ""))
+        chosen.extend(h for h in hits if h not in seen)
+        seen.update(hits)
+    return chosen, errors

--- a/tests/conformance/selftest/__init__.py
+++ b/tests/conformance/selftest/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/conformance/selftest/test_backends.py
+++ b/tests/conformance/selftest/test_backends.py
@@ -1,0 +1,291 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import stat
+import tempfile
+import time
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from conformance.backends import BackendError, elfuse, proc, qemu, ssh
+
+
+def script(path, body):
+    path.write_text("#!/bin/sh\n" + body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+class ProcTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_normal(self):
+        inv = proc.run_local(["sh", "-c", "echo out; echo err >&2; exit 3"], 10, self.dir)
+        self.assertEqual((inv.execution, inv.exit_code, inv.signal), ("normal", 3, None))
+        self.assertEqual(Path(inv.stdout).read_text(), "out\n")
+        self.assertEqual(Path(inv.stderr).read_text(), "err\n")
+        self.assertGreater(inv.wall_us, 0)
+
+    def test_unspawnable(self):
+        inv = proc.run_local([str(self.dir / "absent")], 10, self.dir)
+        self.assertEqual(inv.execution, "transport")
+        self.assertIn("cannot spawn", Path(inv.stderr).read_text())
+
+    def test_signal(self):
+        inv = proc.run_local(["sh", "-c", "kill -SEGV $$"], 10, self.dir)
+        self.assertEqual((inv.execution, inv.exit_code, inv.signal), ("signal", None, 11))
+
+    def test_timeout_kills_the_group(self):
+        started = time.monotonic()
+        inv = proc.run_local(["sh", "-c", "sleep 30 & echo $! > pid; wait"], 1, self.dir)
+        self.assertEqual(inv.execution, "timeout")
+        self.assertLess(time.monotonic() - started, 5)
+        self.assertIsNone(inv.exit_code)
+        child = int((self.dir / "pid").read_text())
+        for _ in range(50):  # SIGKILL reaches the orphan asynchronously
+            try:
+                os.kill(child, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.1)
+        else:
+            self.fail("background child %d survived the group kill" % child)
+
+
+class SshTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.args = self.dir / "args"
+        self.stub = script(
+            self.dir / "ssh",
+            'printf "%%s\\n" "$@" >> "%s"\n' % self.args
+            + 'case "$*" in *"cat /tmp/conf.abc/result.xml") printf "<xml/>"; exit 0 ;; esac\n'
+            + 'case "$*" in *"rm -rf /tmp/conf"*) exit 0 ;; esac\n'
+            + 'case "$STUB" in\n'
+            '  ok) printf "hello\\n\\n__CONF_RC=3 __CONF_DIR=/tmp/conf.abc\\n"; exit 3 ;;\n'
+            '  sig) printf "__CONF_RC=139 __CONF_DIR=/tmp/x\\n"; exit 139 ;;\n'
+            "  lost) exit 255 ;;\n"
+            "esac\n",
+        )
+        self.session = ssh.SshSession(2222, Path("/k"), ssh=str(self.stub))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_stub(self, mode, **kw):
+        os.environ["STUB"] = mode
+        try:
+            return self.session.run(["true", "a b"], 5, self.dir / mode, **kw)
+        finally:
+            del os.environ["STUB"]
+
+    def test_script(self):
+        text = ssh.SshSession.remote_script(["cmd", "a b"], 7, {"X": "y z"}, None)
+        self.assertIn("mktemp -d /tmp/conf.XXXXXX", text)
+        self.assertNotIn("rm -rf", text)
+        self.assertIn("export LC_ALL=C;", text)
+        self.assertIn("trap 'cd / && rm -rf \"$d\"' EXIT", ssh.SshSession.remote_script(["x"], 1, {}, None, cleanup=True))
+        self.assertIn("/usr/bin/timeout -s KILL 7 cmd 'a b'", text)
+        self.assertIn("export X='y z';", text)
+        self.assertIn('export HOME="$PWD"', text)
+        self.assertIn(ssh.SENTINEL, text)
+        self.assertIn("cd /opt/ltp", ssh.SshSession.remote_script(["x"], 1, {}, "/opt/ltp"))
+
+    def test_ok(self):
+        inv = self.run_stub("ok", fetch=["result.xml"])
+        self.assertEqual((inv.execution, inv.exit_code), ("normal", 3))
+        self.assertEqual(Path(inv.stdout).read_text(), "hello\n")
+        args = self.args.read_text().splitlines()
+        self.assertIn("BatchMode=yes", args)
+        self.assertEqual(args[args.index("-p") + 1], "2222")
+        self.assertEqual(args[-2], "root@127.0.0.1")
+        self.assertEqual((self.dir / "ok" / "result.xml").read_text(), "<xml/>")
+        self.assertIn("rm -rf /tmp/conf.abc", self.args.read_text())
+
+    def test_signal(self):
+        inv = self.run_stub("sig")
+        self.assertEqual((inv.execution, inv.signal), ("signal", 11))
+
+    def test_a_sentinel_cut_mid_write_is_a_transport_loss(self):
+        self.assertIsNone(ssh.SshSession.parse_sentinel("x\n" + ssh.SENTINEL + "1"))
+        self.assertEqual(ssh.SshSession.parse_sentinel(ssh.SENTINEL + "12" + ssh.DIR_MARK + "/t"), (12, "/t"))
+
+    def test_a_garbled_sentinel_is_a_transport_loss(self):
+        # A partial sentinel is a transport loss, not a parser error.
+        for line in ("__CONF_RC=", "__CONF_RC=xx __CONF_DIR=/tmp/a", "__CONF_RC=-"):
+            self.assertIsNone(ssh.SshSession.parse_sentinel(line), line)
+        self.assertEqual(ssh.SshSession.parse_sentinel("__CONF_RC=3 __CONF_DIR=/tmp/a b"),
+                         (3, "/tmp/a b"))
+
+    def test_transport(self):
+        inv = self.run_stub("lost")
+        self.assertEqual(inv.execution, "transport")
+        self.assertIsNone(inv.exit_code)
+
+
+class ElfuseTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_argv_and_prerequisites(self):
+        b = elfuse.ElfuseBackend(self.dir, sysroot=self.dir / "root")
+        self.assertIn("absent; run: make", b.prerequisites())
+        script(self.dir / "elfuse", "exit 0\n")
+        (self.dir / "build").mkdir()
+        os.rename(self.dir / "elfuse", self.dir / "build" / "elfuse")
+        self.assertIn("sysroot", b.prerequisites())
+        (self.dir / "root").mkdir()
+        self.assertIsNone(b.prerequisites())
+        self.assertEqual(
+            b.argv(["/bin/true", "x"]),
+            [str(self.dir / "build" / "elfuse"), "--timeout", "0", "--sysroot",
+             str(self.dir / "root"), "/bin/true", "x"],
+        )
+
+    def test_run_scrubs_the_environment(self):
+        (self.dir / "build").mkdir()
+        script(self.dir / "build" / "elfuse", 'shift 2; echo "$TZ $HOME"; exec "$@"\n')
+        b = elfuse.ElfuseBackend(self.dir)
+        with unittest.mock.patch.dict(os.environ, {"LEAK": "1"}):
+            inv = b.run(["sh", "-c", 'echo "${LEAK:-clean}"'], 5, self.dir / "s")
+        self.assertEqual(inv.exit_code, 0)
+        self.assertEqual(Path(inv.stdout).read_text(), "UTC %s\nclean\n" % (self.dir / "s"))
+
+    def test_orphan_pids(self):
+        listing = ("  12   1 40 /repo/build/elfuse --fork-child 8\n"
+                   "  13 500 40 /repo/build/elfuse --fork-child 8\n"
+                   "  14   1 40 /repo/build/elfuse --timeout 0 /bin/true\n"
+                   "  15   1 40 /other/build/elfuse --fork-child 8\n"
+                   "  16   1 41 /repo/build/elfuse --fork-child 9\n")
+        self.assertEqual(elfuse.orphan_pids(listing, "/repo/build/elfuse", 40), [12])
+
+    def test_serialize_excludes_a_second_session(self):
+        a, b = elfuse.ElfuseBackend(self.dir), elfuse.ElfuseBackend(self.dir)
+        a.lock_file = b.lock_file = self.dir / "lock"
+        with a.serialize():
+            with self.assertRaises(BackendError):
+                with b.serialize():
+                    pass
+        with b.serialize():
+            pass
+
+
+class QemuTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_prerequisites_report_the_tree_before_the_host(self):
+        # Missing fixtures produce the same answer on every host.
+        b = qemu.QemuBackend(self.dir)
+        with unittest.mock.patch("shutil.which", return_value=None):
+            self.assertIn("QEMU fixtures missing", b.prerequisites())
+
+    def test_guest_path(self):
+        b = qemu.QemuBackend(self.dir)
+        (self.dir / "tests").mkdir()
+        self.assertEqual(b.guest_path(self.dir / "tests" / "x"), "/mnt/host/tests/x")
+        with self.assertRaises(BackendError):
+            b.guest_path(Path("/etc/passwd"))
+
+    def test_start_reads_the_state_file(self):
+        runner = script(
+            self.dir / "runner.sh",
+            '[ "$1" = start ] && printf "port=2200\\nkey=/k\\npidfile=/p\\n" > "$3"\n'
+            'echo "$QEMU_MEM $QEMU_BOOT_TIMEOUT" > "%s/mem"\n' % self.dir,
+        )
+        b = qemu.QemuBackend(self.dir, mem_mib=4096, runner=runner, state_dir=self.dir)
+        with unittest.mock.patch.dict(os.environ, {"QEMU_BOOT_TIMEOUT": "300", "QEMU_MEM": "1"}):
+            b.start()
+        self.assertEqual((b.session.port, b.session.key), (2200, Path("/k")))
+        self.assertEqual((self.dir / "mem").read_text().split(), ["4096", "300"])
+        b.stop()
+        self.assertIsNone(b.session)
+
+    def test_start_without_state_is_an_error(self):
+        runner = script(self.dir / "runner.sh", "exit 0\n")
+        b = qemu.QemuBackend(self.dir, runner=runner, state_dir=self.dir)
+        with self.assertRaises(BackendError):
+            b.start()
+
+    def test_start_reaps_the_vm_a_stale_state_file_names(self):
+        runner = script(
+            self.dir / "runner.sh",
+            'echo "$1" >> "%s/verbs"\n' % self.dir +
+            '[ "$1" = start ] && printf "port=2200\\nkey=/k\\n" > "$3"\nexit 0\n',
+        )
+        (self.dir / "qemu.state").write_text("port=2199\nkey=/k\npidfile=/p\n")
+        b = qemu.QemuBackend(self.dir, runner=runner, state_dir=self.dir)
+        b.start()
+        self.assertEqual((self.dir / "verbs").read_text().split(), ["stop", "start"])
+        self.assertEqual(b.session.port, 2200)
+
+    def test_start_after_a_bad_state_stops_the_vm(self):
+        for state in ("key=/k\n", "port=abc\nkey=/k\n"):
+            runner = script(
+                self.dir / "runner.sh",
+                'echo "$1" >> "%s/verbs"\n' % self.dir +
+                '[ "$1" = stop ] && rm -f "$3"\n'
+                '[ "$1" = start ] && printf "%s" > "$3"\nexit 0\n' % state,
+            )
+            b = qemu.QemuBackend(self.dir, runner=runner, state_dir=self.dir)
+            with self.assertRaises(BackendError):
+                b.start()
+            self.assertEqual((self.dir / "verbs").read_text().split(), ["start", "stop"])
+            (self.dir / "verbs").unlink()
+
+    def test_a_failed_stop_is_an_error(self):
+        runner = script(
+            self.dir / "runner.sh",
+            '[ "$1" = start ] && printf "port=2200\\nkey=/k\\n" > "$3"\n'
+            '[ "$1" = stop ] && { echo "no such vm"; exit 1; }\nexit 0\n',
+        )
+        b = qemu.QemuBackend(self.dir, runner=runner, state_dir=self.dir)
+        b.start()
+        with self.assertRaises(BackendError) as cm:
+            b.stop()
+        self.assertIn("no such vm", str(cm.exception))
+
+    def test_a_relative_scratch_still_names_an_absolute_home(self):
+        env = elfuse.base.guest_environment("rel/x")
+        self.assertTrue(Path(env["HOME"]).is_absolute())
+        self.assertEqual(env["HOME"], env["TMPDIR"])
+
+    def test_serialize_excludes_a_second_session_on_the_state_dir(self):
+        a = qemu.QemuBackend(self.dir, state_dir=self.dir)
+        b = qemu.QemuBackend(self.dir, state_dir=self.dir)
+        with a.serialize():
+            with self.assertRaises(BackendError):
+                with b.serialize():
+                    pass
+
+    def test_start_after_an_unreadable_state_stops_the_vm(self):
+        runner = script(
+            self.dir / "runner.sh",
+            'echo "$1" >> "%s/verbs"\n' % self.dir +
+            '[ "$1" = stop ] && rm -rf "$3"\n'
+            '[ "$1" = start ] && mkdir "$3"\nexit 0\n',
+        )
+        b = qemu.QemuBackend(self.dir, runner=runner, state_dir=self.dir)
+        with self.assertRaises(BackendError):
+            b.start()
+        self.assertEqual((self.dir / "verbs").read_text().split(), ["start", "stop"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_cli.py
+++ b/tests/conformance/selftest/test_cli.py
@@ -1,0 +1,203 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from conformance import cli as cli_mod
+from conformance.providers import fake as fake_mod
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "conformance"
+
+
+class CliTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.results = Path(self.tmp.name) / "results"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_cli(self, *args, env=None, cwd=None):
+        full = dict(os.environ)
+        full.pop("CONF_REQUIRE", None)
+        full.update(env or {})
+        done = subprocess.run([sys.executable, str(SCRIPT)] + list(args), cwd=cwd or REPO,
+                              env=full, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        return done.returncode, done.stdout
+
+    def test_pr_is_green(self):
+        rc, out = self.run_cli("--backend", "host", "--results", str(self.results), "fake", "pr")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("conformance fake/host pr: 6 cases in", out)
+        self.assertIn("  as_expected 4  flaked 1  filtered 1", out)
+        self.assertTrue(out.rstrip().splitlines()[-1].startswith("RESULT: GREEN"))
+        latest = self.results / "fake" / "host" / "latest"
+        self.assertTrue((latest / "results.json").is_file())
+        self.assertTrue((latest / "junit.xml").is_file())
+        doc = json.loads((latest / "results.json").read_text())
+        self.assertEqual(doc["gate"], "green")
+        flaky = next(c for c in doc["cases"] if c["id"] == "fake:basic/flaky")
+        self.assertEqual(len(flaky["attempts"]), 2)
+        self.assertGreater(flaky["attempts"][0]["invocation"]["wall_us"], 0)
+        self.assertTrue((latest / flaky["attempts"][0]["invocation"]["stdout"]).is_file())
+
+    def test_full_is_red_and_gate_agrees(self):
+        rc, out = self.run_cli("fake", "full", "--backend", "host", "--results", str(self.results))
+        self.assertEqual(rc, 1, out)
+        self.assertIn("  RED fake:slow/timeout: TIMEOUT, which no expectation can satisfy", out)
+        self.assertIn("narrow or delete that matcher", out)
+        latest = self.results / "fake" / "host" / "latest"
+        rc, out = self.run_cli("gate", str(latest))
+        self.assertEqual(rc, 1)
+        self.assertIn("RESULT: RED", out)
+        rc, out = self.run_cli("report", str(self.results))
+        self.assertEqual(rc, 0)
+        self.assertIn("| fake/host | full | red | 6 | 1 | 1 | 3 |", out)
+
+    def test_named_tests(self):
+        rc, out = self.run_cli("--backend", "host", "--results", str(self.results),
+                               "fake", "test", "fake:basic/pass", "fake:basic/fa*")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("2 cases", out)
+        rc, out = self.run_cli("--backend", "host", "fake", "test", "fake:basic/pas")
+        self.assertEqual(rc, 2)
+        self.assertIn("no such test; near: ", out)
+        rc, out = self.run_cli("--backend", "host", "fake", "test", "fake:basic/pass", "--dry-run")
+        self.assertEqual((rc, out.strip()), (0, "fake:basic/pass"))
+
+    def test_prerequisite_skip_and_require(self):
+        # The copied tree lacks QEMU fixtures on every host.
+        copy, run = self.repo_copy()
+        rc, out = run("--backend", "qemu", "fake", "pr")
+        self.assertEqual(rc, 77, out)
+        self.assertIn("QEMU fixtures missing", out)
+        rc, _ = run("--backend", "qemu", "--require", "fake", "pr")
+        self.assertEqual(rc, 2)
+        rc, _ = run("--backend", "qemu", "fake", "pr", env={"CONF_REQUIRE": "1"})
+        self.assertEqual(rc, 2)
+
+    def repo_copy(self):
+        copy = Path(self.tmp.name) / "repo"
+        shutil.copytree(REPO / "tests" / "conformance", copy / "tests" / "conformance",
+                        ignore=shutil.ignore_patterns("__pycache__"))
+        (copy / "scripts").mkdir()
+        shutil.copy(SCRIPT, copy / "scripts" / "conformance")
+        base = dict(os.environ)
+        base.pop("CONF_REQUIRE", None)
+
+        def run(*args, env=None):
+            done = subprocess.run([sys.executable, str(copy / "scripts" / "conformance")] + list(args),
+                                  cwd=copy, env=dict(base, **(env or {})), stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT, text=True)
+            return done.returncode, done.stdout
+
+        return copy, run
+
+    def test_malformed_selection_is_a_usage_error(self):
+        copy, run = self.repo_copy()
+        data = copy / "tests" / "conformance" / "data" / "fake.jsonc"
+
+        data.write_text("{ /* open")
+        rc, out = run("--backend", "host", "fake", "pr")
+        self.assertEqual(rc, 2, out)
+        self.assertIn("unterminated block comment", out)
+        self.assertNotIn("Traceback", out)
+
+    def test_seed_round_trip(self):
+        copy, run = self.repo_copy()
+        rc, out = run("--backend", "host", "--results", str(self.results), "fake", "full")
+        self.assertEqual(rc, 1, out)
+        latest = self.results / "fake" / "host" / "latest"
+        rc, out = run("fake", "seed", str(latest), "--reason", "measured on the host", "--write")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("2 action(s) appended", out)
+        leaf = copy / "tests" / "conformance" / "expectations" / "fake_host.jsonc"
+        self.assertTrue(leaf.read_text().startswith("// Host expectations used by selftests."))
+        rc, out = run("--backend", "host", "--results", str(self.results), "fake", "full")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("RESULT: GREEN", out)
+        rc, out = run("lint")
+        self.assertEqual(rc, 0, out)
+        rc, out = run("fake", "seed", str(self.results / "fake" / "host" / "latest"))
+        self.assertIn("nothing to seed", out)
+
+    def test_lint_and_selftest_entry(self):
+        rc, out = self.run_cli("lint")
+        self.assertEqual((rc, out.strip().splitlines()[-1]), (0, "conformance: lint clean"))
+        rc, out = self.run_cli("nosuch", "pr")
+        self.assertEqual(rc, 2)
+
+    def test_gate_reports_a_truncated_results_file(self):
+        (self.results).mkdir()
+        (self.results / "results.json").write_text('{"run": {}}')
+        rc, out = self.run_cli("gate", str(self.results))
+        self.assertEqual(rc, 2, out)
+        self.assertNotIn("Traceback", out)
+
+    def test_list_on_all_backends_never_boots_the_reference(self):
+        rc, out = self.run_cli("fake", "list", "--backend", "all")
+        self.assertEqual(rc, 77, out)
+        self.assertIn("build/elfuse", out)
+        self.assertNotIn("Traceback", out)
+
+    def test_list_reports_a_backend_error_during_enumerate(self):
+        def boom(self, backend, entries):
+            raise cli_mod.BackendError("guest gone")
+
+        lines = []
+        args = argparse.Namespace(suite="fake", backend="host", scope="pr", json=False, require=False)
+        with unittest.mock.patch.object(fake_mod.FakeProvider, "enumerate", boom):
+            rc = cli_mod.Cli(REPO, out=lines.append).list_ids(args)
+        self.assertEqual((rc, lines), (cli_mod.EXIT_RED, ["conformance: backend error: guest gone"]))
+
+    def test_update_needs_a_real_suite(self):
+        rc, out = self.run_cli("fake", "update", "--check")
+        self.assertEqual(rc, 2)
+        self.assertIn("pins.json", out)
+
+
+class UnsupportedVerbTest(unittest.TestCase):
+    def test_a_provider_message_is_printed_verbatim(self):
+        lines = []
+        with unittest.mock.patch.object(cli_mod.Cli, "provider",
+                                        lambda self, n: (_ for _ in ()).throw(NotImplementedError("fake runs nowhere"))):
+            rc = cli_mod.main(["fake", "pr"], Path("."), lines.append)
+        self.assertEqual(rc, 2)
+        self.assertEqual(lines, ["conformance: fake runs nowhere"])
+        with unittest.mock.patch.object(cli_mod.Cli, "provider",
+                                        lambda self, n: (_ for _ in ()).throw(NotImplementedError())):
+            lines = []
+            rc = cli_mod.main(["fake", "pr"], Path("."), lines.append)
+        self.assertEqual(lines, ["conformance: the fake suite does not support run"])
+
+
+class UpdateExitCodeTest(unittest.TestCase):
+    def fold(self, codes):
+        seq = list(codes)
+        args = argparse.Namespace(suite=None, ref=None, check=True)
+        names = {"a": "x:A", "b": "x:B"}
+        with unittest.mock.patch.dict(cli_mod.providers.REGISTRY, names, clear=True), \
+                unittest.mock.patch.object(cli_mod.Cli, "provider", lambda self, n: None), \
+                unittest.mock.patch.object(cli_mod.update_mod, "refresh",
+                                           lambda *a, **k: seq.pop(0)):
+            return cli_mod.Cli(REPO, out=lambda _: None).update(args)
+
+    def test_an_error_outranks_drift(self):
+        self.assertEqual(self.fold([0, 0]), 0)
+        self.assertEqual(self.fold([0, 3]), 3)
+        self.assertEqual(self.fold([3, 2]), 2)
+        self.assertEqual(self.fold([2, 3]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_elfcheck.py
+++ b/tests/conformance/selftest/test_elfcheck.py
@@ -1,0 +1,92 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from conformance import elfcheck
+
+
+def elf(machine=elfcheck.EM_AARCH64, interp=None, needed=(), load=True):
+    phdrs = []
+    body = bytearray()
+    strtab = b"\0" + b"\0".join(n.encode() for n in needed) + b"\0"
+    offsets, pos = [], 1
+    for n in needed:
+        offsets.append(pos)
+        pos += len(n) + 1
+    interp_bytes = (interp.encode() + b"\0") if interp else b""
+    dyn = b"".join(struct.pack("<qQ", elfcheck.DT_NEEDED, o) for o in offsets)
+    if needed:
+        dyn += struct.pack("<qQ", elfcheck.DT_STRTAB, 0x10000)
+    dyn += struct.pack("<qQ", elfcheck.DT_NULL, 0)
+    body += strtab
+    interp_off = len(body)
+    body += interp_bytes
+    dyn_off = len(body)
+    body += dyn
+    count = 1 + (1 if interp else 0) + (1 if needed else 0)
+    if not load:
+        count -= 1
+    data_off = 64 + 56 * count
+    if load:
+        phdrs.append((elfcheck.PT_LOAD, 5, data_off, 0x10000, 0x10000, len(body), len(body), 0x1000))
+    if interp:
+        phdrs.append((elfcheck.PT_INTERP, 4, data_off + interp_off, 0, 0, len(interp_bytes), len(interp_bytes), 1))
+    if needed:
+        phdrs.append((elfcheck.PT_DYNAMIC, 6, data_off + dyn_off, 0, 0, len(dyn), len(dyn), 8))
+    header = bytearray(64)
+    header[:4] = b"\x7fELF"
+    header[4], header[5] = 2, 1
+    struct.pack_into("<H", header, 18, machine)
+    struct.pack_into("<Q", header, 32, 64)
+    struct.pack_into("<HH", header, 54, 56, len(phdrs))
+    return bytes(header) + b"".join(struct.pack("<IIQQQQQQ", *p) for p in phdrs) + bytes(body)
+
+
+class ElfcheckTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "bin"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def check(self, image):
+        self.path.write_bytes(image)
+        elfcheck.validate_static_aarch64(self.path)
+
+    def test_static(self):
+        self.check(elf())
+
+    def test_rejections(self):
+        for image, fragment in (
+            (elf(machine=62), "not AArch64"),
+            (elf(interp="/lib/ld-linux-aarch64.so.1"), "PT_INTERP"),
+            (elf(needed=("libc.so.6",)), "needs libc.so.6"),
+            (b"not an elf", "not an ELF"),
+            (elf(load=False), "PT_LOAD"),
+        ):
+            self.path.write_bytes(image)
+            with self.assertRaises(elfcheck.ElfError) as cm:
+                elfcheck.validate_static_aarch64(self.path)
+            self.assertIn(fragment, str(cm.exception))
+
+    def test_truncated_dynamic_is_an_elf_error(self):
+        image = elf(needed=("libc.so.6",))
+        self.path.write_bytes(image[:-8])
+        with self.assertRaises(elfcheck.ElfError) as cm:
+            elfcheck.read_dynamic(self.path)
+        self.assertIn("dynamic segment out of range", str(cm.exception))
+
+    def test_read_dynamic(self):
+        self.path.write_bytes(elf(interp="/lib/ld.so", needed=("libc.so.6", "libm.so.6")))
+        info = elfcheck.read_dynamic(self.path)
+        self.assertEqual(info.interp, "/lib/ld.so")
+        self.assertEqual(info.needed, ["libc.so.6", "libm.so.6"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_expectations.py
+++ b/tests/conformance/selftest/test_expectations.py
@@ -1,0 +1,113 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from conformance import expectations as ex
+
+ROOT = Path(__file__).resolve().parents[1] / "expectations"
+
+
+def write(root, name, text):
+    (root / name).write_text(text)
+
+
+class ShippedFilesTest(unittest.TestCase):
+    def test_lint_clean(self):
+        self.assertEqual(ex.lint(ROOT), [])
+
+    def test_resolve_fake_host(self):
+        e = ex.load("fake", "host", ROOT)
+        self.assertEqual(e.resolve("fake:basic/pass").type, "expect_pass")
+        r = e.resolve("fake:basic/fail")
+        self.assertEqual((r.type, r.matcher), ("expect_failure", "fake:basic/fail"))
+        self.assertEqual(e.resolve("fake:basic/skipped").type, "skip")
+        flaky = e.resolve("fake:basic/flaky")
+        self.assertEqual(flaky.type, "expect_pass")
+        self.assertTrue(flaky.quarantined)
+        self.assertFalse(e.resolve("fake:basic/pass").quarantined)
+
+    def test_stale(self):
+        e = ex.load("fake", "host", ROOT)
+        stale = e.stale(["fake:basic/pass", "fake:basic/fail", "fake:basic/conf",
+                         "fake:basic/skipped", "fake:basic/flaky"])
+        self.assertEqual(len(stale), 1)
+        self.assertIn("recorded/passes", stale[0])
+
+
+class LintTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        write(self.root, "s.jsonc", '{"actions":[{"type":"expect_pass","matchers":["*"]}]}')
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def leaf(self, body):
+        write(self.root, "s_b.jsonc", '{"actions":[{"include":"s.jsonc"},%s]}' % body)
+        return ex.lint(self.root)
+
+    def test_clean(self):
+        self.assertEqual(self.leaf(""), [])
+
+    def test_first_action(self):
+        write(self.root, "s_b.jsonc",
+              '{"actions":[{"type":"skip","reason":"r","matchers":["s:a"]}]}')
+        self.assertIn("first effective action", ex.lint(self.root)[0])
+
+    def test_rules(self):
+        cases = {
+            "needs a reason": '{"type":"expect_failure","matchers":["s:a"]}',
+            "not sorted": '{"type":"skip","reason":"r","matchers":["s:b","s:a"]}',
+            "not in suite s": '{"type":"skip","reason":"r","matchers":["t:a"]}',
+            "unknown keys": '{"type":"skip","reason":"r","matchers":["s:a"],"bug":"#1"}',
+            "unknown action type": '{"type":"xfail","reason":"r","matchers":["s:a"]}',
+            "legal only in flaky": '{"type":"quarantine","reason":"r","matchers":["s:a"]}',
+            "tracking must be": '{"type":"skip","reason":"r","matchers":["s:a"],"tracking":"1"}',
+            "since must be": '{"type":"skip","reason":"r","matchers":["s:a"],"since":"x"}',
+            "em dash": '{"type":"skip","reason":"a \\u2014 b","matchers":["s:a"]}',
+            "legal only on expect_pass": '{"type":"skip","reason":"r","matchers":["*"]}',
+        }
+        for fragment, body in cases.items():
+            problems = self.leaf(body)
+            self.assertEqual(len(problems), 1, (fragment, problems))
+            self.assertIn(fragment, problems[0])
+
+    def test_seeded_reason_is_reported(self):
+        problems = self.leaf(
+            '{"type":"expect_failure","reason":"seeded from x on 2026-01-01; untriaged",'
+            '"matchers":["s:a"]}')
+        self.assertEqual(len(problems), 1)
+        self.assertIn("seeded reason", problems[0])
+
+    def test_include_cycle(self):
+        write(self.root, "s.jsonc", '{"actions":[{"include":"s_b.jsonc"}]}')
+        self.assertIn("include cycle", self.leaf("")[0])
+
+    def test_last_match_wins(self):
+        self.leaf('{"type":"skip","reason":"r","matchers":["s:g/*"]},'
+                  '{"type":"expect_failure","reason":"r","matchers":["s:g/one"]}')
+        e = ex.load("s", "b", self.root)
+        self.assertEqual(e.resolve("s:g/one").type, "expect_failure")
+        self.assertEqual(e.resolve("s:g/two").type, "skip")
+        self.assertEqual(e.resolve("s:h").type, "expect_pass")
+
+    def test_flaky_matchers_are_validated_not_indexed(self):
+        self.leaf("")
+        for value in ("[]", "null", "[7]"):
+            write(self.root, "flaky.jsonc",
+                  '{"actions":[{"type":"quarantine","reason":"r","matchers":%s}]}' % value)
+            self.assertIn("matchers must be", ex.lint(self.root)[0])
+
+    def test_flaky_only_quarantine(self):
+        self.leaf("")
+        write(self.root, "flaky.jsonc",
+              '{"actions":[{"type":"skip","reason":"r","matchers":["s:a"]}]}')
+        self.assertIn("holds only quarantine", ex.lint(self.root)[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_ids.py
+++ b/tests/conformance/selftest/test_ids.py
@@ -1,0 +1,37 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from conformance import ids
+
+
+class IdsTest(unittest.TestCase):
+    def test_parse(self):
+        self.assertEqual(ids.parse("ltp:chmod09"), ("ltp", "chmod09", None))
+        self.assertEqual(
+            ids.parse("gvisor:pipe_test/Pipes/PipeTest.Count/blocking"),
+            ("gvisor", "pipe_test", "Pipes/PipeTest.Count/blocking"),
+        )
+
+    def test_rejects(self):
+        for bad in ("chmod09", "ltp:", "LTP:x", "gvisor:a//b", "gvisor:a/b c", ""):
+            self.assertFalse(ids.is_valid(bad), bad)
+            with self.assertRaises(ids.IdError):
+                ids.parse(bad)
+
+    def test_glob(self):
+        universe = ["gvisor:pipe_test/A.b", "gvisor:pipe_test/A.c/p", "gvisor:open_test/A.b"]
+        self.assertEqual(ids.expand(["gvisor:pipe_test/*"], universe), universe[:2])
+        self.assertEqual(ids.expand(["*"], universe), universe)
+        self.assertEqual(ids.suite_of("gvisor:x/*"), "gvisor")
+        self.assertEqual(ids.suite_of("*"), "")
+
+    def test_slug_unique(self):
+        a, b = ids.slug("gvisor:a_test/X.y"), ids.slug("gvisor:a/test_X.y")
+        self.assertNotEqual(a, b)
+        self.assertRegex(a, r"^[A-Za-z0-9_.-]+$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_jsonc.py
+++ b/tests/conformance/selftest/test_jsonc.py
@@ -1,0 +1,49 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from conformance import jsonc
+
+
+class JsoncTest(unittest.TestCase):
+    def test_comments_and_commas(self):
+        text = '''// head
+        { "a": [1, 2, /* inner */ 3,], // tail
+          "b": "http://x/y // not a comment", "c": "a\\"/*b*/", }'''
+        self.assertEqual(
+            jsonc.loads(text),
+            {"a": [1, 2, 3], "b": "http://x/y // not a comment", "c": 'a"/*b*/'},
+        )
+
+    def test_a_comma_inside_a_string_survives(self):
+        self.assertEqual(jsonc.loads('{"a": "foo,] bar,}"}'), {"a": "foo,] bar,}"})
+        self.assertEqual(jsonc.loads('{"a": "x\\",] y"}'), {"a": 'x",] y'})
+        self.assertEqual(jsonc.loads('[[1,],]'), [[1]])
+
+    def test_line_numbers_survive(self):
+        text = '{\n"a": 1,\n/* two\nlines */\n"b": }'
+        with self.assertRaises(jsonc.JsoncError) as cm:
+            jsonc.loads(text)
+        self.assertIn("line 5", str(cm.exception))
+
+    def test_a_block_comment_separates_its_neighbours(self):
+        # Newlines alone would turn "1/*c*/2" into valid JSON containing 12.
+        for text in ("[1/*c*/2]", '{"a":1/*c*/2}'):
+            with self.assertRaises(jsonc.JsoncError):
+                jsonc.loads(text)
+        self.assertEqual(jsonc.loads('["a"/*c*/,"b"]'), ["a", "b"])
+
+    def test_json5_constants_are_refused(self):
+        # json.loads accepts values that other JSON tools reject.
+        for text in ('{"a": NaN}', '{"a": Infinity}', '{"a": -Infinity}'):
+            with self.assertRaises(jsonc.JsoncError):
+                jsonc.loads(text)
+
+    def test_unterminated(self):
+        with self.assertRaises(jsonc.JsoncError):
+            jsonc.loads("{ /* open")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_judge.py
+++ b/tests/conformance/selftest/test_judge.py
@@ -1,0 +1,61 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from conformance import judge
+from conformance.expectations import Resolution
+from conformance.model import Status, Verdict
+
+
+def res(kind, quarantined=False):
+    return Resolution(kind, "why", "s_b.jsonc:1", "s:a", quarantined)
+
+
+class JudgeTest(unittest.TestCase):
+    def test_table(self):
+        table = [
+            ("expect_pass", Status.PASS, Verdict.AS_EXPECTED),
+            ("expect_pass", Status.WARN, Verdict.AS_EXPECTED),
+            ("expect_pass", Status.FAIL, Verdict.UNEXPECTED_FAILURE),
+            ("expect_pass", Status.CONF, Verdict.UNEXPECTED_FAILURE),
+            ("expect_failure", Status.FAIL, Verdict.AS_EXPECTED),
+            ("expect_failure", Status.BROK, Verdict.AS_EXPECTED),
+            ("expect_failure", Status.PASS, Verdict.UNEXPECTED_PASS),
+            ("expect_conf", Status.CONF, Verdict.AS_EXPECTED),
+            ("expect_conf", Status.PASS, Verdict.UNEXPECTED_PASS),
+            ("expect_conf", Status.FAIL, Verdict.UNEXPECTED_FAILURE),
+            ("expect_pass", Status.SKIP, Verdict.FILTERED),
+            ("expect_failure", Status.SKIP, Verdict.FILTERED),
+            ("expect_pass", Status.ERROR, Verdict.ERROR),
+        ]
+        for kind, status, want in table:
+            verdict, _ = judge.decide("s:a", status, res(kind))
+            self.assertEqual(verdict, want, (kind, status))
+
+    def test_never_satisfiable(self):
+        for status in (Status.TIMEOUT, Status.CRASH, Status.INCONSISTENT):
+            for kind in ("expect_pass", "expect_failure", "expect_conf"):
+                verdict, msg = judge.decide("s:a", status, res(kind))
+                self.assertEqual(verdict, Verdict.UNEXPECTED_FAILURE)
+                self.assertIn("no expectation can satisfy", msg)
+
+    def test_messages_name_the_matcher(self):
+        _, msg = judge.decide("s:a", Status.PASS, res("expect_failure"))
+        self.assertEqual(
+            msg,
+            "s:a: passed but s_b.jsonc:1 expects expect_failure (matcher 's:a'); "
+            "narrow or delete that matcher in this same change",
+        )
+        _, msg = judge.decide("s:a", Status.FAIL, res("expect_pass"))
+        self.assertIn("record the divergence in the backend leaf", msg)
+
+    def test_retry_only_quarantined(self):
+        self.assertFalse(judge.may_retry(res("expect_pass"), 1))
+        self.assertTrue(judge.may_retry(res("expect_pass", True), 1))
+        self.assertTrue(judge.may_retry(res("expect_pass", True), 2))
+        self.assertFalse(judge.may_retry(res("expect_pass", True), 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_model.py
+++ b/tests/conformance/selftest/test_model.py
@@ -1,0 +1,53 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from conformance.model import Attempt, CaseResult, Invocation, Status, Verdict
+
+
+class ModelTest(unittest.TestCase):
+    def test_round_trip(self):
+        inv = Invocation(execution="signal", wall_us=1234, signal=11, stdout="cases/x/stdout")
+        att = Attempt(status=Status.CRASH, invocation=inv, detail="SIGSEGV")
+        case = CaseResult(
+            id="fake:basic/crash",
+            suite="fake",
+            backend="host",
+            status=Status.CRASH,
+            verdict=Verdict.UNEXPECTED_FAILURE,
+            expectation={"type": "expect_pass"},
+            attempts=[att],
+        )
+        again = CaseResult.from_dict(case.to_dict())
+        self.assertEqual(again, case)
+        self.assertEqual(again.attempts[0].invocation.exit_code, None)
+
+    def test_execution_is_checked(self):
+        with self.assertRaises(ValueError):
+            Invocation(execution="lost", wall_us=0)
+        with self.assertRaises(ValueError):
+            Invocation(execution="normal", wall_us=-1)
+
+    def test_execution_decides_which_field_is_set(self):
+        Invocation(execution="normal", wall_us=0, exit_code=0)
+        Invocation(execution="signal", wall_us=0, signal=11)
+        Invocation(execution="timeout", wall_us=0)
+        Invocation(execution="transport", wall_us=0)
+        for kwargs in ({"execution": "normal", "signal": 11},
+                       {"execution": "normal"},
+                       {"execution": "signal", "exit_code": 0},
+                       {"execution": "timeout", "exit_code": 3},
+                       {"execution": "transport", "signal": 9}):
+            with self.assertRaises(ValueError):
+                Invocation(wall_us=0, **kwargs)
+
+    def test_red_verdicts(self):
+        red = {v for v in Verdict if v.is_red}
+        self.assertEqual(
+            red, {Verdict.UNEXPECTED_FAILURE, Verdict.UNEXPECTED_PASS, Verdict.ERROR}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_payload.py
+++ b/tests/conformance/selftest/test_payload.py
@@ -1,0 +1,147 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from conformance import payload
+
+SCHEMA = {"tool": {"commit": "hex40", "archive_sha256": "hex64", "url": "url", "epoch": "int"}}
+GOOD = {"schema_version": 1, "tool": {"commit": "a" * 40, "archive_sha256": "b" * 64,
+                                      "url": "https://x/y.tar.xz", "epoch": 7}}
+
+
+class FingerprintTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.src = self.dir / "builder.py"
+        self.src.write_text("v1")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_inputs_move_it(self):
+        base = payload.fingerprint({"a": 1}, [self.src])
+        self.assertEqual(base, payload.fingerprint({"a": 1}, [self.src]))
+        self.assertNotEqual(base, payload.fingerprint({"a": 2}, [self.src]))
+        self.assertNotEqual(base, payload.fingerprint({"a": 1}, [self.src], "docker"))
+        os.utime(self.src, (1, 1))
+        self.assertEqual(base, payload.fingerprint({"a": 1}, [self.src]))
+        self.src.write_text("v2")
+        self.assertNotEqual(base, payload.fingerprint({"a": 1}, [self.src]))
+
+
+class ManifestTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name) / "p"
+        (self.root / "bin").mkdir(parents=True)
+        (self.root / "bin" / "a").write_bytes(b"A")
+        (self.root / "bin" / "a").chmod(0o755)
+        os.symlink("bin", self.root / "lib64")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_round_trip(self):
+        doc = payload.write_manifest(self.root, "f" * 64, {"binaries": 1})
+        self.assertEqual(doc["files"]["bin/a"]["mode"], "755")
+        self.assertEqual(doc["files"]["lib64"], {"link": "bin"})
+        self.assertNotIn(payload.MANIFEST, doc["files"])
+        self.assertEqual(payload.verify(self.root, "f" * 64)["extra"], {"binaries": 1})
+        self.assertEqual(payload.status(self.root, "f" * 64), "ok")
+        self.assertEqual(payload.status(self.root, "0" * 64), "stale")
+
+    def test_missing_stale_corrupt(self):
+        with self.assertRaises(payload.PayloadError) as cm:
+            payload.verify(self.root)
+        self.assertEqual(cm.exception.kind, "missing")
+        self.assertEqual(payload.status(self.root, "x"), "missing")
+        payload.write_manifest(self.root, "f" * 64)
+        with self.assertRaises(payload.PayloadError) as cm:
+            payload.verify(self.root, "0" * 64)
+        self.assertEqual(cm.exception.kind, "stale")
+        (self.root / "bin" / "a").write_bytes(b"B")
+        (self.root / "bin" / "extra").write_bytes(b"")
+        with self.assertRaises(payload.PayloadError) as cm:
+            payload.verify(self.root, "f" * 64)
+        self.assertEqual(cm.exception.kind, "corrupt")
+        self.assertIn("changed: bin/a", str(cm.exception))
+        self.assertIn("extra: bin/extra", str(cm.exception))
+
+    def test_a_wrong_manifest_shape_is_corrupt(self):
+        good = payload.write_manifest(self.root, "f" * 64)
+        (self.root / payload.MANIFEST).write_text(json.dumps({k: v for k, v in good.items() if k != "volatile"}))
+        payload.verify(self.root, "f" * 64)
+        for field, value in (("files", ["bin/a"]), ("volatile", "tmp"), ("volatile", [7])):
+            doc = dict(good, **{field: value})
+            (self.root / payload.MANIFEST).write_text(json.dumps(doc))
+            with self.assertRaises(payload.PayloadError, msg=field) as cm:
+                payload.verify(self.root, "f" * 64)
+            self.assertEqual(cm.exception.kind, "corrupt")
+            self.assertIn("unexpected shape", str(cm.exception))
+
+    def test_volatile_prefixes(self):
+        payload.write_manifest(self.root, "f" * 64, volatile=["bin/scratch/"])
+        (self.root / "bin" / "scratch").mkdir()
+        (self.root / "bin" / "scratch" / "left-by-a-guest").write_bytes(b"x")
+        payload.verify(self.root, "f" * 64)
+        (self.root / "bin" / "stray").write_bytes(b"x")
+        with self.assertRaises(payload.PayloadError):
+            payload.verify(self.root, "f" * 64)
+
+    def test_volatile_bounds_at_a_path_segment(self):
+        payload.write_manifest(self.root, "f" * 64, volatile=["bin/scratch"])
+        (self.root / "bin" / "scratch").mkdir()
+        (self.root / "bin" / "scratch" / "left-by-a-guest").write_bytes(b"x")
+        payload.verify(self.root, "f" * 64)
+        (self.root / "bin" / "scratchpad").mkdir()
+        (self.root / "bin" / "scratchpad" / "sneaky").write_bytes(b"x")
+        with self.assertRaises(payload.PayloadError) as cm:
+            payload.verify(self.root, "f" * 64)
+        self.assertIn("bin/scratchpad/sneaky", str(cm.exception))
+
+    def test_message(self):
+        msg = payload.absent_message("gvisor", self.root, "missing", "make gvisor-payload")
+        self.assertTrue(msg.startswith("conformance: gvisor payload missing ("))
+        self.assertIn("run: make gvisor-payload", msg)
+
+
+class PinsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "pins.json"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_shape(self):
+        payload.check_pins(GOOD, SCHEMA)
+        for field, value in (("commit", "A" * 40), ("archive_sha256", "b" * 63),
+                             ("url", "http://x"), ("epoch", "7"), ("epoch", True)):
+            doc = json.loads(json.dumps(GOOD))
+            doc["tool"][field] = value
+            with self.assertRaises(payload.PinError, msg=field):
+                payload.check_pins(doc, SCHEMA)
+        with self.assertRaises(payload.PinError):
+            payload.check_pins({"schema_version": 1}, SCHEMA)
+
+    def test_write_is_validated_and_atomic(self):
+        payload.write_pins(self.path, GOOD, SCHEMA)
+        before = self.path.read_text()
+        bad = json.loads(before)
+        bad["tool"]["commit"] = "nope"
+        with self.assertRaises(payload.PinError):
+            payload.write_pins(self.path, bad, SCHEMA)
+        self.assertEqual(self.path.read_text(), before)
+        self.assertEqual(payload.load_pins(self.path, SCHEMA), GOOD)
+        self.assertEqual([p.name for p in self.path.parent.iterdir()], ["pins.json"])
+        self.assertEqual(self.path.stat().st_mode & 0o777, 0o644)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_report.py
+++ b/tests/conformance/selftest/test_report.py
@@ -1,0 +1,87 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from conformance import report
+from conformance.model import Attempt, CaseResult, Invocation, Status, Verdict
+
+
+def case(cid, status, verdict, detail=""):
+    inv = Invocation("normal", 1500, exit_code=0 if status is Status.PASS else 1)
+    return CaseResult(cid, "fake", "host", status, verdict, {"type": "expect_pass"},
+                      [Attempt(status, inv)], detail)
+
+
+class ReportTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.meta = {"suite": "fake", "backend": "host", "scope": "pr", "elapsed_s": 61.4}
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_empty_is_red(self):
+        self.assertEqual(report.gate([]), "red")
+        lines = report.summary_lines(self.meta, [], self.dir)
+        self.assertIn("  RED no cases ran", lines)
+        self.assertTrue(lines[-1].startswith("RESULT: RED"))
+
+    def test_round_trip_and_summary(self):
+        cases = [case("fake:b/p", Status.PASS, Verdict.AS_EXPECTED),
+                 case("fake:b/f", Status.FAIL, Verdict.UNEXPECTED_FAILURE, "fake:b/f: FAIL \x01 raw")]
+        report.write(self.dir, self.meta, cases)
+        meta, again = report.load(self.dir)
+        self.assertEqual(again, cases)
+        self.assertEqual(meta["scope"], "pr")
+        text = (self.dir / "summary.txt").read_text()
+        self.assertIn("conformance fake/host pr: 2 cases in 1m01s", text)
+        self.assertIn("  unexpected_failure 1  unexpected_pass 0  error 0", text)
+        self.assertIn("  RED fake:b/f: FAIL", text)
+        self.assertIn("RESULT: RED", text)
+        xml = (self.dir / "junit.xml").read_text()
+        self.assertIn('failures="1"', xml)
+        self.assertIn("FAIL ? raw", xml)
+
+    def test_contradiction_is_rejected(self):
+        report.write(self.dir, self.meta, [case("fake:b/p", Status.PASS, Verdict.AS_EXPECTED)])
+        doc = json.loads((self.dir / report.RESULTS).read_text())
+        doc["gate"] = "red"
+        (self.dir / report.RESULTS).write_text(json.dumps(doc))
+        with self.assertRaises(report.ReportError):
+            report.load(self.dir)
+
+    def test_a_wrong_shape_is_rejected(self):
+        for text in ("[]", '{"schema_version": 1, "cases": null, "run": {}}',
+                     '{"schema_version": 1, "cases": [], "run": []}'):
+            (self.dir / report.RESULTS).write_text(text)
+            with self.assertRaises(report.ReportError, msg=text):
+                report.load(self.dir)
+
+    def test_markdown(self):
+        report.write(self.dir / "fake" / "host" / "1", self.meta,
+                     [case("fake:b/p", Status.PASS, Verdict.AS_EXPECTED)])
+        text = report.markdown(self.dir)
+        self.assertIn("| fake/host | pr | green | 1 | 0 | 0 | 0 |", text)
+        self.assertIn("no conformance results", report.markdown(self.dir / "none"))
+
+    def test_markdown_renders_a_bad_lane_as_a_row(self):
+        report.write(self.dir / "fake" / "host" / "1", self.meta,
+                     [case("fake:b/p", Status.PASS, Verdict.AS_EXPECTED)])
+        bad = self.dir / "fake" / "host" / "2"
+        bad.mkdir(parents=True)
+        (bad / report.RESULTS).write_text('{"schema_version": 1}')
+        worse = self.dir / "fake" / "host" / "3"
+        worse.mkdir(parents=True)
+        (worse / report.RESULTS).write_text("[]")
+        text = report.markdown(self.dir)
+        self.assertIn("| fake/host | pr | green | 1 | 0 | 0 | 0 |", text)
+        self.assertEqual(text.count("| error |"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_runner.py
+++ b/tests/conformance/selftest/test_runner.py
@@ -1,0 +1,84 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from conformance import expectations, providers, report, runner
+from conformance.backends.host import HostBackend
+from conformance.model import Status, Verdict
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+class RunnerTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.results = Path(self.tmp.name)
+        self.provider = providers.make("fake", REPO)
+        self.backend = HostBackend(REPO)
+        self.exps = expectations.load("fake", "host", self.provider.expectations_dir)
+        self.log = []
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def lane(self, scope, **kw):
+        cases = self.provider.enumerate(self.backend, self.provider.selection.groups(scope))
+        return {r.id: r for r in runner.run_lane(
+            self.provider, self.backend, cases, self.exps, self.results, log=self.log.append, **kw)}
+
+    def test_pr_scope_is_green(self):
+        by_id = self.lane("pr")
+        self.assertEqual(report.gate(by_id.values()), "green", [r.detail for r in by_id.values()])
+        self.assertEqual(by_id["fake:basic/pass"].verdict, Verdict.AS_EXPECTED)
+        self.assertEqual(by_id["fake:basic/fail"].verdict, Verdict.AS_EXPECTED)
+        self.assertEqual(by_id["fake:basic/conf"].status, Status.CONF)
+        self.assertEqual(by_id["fake:basic/warn"].verdict, Verdict.AS_EXPECTED)
+        skipped = by_id["fake:basic/skipped"]
+        self.assertEqual((skipped.status, skipped.verdict, skipped.attempts), (Status.SKIP, Verdict.FILTERED, []))
+        self.assertEqual(self.provider.runs.get("fake:basic/skipped"), None)
+
+    def test_flake_is_retried_and_measured(self):
+        r = self.lane("pr")["fake:basic/flaky"]
+        self.assertEqual(r.verdict, Verdict.FLAKED)
+        self.assertEqual([a.status for a in r.attempts], [Status.FAIL, Status.PASS])
+        self.assertTrue(all(a.invocation.wall_us > 0 for a in r.attempts))
+        self.assertEqual(r.attempts[0].invocation.exit_code, 1)
+        self.assertTrue((self.results / r.attempts[1].invocation.stdout).is_file())
+        self.assertFalse(Path(r.attempts[1].invocation.stdout).is_absolute())
+        self.assertTrue(any("quarantined, retrying" in line for line in self.log))
+
+    def test_no_retry_flag(self):
+        r = self.lane("pr", retry=False)["fake:basic/flaky"]
+        self.assertEqual(r.verdict, Verdict.UNEXPECTED_FAILURE)
+        self.assertEqual(len(r.attempts), 1)
+
+    def test_full_scope_reds(self):
+        by_id = self.lane("full", jobs=3)
+        self.assertEqual(report.gate(by_id.values()), "red")
+        self.assertEqual(by_id["fake:slow/timeout"].status, Status.TIMEOUT)
+        self.assertEqual(by_id["fake:slow/timeout"].verdict, Verdict.UNEXPECTED_FAILURE)
+        self.assertIsNone(by_id["fake:slow/timeout"].attempts[0].invocation.exit_code)
+        self.assertEqual(by_id["fake:slow/crash"].status, Status.CRASH)
+        self.assertEqual(by_id["fake:slow/crash"].attempts[0].invocation.signal, 11)
+        unresolved = by_id["fake:slow/unresolved"]
+        self.assertEqual(unresolved.verdict, Verdict.AS_EXPECTED)
+        self.assertTrue(any("unresolved by the batch" in line for line in self.log))
+        recorded = by_id["fake:recorded/passes"]
+        self.assertEqual(recorded.verdict, Verdict.UNEXPECTED_PASS)
+        self.assertIn("narrow or delete that matcher", recorded.detail)
+        self.assertIn("fake:narrow/keep", by_id)
+        self.assertNotIn("fake:narrow/drop", by_id)
+
+    def test_bootstrap_records_without_judging(self):
+        by_id = self.lane("full", bootstrap=True)
+        self.assertEqual(report.gate(by_id.values()), "green")
+        self.assertEqual(by_id["fake:slow/crash"].verdict, Verdict.AS_EXPECTED)
+        self.assertEqual(by_id["fake:basic/skipped"].status, Status.PASS)
+        self.assertEqual(len(by_id["fake:basic/flaky"].attempts), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_seed.py
+++ b/tests/conformance/selftest/test_seed.py
@@ -1,0 +1,84 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from conformance import expectations, jsonc, seed
+from conformance.model import Attempt, CaseResult, Invocation, Status, Verdict
+
+
+def case(cid, status, verdict=Verdict.AS_EXPECTED, expectation="expect_pass"):
+    inv = Invocation("normal", 1, exit_code=0)
+    return CaseResult(cid, "s", "b", status, verdict, {"type": expectation}, [Attempt(status, inv)])
+
+
+class SeedTest(unittest.TestCase):
+    def test_bootstrap_collapses_whole_groups(self):
+        cases = [case("s:a/1", Status.FAIL), case("s:a/2", Status.BROK),
+                 case("s:b/1", Status.FAIL), case("s:b/2", Status.PASS),
+                 case("s:c/1", Status.CONF), case("s:d/1", Status.TIMEOUT), case("s:d/2", Status.CRASH),
+                 case("s:e/1", Status.PASS), case("s:e/2", Status.SKIP)]
+        actions = seed.propose(cases, "r", bootstrap=True)
+        self.assertEqual(actions, [
+            {"type": "expect_failure", "reason": "r", "matchers": ["s:a/*", "s:b/1"]},
+            {"type": "expect_conf", "reason": "r", "matchers": ["s:c/1"]},
+            {"type": "skip", "reason": "r", "matchers": ["s:d/*"]},
+        ])
+
+    def test_a_partial_group_never_collapses(self):
+        cases = [case("s:a/1", Status.FAIL, Verdict.UNEXPECTED_FAILURE),
+                 case("s:a/2", Status.FAIL, Verdict.UNEXPECTED_FAILURE)]
+        self.assertEqual(seed.propose(cases, "r", False, whole_groups=False)[0]["matchers"],
+                         ["s:a/1", "s:a/2"])
+
+    def test_bootstrap_ignores_what_an_earlier_leaf_recorded(self):
+        cases = [case("s:a/1", Status.FAIL, expectation="expect_failure"), case("s:a/2", Status.FAIL)]
+        self.assertEqual(seed.propose(cases, "r", True),
+                         [{"type": "expect_failure", "reason": "r", "matchers": ["s:a/*"]}])
+
+    def test_gated_seeds_only_reds(self):
+        cases = [case("s:a/1", Status.PASS, Verdict.UNEXPECTED_PASS, "expect_failure"),
+                 case("s:a/2", Status.FAIL, Verdict.AS_EXPECTED, "expect_failure"),
+                 case("s:b/1", Status.FAIL, Verdict.UNEXPECTED_FAILURE)]
+        self.assertEqual(seed.propose(cases, "r", False), [
+            {"type": "expect_pass", "reason": "r", "matchers": ["s:a/1"]},
+            {"type": "expect_failure", "reason": "r", "matchers": ["s:b/1"]},
+        ])
+
+    def test_error_refused(self):
+        with self.assertRaises(ValueError):
+            seed.propose([case("s:a/1", Status.ERROR, Verdict.ERROR)], "r", True)
+
+    def test_append_keeps_header_and_loads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "s.jsonc").write_text('{"actions":[{"type":"expect_pass","matchers":["*"]}]}')
+            leaf = root / "s_b.jsonc"
+            leaf.write_text('// head\n// two\n{\n  "actions": [\n    { "include": "s.jsonc" }, // inline\n  ],\n}\n')
+            seed.append(leaf, [{"type": "skip", "reason": "r", "since": "2026-08-25", "matchers": ["s:a/1", "s:a/2"]}])
+            text = leaf.read_text()
+            self.assertTrue(text.startswith("// head\n// two\n{"))
+            self.assertNotIn("inline", text)
+            self.assertEqual(jsonc.loads(text)["actions"][0], {"include": "s.jsonc"})
+            e = expectations.load("s", "b", root)
+            self.assertEqual(e.resolve("s:a/2").type, "skip")
+            self.assertEqual(expectations.lint(root), [])
+
+    def test_append_creates_a_loadable_leaf(self):
+        action = {"type": "skip", "reason": "r", "matchers": ["s:a/1"]}
+        for base in (True, False):
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                if base:
+                    (root / "s.jsonc").write_text('{"actions":[{"type":"expect_pass","matchers":["*"]}]}')
+                seed.append(root / "s_b.jsonc", [action])
+                first = jsonc.loads((root / "s_b.jsonc").read_text())["actions"][0]
+                self.assertEqual(first, {"include": "s.jsonc"} if base
+                                 else {"type": "expect_pass", "matchers": ["*"]})
+                self.assertEqual(expectations.load("s", "b", root).resolve("s:a/1").type, "skip")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_selection.py
+++ b/tests/conformance/selftest/test_selection.py
@@ -1,0 +1,60 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from pathlib import Path
+
+from conformance import selection
+
+DATA = Path(__file__).resolve().parents[1] / "data" / "fake.jsonc"
+
+
+class SelectionTest(unittest.TestCase):
+    def test_shipped_file(self):
+        sel = selection.load(DATA)
+        self.assertEqual([e.group for e in sel.groups("pr")], ["basic"])
+        self.assertEqual([e.group for e in sel.groups("full")], ["basic", "slow", "narrow", "recorded"])
+        self.assertEqual(sel.entry("slow").timeout_s, 1)
+        self.assertEqual(sel.entry("narrow").only, ("keep*",))
+        self.assertEqual(sel.declined, [("needs a kernel facility the host does not have", ("kernel",))])
+
+    def test_full_is_a_superset(self):
+        sel = selection.load(DATA)
+        pr = {e.group for e in sel.groups("pr")}
+        self.assertTrue(pr <= {e.group for e in sel.groups("full")})
+        with self.assertRaises(selection.SelectionError):
+            sel.groups("nightly")
+
+    def test_rejections(self):
+        base = {"schema_version": 1, "enabled": [{"group": "a", "scope": "pr"}]}
+        cases = [
+            ({**base, "enabled": [{"group": "a", "scope": "pr"}, {"group": "a", "scope": "full"}]},
+             "enabled twice"),
+            ({**base, "declined": [{"reason": "r", "groups": ["a"]}]}, "both enabled and declined"),
+            ({**base, "enabled": [{"group": "a", "scope": "nightly"}]}, "want pr or full"),
+            ({**base, "enabled": [{"group": "a", "scope": "pr", "tier": 1}]}, "unknown keys"),
+            ({**base, "enabled": [{"group": "a", "scope": "pr", "timeout_s": 0}]}, "positive"),
+            # isinstance(True, int) holds.
+            ({**base, "enabled": [{"group": "a", "scope": "pr", "timeout_s": True}]}, "positive"),
+            ({**base, "declined": [{"reason": "", "groups": ["b"]}]}, "reason and a group list"),
+            ({"schema_version": 2, "enabled": []}, "schema_version"),
+        ]
+        for doc, fragment in cases:
+            with self.assertRaises(selection.SelectionError) as cm:
+                selection.parse(doc, "t.jsonc")
+            self.assertIn(fragment, str(cm.exception))
+
+    def test_resolve_ids(self):
+        universe = ["fake:basic/pass", "fake:basic/fail", "fake:slow/crash"]
+        chosen, errors = selection.resolve_ids(
+            ["fake:basic/*", "fake:basic/pass", "fake:basic/pas", "ltp:x"], universe, "fake")
+        self.assertEqual(chosen, ["fake:basic/pass", "fake:basic/fail"])
+        self.assertEqual(len(errors), 2)
+        self.assertIn("near: fake:basic/pass", errors[0])
+        self.assertIn("not a fake id", errors[1])
+        chosen, errors = selection.resolve_ids(["fake:basic"], universe, "fake")
+        self.assertEqual((chosen, errors), (["fake:basic/pass", "fake:basic/fail"], []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/selftest/test_update.py
+++ b/tests/conformance/selftest/test_update.py
@@ -1,0 +1,101 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from conformance import payload, update
+
+SCHEMA = {"tool": {"commit": "hex40"}}
+
+
+class Stub:
+    def __init__(self, path, commit, fail=False, error=None):
+        self.pins_path, self.pins_schema = path, SCHEMA
+        self.commit, self.fail, self.refs = commit, fail, []
+        self.error = error
+
+    def latest_pin(self, doc, ref):
+        self.refs.append(ref)
+        if self.error is not None:
+            raise self.error
+        if self.fail:
+            raise update.UpdateError("api unreachable")
+        doc["tool"]["commit"] = self.commit
+        return doc
+
+    def update_next_steps(self):
+        return ["make tool-payload"]
+
+
+class UpdateTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "pins.json"
+        payload.write_pins(self.path, {"schema_version": 1, "tool": {"commit": "a" * 40}}, SCHEMA)
+        self.before = self.path.read_text()
+        self.lines = []
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_current_is_untouched(self):
+        rc = update.refresh(Stub(self.path, "a" * 40), out=self.lines.append)
+        self.assertEqual(rc, update.EXIT_CURRENT)
+        self.assertEqual(self.path.read_text(), self.before)
+        self.assertIn("pins are current", self.lines[-1])
+
+    def test_check_reports_drift_without_writing(self):
+        stub = Stub(self.path, "b" * 40)
+        rc = update.refresh(stub, ref="v2", check=True, out=self.lines.append)
+        self.assertEqual(rc, update.EXIT_DRIFT)
+        self.assertEqual(self.path.read_text(), self.before)
+        self.assertEqual(stub.refs, ["v2"])
+        self.assertIn("tool.commit: %r -> %r" % ("a" * 40, "b" * 40), self.lines[0])
+
+    def test_write(self):
+        rc = update.refresh(Stub(self.path, "b" * 40), out=self.lines.append)
+        self.assertEqual(rc, update.EXIT_CURRENT)
+        self.assertEqual(json.loads(self.path.read_text())["tool"]["commit"], "b" * 40)
+        self.assertIn("next: make tool-payload", self.lines[-1])
+
+    def test_invalid_never_replaces(self):
+        rc = update.refresh(Stub(self.path, "not a digest"), out=self.lines.append)
+        self.assertEqual(rc, update.EXIT_ERROR)
+        self.assertEqual(self.path.read_text(), self.before)
+
+    def test_upstream_error(self):
+        rc = update.refresh(Stub(self.path, "b" * 40, fail=True), out=self.lines.append)
+        self.assertEqual(rc, update.EXIT_ERROR)
+        self.assertIn("api unreachable", self.lines[0])
+
+    def test_diff_sections(self):
+        self.assertEqual(update.diff({"a": {"x": 1}}, {"a": {"x": 1}, "b": {"y": 2}}),
+                         ["b: None -> {'y': 2}"])
+        self.assertEqual(update.diff({"a": {"x": 1, "y": 1}}, {"a": {"x": 2, "y": 1}}),
+                         ["a.x: 1 -> 2"])
+
+    def test_a_network_failure_is_an_error_not_a_traceback(self):
+        out = []
+        rc = update.refresh(Stub(self.path, "b" * 40, error=OSError("unreachable")),
+                            None, False, out.append)
+        self.assertEqual(rc, update.EXIT_ERROR)
+        self.assertIn("unreachable", out[0])
+        self.assertEqual(self.path.read_text(), self.before)
+
+    def test_an_unwritable_pins_directory_is_an_error(self):
+        os.chmod(self.tmp.name, 0o500)
+        try:
+            rc = update.refresh(Stub(self.path, "b" * 40), out=self.lines.append)
+        finally:
+            os.chmod(self.tmp.name, 0o700)
+        self.assertEqual(rc, update.EXIT_ERROR)
+        self.assertTrue(self.lines[-1].startswith("conformance: "))
+        self.assertEqual(self.path.read_text(), self.before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/update.py
+++ b/tests/conformance/update.py
@@ -1,0 +1,60 @@
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Callable, Dict, List, Optional
+
+from conformance import payload
+
+EXIT_CURRENT, EXIT_ERROR, EXIT_DRIFT = 0, 2, 3
+
+
+class UpdateError(RuntimeError):
+    pass
+
+
+def diff(old: Dict[str, Any], new: Dict[str, Any]) -> List[str]:
+    out = []
+    for section in sorted(set(old) | set(new)):
+        a, b = old.get(section), new.get(section)
+        if not isinstance(a, dict) or not isinstance(b, dict):
+            if a != b:
+                out.append("%s: %r -> %r" % (section, a, b))
+            continue
+        for key in sorted(set(a) | set(b)):
+            if a.get(key) != b.get(key):
+                out.append("%s.%s: %r -> %r" % (section, key, a.get(key), b.get(key)))
+    return out
+
+
+def refresh(provider: Any, ref: Optional[str] = None, check: bool = False,
+            out: Callable[[str], None] = print) -> int:
+    """Refresh pins through the provider schema and latest_pin hook."""
+    try:
+        current = payload.load_pins(provider.pins_path, provider.pins_schema)
+        fresh = provider.latest_pin(copy.deepcopy(current), ref)
+        payload.check_pins(fresh, provider.pins_schema)
+    except (payload.PinError, UpdateError, OSError) as e:
+        # Network failures from latest_pin are update errors.
+        out("conformance: %s" % e)
+        return EXIT_ERROR
+    changes = diff(current, fresh)
+    if not changes:
+        out("%s: pins are current" % provider.pins_path)
+        return EXIT_CURRENT
+    for line in changes:
+        out("  " + line)
+    if check:
+        out("%s: upstream has moved; run without --check to rewrite" % provider.pins_path)
+        return EXIT_DRIFT
+    try:
+        payload.write_pins(provider.pins_path, fresh, provider.pins_schema)
+    except OSError as e:
+        out("conformance: %s" % e)
+        return EXIT_ERROR
+    out("%s: rewritten" % provider.pins_path)
+    for step in provider.update_next_steps():
+        out("  next: " + step)
+    return EXIT_CURRENT

--- a/tests/qemu-runner.sh
+++ b/tests/qemu-runner.sh
@@ -165,7 +165,11 @@ qemu_start()
     # a dedicated tmpfs, as any regular system has, so paths under /tmp map to a
     # resolvable st_dev. Guarded so a repeated qemu_start against a running VM
     # does not stack mounts.
-    _qemu_ssh_raw 'grep -q " /tmp tmpfs " /proc/mounts || mount -t tmpfs tmpfs /tmp'
+    if ! _qemu_ssh_raw 'grep -q " /tmp tmpfs " /proc/mounts || mount -t tmpfs tmpfs /tmp'; then
+        echo "qemu-runner: could not prepare /tmp in the guest" >&2
+        qemu_stop
+        return 1
+    fi
 }
 
 # Each call opens a fresh ssh connection. Avoids ControlMaster pitfalls (master
@@ -229,30 +233,63 @@ qemu_stop()
     _QR_CTL=""
 }
 
-# When sourced, register a cleanup trap that does not clobber the caller's
-# existing trap chain. When executed directly, the EXIT trap fires on script
-# exit.
-trap 'qemu_stop' EXIT
+qemu_write_state()
+{
+    printf 'port=%s\nkey=%s\npidfile=%s\n' \
+        "$QEMU_PORT" "$QEMU_SSH_KEY" "$_QR_PIDFILE" > "$1.tmp" && mv -f "$1.tmp" "$1"
+}
 
-# CLI driver: when run directly, support 'qemu-runner.sh start|exec|stop'.
+qemu_read_state()
+{
+    [ -s "$1" ] || {
+        echo "qemu-runner: no state file $1" >&2
+        return 1
+    }
+    QEMU_PORT="$(sed -n 's/^port=//p' "$1")"
+    QEMU_SSH_KEY="$(sed -n 's/^key=//p' "$1")"
+    _QR_PIDFILE="$(sed -n 's/^pidfile=//p' "$1")"
+
+    # Restrict cleanup to the directory shape created by mktemp.
+    case "$_QR_PIDFILE" in
+        */elfuse-qemu.*/qemu.pid) ;;
+        *)
+            echo "qemu-runner: $1 names no qemu-runner pidfile: $_QR_PIDFILE; remove the file once the VM is gone" >&2
+            return 1
+            ;;
+    esac
+}
+
 if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
     cmd="${1:-help}"
     shift || true
+    state_file=""
+    if [ "$cmd" != exec ] && [ "${1:-}" = "--state-file" ]; then
+        state_file="${2:?--state-file needs a path}"
+        shift 2
+    fi
     case "$cmd" in
         start)
-            qemu_start
+            trap 'qemu_stop' EXIT
+            qemu_start || exit 1
+            if [ -n "$state_file" ]; then
+                qemu_write_state "$state_file" || exit 1
+                trap - EXIT
+            fi
             echo "PORT=$QEMU_PORT KEY=$QEMU_SSH_KEY"
             ;;
         exec)
+            trap 'qemu_stop' EXIT
             qemu_start
             qemu_exec "$@"
             ;;
         stop)
+            [ -z "$state_file" ] || qemu_read_state "$state_file" || exit 1
             qemu_stop
+            [ -z "$state_file" ] || rm -f "$state_file"
             ;;
         *)
             cat << EOF
-Usage: $0 <start|exec ARGS...|stop>
+Usage: $0 <start [--state-file PATH]|exec ARGS...|stop [--state-file PATH]>
 
 Boots qemu-system-aarch64 with the test fixtures and exposes ssh.
 The host repo is shared into the VM at /mnt/host (read-only).


### PR DESCRIPTION
The foundation for executing gvisor and LTP conformance test suite. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a conformance harness for comparing `elfuse` with a QEMU Linux reference against checked-in expectations, with hermetic fake tests covering the framework before real suites land.

**Harness**
- Supports `elfuse`, `qemu`, and `host` backends and records exits, signals, timeouts, and transport failures.
- Uses canonical IDs, JSONC selection and expectation files, bidirectional judging, quarantined retries, isolated reruns, and result reports.
- Verifies pinned payloads with content fingerprints and ELF64 checks, and provides pin-drift checks and expectation seeding.
- Exposes `scripts/conformance` and Make targets with stable exit codes, including optional-prerequisite skips and `--require`.

**Integration**
- Adds hermetic fake-suite selftests to `make check`; gVisor and LTP providers remain follow-ups.
- Adds a dedicated Conformance workflow with a stable required gate that reaches every macOS job and can report pin drift.
- Extends `tests/qemu-runner.sh` with stateful start/stop so QEMU can outlive its launching shell, and documents setup and operations.

<sup>Written for commit 5a47a3bbd8ccf5f2e182e926ff5022fbc7f8ba21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

