### PR TITLE
Cover the dynamic loader with a sharun lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,34 @@ $(BUILD_DIR)/test-stdio-nonblock-host: tests/test-stdio-nonblock-host.c | $(BUIL
 # Guest test binaries (cross-compiled, aarch64-linux)
 # Only used when GUEST_TEST_BINARIES is not set.
 
+# Before the "ifndef GUEST_TEST_BINARIES" block below, and outside it. Two
+# rules name this stamp: the glibc benchmark inside that block and the sharun
+# fixtures outside it. Defined inside, a prebuilt-guest-binaries build left it
+# empty and the fixtures took a blank prerequisite; defined after the block, the
+# benchmark took one. Ahead of both is the only spot that serves both.
+#
+# The identity is in the stamp's name, not its contents, so a switched toolchain
+# names a file that does not exist and the fixtures rebuild on the ordinary
+# missing-prerequisite rule. Writing the identity into a fixed name instead
+# needs a phony prerequisite to re-run a comparison on every build, and that
+# also makes "make -n" report a rebuild a real build does not do, because a dry
+# run assumes the recipe wrote the file.
+#
+# A real target, not a write while the makefile is read: the FLAVOR stamp in
+# mk/common.mk is written at parse time, which it can be because nothing names
+# it as a prerequisite, whereas a parse-time write here would happen before
+# "make clean test-sharun" runs clean and leave the fixtures naming a
+# prerequisite that no longer exists and has no rule to recreate it.
+CROSS_GLIBC_STAMP := $(BUILD_DIR)/.sharun-toolchain-$(CROSS_GLIBC_ID_HASH)
+$(CROSS_GLIBC_STAMP): | $(BUILD_DIR)
+
+	# Exactly one stamp exists at a time. Leaving the old ones behind means
+	# switching back to a toolchain used earlier finds its stamp still there and
+	# older than the fixtures the other toolchain built, so make calls them up to
+	# date and the lane runs binaries linked against the wrong runtime.
+	$(Q)rm -f $(BUILD_DIR)/.sharun-toolchain-*
+	$(Q)touch $@
+
 ifndef GUEST_TEST_BINARIES
 $(BUILD_DIR)/test-hello: tests/hello.S tests/simple.ld | $(BUILD_DIR)
 	@echo "  AS      tests/hello.S"
@@ -506,17 +534,18 @@ $(BUILD_DIR)/bench-hot-guard: tests/bench-hot-guard.c | $(BUILD_DIR)
 # suite). Linked without -static so glibc resolves time / urandom
 # syscalls through the vDSO trampoline -- which is exactly what the
 # guardrail script verifies against the 50 ns / 200 ns ceilings.
-ifneq ($(wildcard $(LINUX_TOOLCHAIN)/aarch64-unknown-linux-gnu/sysroot/.),)
+ifneq ($(CROSS_GLIBC_SYSROOT_PRESENT),)
 # -DGUARD_USE_LIBC_CG switches the bench's clock_gettime case from a
 # direct vDSO trampoline call to the libc wrapper, so the dynamic-glibc
 # build measures glibc's actual routing decision. A regression in the
 # NT_GNU_ABI_TAG note or LINUX_2.6.39 versioning would push this
 # measurement from ~7 ns up to SVC time (~2000 ns) and fail the
 # guardrail.
-$(BUILD_DIR)/bench-hot-guard-glibc: tests/bench-hot-guard.c | $(BUILD_DIR)
+$(BUILD_DIR)/bench-hot-guard-glibc: tests/bench-hot-guard.c \
+		$(CROSS_GLIBC_STAMP) | $(BUILD_DIR)
 	@echo "  CROSS   $< (dynamic glibc)"
-	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -DGUARD_USE_LIBC_CG=1 -O2 \
-		-o $@ $< -lpthread
+	$(Q)$(CROSS_COMPILE)gcc --sysroot=$(CROSS_GLIBC_SYSROOT) \
+		-D_GNU_SOURCE -DGUARD_USE_LIBC_CG=1 -O2 -o $@ $< -lpthread
 endif
 
 endif
@@ -525,6 +554,40 @@ endif
 $(BUILD_DIR)/test-mremap-tail-emfile: tests/test-mremap-tail-emfile.c | $(BUILD_DIR)
 	@echo "  CROSS   $<"
 	$(Q)$(CROSS_COMPILE)gcc -D_GNU_SOURCE -static -O2 -o $@ $<
+
+# Deliberately outside the "ifndef GUEST_TEST_BINARIES" block that ends above:
+# mk/tests.mk makes build/probe a prerequisite of test-sharun whenever a cross
+# glibc is present, regardless of GUEST_TEST_BINARIES, so a rule hidden by that
+# guard would leave the lane with no way to build what it requires.
+#
+# The sharun probe and its two DSOs, for test-sharun. Dynamic on purpose:
+# the point is the loader path (DT_NEEDED, dlopen, $$ORIGIN rpath), so a static
+# link would test nothing. Built only when the cross-glibc toolchain ships its
+# own sysroot, same guard as bench-hot-guard-glibc above.
+#
+# All three land in $(BUILD_DIR) together so the probe's $$ORIGIN rpath finds
+# libprobe.so at load time and libprobe-dlopen.so at dlopen time, with no
+# LD_LIBRARY_PATH. libprobe-dlopen.so is deliberately not linked into the probe,
+# so it can only arrive through dlopen.
+ifneq ($(CROSS_GLIBC_SYSROOT_PRESENT),)
+# Which toolchain and sysroot the fixtures below were built against. Make
+# compares timestamps, and neither of those is a file, so a probe built against
+# one glibc looks up to date after a switch to another and the lane then runs it
+# against a sysroot it was never linked for.
+#
+$(BUILD_DIR)/libprobe.so $(BUILD_DIR)/libprobe-dlopen.so: \
+		$(BUILD_DIR)/lib%.so: tests/fixtures/sharun/%-lib.c \
+		$(CROSS_GLIBC_STAMP) | $(BUILD_DIR)
+	@echo "  CROSS   $< (shared)"
+	$(Q)$(CROSS_COMPILE)gcc --sysroot=$(CROSS_GLIBC_SYSROOT) -fPIC -shared -o $@ $<
+
+$(BUILD_DIR)/probe: tests/fixtures/sharun/probe.c \
+		$(BUILD_DIR)/libprobe.so $(BUILD_DIR)/libprobe-dlopen.so \
+		$(CROSS_GLIBC_STAMP) | $(BUILD_DIR)
+	@echo "  CROSS   $< (dynamic glibc)"
+	$(Q)$(CROSS_COMPILE)gcc --sysroot=$(CROSS_GLIBC_SYSROOT) -o $@ $< \
+		-L$(BUILD_DIR) -lprobe -ldl -lm -pthread -Wl,-rpath,'$$ORIGIN'
+endif
 
 include mk/tests.mk
 include mk/lint.mk

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -151,6 +151,34 @@ What they do:
 - `make test-fuse-alpine`: validate guest `/dev/fuse` + `mount("fuse")`
   against the Alpine musl sysroot fixture
 - `make test-gdbstub`: debugger integration checks against the built-in GDB stub
+- `make test-sharun`: run sharun and its probe under elfuse in six arms of
+  increasing host requirements. The prebuilt launcher (`--version`) is a static
+  aarch64 ELF and runs anywhere elfuse does; the x86_64 build of the same
+  release goes through the Rosetta path as a static-pie musl Rust binary, a
+  shape no other lane covers, and skips without the translator. The cross-built
+  probe covers the loader path (`DT_NEEDED`, `dlopen`, `$ORIGIN` rpath, libm,
+  pthreads, fork) that no other aarch64 lane reaches, and skips without the
+  cross-glibc sysroot. Three further arms drive a bundle: the probe under the
+  real launcher, `--gen-lib-path` walking the tree and writing back to it from
+  inside the guest, and the negative path where the `dlopen` target is removed
+  and the loader's errno must surface rather than hang or crash. Nothing shells
+  out to `lib4bin`, so there is no Linux dependency: `tests/build-sharun-bundle.sh`
+  writes the bundle layout directly from the launcher, the probe, and a prebuilt
+  Debian glibc fetched by `tests/fetch-glibc.sh`. Point `SHARUN_FIXTURE_DIR` at
+  an unpacked bundle to test one built elsewhere instead. The lane skips
+  entirely with status 77 in two cases: it cannot reach the launcher for the
+  first arm, or that arm passed but every dynamic-loader arm skipped (no
+  cross-glibc sysroot and no `SHARUN_FIXTURE_DIR`). The second
+  keeps a run that covered only the static launcher from reporting the same
+  green as one that exercised the loader. Launcher
+  binaries and the glibc package are pinned and digest-checked by
+  `tests/sharun-fixture.lock` and cached under `$FIXTURES_DIR`, so they download
+  once and survive `make clean`. Every download happens inside the lane rather
+  than as a make prerequisite, so an unreachable network skips the affected arms
+  instead of failing `make check`. Editing a probe source under
+  `tests/fixtures/sharun/` is picked up on the next run: make rebuilds
+  `$(BUILD_DIR)/probe` and its two DSOs from those sources, and the bundle is
+  assembled from the rebuilt binaries. It also runs as a lane of `make check`.
 - `make test-matrix`: cross-check `elfuse` (aarch64), QEMU (aarch64),
   and `elfuse` (x86_64-via-Rosetta) on overlapping corpora
 - `make lint`: static analysis through `clang-tidy`

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -14,7 +14,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-rosetta-cli test-rosetta-statics test-rosetta-failure-modes \
         test-rosetta-alpine test-rosetta-audit test-rosetta-jit \
         test-rosetta-glibc test-rosetta-madvise test-rosetta-msync \
-        test-rosetta-mremap test-rosetta-all bench-rosetta \
+        test-rosetta-mremap test-rosetta-all test-sharun bench-rosetta \
         test-matrix test-matrix-elfuse-aarch64 test-matrix-qemu-aarch64 \
         test-full test-multi-vcpu test-rwx test-sysroot-rename \
         test-case-collision test-case-collision-fallback test-getdents64-overlong \
@@ -274,6 +274,7 @@ check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-eintr-contract ch
 	$(call run-lane,test-launch-flags,launch flags)
 	$(call run-lane,test-rosetta-cli,rosetta CLI gating)
 	$(call run-lane,test-bench-guardrail,hot-syscall guardrail)
+	$(call run-lane,test-sharun,sharun launcher and probe)
 
 ## Hot-syscall performance guardrail: ensure getpid, libc clock_gettime,
 ## and 1-byte /dev/urandom reads stay under their TODO ns/op ceilings.
@@ -284,7 +285,7 @@ BENCH_GUARDRAIL_REQUIRE_STATIC := 0
 ifndef GUEST_TEST_BINARIES
   BENCH_GUARDRAIL_DEPS += $(BUILD_DIR)/bench-hot-guard
   BENCH_GUARDRAIL_REQUIRE_STATIC := 1
-  ifneq ($(wildcard $(LINUX_TOOLCHAIN)/aarch64-unknown-linux-gnu/sysroot/.),)
+  ifneq ($(CROSS_GLIBC_SYSROOT_PRESENT),)
     BENCH_GUARDRAIL_DEPS += $(BUILD_DIR)/bench-hot-guard-glibc
   endif
 endif
@@ -293,6 +294,7 @@ test-bench-guardrail: $(BENCH_GUARDRAIL_DEPS)
 	    BENCH_GUARDRAIL_DIR="$(TEST_DIR)" \
 	    BENCH_GUARDRAIL_REQUIRE_STATIC="$(BENCH_GUARDRAIL_REQUIRE_STATIC)" \
 	    LINUX_TOOLCHAIN="$(LINUX_TOOLCHAIN)" \
+	    GLIBC_SYSROOT="$(CROSS_GLIBC_SYSROOT)" \
 	    bash tests/test-bench-guardrail.sh
 
 test-sysroot-rename: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-rename
@@ -1211,6 +1213,22 @@ ifeq ($(BUSYBOX_BIN),$(BUILD_DIR)/busybox)
 else
   BUSYBOX_DEPS :=
 endif
+
+# The probe is built only when the cross-glibc sysroot exists; without it the
+# lane still covers the launcher and reports the probe arm as skipped.
+# The launcher binaries are fetched by tests/fetch-sharun-bin.sh, not listed
+# here: a make prerequisite that cannot be downloaded is fatal, and this lane
+# runs inside "make check". Fetching from the script lets an unreachable
+# network degrade to a skip, the same way the glibc package already does.
+TEST_SHARUN_PROBE_DIR :=
+ifneq ($(CROSS_GLIBC_SYSROOT_PRESENT),)
+  TEST_SHARUN_PROBE_DIR := $(BUILD_DIR)
+endif
+
+## Run sharun and its probe under elfuse: the prebuilt launcher and the
+## cross-built probe always, plus a bundle assembled from those two.
+test-sharun: $(ELFUSE_BIN) $(TEST_SHARUN_PROBE_DIR:%=%/probe)
+	$(call RUN_OPTIONAL_SKIP77,FIXTURES_DIR="$(FIXTURES_DIR)" CROSS_COMPILE="$(CROSS_COMPILE)" SHARUN_FIXTURE_DIR="$(SHARUN_FIXTURE_DIR)" MATRIX_ROSETTA_TRANSLATOR="$(MATRIX_ROSETTA_TRANSLATOR)" ELFUSE_NO_ROSETTA="$(ELFUSE_NO_ROSETTA)" TEST_TIMEOUT="$(TEST_TIMEOUT)" bash tests/test-sharun.sh $(ELFUSE_BIN) $(TEST_SHARUN_PROBE_DIR),test-sharun)
 
 $(BUILD_DIR)/busybox: | $(BUILD_DIR)
 	@printf "$(BLUE)▸ Downloading$(RESET) busybox-static (arm64) from $(BUSYBOX_PACKAGE_PAGE)\n"

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -36,6 +36,135 @@ else
   CROSS_COMPILE ?= aarch64-linux-gnu-
 endif
 
+# The cross-glibc sysroot that ships with LINUX_TOOLCHAIN, and whether anything
+# can actually be built against it. Guards that build dynamic guest binaries and
+# the --sysroot those binaries need are the same fact, so they read it from here
+# rather than each spelling the path.
+#
+# Computed once and exported. Answering this costs several compiler probes, and
+# "make check" reaches 43 recursive sub-makes, each of which re-parses this file:
+# measured at 218 compiler spawns for one "make -n check" before the export, all
+# but five of them recomputing an answer the parent already had. The origin test
+# keeps a command-line override winning, since that origin is not "undefined".
+
+CROSS_GLIBC_CC := $(CROSS_COMPILE)gcc
+
+# := not ?=, and expanded once into a simple variable. A recursively-expanded
+# ?= re-runs its $(shell) at every reference, and this block references the
+# sysroot three times, so the probe ran three times per parse.
+ifeq ($(origin CROSS_GLIBC_SYSROOT),undefined)
+  CROSS_GLIBC_SYSROOT := $(shell $(CROSS_GLIBC_CC) -print-sysroot 2> /dev/null)
+endif
+
+# Guarded on the identity, not on the presence answer below. The two are
+# different questions: what the fixtures were built against, versus whether they
+# can be built at all. Sharing one guard meant that overriding
+# CROSS_GLIBC_SYSROOT_PRESENT on the command line left the hash empty, so every
+# toolchain named the same stamp and fixtures linked against one runtime were
+# reused with another.
+ifeq ($(origin CROSS_GLIBC_ID_HASH),undefined)
+# What the fixtures were built against, not merely where it lives. Two paths
+# are the same two paths after a toolchain is upgraded in place, so a stamp keyed
+# on them alone leaves fixtures linked against the old glibc looking current. The
+# compiler version and the size and date of the libc it resolves to move when the
+# install does. -dumpfullversion first: GCC 7 and later answer -dumpversion with
+# the major alone, so two compilers in one release series would hash the same
+# and the fixtures one built would be reused by the other. -dumpversion is the
+# fallback for the compilers that predate the fuller spelling. Not a content hash: this is read on every top-level make, and
+# hashing a sysroot to catch an edit that leaves both untouched would cost more
+# than the rebuild it saves.
+#
+# No 'case' here, and no bare ')' anywhere in the recipe: make counts parentheses
+# to find the end of $(shell ...), so the ')' that closes a case pattern ends the
+# expansion early and leaves the rest of the line as literal text. That is not a
+# syntax error, it is a fingerprint that silently becomes a constant, which is
+# what happened: the compiler version and the libc timestamp dropped out of the
+# hash while every test still passed, because a constant is stable across
+# locales and the sysroot reached the identity by another component.
+CROSS_GLIBC_FINGERPRINT := $(shell { \
+    $(CROSS_GLIBC_CC) -dumpfullversion 2> /dev/null \
+        || $(CROSS_GLIBC_CC) -dumpversion; \
+    f="$$($(CROSS_GLIBC_CC) --sysroot=$(CROSS_GLIBC_SYSROOT) \
+        -print-file-name=libc.so.6)"; \
+    m="$$(stat -Lf '%z %m' "$$f" 2> /dev/null)"; \
+    [ -n "$$m" ] && [ -z "$$(printf '%s' "$$m" | tr -d '0-9 ')" ] \
+        || m="$$(stat -Lc '%s %Y' "$$f" 2> /dev/null)"; \
+    printf '%s' "$$m"; \
+    } 2> /dev/null | tr -s ' \n' '__')
+CROSS_GLIBC_ID := $(CROSS_COMPILE)|$(CROSS_GLIBC_SYSROOT)|$(CROSS_GLIBC_FINGERPRINT)
+CROSS_GLIBC_ID_HASH := $(shell printf '%s' '$(CROSS_GLIBC_ID)' \
+    | shasum -a 256 2> /dev/null | cut -c1-12)
+
+# The hash names a file, so an empty one is not a degraded answer, it is every
+# toolchain sharing a stamp and reusing each other's fixtures. cksum is POSIX
+# and answers when shasum does not; if neither does, say so rather than build
+# against a stamp that cannot tell toolchains apart.
+ifeq ($(CROSS_GLIBC_ID_HASH),)
+  CROSS_GLIBC_ID_HASH := $(shell printf '%s' '$(CROSS_GLIBC_ID)' \
+      | cksum 2> /dev/null | cut -d' ' -f1)
+endif
+
+endif
+
+ifeq ($(origin CROSS_GLIBC_SYSROOT_PRESENT),undefined)
+# Link something, rather than looking for parts. Every earlier spelling of this
+# guard asked whether some file was present (the sysroot directory, then the
+# loader, then crt1.o) and each one accepted a tree that still could not build:
+# "/" exists everywhere, a runtime-only tree has a loader but no headers, and a
+# tree with crt1.o can still be missing crti.o. The guarded targets compile and
+# link, so compiling and linking is the question, and it answers every layout
+# including a distro multiarch compiler whose sysroot is "/".
+#
+# Build the fixtures, rather than asking questions that resemble building them.
+# Four earlier spellings of this guard each asked something narrower than the
+# targets ask ("does the sysroot exist", "is the loader there", "is crt1.o
+# there", "does a bare main link", "do the headers parse and do the libraries
+# link") and each let through a sysroot the build then failed on. The targets
+# compile a shared library and link a program against it, so that is what this
+# does, into a temporary directory it removes.
+#
+# Measured at 0.49s, paid once: this block is guarded on its own origin and
+# exported below, so the 43 recursive sub-makes "make check" spawns inherit the
+# answer rather than each re-deriving it. It is on the path of every top-level
+# make, including ones that build nothing, which is the price of the guard being
+# right.
+CROSS_GLIBC_SYSROOT_PRESENT := $(shell d=$$(mktemp -d 2> /dev/null) || exit 0; \
+    $(CROSS_GLIBC_CC) --sysroot=$(CROSS_GLIBC_SYSROOT) -fPIC -shared \
+        -o "$$d/libprobe.so" tests/fixtures/sharun/probe-lib.c > /dev/null 2>&1 \
+    && $(CROSS_GLIBC_CC) --sysroot=$(CROSS_GLIBC_SYSROOT) -o "$$d/probe" \
+        tests/fixtures/sharun/probe.c -L"$$d" -lprobe -ldl -lm -pthread \
+        > /dev/null 2>&1 && echo yes; \
+    rm -rf "$$d")
+
+# Which toolchain and sysroot the guest fixtures were built against. Make
+# compares timestamps, and neither of those is a file, so a probe built against
+# one glibc looks up to date after a switch to another and the lane then runs it
+# against a sysroot it was never linked for. The fixture targets take this stamp
+# as an ordinary prerequisite, so a changed identity rebuilds them.
+#
+# The FLAVOR stamp in mk/common.mk does this for the host objects and
+# deliberately excludes the cross-compiled guest binaries, which carry
+# CROSS_TEST_CFLAGS rather than CFLAGS. This is the matching record for them.
+#
+# Named here beside the rest of the cross-glibc configuration, but written in
+# mk/common.mk: BUILD_DIR comes from mk/config.mk, which is read after this
+# file, so a path built from it here resolves to "/" and the write lands on a
+# read-only filesystem.
+endif
+
+# Checked outside the block that computes it, so an override is checked too. The
+# hash names a file, and an empty one is not a weaker key, it is every toolchain
+# sharing one stamp and reusing each other's fixtures. Supplying it empty on the
+# command line skipped the computation and the check with it.
+ifeq ($(strip $(CROSS_GLIBC_ID_HASH)),)
+  $(error CROSS_GLIBC_ID_HASH is empty; it names the fixture stamp, so an empty \
+value would let every toolchain share one)
+endif
+
+export CROSS_GLIBC_SYSROOT
+export CROSS_GLIBC_SYSROOT_PRESENT
+export CROSS_GLIBC_ID_HASH
+
 # Shim assembler (defaults to Apple's assembler)
 SHIM_AS ?= as
 SHIM_ASFLAGS ?= -arch arm64

--- a/tests/build-sharun-bundle.sh
+++ b/tests/build-sharun-bundle.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+# build-sharun-bundle.sh - Assemble a sharun bundle without lib4bin
+#
+# lib4bin computes a binary's library closure with ldd and rewrites it with
+# patchelf, which needs a Linux host. The probe's closure is known and fixed
+# (libc, libm, libdl, libpthread, and its own two DSOs), so the layout can be
+# written out directly and the bundle assembled anywhere, from the prebuilt
+# launcher plus a prebuilt glibc.
+#
+# This is the only bundle builder: nothing in the tree shells out to lib4bin, so
+# the lane has no Linux dependency and no published artifact to keep in step.
+#
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage="Usage: $0 <sharun-binary> <probe-dir> <glibc-dir> <out-dir>"
+sharun="${1:?$usage}"
+probe_dir="${2:?$usage}"
+glibc_dir="${3:?$usage}"
+out="${4:?$usage}"
+
+# For GLIBC_CLOSURE, the one list of what the bundle's glibc holds.
+# tests/fetch-glibc.sh copies those out of the package, this copies them in, and
+# a list in each is how the two drift.
+# shellcheck source=tests/sharun-fixture.lock
+. "$(dirname "$0")/sharun-fixture.lock"
+
+# readelf is a precondition of the DT_NEEDED gate at the end. Resolve it here so
+# a missing cross toolchain fails before anything is created, rather than after
+# a bundle has been assembled.
+#
+# One line rather than a copy of mk/toolchain.mk's search. The makefile always
+# passes CROSS_COMPILE, so the ladder that used to be here only ran for a hand
+# invocation, and it probed for -readelf where the makefile probes for -gcc: a
+# toolchain with one and not the other made the two disagree. The guard below
+# reports a bad hand-run just as well.
+readelf="${CROSS_COMPILE:-aarch64-linux-gnu-}readelf"
+command -v "$readelf" > /dev/null || {
+    printf 'readelf not found: %s\n' "$readelf" >&2
+    exit 1
+}
+
+for f in "$sharun" "$probe_dir/probe" "$probe_dir/libprobe.so" \
+    "$probe_dir/libprobe-dlopen.so"; do
+    [ -e "$f" ] || {
+        printf 'sharun bundle input missing: %s\n' "$f" >&2
+        exit 1
+    }
+done
+
+# Never deletes: the output directory must not already exist. The only caller
+# hands over a fresh path inside its own mktemp -d, and refusing to create the
+# bundle on top of anything is a shorter and more honest contract than trying to
+# decide which directories are safe to erase. A hand run passes a new path too.
+[ -e "$out" ] && {
+    printf 'bundle output already exists: %s\n' "$out" >&2
+    exit 1
+}
+
+mkdir -p "$out/bin" "$out/shared/bin" "$out/shared/lib"
+cp "$probe_dir/probe" "$out/shared/bin/probe"
+cp "$probe_dir/libprobe.so" "$probe_dir/libprobe-dlopen.so" "$out/shared/lib/"
+
+# Only the probe's own closure. Copying the whole package would drag in the nss
+# and locale modules, which nothing here loads. Every one of them, not "copy it
+# if it happens to be there": this reports a missing library against the glibc
+# runtime it came from, which is the directory worth naming when one is absent.
+for l in $GLIBC_CLOSURE; do
+    [ -e "$glibc_dir/$l" ] || {
+        printf 'glibc runtime is missing %s: %s\n' "$l" "$glibc_dir" >&2
+        exit 1
+    }
+    cp -L "$glibc_dir/$l" "$out/shared/lib/$l"
+done
+
+# bin/probe is the launcher, not the program: sharun dispatches on argv[0] and
+# runs shared/bin/<argv0> under the bundled loader. lib4bin hard-links the two;
+# a copy is the same thing at this size.
+cp "$sharun" "$out/sharun"
+cp "$sharun" "$out/bin/probe"
+
+# shared/bin/probe too, not just the two launcher copies. It is what the
+# launcher execs, and leaving its mode to whatever cp carried over makes the
+# bundle depend on how the probe was built rather than on what this writes.
+chmod +x "$out/sharun" "$out/bin/probe" "$out/shared/bin/probe"
+
+# lib.path is what sharun passes to the loader as --library-path, one directory
+# per line, "+" meaning relative to the file's own directory. Written exactly as
+# the launcher's own --gen-lib-path writes it, so the bundle and a regenerated
+# one are byte-identical and tests/test-sharun.sh can assert one format.
+printf '+\n' > "$out/shared/lib/lib.path"
+printf 'SHARUN_FIXTURE_MARKER=ok\n' > "$out/.env"
+{
+    printf 'sharun=%s\n' "$sharun"
+    printf 'glibc_dir=%s\n' "$glibc_dir"
+    printf 'assembled_by=%s\n' "$0"
+    printf 'assembled_on=%s\n' "$(uname -m)"
+} > "$out/manifest.txt"
+
+# The library list above is hardcoded, which is the one job lib4bin used to do
+# by walking ldd. Nothing else would notice a fixture that grew a dependency:
+# the bundle would simply lack it and the lane would fail with a loader error
+# pointing at the wrong thing. readelf comes from the same cross toolchain that
+# built the probe, so it is always present when this script runs.
+#
+# The DSOs are checked as well as the probe: a dependency added to either of
+# them (libgcc_s.so.1 from a new builtin, say) is the same silent fall-behind.
+# One readelf call takes all three, since the gate is a union over them.
+#
+# Command substitution, not process substitution into a while loop: there a
+# readelf failure feeds the loop empty output, set -e never sees the producer's
+# status, and the guard passes without having looked. Every ELF the bundle
+# ships, not just the three this repo builds. The runtime libraries have their
+# own DT_NEEDED, and reading only the probe's made the gate a check on the first
+# level of the closure rather than the closure: a glibc whose libm grew a
+# dependency would ship a bundle missing it and fail inside the guest, which is
+# the error this gate exists to turn into a build failure.
+needed="$("$readelf" -d "$out/shared/bin/probe" "$out"/shared/lib/*.so*)" || {
+    printf 'readelf failed on the assembled bundle\n' >&2
+    exit 1
+}
+
+# read, not "for lib in $(...)": an unquoted command substitution in a for list
+# is word-split and glob-expanded, so a soname carrying whitespace or a bracket
+# would be torn apart or matched against the filesystem. The colon is optional:
+# GNU readelf prints "Shared library: [x]" and llvm-readelf omits it. Getting
+# that wrong does not fail the gate, it empties it, which passes everything.
+sonames="$(printf '%s\n' "$needed" \
+    | sed -n 's/.*Shared library:*[[:space:]]*\[\(.*\)\]/\1/p' | sort -u)"
+
+# The probe links at least libc, so extracting nothing means the pattern no
+# longer matches this readelf's output rather than that the bundle is complete.
+[ -n "$sonames" ] || {
+    printf 'no DT_NEEDED entries parsed; readelf output format changed?\n' >&2
+    "$readelf" -d "$out/shared/bin/probe" >&2
+    exit 1
+}
+
+# Present is not the same as usable. The probe is linked against the toolchain's
+# own glibc while the bundle ships the pinned Debian one, so a newer toolchain
+# can leave the probe asking for symbol versions the bundled libc never defines.
+# Every soname would still be present and the gate above would pass, and the
+# failure would arrive inside the guest as a loader error naming a symbol rather
+# than the skew that caused it.
+#
+# Highest versioned GLIBC_ tag on each side: .gnu.version_r across every ELF the
+# cross toolchain built, against libc's .gnu.version_d, compared with sort -V.
+# The DSOs as well as the probe, matching the DT_NEEDED gate above: a newer
+# toolchain can leave one of them naming a symbol version the probe itself never
+# asks for. Section-scoped, because libc carries both sections and what it needs
+# says nothing about what it provides.
+version_slice()
+{
+    awk -v s="$1" "index(\$0, \"section '\" s \"'\"){f=1;next} /section '/{f=0} f" \
+        | sed -n 's/.*Name: GLIBC_\([0-9.]*\).*/\1/p' | sort -V -u | tail -1
+}
+want_glibc="$("$readelf" -V "$out/shared/bin/probe" \
+    "$out/shared/lib/libprobe.so" "$out/shared/lib/libprobe-dlopen.so" \
+    | version_slice .gnu.version_r)"
+have_glibc="$("$readelf" -V "$out/shared/lib/libc.so.6" | version_slice .gnu.version_d)"
+
+# Which readelf this is decides what an empty parse means. The section headings
+# this reads are GNU readelf's; llvm-readelf lays -V out differently, and the
+# soname gate above works with either, so a bundle assembled by hand with the
+# llvm tools would fail here claiming the format changed when nothing had. GNU
+# and nothing parsed is a real format change and stays fatal; anything else says
+# what it skipped and why. Untested against llvm-readelf: none is installed
+# here, so this is written from the two tools' documented output, not measured.
+[ -n "$want_glibc" ] && [ -n "$have_glibc" ] || {
+    if "$readelf" --version 2>&1 | grep -q GNU; then
+        printf 'could not read GLIBC symbol versions; readelf output changed?\n' >&2
+        exit 1
+    fi
+    printf 'skipping the glibc version check: %s is not GNU readelf\n' \
+        "$readelf" >&2
+    want_glibc=''
+}
+[ -z "$want_glibc" ] \
+    || [ "$(printf '%s\n%s\n' "$want_glibc" "$have_glibc" | sort -V | tail -1)" \
+        = "$have_glibc" ] || {
+    printf 'glibc skew: the probe needs GLIBC_%s, the bundle ships GLIBC_%s\n' \
+        "$want_glibc" "$have_glibc" >&2
+    printf 'the cross toolchain is newer than GLIBC_VERSION in %s\n' \
+        "$(dirname "$0")/sharun-fixture.lock" >&2
+    exit 1
+}
+
+missing=''
+while IFS= read -r lib; do
+    [ -e "$out/shared/lib/$lib" ] || missing="$missing $lib"
+done <<< "$sonames"
+[ -z "$missing" ] || {
+    printf 'bundle is missing DT_NEEDED entries:%s\n' "$missing" >&2
+    printf 'add them to GLIBC_CLOSURE in %s\n' \
+        "$(dirname "$0")/sharun-fixture.lock" >&2
+    exit 1
+}

--- a/tests/fetch-glibc.sh
+++ b/tests/fetch-glibc.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+# fetch-glibc.sh - Resolve an aarch64 glibc runtime from a prebuilt .deb
+#
+# Prints a directory holding the aarch64 loader and shared objects. Nothing is
+# compiled: the package is Debian's own build, pinned by digest, so this runs on
+# a macOS host with no Linux and no cross-libc.
+#
+# The pin lives in tests/sharun-fixture.lock and points at snapshot.debian.org,
+# whose file URLs are permanent. Distribution pools are not: Ubuntu's ports pool
+# drops a package as soon as a point release supersedes it, which would rot this
+# fetch within weeks.
+#
+# Override with GLIBC_DIR to point at a runtime you staged yourself.
+#
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=tests/lib/fixture-cache.sh
+. "$repo_root/tests/lib/fixture-cache.sh"
+# shellcheck source=tests/sharun-fixture.lock
+. "$repo_root/tests/sharun-fixture.lock"
+
+if [ -n "${GLIBC_DIR:-}" ]; then
+    [ -d "$GLIBC_DIR" ] || {
+        printf 'glibc directory missing: %s\n' "$GLIBC_DIR" >&2
+        exit 1
+    }
+    printf '%s\n' "$GLIBC_DIR"
+    exit 0
+fi
+
+fixtures="${FIXTURES_DIR:-$repo_root/externals/test-fixtures}"
+runtime="$fixtures/glibc/$GLIBC_VERSION"
+
+# Called by fixture_cache_build with the staging directory last. Everything here
+# writes only into that directory, so a failure leaves no partial runtime.
+extract_glibc()
+{
+    local stage="$1"
+    local work="$stage/.work"
+
+    # Required here, not at the top of the script: a warm cache never reaches
+    # this function, and demanding ar in order to hand back an already extracted
+    # runtime turned a good cache into a skip.
+    #
+    # 1, not 77: 77 means the network could not be reached, and a host that has
+    # the network but no binutils has a broken build environment, which must be
+    # loud rather than a green skip. build-sharun-bundle.sh treats a missing
+    # readelf the same way. Checked before the download so a missing tool does
+    # not cost a transfer first.
+    command -v ar > /dev/null || {
+        printf 'ar(1) not found; install binutils\n' >&2
+        return 1
+    }
+
+    mkdir -p "$work"
+    fixture_cache_download "$GLIBC_DEB_URL" "$work/libc6.deb" \
+        "glibc package $GLIBC_DEB_URL" || return $?
+    fixture_cache_digest_ok "$work/libc6.deb" "$GLIBC_DEB_SHA256" \
+        'glibc package' || return 1
+
+    # ar(1) writes into the current directory whatever its arguments say, so the
+    # extraction runs in a subshell that has already cd'd into the work
+    # directory rather than trusting it to honor an output path.
+    (cd "$work" && ar x libc6.deb && tar -xf data.tar.*) || {
+        printf 'glibc package extraction failed\n' >&2
+        return 1
+    }
+
+    # Debian and Ubuntu disagree on whether the multiarch directory sits under
+    # /lib or /usr/lib, and merged-usr moved it once already. Copy whatever the
+    # package actually shipped rather than encoding one layout. A loop rather
+    # than find -exec: find reports success even when the command it ran failed,
+    # so an -exec copy that hits a full disk or a permission problem would
+    # publish a partial runtime, and only three of its members are re-validated
+    # afterwards.
+    #
+    # The list goes to a file and find's own status is checked, rather than the
+    # loop reading a process substitution: there a find that dies mid-scan on an
+    # unreadable directory feeds the loop what it managed to print and its
+    # failure is never seen, and the partial tree is then digest-recorded and
+    # published as a complete cache.
+    local pattern=''
+    for lib in $GLIBC_CLOSURE; do
+        pattern="$pattern -o -name $lib"
+    done
+    # shellcheck disable=SC2086  # the pattern is a deliberate word list
+    find -L "$work" -type f \( -false $pattern \) > "$work/.members" || {
+        printf 'glibc extraction could not list package members\n' >&2
+        return 1
+    }
+
+    local seen=' ' base=''
+    while IFS= read -r member; do
+
+        # Skip a basename already copied. -L follows the package's own symlinks,
+        # so one real file reachable through both /lib and /usr/lib is listed
+        # twice and copied over itself. Measured on this package against this
+        # closure: 6 paths for 5 files, the loader being the one reachable both
+        # ways. Harmless, since the second copy has the same contents, but it
+        # hides the layout and does the work twice.
+        base="$(basename "$member")"
+        case "$seen" in
+            *" $base "*) continue ;;
+        esac
+        seen="$seen$base "
+        cp -L "$member" "$stage/" || {
+            printf 'glibc extraction could not copy %s\n' "$member" >&2
+            return 1
+        }
+    done < "$work/.members"
+    rm -rf "$work"
+
+    # Digests of what the bundle will consume, so a cache hit can be checked
+    # rather than assumed. Sizes alone let a corrupted-but-same-length file
+    # through, and the launcher cache is re-verified on every run; this was the
+    # one path that trusted itself. *.so.* already matches
+    # ld-linux-aarch64.so.1, so naming it again hashed it twice here and
+    # verified it twice on every cache hit. Mandatory, not
+    # "|| true": a manifest nobody notices missing is a check that silently
+    # switches itself off, and the consumer below would then trust the tree.
+    # shellcheck disable=SC2086  # one file per closure member, deliberately split
+    (cd "$stage" && shasum -a 256 -- $GLIBC_CLOSURE) > "$stage/.sha256" || {
+        printf 'could not record glibc digests: %s\n' "$stage" >&2
+        return 1
+    }
+    [ -e "$stage/ld-linux-aarch64.so.1" ] || {
+        printf 'glibc package carried no aarch64 loader\n' >&2
+        return 1
+    }
+    return 0
+}
+
+# Checked on a cache hit, by fixture_cache_build, which runs this without
+# holding its publish lock: verification reads the whole tree, and a lock held
+# that long would break the assumption its stale-lock reaper rests on. Only the
+# eviction that follows a failed check takes the lock, because that is a rename.
+# extract_glibc validates what it wrote, but a hit returns before it runs and
+# the runtime is then trusted by path, so this is the only thing that notices a
+# cached tree truncated or emptied after the fact.
+#
+# A tree published before this script recorded digests has no manifest, and
+# there is no telling a good one of those from a damaged one; it fails here like
+# any other unverifiable tree and is rebuilt. That used to be a block of its own
+# that evicted from outside the lock, which is the same job done twice.
+#
+# Captured, not streamed: this script returns the runtime path on stdout, so
+# shasum's per-file lines would be read by the caller as part of the path. On
+# failure the lines that matter go to stderr, which is where the reader needs
+# the name of the file that did not match.
+verify_glibc()
+{
+    local out=''
+
+    [ -s "$1/.sha256" ] || {
+        printf 'cached glibc runtime has no digest manifest\n' >&2
+        return 1
+    }
+    out="$(cd "$1" && shasum -a 256 -c .sha256 2>&1)" || {
+        printf 'cached glibc runtime failed its digests: %s\n' "$1" >&2
+        printf '%s\n' "$out" | grep -v ': OK$' >&2
+        return 1
+    }
+
+    # The member set as well as the members. Checking only what the manifest
+    # lists means a file added to the runtime after publish is never noticed:
+    # every listed entry still hashes, so the tree passes while holding
+    # something this script never put there.
+    local listed='' present=''
+
+    # The pinned closure, not the manifest this tree happens to carry. Comparing
+    # a cache against its own manifest only proves it is self-consistent: a tree
+    # published when GLIBC_CLOSURE was smaller has listed == present and passes,
+    # under the same GLIBC_VERSION that names the cache directory, while missing
+    # a member the bundle now needs. The closure changed that way inside this
+    # change, so it is not a hypothetical.
+    # shellcheck disable=SC2086  # one word per closure member, deliberately split
+    listed="$(printf '%s\n' $GLIBC_CLOSURE | sort)"
+
+    # Dotfiles excluded, .sha256 among them. This runs on macOS, where opening
+    # the cache directory in Finder drops a .DS_Store into it, and counting that
+    # as drift would evict a healthy runtime and re-download the package on
+    # every run after someone looked at the tree. What the check is for is a
+    # library appearing beside the ones this script put there.
+    present="$(cd "$1" && find . -maxdepth 1 ! -name . ! -name '.*' \
+        -exec basename {} \; | sort)"
+
+    [ "$listed" = "$present" ] || {
+        printf 'cached glibc runtime does not match its manifest: %s\n' "$1" >&2
+        diff <(printf '%s\n' "$listed") <(printf '%s\n' "$present") >&2 || true
+        return 1
+    }
+    return 0
+}
+
+fixture_cache_build "$runtime" verify_glibc extract_glibc || exit $?
+
+printf '%s\n' "$runtime"

--- a/tests/fetch-sharun-bin.sh
+++ b/tests/fetch-sharun-bin.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# fetch-sharun-bin.sh - Resolve a prebuilt sharun launcher for one architecture
+#
+# Usage: fetch-sharun-bin.sh aarch64|x86_64
+#
+# Prints the path to the launcher. Exits 77 when it cannot be fetched, so an
+# unreachable network degrades the lane to a skip instead of failing the build.
+# That is the whole reason this is a script and not a make rule: a make
+# prerequisite that cannot be downloaded is fatal, and "make check" runs this
+# lane.
+#
+# The binary is cached as "sharun" whatever the release calls it, because the
+# launcher dispatches on argv[0] and looks for shared/bin/<argv0>. Under its
+# release name it hunts for a bundle entry instead of serving --version.
+# Upstream's own install line does the same rename.
+#
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+arch="${1:?Usage: $0 aarch64|x86_64}"
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=tests/lib/fixture-cache.sh
+. "$repo_root/tests/lib/fixture-cache.sh"
+# shellcheck source=tests/sharun-fixture.lock
+. "$repo_root/tests/sharun-fixture.lock"
+
+case "$arch" in
+    aarch64)
+        asset="$SHARUN_BIN_NAME"
+        want="$SHARUN_BIN_SHA256"
+        ;;
+    x86_64)
+        asset="$SHARUN_BIN_X86_64"
+        want="$SHARUN_BIN_X86_64_SHA256"
+        ;;
+    *)
+        printf 'unknown sharun architecture: %s\n' "$arch" >&2
+        exit 1
+        ;;
+esac
+
+fixtures="${FIXTURES_DIR:-$repo_root/externals/test-fixtures}"
+
+# One cache entry per architecture, so an unreachable x86_64 asset cannot cost
+# the aarch64 arms their coverage.
+dir="$fixtures/sharun/$SHARUN_VERSION/$arch"
+
+# Called by fixture_cache_build with the staging directory last. Everything here
+# writes only into that directory, so a failure leaves no partial cache.
+fetch_launcher()
+{
+    local stage="$1"
+    local out="$stage/sharun"
+
+    fixture_cache_download \
+        "https://github.com/VHSgunzo/sharun/releases/download/$SHARUN_VERSION/$asset" \
+        "$out" "sharun launcher $SHARUN_VERSION $asset" || return $?
+    fixture_cache_digest_ok "$out" "$want" 'sharun launcher' || return 1
+    chmod +x "$out"
+    return 0
+}
+
+# Checked on a cache hit, by fixture_cache_build, which runs this without
+# holding its publish lock: verification reads the whole tree, and a lock held
+# that long would break the assumption its stale-lock reaper rests on. Only the
+# eviction that follows a failed check takes the lock, because that is a rename.
+# fetch_launcher verifies before the file lands, but a hit skips the builder and
+# the binary is then trusted by path, so this is the only thing that notices a
+# cache corrupted after the fact; failing it evicts and rebuilds rather than
+# reporting, because the cache is keyed by version and architecture, so every
+# later run would fail identically until a human guessed which directory to
+# delete. Here rather than in the caller so every architecture gets it from one
+# rule: when the caller did it, the second architecture was added without one.
+verify_launcher()
+{
+    fixture_cache_digest_ok "$1/sharun" "$want" 'cached sharun launcher'
+}
+
+# Propagate rather than flatten: 77 means it could not be fetched, anything else
+# means what arrived was wrong. Collapsing them here turned a pinned-digest
+# mismatch on a cold cache into a green skip.
+fixture_cache_build "$dir" verify_launcher fetch_launcher || exit $?
+
+# Separately from the digest, because it is not a property of the bytes: chmod
+# runs only in the builder, which a cache hit skips, so a cached binary that
+# lost its bit hashes correctly and would fail later at exec. Restored rather
+# than reported: the bytes are already proven right, this directory belongs to
+# this script, and one chmod is shorter than the message explaining why it will
+# not do it. Tolerant of failure. This writes into the shared cache from outside
+# the publish lock, so a peer that just failed its own verify can rename this
+# directory away between the build returning and the chmod landing. That is a
+# benign race over a tree already proven correct, and under errexit a hard chmod
+# would turn it into "launcher present but unusable" and fail the lane.
+chmod +x "$dir/sharun" 2> /dev/null || true
+printf '%s\n' "$dir/sharun"

--- a/tests/fixtures/sharun/probe-dlopen-lib.c
+++ b/tests/fixtures/sharun/probe-dlopen-lib.c
@@ -1,0 +1,11 @@
+/*
+ * sharun runtime DSO
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const char *probe_dlopen_value(void)
+{
+    return "sharun-dlopen-ok";
+}

--- a/tests/fixtures/sharun/probe-lib.c
+++ b/tests/fixtures/sharun/probe-lib.c
@@ -1,0 +1,11 @@
+/*
+ * sharun probe DSO
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const char *probe_library_value(void)
+{
+    return "sharun-library-ok";
+}

--- a/tests/fixtures/sharun/probe.c
+++ b/tests/fixtures/sharun/probe.c
@@ -1,0 +1,163 @@
+/*
+ * sharun dynamic-loader probe
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Verifies loader state and ordinary dynamic-process behavior from a sharun
+ * bundle.
+ */
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern const char *probe_library_value(void);
+
+typedef const char *(*probe_value_fn)(void);
+
+static void *thread_value(void *arg)
+{
+    return arg;
+}
+
+/* Name the failed check on stderr. A bare exit code out of a guest running
+ * under a hypervisor says nothing about which stage broke.
+ */
+static int fail(int code, const char *what)
+{
+    fprintf(stderr, "probe: %s\n", what);
+    return code;
+}
+
+static int check_process(void)
+{
+    char value[2] = {0};
+    int fd[2];
+    int status;
+    int carried;
+    pid_t child;
+
+    if (pipe(fd) != 0)
+        return fail(6, "pipe failed");
+    child = fork();
+    if (child < 0) {
+        close(fd[0]);
+        close(fd[1]);
+        return fail(6, "fork failed");
+    }
+    if (child == 0) {
+        size_t sent = 0;
+
+        close(fd[0]);
+
+        /* Looped like the parent's read below, and for the same reason: one
+         * write can come back short or EINTR, and the child would then exit 1
+         * and fail this arm for something that has nothing to do with the
+         * loader it exercises.
+         */
+        while (sent < 2) {
+            ssize_t n = write(fd[1], "ok" + sent, 2 - sent);
+            if (n > 0) {
+                sent += (size_t) n;
+                continue;
+            }
+            if (n < 0 && errno == EINTR)
+                continue;
+            break;
+        }
+        _exit(sent == 2 ? 0 : 1);
+    }
+    close(fd[1]);
+
+    /* Loop rather than trusting one read: a pipe read can return short, and
+     * both read and waitpid can come back EINTR. Treating either as a failure
+     * would make this arm flake for reasons that have nothing to do with the
+     * loader it is here to exercise.
+     */
+    carried = 0;
+    while (carried < 2) {
+        ssize_t n = read(fd[0], value + carried, (size_t) (2 - carried));
+        if (n > 0) {
+            carried += (int) n;
+            continue;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        break;
+    }
+    close(fd[0]);
+    if (carried != 2 || memcmp(value, "ok", 2) != 0)
+        return fail(6, "pipe did not carry the child's two bytes");
+    while (waitpid(child, &status, 0) != child) {
+        if (errno == EINTR)
+            continue;
+        return fail(6, "waitpid failed");
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return fail(6, "child did not exit cleanly");
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    const char *marker = getenv("SHARUN_FIXTURE_MARKER");
+    const char *sharun_dir = getenv("SHARUN_DIR");
+    const char *name;
+    volatile double angle = 0.0;
+    int rc;
+    void *handle;
+    void *thread_result;
+    pthread_t thread;
+    probe_value_fn lookup;
+
+    if (argc != 1)
+        return fail(1, "the launcher passed extra arguments");
+    if (marker == NULL || strcmp(marker, "ok") != 0)
+        return fail(1, "SHARUN_FIXTURE_MARKER unset; .env was not applied");
+    if (sharun_dir == NULL || *sharun_dir == '\0')
+        return fail(1, "SHARUN_DIR unset; the launcher found no bundle root");
+    name = strrchr(argv[0], '/');
+    if (name == NULL || strcmp(name + 1, "probe") != 0)
+        return fail(2, "argv[0] does not name the probe");
+    if (strcmp(probe_library_value(), "sharun-library-ok") != 0)
+        return fail(2, "DT_NEEDED libprobe.so gave the wrong value");
+    handle = dlopen("libprobe-dlopen.so", RTLD_NOW | RTLD_LOCAL);
+    if (handle == NULL)
+        return fail(3, dlerror());
+    lookup = (probe_value_fn) dlsym(handle, "probe_dlopen_value");
+    if (lookup == NULL)
+        return fail(4, dlerror());
+    if (strcmp(lookup(), "sharun-dlopen-ok") != 0)
+        return fail(4, "the dlopened DSO gave the wrong value");
+
+    /* Checked like every other loader step: unmapping is the teardown half of
+     * what this probe exists to cover, and discarding the result would let a
+     * bundle whose DSO cannot be unloaded still report success.
+     */
+    if (dlclose(handle) != 0)
+        return fail(4, dlerror());
+    if (cos(angle) != 1.0)
+        return fail(5, "libm cos(0.0) did not return 1.0");
+
+    /* pthread_create returns the error code rather than setting errno, so
+     * strerror needs the return value, not errno.
+     */
+    rc = pthread_create(&thread, NULL, thread_value, (void *) argv);
+    if (rc != 0)
+        return fail(5, strerror(rc));
+    if (pthread_join(thread, &thread_result) != 0 ||
+        thread_result != (void *) argv)
+        return fail(5, "pthread_join lost the thread return value");
+    rc = check_process();
+    if (rc != 0)
+        return rc;
+    puts("sharun-probe-ok");
+    return 0;
+}

--- a/tests/lib/fixture-cache.sh
+++ b/tests/lib/fixture-cache.sh
@@ -1,0 +1,451 @@
+# fixture-cache.sh - Download a fixture into a shared cache exactly once
+#
+# Sourced, not executed. Two things live here: classifying a curl failure as
+# "never reached the server" versus "answered and was wrong", and publishing a
+# built tree into the cache without two concurrent builders corrupting it.
+#
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# shellcheck shell=bash
+
+# fixture_cache_download <url> <output> <what>
+#
+# Returns 0 on success, 77 when the transfer never reached the server, and 1
+# when it reached it and got an error. That split matters: an unreachable
+# network is a skip, but a 404 on a URL the lock file pins is a rotten pin, and
+# reporting that as a skip hides exactly the drift the pin is there to catch.
+# curl's transport failures are the resolve, connect, timeout and TLS-handshake
+# codes; everything else means the far end answered.
+fixture_cache_download()
+{
+    local url="$1" out="$2" what="$3" rc=0
+
+    # --speed-limit/--speed-time rather than --max-time: a transfer that opens
+    # and then stalls must fail, but a slow one that is still moving must not,
+    # and a flat deadline cannot tell those apart. The builder holds the lock
+    # for its whole run, so a wedged transfer would otherwise hold it forever.
+    #
+    # The connect timeout is short on purpose. It measures "did the far end
+    # answer at all", never transfer speed, and --retry multiplies it: at 30
+    # seconds an offline "make check" spent about two minutes reaching the skip
+    # that the 77 exit exists to deliver quickly.
+    curl --fail --location --retry 3 --retry-max-time 10 --silent --show-error \
+        --connect-timeout 5 --speed-limit 1024 --speed-time 60 \
+        --output "$out" "$url" || rc=$?
+    [ "$rc" -eq 0 ] && return 0
+    rc="$(_fixture_cache_classify "$rc" "$out")"
+
+    # 77 is "never reached the server", the ordinary offline case, which the
+    # lane turns into a skip. Anything else means the far end answered with
+    # something wrong, and that has to be loud rather than degrade to a skip.
+    # Said here, where the status is decided, so no caller has to pair a second
+    # function with this one and none can word it differently.
+    if [ "$rc" -eq 77 ]; then
+        printf '%s unreachable, skipping\n' "$what" >&2
+    else
+        printf '%s download failed\n' "$what" >&2
+    fi
+    return "$rc"
+}
+
+_fixture_cache_classify()
+{
+    local rc="$1" out="$2"
+
+    case "$rc" in
+        5 | 6 | 7 | 35) echo 77 ;;
+        18 | 28 | 52 | 56)
+
+            # Timeouts and dropped connections. Each of these covers both a
+            # transfer that never got going (a skip) and one the server began
+            # and then abandoned (loud). The code cannot tell them apart, but
+            # the output can: bytes on disk mean the far end answered and then
+            # stopped, nothing on disk means it was never really reached.
+            if [ -s "$out" ]; then echo 1; else echo 77; fi
+            ;;
+        *) echo 1 ;;
+    esac
+    return 0
+}
+
+# fixture_cache_digest_ok <file> <want> <what>
+#
+# True when the file is there and hashes to what the lock pins. Never 77: the
+# bytes arrived and are not what was asked for, which is drift or tampering.
+#
+# The existence test is part of the check, not the caller's job. Without it
+# shasum fails on its own under errexit and the mismatch message never prints,
+# and that guard had been added to one of the three copies of this and not the
+# others, which is the reason they are now one.
+fixture_cache_digest_ok()
+{
+    local file="$1" want="$2" what="$3" have=''
+
+    [ -s "$file" ] || {
+        printf '%s is missing or empty: %s\n' "$what" "$file" >&2
+        return 1
+    }
+    have="$(shasum -a 256 "$file" | awk '{print $1}')"
+    [ "$want" = "$have" ] || {
+        printf '%s digest mismatch: %s\nwanted %s\ngot    %s\n' \
+            "$what" "$file" "$want" "$have" >&2
+        return 1
+    }
+    return 0
+}
+
+# _fixture_cache_disarm <saved-traps>
+#
+# Drops the cleanup handler and puts back whatever the caller had. Called at
+# every exit rather than once after the build: the lock wait and the publish
+# rename come after the builder, and a kill in either of those windows used to
+# leave the staging tree under the fixture cache with nothing to remove it.
+_fixture_cache_disarm()
+{
+    trap - EXIT INT TERM
+    [ -z "$1" ] || eval "$1"
+    return 0
+}
+
+# _fixture_cache_inode <path>
+#
+# The inode number, or nothing. Two spellings because the flag that means "read
+# this file" to BSD stat means "read the filesystem it sits on" to GNU stat,
+# which answers with the same number for every path and so silently defeats the
+# identity check below rather than failing it.
+_fixture_cache_inode()
+{
+    if [ "$(uname -s)" = Darwin ]; then
+        stat -f %i "$1" 2> /dev/null || true
+    else
+        stat -Lc %i "$1" 2> /dev/null || true
+    fi
+}
+
+# _fixture_cache_lock_acquire <lock-dir>
+#
+# Blocks until this process owns the lock. Factored out of the publish path so
+# eviction can hold the same lock rather than inventing a second exclusion
+# scheme beside it: two mechanisms guarding one directory is how a cache ends up
+# being torn down by one process while another is publishing into it.
+_fixture_cache_lock_acquire()
+{
+    local lock="$1" waited=0 spent=0 lock_ino='' cur_ino='' now_ino=''
+
+    # mkdir is the atomic claim, held across one rename. A lock older than the
+    # grace period below cannot be a publish in progress.
+    #
+    # Which lock, though: removing whatever happens to sit at $lock lets two
+    # waiters that time out together destroy each other. The first removes the
+    # dead lock and acquires a fresh one; the second is already past its grace
+    # period with no sleep left to take, so it deletes that fresh lock and
+    # acquires as well. Both then believe they hold it, one loses its rename,
+    # and the caller is told the build failed over a cache that is complete. So
+    # this waits on a specific lock, identified by inode, and only removes that
+    # one. A lock that changed hands is a live publisher and the wait starts
+    # over against it.
+    while ! mkdir "$lock" 2> /dev/null; do
+        cur_ino="$(_fixture_cache_inode "$lock")"
+        if [ -z "$lock_ino" ]; then
+            lock_ino="$cur_ino"
+        elif [ "$cur_ino" != "$lock_ino" ]; then
+            lock_ino="$cur_ino"
+            waited=0
+        fi
+
+        # Reaped only when the grace period has passed and this is still the
+        # same lock, proven by inode. Falling back to "no inode means it
+        # matches" made the test vacuously true and reaped whatever was there,
+        # which is the two-waiter destruction described above, reintroduced by
+        # the concession meant to keep the reaper portable. _fixture_cache_inode
+        # handles both stat dialects, so an unreadable inode now means the lock
+        # is gone rather than that this host cannot read one, and the next mkdir
+        # takes it.
+        if [ "$waited" -ge 50 ] && [ -n "$cur_ino" ] \
+            && [ "$cur_ino" = "$lock_ino" ]; then
+
+            # Read again here, not trusted from the top of the iteration. Two
+            # waiters can both reach this test holding the same old inode; the
+            # first reaps and takes a fresh lock, and the second would then
+            # remove that live one, which is the destruction the inode is here
+            # to stop. Re-reading narrows the window to the gap between this
+            # line and the rm; it does not close it, because the shell has no
+            # way to remove a directory by inode.
+            now_ino="$(_fixture_cache_inode "$lock")"
+            if [ "$now_ino" = "$lock_ino" ]; then
+                printf 'fixture cache publish lock is stale; removing %s\n' \
+                    "$lock" >&2
+                rm -rf "$lock"
+                lock_ino=''
+                waited=0
+            fi
+            continue
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+        spent=$((spent + 1))
+
+        # An absolute cap on top of the per-identity grace. The reaper only
+        # fires for a lock whose inode this call can read and has been waiting
+        # on, which is right, but stat also fails on a directory it lacks
+        # permission to read, and then nothing would ever reap and this would
+        # sleep forever. Sixty seconds is far past any real publish, so reaching
+        # it means something is wrong that waiting will not fix.
+        [ "$spent" -lt 600 ] || {
+            printf 'gave up waiting for the fixture cache lock: %s\n' "$lock" >&2
+            return 1
+        }
+    done
+    return 0
+}
+
+# _fixture_cache_evict <final> <lock-dir>
+#
+# Removes a cached tree, taking the publish lock itself for the rename.
+#
+# A rename, then the delete outside the claim. The reaper above calls a lock
+# older than five seconds abandoned, which is only true because the lock is held
+# across a single same-filesystem rename; an rm -rf of a multi-megabyte tree
+# under the same lock breaks that assumption, and a waiter would reap a live
+# lock mid-eviction. The rename also makes the removal atomic to a reader: the
+# tree is either wholly there or wholly gone, never a directory being emptied
+# under someone reading it.
+_fixture_cache_evict()
+{
+    local final="$1" lock="$2" doomed="$1.evicting.$$"
+
+    # The claim covers the rename and nothing else. Holding it across the delete
+    # is what the reaper above cannot survive: it calls a lock older than five
+    # seconds abandoned, which is true of a rename and not of removing a
+    # multi-megabyte tree on a loaded host, and a waiter would then reap a live
+    # claim while this call still believes it holds it. Renaming first also
+    # makes the removal atomic to a reader: the tree is wholly there or wholly
+    # gone, never a directory being emptied underneath one.
+    _fixture_cache_lock_acquire "$lock" || return 1
+
+    # Tested under the claim, not before it. Two runs that fail the same cache
+    # hit both come here; the first renames the tree away and the second finds
+    # nothing to rename. That is the eviction it wanted, already done, so it
+    # succeeds. Asking before taking the lock let both pass the test and made
+    # the loser report a hard failure over work that had happened.
+    if [ -d "$final" ] && ! mv "$final" "$doomed" 2> /dev/null; then
+        rmdir "$lock" 2> /dev/null || true
+        return 1
+    fi
+    rmdir "$lock" 2> /dev/null || true
+    rm -rf "$doomed"
+    return 0
+}
+
+# fixture_cache_build <final_dir> <verify_fn|-> <builder> [args...]
+#
+# Returns 0 when final_dir holds the fixture, whether this call built it or
+# found it. A tree that is already there is handed to verify_fn first and
+# rebuilt if it does not pass; "-" skips that. The check runs without the
+# publish lock, which only the eviction that follows a failure takes:
+# verification reads the whole tree, and holding the lock that long would break
+# the assumption its stale-lock reaper rests on. Otherwise runs "builder
+# [args...] <stage_dir>" with stage_dir created and empty, and publishes it. The
+# builder's exit code is returned unchanged, so it can distinguish "could not
+# fetch" (77, a skip) from "fetched something wrong" (anything else, loud).
+#
+# Builders run without holding anything. Every builder here produces the same
+# pinned bytes, so two of them racing costs a duplicate download and nothing
+# else, and the alternative (a lock held across a multi-megabyte transfer) has
+# to answer what to do about a holder that was killed mid-download, which is
+# where the complexity lives. Only the publish is serialized, and it is a single
+# rename, so a lock still present after a few seconds is unambiguously abandoned
+# rather than possibly-still-working.
+_fixture_cache_stage=''
+
+# Set when a cache hit failed its check and was evicted. Internal to
+# fixture_cache_build, which reads it in one place: the guard that turns a
+# builder's 77 into a loud failure when this call had already thrown a tree
+# away. Not for callers, and the underscore says so. It was public once, and
+# read by a fetch script, until the rule it fed moved in here; leaving the name
+# and the comment behind advertised something no longer true, and every return
+# path restores the value anyway, so a caller reading it would see what it held
+# before the call.
+_fixture_cache_rebuilt=0
+
+# Cleans up, then dies of the signal it was given. A handler that only cleans up
+# and returns leaves bash carrying on at the next command, so a Ctrl-C or a
+# CI-sent SIGTERM during a download aborts curl and then resumes the build
+# instead of ending it. Restoring the default and re-raising is what makes the
+# process exit the way the sender asked.
+_fixture_cache_on_signal()
+{
+    _fixture_cache_cleanup
+    trap - "$1"
+
+    # BASHPID, not $$: inside a subshell $$ still holds the PID of the shell
+    # that started the script, so re-raising there signals the parent instead of
+    # the process that took the signal.
+    kill -"$1" "${BASHPID:-$$}"
+}
+
+_fixture_cache_cleanup()
+{
+    [ -z "$_fixture_cache_stage" ] || rm -rf "$_fixture_cache_stage"
+    _fixture_cache_stage=''
+    return 0
+}
+
+fixture_cache_build()
+{
+    local final="$1" verify="$2"
+    shift 2
+    local lock="$final.lock" rc=0
+
+    # Saved before this call claims the global below, and restored on every
+    # exit. _fixture_cache_stage is process-global, like the traps further down,
+    # so a builder that itself calls fixture_cache_build would have the inner
+    # call overwrite and then clear the outer one's stage: the outer publish
+    # would then report failure and orphan its own staged tree.
+    local prev_stage="$_fixture_cache_stage" prev_rebuilt="$_fixture_cache_rebuilt"
+
+    # Cleared per call. It reports what this call did, and a caller that fetches
+    # two fixtures would otherwise read the first one's eviction as the second
+    # one's and turn an ordinary offline skip into a failure.
+    _fixture_cache_rebuilt=0
+
+    # A cache hit is checked before it is trusted, and checked under the lock,
+    # so a tree that fails is evicted where no publisher can be mid-rename into
+    # it. Callers used to do this after the call and then evict from outside,
+    # which is a second mechanism guarding one directory: it could delete a
+    # peer's fresh publish, or pull a launcher out from under an arm about to
+    # exec it. "-" means the caller has nothing to check.
+    if [ -d "$final" ]; then
+
+        # Outside the lock. Verification reads the whole tree (a shasum of every
+        # member), and the reaper above calls a lock older than five seconds
+        # abandoned, which holds only while the lock covers a single rename. A
+        # verify under the lock breaks exactly the assumption the reaper is
+        # built on, and a loaded machine would then have a waiter tear down a
+        # live claim. A read needs no exclusion: the worst a concurrent evict
+        # can do is remove a tree this call was about to call good, and the
+        # caller then fails on a missing path rather than trusting a bad one.
+        if [ "$verify" = - ] || "$verify" "$final"; then
+            _fixture_cache_rebuilt="$prev_rebuilt"
+            return 0
+        fi
+        printf 'cached fixture failed its check; rebuilding: %s\n' "$final" >&2
+
+        # The eviction takes the lock itself, for the rename alone.
+        _fixture_cache_evict "$final" "$lock" || {
+            _fixture_cache_rebuilt="$prev_rebuilt"
+            return 1
+        }
+
+        # Told to the caller, because a rebuild that then cannot reach the
+        # network returns 77 and the lane turns that into a green skip. A
+        # corrupt cache is not an offline run and must not read like one.
+        _fixture_cache_rebuilt=1
+    fi
+    mkdir -p "$(dirname "$final")" || {
+        printf 'cannot create fixture cache directory: %s\n' \
+            "$(dirname "$final")" >&2
+        _fixture_cache_rebuilt="$prev_rebuilt"
+        return 1
+    }
+
+    _fixture_cache_stage="$final.stage.$$"
+    rm -rf "$_fixture_cache_stage"
+    mkdir -p "$_fixture_cache_stage" || {
+
+        # Restored here too. Leaving the global pointing at a stage this call
+        # never created makes a nested caller's failure path clean up the inner
+        # path and orphan the outer one's real tree.
+        _fixture_cache_stage="$prev_stage"
+        _fixture_cache_rebuilt="$prev_rebuilt"
+        return 1
+    }
+
+    # Armed across the build, which is the only part that can be interrupted:
+    # without it a builder killed mid-download abandons its staging tree under
+    # the fixture cache, once per occurrence, forever. Saved and restored rather
+    # than cleared, because trap state is process-global and a bare "trap -"
+    # would take an EXIT handler the caller installed for its own reasons.
+    local prev_traps
+    prev_traps="$(trap -p EXIT INT TERM)"
+    trap _fixture_cache_cleanup EXIT
+    trap '_fixture_cache_on_signal INT' INT
+    trap '_fixture_cache_on_signal TERM' TERM
+    "$@" "$_fixture_cache_stage" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        _fixture_cache_cleanup
+        _fixture_cache_stage="$prev_stage"
+        _fixture_cache_disarm "$prev_traps"
+
+        # Here rather than in each fetcher. 77 is "never reached the server",
+        # which the lane turns into a skip, but this call threw away a tree that
+        # failed its check before trying, so the cache is now gone and reporting
+        # an ordinary offline run would hide the corruption that caused it. One
+        # fetcher had this guard and the other did not, which is the whole
+        # argument for it living where the eviction happens.
+        if [ "$rc" -eq 77 ] && [ "$_fixture_cache_rebuilt" -eq 1 ]; then
+            printf 'the cached fixture was unusable and could not be rebuilt: %s\n' \
+                "$final" >&2
+            _fixture_cache_rebuilt="$prev_rebuilt"
+            return 1
+        fi
+        _fixture_cache_rebuilt="$prev_rebuilt"
+        return "$rc"
+    fi
+
+    _fixture_cache_lock_acquire "$lock" || {
+        _fixture_cache_cleanup
+        _fixture_cache_stage="$prev_stage"
+        _fixture_cache_rebuilt="$prev_rebuilt"
+        _fixture_cache_disarm "$prev_traps"
+        return 1
+    }
+
+    # Under the claim, so this cannot race a second publisher. Never mv onto an
+    # existing directory: that puts the stage inside it and the cache answers
+    # with final/final for good. A publish that lost simply drops its own work.
+    if [ -d "$final" ] || [ -z "$_fixture_cache_stage" ]; then
+
+        # Either another publisher won, or a signal handler already reclaimed
+        # this stage. Renaming an empty name would land on the cwd.
+        rc=1
+        [ ! -d "$final" ] || rc=0
+    else
+
+        # Cleared only on success: clearing first would leave the cleanup below
+        # with nothing to remove and the staging tree orphaned.
+        if mv "$_fixture_cache_stage" "$final"; then
+            _fixture_cache_stage=''
+        else
+            rc=1
+        fi
+    fi
+    rmdir "$lock" 2> /dev/null || true
+
+    # After the claim is released, not before. A publish that lost still holds a
+    # fully built tree, and for the glibc runtime that is several megabytes; an
+    # rm -rf of it under the lock is the same thing the reaper cannot survive,
+    # which is why _fixture_cache_evict renames aside and deletes outside too.
+    # Nothing races this: the stage is this call's own path. A no-op on the
+    # winning path, where the rename already cleared the name.
+    _fixture_cache_cleanup
+
+    [ "$rc" -eq 0 ] && [ -d "$final" ] || {
+        _fixture_cache_stage="$prev_stage"
+        _fixture_cache_rebuilt="$prev_rebuilt"
+        _fixture_cache_disarm "$prev_traps"
+        return 1
+    }
+
+    # Restored on every exit, so a nested call hands the outer one its stage
+    # back exactly as it found it.
+    # Restored beside the stage and the traps, and for the same reason: a builder
+    # that itself fetches a fixture would otherwise hand the outer call the inner
+    # one's verdict, and an offline rebuild of a tree evicted out here would read
+    # as an ordinary skip.
+    _fixture_cache_stage="$prev_stage"
+    _fixture_cache_rebuilt="$prev_rebuilt"
+    _fixture_cache_disarm "$prev_traps"
+    return 0
+}

--- a/tests/sharun-fixture.lock
+++ b/tests/sharun-fixture.lock
@@ -1,0 +1,49 @@
+# Pins for the sharun lane. Sourced as shell by tests/test-sharun.sh,
+# tests/fetch-glibc.sh, and tests/fetch-sharun-bin.sh.
+#
+# An upstream prebuilt release, not a source build. SHARUN_BIN_NAME names the
+# default-features build, which is what a user downloads; the -lite variant
+# would serve this lane too, since nothing here needs the lib4bin cargo feature
+# it drops, but the point is to run what users run. Refresh version and digest
+# together, and verify against a fresh download rather than trusting the release
+# page:
+#   curl -fLsS -o /tmp/sharun \
+#     "https://github.com/VHSgunzo/sharun/releases/download/$SHARUN_VERSION/$SHARUN_BIN_NAME"
+#   shasum -a 256 /tmp/sharun
+SHARUN_VERSION=v0.8.1
+
+# What "sharun --version" prints, whole. Arm 1 is the one arm with no skip, so a
+# mismatch reds the lane everywhere, and it compares against output this project
+# does not control. Pinned beside the digest so an upstream change in how the
+# version is rendered is a one-line edit here rather than a lane that cannot
+# pass. Measured from the pinned binary, not assumed.
+SHARUN_VERSION_OUTPUT=v0.8.1
+SHARUN_BIN_NAME=sharun-aarch64
+SHARUN_BIN_SHA256=36a0d16e9d6085e0f11a3e3f76727a0a14aee44ef8e626a76a99555f4da541dc
+# The x86_64 build of the same release, run through elfuse's Rosetta path. It
+# is a static-pie musl Rust binary, which is a shape the aarch64 lanes never
+# exercise. Verified with the same "curl then shasum" recipe above.
+SHARUN_BIN_X86_64=sharun-x86_64
+SHARUN_BIN_X86_64_SHA256=18d970f56eca2c527ffd3993b161b6bc340055129db14b394a77cb67d8bbfff9
+
+# The aarch64 glibc runtime the local bundle is assembled from, taken from
+# Debian's own build so no cross-libc or Linux host is needed. snapshot.debian.org
+# file URLs are permanent; a distribution pool URL is not, because the pool drops
+# a package as soon as a point release supersedes it.
+#
+# Must stay at glibc 2.33 or newer: sharun invokes the loader as
+# "ld.so ... --argv0 ...", which older loaders treat as a filename and die with
+# "--argv0: cannot open shared object file". Measured against a 2.28 sysroot.
+# The probe's runtime closure, and the whole of what the glibc runtime holds.
+# Named here because two scripts act on it: tests/fetch-glibc.sh copies these out
+# of the package, and tests/build-sharun-bundle.sh copies them into the bundle.
+# It used to be a glob in one and a list in the other, so the cache carried the
+# package's other twenty-odd modules, nothing consumed them, and every cache hit
+# re-hashed them. tests/build-sharun-bundle.sh's DT_NEEDED gate is what keeps
+# this honest: a fixture that grows a dependency fails there rather than
+# silently shipping without it.
+GLIBC_CLOSURE="ld-linux-aarch64.so.1 libc.so.6 libm.so.6 libdl.so.2 libpthread.so.0"
+
+GLIBC_VERSION=2.36-9+deb12u14
+GLIBC_DEB_URL=https://snapshot.debian.org/file/85af57bf1f9fa075163e51c99d9536154c21ab7e
+GLIBC_DEB_SHA256=01f4330719fd4f65580e16ea5a0527f372fca750e8f588d26deaf09f2d3b1cf4

--- a/tests/test-bench-guardrail.sh
+++ b/tests/test-bench-guardrail.sh
@@ -31,7 +31,12 @@ BENCH_GUARDRAIL_REQUIRE_STATIC="${BENCH_GUARDRAIL_REQUIRE_STATIC:-1}"
 STATIC_BENCH="${BENCH_GUARDRAIL_DIR}/bench-hot-guard"
 GLIBC_BENCH="${BENCH_GUARDRAIL_DIR}/bench-hot-guard-glibc"
 GLIBC_TOOLCHAIN="${LINUX_TOOLCHAIN:-/opt/toolchain/aarch64-linux-gnu}"
-GLIBC_SYSROOT="${GLIBC_TOOLCHAIN}/aarch64-unknown-linux-gnu/sysroot"
+
+# Honor the makefile's CROSS_GLIBC_SYSROOT when it passes one: the prerequisite
+# guard that decides whether bench-hot-guard-glibc gets built reads that
+# variable, so deriving a different path here would run the benchmark against a
+# sysroot the guard never checked.
+GLIBC_SYSROOT="${GLIBC_SYSROOT:-${GLIBC_TOOLCHAIN}/aarch64-unknown-linux-gnu/sysroot}"
 ITERS="${BENCH_GUARDRAIL_ITERS:-200000}"
 
 # Absolute ceilings for the three shim/vDSO-served lanes. The wide headroom is

--- a/tests/test-sharun.sh
+++ b/tests/test-sharun.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+
+# test-sharun.sh - Run sharun and its probe under elfuse
+#
+# Six arms, in increasing order of what they need from the host:
+#   1  the prebuilt launcher, a static aarch64 ELF, so it runs anywhere elfuse
+#      does
+#   2  the x86_64 build of that same launcher through elfuse's Rosetta path, a
+#      static-pie musl Rust binary, a shape no aarch64 lane exercises
+#   3  the cross-built probe against the cross-glibc sysroot, which is the
+#      loader coverage (DT_NEEDED, dlopen, $ORIGIN rpath) and skips without
+#      that toolchain
+#   4  the same probe inside a bundle, driven by the real launcher
+#   5  the launcher regenerating the bundle's lib.path, which walks the tree
+#      and writes to it from inside the guest
+#   6  the bundle with its dlopen target removed, which must surface the
+#      loader's errno rather than hang or crash
+#
+# The whole lane exits 77 in two places: when it cannot even reach arm 1, and
+# when arm 1 passed but no dynamic-loader arm could run at all. The second is
+# what stops a run that covered only the static launcher from reporting the same
+# green as one that exercised the loader. Short of that, a developer without a
+# bundle still gets the launcher and the loader covered on every run.
+#
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+elfuse_input="${1:-build/elfuse}"
+case "$elfuse_input" in
+    /*) elfuse="$elfuse_input" ;;
+    *) elfuse="$(pwd)/$elfuse_input" ;;
+esac
+probe_dir="${2:-}"
+case "$probe_dir" in
+    '' | /*) ;;
+
+    # Absolutized like elfuse above: the lane cd's nowhere itself, but it hands
+    # this path to build-sharun-bundle.sh and reads it after the guest runs, so
+    # a relative one silently breaks every arm when the lane is invoked from
+    # anywhere but the repo root.
+    *) probe_dir="$(pwd)/$probe_dir" ;;
+esac
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+# CROSS_GLIBC_SYSROOT is exported by mk/toolchain.mk, so a make run already has
+# it; the fallback asks the compiler the same question mk/toolchain.mk asks,
+# which is what makes a hand run work. Spelling the path out here instead would
+# reintroduce the literal that variable exists to remove, and would be wrong for
+# a distro multiarch compiler whose sysroot is "/".
+# "|| true" because the compiler need not exist: a host without the cross
+# toolchain is the ordinary case this lane skips on, and without it the failed
+# substitution takes errexit and the lane dies before it can report anything.
+probe_sysroot="${CROSS_GLIBC_SYSROOT:-$(
+    "${CROSS_COMPILE:-aarch64-linux-gnu-}gcc" -print-sysroot 2> /dev/null || true
+)}"
+
+# Exported, not just inherited: the fetch scripts run as subprocesses and read
+# FIXTURES_DIR themselves, so without this a "make check FIXTURES_DIR=..." moved
+# every other fixture and left these two caching under the repo default.
+export FIXTURES_DIR="${FIXTURES_DIR:-$repo_root/externals/test-fixtures}"
+
+# Before report.sh, which sources tests/lib/test-runner.sh, which defaults this
+# to 10. Every arm here boots the hypervisor and runs a dynamically linked
+# probe, so 10 is where a slow machine starts reporting timeouts as failures.
+# Assigned rather than tested afterwards so "TEST_TIMEOUT=60 make check" still
+# wins.
+: "${TEST_TIMEOUT:=20}"
+
+# shellcheck source=tests/lib/report.sh
+. "$repo_root/tests/lib/report.sh"
+
+# The lock is plain KEY=VALUE and every other consumer sources it. Re-reading
+# individual keys with sed here would be a second parser for one format.
+# shellcheck source=tests/sharun-fixture.lock
+. "$repo_root/tests/sharun-fixture.lock"
+
+[ -x "$elfuse" ] || {
+    printf 'elfuse binary not found: %s\n' "$elfuse" >&2
+    exit 1
+}
+
+# One answer to "is there a probe to run", so arms 3 and 4 ask it the same way.
+# The probe itself, not the sysroot directory: make builds it only when the
+# sysroot could compile and link it, so its presence is the tested fact, while a
+# -d on a path this script guessed skips the two arms the lane exists for on any
+# host whose sysroot is somewhere else.
+#
+# An empty probe_dir is a host without the cross toolchain, which is the skip
+# this lane is built to degrade to. A probe_dir that was given but holds no
+# usable probe is a broken build, and reporting that as "no cross-glibc sysroot"
+# names a cause that is not the one in front of the reader, in the same green
+# shape as a host that legitimately has no toolchain. Missing and present but
+# not executable are the same answer here: a directory was named and there is
+# nothing runnable in it.
+if [ -n "$probe_dir" ] && [ ! -x "$probe_dir/probe" ]; then
+    printf 'no runnable probe in the directory given: %s/probe\n' "$probe_dir" >&2
+    printf 'the cross build produces it; "make test-sharun" builds it first\n' >&2
+    exit 1
+fi
+
+# A probe with no sysroot to run it against. Only reachable by hand: a make run
+# exports CROSS_GLIBC_SYSROOT, and the guard that builds the probe links against
+# it. Loud rather than passing --sysroot '' to elfuse, which fails inside the
+# guest as a loader error naming neither the empty sysroot nor the reason.
+if [ -n "$probe_dir" ] && [ -z "$probe_sysroot" ]; then
+    printf 'a probe was built but no cross-glibc sysroot is known; set\n' >&2
+    printf 'CROSS_GLIBC_SYSROOT or run this through "make test-sharun"\n' >&2
+    exit 1
+fi
+
+# timeout, not "$TIMEOUT": tests/lib/test-runner.sh, which report.sh sources,
+# defines a timeout wrapper over the whole ladder it searches (TIMEOUT_BIN, then
+# timeout, then gtimeout, then Homebrew's opt symlinks). report.sh's
+# require_timeout looks only on PATH, so a host with coreutils installed but not
+# linked skipped this entire lane while every other lane ran.
+#
+# One timeout for every guest invocation, applied in run_guest so no arm can
+# choose its own. It was a literal at each call site, with nothing keeping them
+# equal.
+GUEST_TIMEOUT="$TEST_TIMEOUT"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# Resolve a launcher. The fetcher separates the two ways this goes wrong, and
+# the difference matters: 77 means it could not be downloaded, which is a skip,
+# while anything else means the cached copy failed its digest, which is a broken
+# tree and has to be loud. Collapsing them would turn a corrupted cache into a
+# green skip. Sets launcher_path and launcher_rc.
+launcher_path=''
+launcher_rc=0
+resolve_launcher()
+{
+    set +e
+    launcher_path="$("$repo_root/tests/fetch-sharun-bin.sh" "$1" \
+        2> "$scratch/fetch-$1.err")"
+    launcher_rc=$?
+    set -e
+    [ "$launcher_rc" -eq 0 ] || launcher_path=''
+}
+
+# Fetched here, not by a make prerequisite: a prerequisite that cannot be
+# downloaded is fatal, and this lane runs inside "make check".
+resolve_launcher aarch64
+if [ "$launcher_rc" -ne 0 ]; then
+    cat "$scratch/fetch-aarch64.err" >&2
+    [ "$launcher_rc" -eq 77 ] && exit 77
+    printf 'sharun launcher is present but unusable; the lane cannot continue\n' >&2
+    exit 1
+fi
+sharun="$launcher_path"
+
+# A literal, not a fixture file. The file it replaced synchronized nothing:
+# tests/fixtures/sharun/probe.c prints this string from its own literal, so both
+# still had to be edited together, and no other lane keeps expected output in
+# tests/fixtures.
+expected='sharun-probe-ok'
+total=6
+
+# Arms that actually exercised a dynamic loader, as opposed to skipping. Read
+# once at the end to decide whether this run covered anything.
+loader_arms_run=0
+
+guest_rc=0
+run_guest()
+{
+    local tag="$1"
+    shift
+    set +e
+    timeout "$GUEST_TIMEOUT" "$@" > "$scratch/$tag.out" 2> "$scratch/$tag.err"
+    guest_rc=$?
+
+    # 124 is the cap firing, not the guest failing. Every arm here boots the
+    # hypervisor, so a machine under load can push a correct run past the cap
+    # and the arm would report rc=124 as though the probe were wrong. Re-run
+    # once, and only when the host is actually busy: an idle machine reports the
+    # timeout immediately and pays nothing, and a real hang reproduces on the
+    # second attempt.
+    #
+    # Without the elapsed-time comparison tests/lib/test-runner.sh makes,
+    # because there is nothing here for it to disambiguate. That runner has two
+    # watchdogs and uses elapsed time to tell its own from the guest's; this
+    # lane has one, the timeout on the line above, and the programs it runs are
+    # the launcher and the probe, which exit 1 to 6 and never 124. A 124 here is
+    # the cap and nothing else, so the only open question is whether load caused
+    # it.
+    if [ "$guest_rc" -eq 124 ] && test_host_is_busy; then
+        printf 'timeout under host load, re-running: %s\n' "$tag" >&2
+        timeout "$GUEST_TIMEOUT" "$@" > "$scratch/$tag.out" 2> "$scratch/$tag.err"
+        guest_rc=$?
+    fi
+    set -e
+}
+
+# Run a guest command under elfuse and require rc 0 plus a marker on stdout.
+# Named separately from tests/lib/test-runner.sh's run(): that resolves the
+# binary as $BIN/$tool, and these arms live in three different directories.
+#
+# Every arm that runs a program and checks what it printed comes through here,
+# arm 4 included. It was written out a second time there, and the two copies had
+# already drifted in how they worded the same failure; one binary checked two
+# ways is how a lane starts disagreeing with itself.
+#
+# The verdict comes back in marker_ok rather than the return status, matching
+# guest_rc and launcher_rc above. A function that returns 1 would abort the lane
+# under errexit at the call sites that do not test it.
+marker_ok=0
+expect_marker()
+{
+    local label="$1" marker="$2" tag="$3"
+    shift 3
+    run_guest "$tag" "$@"
+    marker_ok=0
+
+    # Read once and reused below. Read again for the diagnostic, an arm that
+    # printed nothing and an arm that printed the wrong thing render the same
+    # blank line, and those are the two cases a reader has to tell apart.
+    local got=''
+    got="$(cat "$scratch/$tag.out")"
+
+    # Whole-stdout equality. A substring match would let extra output through in
+    # one arm and fail in another, so two arms would disagree about one binary.
+    if [ "$guest_rc" -eq 0 ] && [ "$got" = "$marker" ]; then
+        report_pass "$label"
+        marker_ok=1
+        return 0
+    fi
+
+    # Which of the two failed. "rc=0" alone reads as a false alarm when the
+    # process succeeded and only the output disagreed.
+    if [ "$guest_rc" -ne 0 ]; then
+        report_fail "$label: rc=$guest_rc"
+    else
+        report_fail "$label: output"
+    fi
+
+    # Name both sides. A wrong-output failure and a no-output failure print the
+    # same thing otherwise, and the probe's stage codes are only readable next
+    # to what it was supposed to say.
+    printf 'expected stdout: %s\n' "$marker" >&2
+    if [ -n "$got" ]; then
+        printf 'actual stdout:   %s\n' "$got" >&2
+    else
+        printf 'actual stdout:   (nothing on stdout)\n' >&2
+    fi
+    sed 's/^/  stderr: /' "$scratch/$tag.err" >&2
+    return 0
+}
+
+# Arm 1: the launcher. --version both pins the binary the lock file names and
+# proves the Rust runtime got far enough to render output.
+expect_marker 'sharun --version' "$SHARUN_VERSION_OUTPUT" version \
+    "$elfuse" "$sharun" --version
+
+# Arm 2: the same check through Rosetta. Skips when the translator is absent,
+# the same gate tests/test-rosetta-statics.sh uses.
+rosetta="${MATRIX_ROSETTA_TRANSLATOR:-/Library/Apple/usr/libexec/oah/RosettaLinux/rosetta}"
+if [ -n "${ELFUSE_NO_ROSETTA:-}" ]; then
+
+    # Present on disk is not the same as willing to use it. This arm hands
+    # elfuse an x86_64 binary, which the documented opt-out makes it refuse, so
+    # without this the lane reports a red failure for a supported configuration.
+    report_skip 'sharun x86_64 (Rosetta disabled)'
+elif [ ! -x "$rosetta" ]; then
+    report_skip 'sharun x86_64 (no Rosetta translator)'
+else
+    resolve_launcher x86_64
+    if [ "$launcher_rc" -eq 77 ]; then
+        report_skip 'sharun x86_64 (launcher unavailable)'
+        cat "$scratch/fetch-x86_64.err" >&2
+    elif [ "$launcher_rc" -ne 0 ]; then
+
+        # Any non-77: a rotten pin, an HTTP error, or a digest that does not
+        # match. Naming one of them here mislabels the other two.
+        report_fail 'sharun x86_64 (launcher unusable)'
+        cat "$scratch/fetch-x86_64.err" >&2
+    else
+        expect_marker 'sharun --version (x86_64 via Rosetta)' \
+            "$SHARUN_VERSION_OUTPUT" version-x86 "$elfuse" "$launcher_path" \
+            --version
+    fi
+fi
+
+# Arm 3: the probe, standalone. SHARUN_FIXTURE_MARKER and SHARUN_DIR are what
+# the bundle's .env and the launcher supply in arm 4; here the lane stands in
+# for them, which is the only difference between the two probe runs.
+if [ -z "$probe_dir" ]; then
+    report_skip 'sharun probe (no cross-glibc sysroot)'
+else
+    loader_arms_run=$((loader_arms_run + 1))
+    expect_marker 'sharun probe (dlopen, rpath, threads, fork)' \
+        "$expected" probe env SHARUN_FIXTURE_MARKER=ok SHARUN_DIR=/sharun \
+        "$elfuse" --sysroot "$probe_sysroot" "$probe_dir/probe"
+fi
+
+# Arms 5 and 6 only exist inside a bundle. Whenever arm 4 cannot run they still
+# have to account for themselves, or the lane prints four lines and claims six.
+skip_bundle_extras()
+{
+    report_skip "sharun --gen-lib-path ($1)"
+    report_skip "sharun missing DSO ($1)"
+}
+
+# Stage a private copy of the bundle. Arms 5 and 6 both mutate what they run
+# against, so they get their own: sharing one tree made a failure in arm 5 come
+# back as an unrelated failure in arm 6. It also keeps an external
+# SHARUN_FIXTURE_DIR read-only.
+stage_bundle()
+{
+    local dest="$scratch/$1"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+
+    # -L, so a SHARUN_FIXTURE_DIR that is a symlink becomes a real tree here.
+    # Without it the stage is itself a symlink back to the caller's bundle, and
+    # the arms below delete through it into their source.
+    #
+    # A plain copy. An APFS clone (cp -c) saved about 7 ms per stage on a 3 MB
+    # bundle, three times in a lane that boots the hypervisor six times, and
+    # cost a Darwin test, an empty branch, and a recovery for the half-created
+    # directory a failed clone leaves behind.
+    cp -aL "$fixture" "$dest/sharun" || return 1
+    printf '%s\n' "$dest"
+}
+
+# Arms 4, 5 and 6, all against one bundle. Every early return has already
+# accounted for all three.
+run_bundle_arms()
+{
+    local file missing='' sysroot
+
+    # What these three arms need, which is the launcher plus this lane's probe
+    # and its two DSOs. That is more than a generic sharun bundle carries, so
+    # SHARUN_FIXTURE_DIR has to point at one built around this probe rather than
+    # at any lib4bin output. manifest.txt is deliberately not required: only
+    # tests/build-sharun-bundle.sh writes it, and the arms never read it.
+    # Everything the arms open, including the two that are not programs: arms 4
+    # and 6 read the marker out of .env, and arm 5 regenerates lib.path. Left
+    # out, an external bundle missing either passed this check and failed later
+    # as a wrong-output or missing-file error pointing at the arm rather than at
+    # the bundle it was handed.
+    for file in sharun bin/probe shared/bin/probe shared/lib/libprobe.so \
+        shared/lib/libprobe-dlopen.so .env shared/lib/lib.path; do
+        [ -e "$fixture/$file" ] || missing="$missing $fixture/$file"
+    done
+    if [ -n "$missing" ]; then
+        printf 'sharun fixture is not a probe bundle; missing:%s\n' \
+            "$missing" >&2
+        report_fail 'sharun bundle (incomplete fixture)'
+        skip_bundle_extras 'bundle unusable'
+        return 0
+    fi
+
+    # Arm 4: the probe under the real launcher. Staging can fail (a full disk, a
+    # bad fixture). Report it as the arm's failure rather than letting errexit
+    # kill the lane with no summary.
+    if ! sysroot="$(stage_bundle probe)"; then
+        report_fail 'sharun bundle (could not stage)'
+        skip_bundle_extras 'bundle unusable'
+        return 0
+    fi
+    loader_arms_run=$((loader_arms_run + 1))
+    expect_marker 'sharun bundle (launcher plus probe)' "$expected" bundle \
+        "$elfuse" --sysroot "$sysroot" /sharun/bin/probe
+
+    # Only this arm has a manifest, and only a failure wants it: it records
+    # which launcher and glibc the bundle was assembled from, which is the first
+    # question asked when the probe runs but says the wrong thing.
+    if [ "$marker_ok" -eq 0 ] && [ -e "$fixture/manifest.txt" ]; then
+        cat "$fixture/manifest.txt" >&2
+    fi
+
+    # Arm 5: the launcher rewriting the bundle from inside the guest.
+    # --gen-lib-path walks shared/lib and writes lib.path back, so this is the
+    # one arm where a sharun subcommand does directory reads and a file create
+    # through elfuse rather than just exec'ing the loader.
+    if ! sysroot="$(stage_bundle genlibpath)"; then
+        report_fail 'sharun --gen-lib-path (could not stage)'
+        report_skip 'sharun missing DSO (could not stage)'
+        return 0
+    fi
+    rm -f "$sysroot/sharun/shared/lib/lib.path"
+
+    # Not counted as a loader arm: --gen-lib-path is the static launcher reading
+    # a directory and writing a file, with no dynamic loader involved. The
+    # counter decides whether this run covered the loader at all, so an arm that
+    # did not must not vote. Harmless today, since arm 4 always runs first, but
+    # the counter's definition is what the exit-77 message claims.
+    run_guest gen "$elfuse" --sysroot "$sysroot" /sharun/sharun --gen-lib-path
+
+    # Content, not just size. The arm exists to show the launcher rewrites the
+    # file correctly, and "not empty" would accept anything it happened to put
+    # there. A bundle whose libraries all sit in shared/lib regenerates to the
+    # single relative entry "+".
+    if [ "$guest_rc" -eq 0 ] \
+        && [ "$(cat "$sysroot/sharun/shared/lib/lib.path" 2> /dev/null)" = '+' ]; then
+        report_pass 'sharun --gen-lib-path'
+    else
+
+        # Which of the two failed. The launcher exiting 0 and writing nothing
+        # reads as a pass otherwise.
+        if [ "$guest_rc" -ne 0 ]; then
+            report_fail "sharun --gen-lib-path: rc=$guest_rc"
+        elif [ ! -s "$sysroot/sharun/shared/lib/lib.path" ]; then
+            report_fail 'sharun --gen-lib-path: no lib.path'
+            ls -l "$sysroot/sharun/shared/lib/" >&2 2> /dev/null || true
+        else
+
+            # Present but not what the launcher should have written. Saying it
+            # is missing and then listing a directory that contains it is worse
+            # than saying nothing.
+            report_fail 'sharun --gen-lib-path: wrong lib.path'
+            printf 'wanted: +\n' >&2
+            sed 's/^/  got: /' "$sysroot/sharun/shared/lib/lib.path" >&2
+        fi
+        sed 's/^/  stderr: /' "$scratch/gen.err" >&2
+    fi
+
+    # Arm 6: the negative path. With the dlopen target gone the probe must come
+    # back with its own exit 3 and the loader's message, which is what proves
+    # elfuse surfaces a failed dlopen instead of hanging or dying.
+    if ! sysroot="$(stage_bundle missingdso)"; then
+        report_fail 'sharun missing DSO (could not stage)'
+        return 0
+    fi
+    rm -f "$sysroot/sharun/shared/lib/libprobe-dlopen.so"
+    loader_arms_run=$((loader_arms_run + 1))
+    run_guest miss "$elfuse" --sysroot "$sysroot" /sharun/bin/probe
+
+    # The two halves report separately. "rc=3, want 3" is what this said when
+    # the exit code was right and only the loader's message was missing, which
+    # reads as a contradiction.
+    if [ "$guest_rc" -ne 3 ]; then
+        report_fail "sharun bundle (missing DSO): rc=$guest_rc, want 3"
+        sed 's/^/  stderr: /' "$scratch/miss.err" >&2
+    elif ! grep -q 'libprobe-dlopen.so' "$scratch/miss.err"; then
+        report_fail 'sharun bundle (missing DSO): no dlerror'
+        printf 'wanted libprobe-dlopen.so named on stderr\n' >&2
+        sed 's/^/  stderr: /' "$scratch/miss.err" >&2
+    else
+        report_pass 'sharun bundle (missing DSO reports dlerror)'
+    fi
+}
+
+# Arm 4: the same probe inside a bundle, driven by the real launcher. The bundle
+# is assembled here from the prebuilt launcher, the probe already built for arm
+# 3, and a prebuilt glibc. lib4bin would compute the probe's library closure
+# with ldd and rewrite it with patchelf, which needs a Linux host; the closure
+# is fixed and known, so the layout is written out directly instead.
+#
+# SHARUN_FIXTURE_DIR still points the arms at an unpacked bundle from elsewhere,
+# which is how a real lib4bin bundle gets tested when someone has one.
+fixture="${SHARUN_FIXTURE_DIR:-}"
+if [ -n "$fixture" ]; then
+    [ -d "$fixture" ] || {
+        report_fail "sharun bundle: SHARUN_FIXTURE_DIR missing: $fixture"
+        skip_bundle_extras 'no bundle'
+        fixture=''
+    }
+elif [ -z "$probe_dir" ]; then
+    report_skip 'sharun bundle (no probe to bundle)'
+    skip_bundle_extras 'no bundle'
+else
+    set +e
+    glibc_dir="$("$repo_root/tests/fetch-glibc.sh" 2> "$scratch/glibc-err")"
+    glibc_rc=$?
+    set -e
+    if [ "$glibc_rc" -eq 77 ]; then
+
+        # 77 is the whole condition, and tests/lib/fixture-cache.sh states what
+        # it means. Enumerating the causes here went stale the day a missing
+        # ar(1) became a loud failure, and a caller that lists them will sooner
+        # or later list one the callee no longer reports that way.
+        report_skip 'sharun bundle (no glibc package)'
+        skip_bundle_extras 'no bundle'
+        cat "$scratch/glibc-err" >&2
+    elif [ "$glibc_rc" -ne 0 ]; then
+
+        # The package arrived and was wrong, or the cached runtime is damaged.
+        # Same rule as the launcher: present but broken has to be loud.
+        report_fail 'sharun bundle (glibc runtime unusable)'
+        skip_bundle_extras 'bundle unusable'
+        cat "$scratch/glibc-err" >&2
+    elif rm -rf "$scratch/local-bundle" \
+        && bash "$repo_root/tests/build-sharun-bundle.sh" "$sharun" "$probe_dir" \
+            "$glibc_dir" "$scratch/local-bundle" 2> "$scratch/build-err"; then
+        fixture="$scratch/local-bundle"
+    else
+
+        # The inputs were all there and assembly still failed, which means the
+        # tree is wrong (a probe that grew a dependency the bundle does not
+        # carry, say). That is a failure, not a skip.
+        report_fail 'sharun bundle (assembly failed)'
+        skip_bundle_extras 'bundle unusable'
+        cat "$scratch/build-err" >&2
+        fixture=''
+    fi
+fi
+
+# An if, not "[ -n ... ] && run_bundle_arms": that form returns nonzero when the
+# fixture is empty, and errexit would then abort the lane before it printed its
+# summary. Nothing to do with suppressing errexit inside the function: a
+# then-branch does not suppress it, only a condition list does.
+if [ -n "$fixture" ]; then
+    run_bundle_arms
+fi
+
+# A run where every loader arm skipped proves nothing about the loader, which is
+# the whole reason this lane exists, and it must not report the same status as
+# one that covered it. It exits 77 rather than failing: the cross-glibc
+# toolchain is optional, RUN_OPTIONAL_SKIP77 turns that into a visible SKIP, and
+# failing here would red "make check" on every machine that simply does not have
+# it. What this rules out is the third outcome, a silent green that covered
+# nothing. Before the summary, not after. tests/test-matrix.sh scrapes the
+# "Results:" line, and RUN_OPTIONAL_SKIP77 adds only a lane-level SKIP, so
+# printing a passes-and-skips tally first and exiting 77 afterwards reads as a
+# partial pass for a run that covered no loader at all.
+if [ "$fail" -eq 0 ] && [ "$loader_arms_run" -eq 0 ]; then
+    printf 'no dynamic-loader arm ran: this host has no cross-glibc sysroot and\n' >&2
+    printf 'no bundle, so only the static launcher was covered\n' >&2
+    report_summary "$total"
+    exit 77
+fi
+
+report_summary "$total"
+
+# Not "exit $fail": mk/tests.mk wraps this lane in RUN_OPTIONAL_SKIP77, which
+# reads the exit status as a sentinel where 77 means skip. Handing it a failure
+# count would report a green skip the day this lane grows 77 failing checks.
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Add make test-sharun, six arms in increasing order of what they need from the host. The prebuilt [sharun](https://github.com/VHSgunzo/sharun) launcher is a static aarch64 ELF and runs anywhere elfuse does. The x86_64 build of the same release goes through the Rosetta path as a static-pie musl Rust binary, a shape no other lane covers. A cross-built probe covers DT_NEEDED, dlopen, $ORIGIN rpath, libm, pthreads and fork. Three further arms drive a bundle: the probe under the real launcher, --gen-lib-path walking the tree and writing back to it from inside the guest, and the negative path where the dlopen target is removed and the loader errno must surface rather than hang or crash.

The bundle is assembled here rather than by sharun's lib4bin, which needs a Linux host to walk ldd and rewrite with patchelf. The probe's library closure is fixed and known, so the layout is written out directly and the lane has no Linux dependency. build-sharun-bundle.sh reads the probe DT_NEEDED afterwards and fails when the hardcoded list falls behind, which is the one job lib4bin was doing for us. SHARUN_FIXTURE_DIR still points the arm at a bundle built elsewhere.

Every download happens inside the lane, never as a make prerequisite: a prerequisite that cannot be fetched is fatal, and this lane runs in make check. An unreachable network skips the affected arms instead of reddening the build, while a cached file that fails its digest is loud, because that is a broken tree rather than a missing one.

Launcher binaries and the glibc runtime are pinned by digest in sharun-fixture.lock and cached under FIXTURES_DIR, so they download once and survive make clean. The glibc package comes from snapshot.debian.org, whose file URLs are permanent; a distribution pool drops a package as soon as a point release supersedes it. It must stay at 2.33 or newer because sharun invokes the loader as "ld.so ... --argv0 ...", which older loaders treat as a filename.

lib/fixture-cache.sh holds the download-once logic both fetchers need. mkdir is the atomic claim: testing for the directory and then renaming is not enough, because mv into an existing directory nests inside it and poisons the cache. Six concurrent cold fetches reproduced that before the lock existed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `test-sharun` to `make check`, covering sharun's static launchers, the x86_64 build through Rosetta, and a cross-built dynamic-loader probe under elfuse. The probe checks `DT_NEEDED`, `dlopen`, `dlclose`, `$ORIGIN` rpath, libm, pthreads, and fork; the bundled arms also exercise `--gen-lib-path` and the missing-`dlopen` negative path. Hosts without the cross toolchain, Rosetta translator, or network skip the affected arms instead of failing.

**Coverage**

- Runs six arms: aarch64 and x86_64 launchers, a standalone probe, a bundled probe, `--gen-lib-path`, and the missing-`dlopen` case surfacing the loader's error.
- Assembles the bundle from a known library closure without Linux, `lib4bin`, or `patchelf`; `SHARUN_FIXTURE_DIR` still accepts an external bundle.
- A run covering only the static launcher exits 77 rather than reporting full loader coverage.

**Fixtures and toolchain**

- Launcher binaries and a Debian glibc are pinned by digest in `tests/sharun-fixture.lock`, cached under `$FIXTURES_DIR`, and verified on cache hits; downloads run inside the lane so offline hosts skip.
- `CROSS_GLIBC_SYSROOT` centralizes sysroot detection; the probe and benchmark build only when a compile-and-link check succeeds.
- Fixtures rebuild when the toolchain or sysroot identity changes, and concurrent cache publication is serialized.
- Bundle assembly fails when the cross toolchain demands GLIBC symbols the pinned libc lacks, keeping the pin at glibc 2.33 or newer.
- `bash tests/test-sharun.sh build/elfuse build` derives the sysroot for standalone runs.

<sup>Written for commit 6d42e956eeb9289b885eb3670d93483235732c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



