### PR TITLE
Spend one host descriptor on a directory fd

### DIFF
--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -518,25 +518,19 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
                  * yields EBADF, an honest signal that the fd did not survive
                  * the fork.
                  */
-                int dir_fd = dup(host_fds[i]);
-                if (dir_fd < 0) {
-                    log_error("fork-child: dup failed for DIR gfd %d: %s", gfd,
-                              strerror(errno));
-                    fd_retire_published(gfd, host_fds[i]);
-                    continue;
-                }
-                DIR *dir = fdopendir(dir_fd);
-                if (!dir) {
-                    close(dir_fd);
-                    log_error("fork-child: fdopendir failed for gfd %d", gfd);
-                    fd_retire_published(gfd, host_fds[i]);
-                    continue;
-                }
-                void *ds = dir_stream_create(dir);
+
+                /* The stream adopts the descriptor that arrived over
+                 * SCM_RIGHTS; it does not take one of its own. On failure the
+                 * descriptor is still this side's, which is what lets
+                 * fd_retire_published close it -- and it must, because a slot
+                 * left published as FD_DIR with a NULL dir owns its descriptor
+                 * the ordinary way (see fd_cleanup_entry).
+                 */
+                void *ds = dir_stream_open(host_fds[i]);
                 if (!ds) {
-                    closedir(dir);
-                    log_error("fork-child: dir_stream_create failed for gfd %d",
-                              gfd);
+                    log_error(
+                        "fork-child: dir_stream_open failed for gfd %d: %s",
+                        gfd, strerror(errno));
                     fd_retire_published(gfd, host_fds[i]);
                     continue;
                 }

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -47,6 +47,14 @@ struct fd_lifetime {
     _Atomic unsigned int refs;
     int host_fd;
     int type;
+
+    /* FD_DIR only: the directory stream that owns host_fd. fdopendir() adopted
+     * the descriptor and only closedir() releases it, so a pin on a directory
+     * cannot close host_fd itself -- it holds a reference on the stream and
+     * lets the stream's last release do it. NULL for every other type, which
+     * closes host_fd directly.
+     */
+    void *dir;
 };
 
 /* RLIMIT_NOFILE tracking. Guest-side soft limit for RLIMIT_NOFILE. fd_alloc
@@ -575,7 +583,8 @@ int fd_alloc_dir_from(int minfd,
                       int host_fd,
                       void (*cleanup)(int),
                       void *dir,
-                      int linux_flags)
+                      int linux_flags,
+                      uint64_t *out_gen)
 {
     fd_host_probe_t probe = fd_probe_host(type, host_fd);
     pthread_mutex_lock(&fd_lock);
@@ -584,6 +593,8 @@ int fd_alloc_dir_from(int minfd,
         fd_table[fd].dir = dir;
         fd_table[fd].linux_flags =
             fd_flags_with_accmode(fd_table[fd].type, linux_flags);
+        if (out_gen)
+            *out_gen = fd_table[fd].generation;
     }
     pthread_mutex_unlock(&fd_lock);
     return fd;
@@ -598,7 +609,8 @@ int fd_alloc_dir_at(int fd,
                     int host_fd,
                     void (*cleanup)(int),
                     void *dir,
-                    int linux_flags)
+                    int linux_flags,
+                    uint64_t *out_gen)
 {
     if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
         return -1;
@@ -616,6 +628,8 @@ int fd_alloc_dir_at(int fd,
     fd_table[fd].dir = dir;
     fd_table[fd].linux_flags =
         fd_flags_with_accmode(fd_table[fd].type, linux_flags);
+    if (out_gen)
+        *out_gen = fd_table[fd].generation;
     pthread_mutex_unlock(&fd_lock);
 
     if (old.type != FD_CLOSED)
@@ -696,13 +710,14 @@ int fd_alloc_alias_dir(const fd_alias_spec_t *spec,
                        int host_fd,
                        void (*cleanup)(int),
                        void *dir,
-                       int linux_flags)
+                       int linux_flags,
+                       uint64_t *out_gen)
 {
     fd_alias_begin(spec);
     int fd = fixed_fd >= 0 ? fd_alloc_dir_at(fixed_fd, type, host_fd, cleanup,
-                                             dir, linux_flags)
+                                             dir, linux_flags, out_gen)
                            : fd_alloc_dir_from(minfd, type, host_fd, cleanup,
-                                               dir, linux_flags);
+                                               dir, linux_flags, out_gen);
     return fd_alias_end(fd);
 }
 
@@ -998,6 +1013,15 @@ static fd_lifetime_t *fd_lifetime_pin_spare(int fd, fd_lifetime_t **spare)
         atomic_init(&lifetime->refs, 1);
         lifetime->host_fd = fd_table[fd].host_fd;
         lifetime->type = fd_table[fd].type;
+
+        /* Taken once, at the object's birth, and dropped once at its death:
+         * every later pin shares this object, so the stream reference is per
+         * lifetime rather than per pin. fd_lock is held, which is the lock
+         * guarding the stream's own refcount.
+         */
+        lifetime->dir = fd_table[fd].type == FD_DIR ? fd_table[fd].dir : NULL;
+        if (lifetime->dir)
+            dir_stream_ref_locked(lifetime->dir);
         fd_table[fd].lifetime = lifetime;
     }
 
@@ -1094,7 +1118,14 @@ void fd_lifetime_release(fd_lifetime_t *lifetime)
     if (prev != 1)
         return;
     atomic_thread_fence(memory_order_acquire);
-    if (lifetime->type != FD_STDIO)
+
+    /* A directory's descriptor belongs to its stream; releasing the reference
+     * taken at birth is this object's whole share of it. dir_stream_release
+     * takes fd_lock, which is why no caller may hold it here.
+     */
+    if (lifetime->dir)
+        dir_stream_release(lifetime->dir);
+    else if (lifetime->type != FD_STDIO)
         close(lifetime->host_fd);
     free(lifetime);
 }
@@ -1366,13 +1397,24 @@ int fd_to_host_dup(int guest_fd)
  */
 void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
 {
-    /* dir_stream_t / epoll_instance_t stored in the dir field */
-    if (snap->dir) {
-        if (snap->type == FD_DIR)
-            dir_stream_release(snap->dir);
-        else if (snap->type == FD_EPOLL)
-            epoll_instance_free(snap->dir);
-    }
+    /* Who owns host_fd, in the order the answers are checked below:
+     *
+     *   a directory with a stream -> the stream (closedir at its last
+     *                                reference, which is taken last here so
+     *                                the descriptor outlives the teardown
+     *                                below that is keyed by its number)
+     *   a lifetime pin            -> the pin (close at its last reference)
+     *   otherwise                 -> this function
+     *
+     * A directory *without* a stream is the third case, not the first: the slot
+     * is one an in-flight open or fork-restore published and has not adopted
+     * yet, so the descriptor is still plain and still closable here.
+     */
+    bool stream_owns_host_fd = snap->type == FD_DIR && snap->dir;
+
+    /* epoll_instance_t shares the dir field with dir_stream_t. */
+    if (snap->dir && snap->type == FD_EPOLL)
+        epoll_instance_free(snap->dir);
 
     /* Type-specific teardown via vtable (replaces per-type switch) */
     if (snap->cleanup)
@@ -1397,6 +1439,12 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap)
 
     if (snap->lifetime)
         fd_lifetime_release(snap->lifetime);
-    else if (snap->type != FD_STDIO)
+    else if (!stream_owns_host_fd && snap->type != FD_STDIO)
         close(snap->host_fd);
+
+    /* Last: the slot's own reference on the stream, and with it the descriptor
+     * when no getdents64 or pin still holds one.
+     */
+    if (stream_owns_host_fd)
+        dir_stream_release(snap->dir);
 }

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -346,27 +346,70 @@ typedef struct {
                            */
 } dir_stream_t;
 
-/* Wrap an already-open DIR* for storage in fd_table[].dir. Takes ownership of
- * dir on success.
+/* Open a stream over host_fd and take ownership of the descriptor.
  *
- * Returns NULL on allocation failure, in which case the caller still owns dir
- * and must closedir() it.
+ * Returns NULL with errno set on failure, in which case host_fd is untouched
+ * and still the caller's to close. The wrapper is allocated before fdopendir
+ * for exactly that reason: once fdopendir succeeds the descriptor is inside the
+ * DIR* and nothing short of closedir() -- which closes it -- gets it back, so
+ * there must be no failure left after that point.
  */
-void *dir_stream_create(DIR *dir)
+void *dir_stream_open(int host_fd)
 {
     dir_stream_t *ds = malloc(sizeof(*ds));
-    if (!ds)
+    if (!ds) {
+        errno = ENOMEM;
         return NULL;
+    }
+
+    /* Darwin's fdopendir sets FD_CLOEXEC on the descriptor it adopts. That was
+     * invisible while the stream ran on a private duplicate; on the guest's own
+     * descriptor it silently flips a flag elfuse never asked for, so the flag
+     * is read before the call and put back after.
+     *
+     * Only the bit fdopendir added is taken back, which is why the before value
+     * is needed rather than an unconditional clear: an open the guest made with
+     * O_CLOEXEC reaches the host open as O_CLOEXEC too (translate_open_flags),
+     * and that descriptor is meant to carry the flag. When the flag cannot be
+     * read the descriptor is left as fdopendir set it, since clearing on a
+     * guess is the direction that loses information.
+     */
+    int flags_before = fcntl(host_fd, F_GETFD);
+
+    DIR *dir = fdopendir(host_fd);
+    if (!dir) {
+        int saved_errno = errno;
+        free(ds);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if (flags_before >= 0 && !(flags_before & FD_CLOEXEC)) {
+        int flags_after = fcntl(host_fd, F_GETFD);
+        if (flags_after >= 0 && (flags_after & FD_CLOEXEC))
+            fcntl(host_fd, F_SETFD, flags_after & ~FD_CLOEXEC);
+    }
+
     ds->dir = dir;
     pthread_mutex_init(&ds->lock, NULL);
     ds->refcount = 1;
     return ds;
 }
 
+/* Take an extra reference. Caller holds fd_lock. */
+void dir_stream_ref_locked(void *ds_ptr)
+{
+    dir_stream_t *ds = ds_ptr;
+    if (ds)
+        ds->refcount++;
+}
+
 /* Tear down a wrapper that was never published to fd_table (an allocation or
- * install failure between dir_stream_create() and the point the pointer would
+ * install failure between dir_stream_open() and the point the pointer would
  * have been written to fd_table[].dir). No other thread can have acquired a
- * reference yet, so this always closes and frees unconditionally.
+ * reference yet, so this always closes and frees unconditionally -- including
+ * the host descriptor the stream owns, which the caller must therefore not
+ * close again.
  */
 static void dir_stream_discard(void *ds_ptr)
 {
@@ -397,11 +440,14 @@ static dir_stream_t *dir_stream_acquire(int fd)
     return ds;
 }
 
-/* Drop a reference taken by dir_stream_acquire(), or the fd-table's own
- * reference from fd_cleanup_entry(). No-op when passed NULL. The decrement
- * happens under fd_lock; the actual closedir()/free() runs after releasing it,
- * matching fd_cleanup_entry's own "do not hold fd_lock across slow syscalls"
- * convention.
+/* Drop a reference taken by dir_stream_acquire(), by an fd_lifetime pin, or the
+ * fd-table's own reference from fd_cleanup_entry(). No-op when passed NULL. The
+ * decrement happens under fd_lock; the actual closedir()/free() runs after
+ * releasing it, matching fd_cleanup_entry's own "do not hold fd_lock across
+ * slow syscalls" convention.
+ *
+ * The closedir() here is what closes the guest fd's host descriptor, so this is
+ * the single point where a directory fd is given back to the host.
  */
 void dir_stream_release(void *ds_ptr)
 {
@@ -421,6 +467,12 @@ void dir_stream_release(void *ds_ptr)
 /* spec is the description this fd inherits from, or NULL for a fresh one. Only
  * the magic-link open passes one: it implements the open as a dup, so the host
  * flags are shared with the source and must not be probed or changed.
+ *
+ * Takes ownership of host_fd unconditionally: every failure path below closes
+ * it, so callers hand the descriptor over and never close it themselves. A
+ * directory makes that mandatory rather than merely tidy -- its stream adopts
+ * the same descriptor (see dir_stream_open) and from then on only the stream
+ * can give it back.
  */
 static int fd_alloc_opened_host(int host_fd,
                                 int type,
@@ -433,33 +485,35 @@ static int fd_alloc_opened_host(int host_fd,
     dir_stream_t *ds = NULL;
 
     if (type == FD_DIR) {
-        int dup_fd = dup(host_fd);
-        if (dup_fd < 0)
-            return -1;
-
-        DIR *dir = fdopendir(dup_fd);
-        if (!dir) {
-            close_keep_errno(dup_fd);
-            return -1;
-        }
-        ds = dir_stream_create(dir);
+        ds = dir_stream_open(host_fd);
         if (!ds) {
-            int saved_errno = errno;
-            closedir(dir);
-            errno = saved_errno;
+            proc_pty_forget_host_fd(host_fd);
+            close_keep_errno(host_fd);
             return -1;
         }
     }
 
-    int guest_fd =
-        min_guest_fd >= 0
-            ? fd_alloc_alias_relaxed(spec, -1, min_guest_fd, type, host_fd,
-                                     cleanup, NULL)
-            : fd_alloc_alias_relaxed(spec, -1, 0, type, host_fd, cleanup, NULL);
+    /* A directory publishes its stream in the same fd_lock window as the slot,
+     * so the slot is never visible as FD_DIR with a NULL dir while this call is
+     * still holding the only reference. Sharing one descriptor is what forces
+     * that: in the gap, a sibling's close would find a directory slot whose
+     * descriptor looks plain, close it, and leave this side's stream sitting on
+     * a number the next open can claim. The other types keep the relaxed
+     * allocator and install their metadata below.
+     */
+    int minfd = min_guest_fd >= 0 ? min_guest_fd : 0;
+    uint64_t alloc_gen = 0;
+    int guest_fd = ds ? fd_alloc_alias_dir(spec, -1, minfd, type, host_fd,
+                                           cleanup, ds, linux_flags, &alloc_gen)
+                      : fd_alloc_alias_relaxed(spec, -1, minfd, type, host_fd,
+                                               cleanup, &alloc_gen);
     if (guest_fd < 0) {
         int saved_errno = errno;
+        proc_pty_forget_host_fd(host_fd);
         if (ds)
-            dir_stream_discard(ds);
+            dir_stream_discard(ds); /* closes host_fd */
+        else
+            close(host_fd);
         errno = saved_errno;
         return -1;
     }
@@ -471,24 +525,26 @@ static int fd_alloc_opened_host(int host_fd,
     bool have_proc_path = resolve_virtual_path(virtual_path, proc_path_buf,
                                                sizeof(proc_path_buf));
 
-    /* Publish linux_flags, dir, proc_path, and the urandom bitmap bit
-     * atomically with respect to the slot's identity. fd_alloc_*_relaxed drops
-     * fd_lock before returning, so a sibling vCPU's pathological
-     * close(guest_fd) + open() could reuse the slot between alloc and the
-     * metadata install below. Re-acquire fd_lock and verify the (type, host_fd)
-     * tuple still matches what just got allocated; if it does not, the slot
-     * belongs to a different file now and any install would clobber the
-     * sibling's entry. The sibling's close path already cleaned up the host_fd
-     * of this side via fd_cleanup_entry, so this side only owns ds, which gets
-     * discarded below.
+    /* Publish linux_flags, proc_path, and the urandom bitmap bit atomically
+     * with respect to the slot's identity. The allocator drops fd_lock before
+     * returning, so a sibling vCPU's pathological close(guest_fd) + open()
+     * could reuse the slot between alloc and the metadata install below.
+     * Re-acquire fd_lock and verify the generation stamped at alloc still
+     * matches; if it does not, the slot belongs to a different file now and any
+     * install would clobber the sibling's entry. A (type, host_fd) tuple alone
+     * cannot tell a close+reopen that landed on the same number, so it stays
+     * only as the cheap early-out.
+     *
+     * Nothing is left to unwind on that path: the sibling's close ran
+     * fd_cleanup_entry over this side's slot, which released the stream (and
+     * with it the descriptor) exactly once, because the stream was published
+     * with the slot rather than installed here.
      */
-    bool installed = false;
     pthread_mutex_lock(&fd_lock);
     if (fd_table[guest_fd].type == type &&
-        fd_table[guest_fd].host_fd == host_fd) {
+        fd_table[guest_fd].host_fd == host_fd &&
+        fd_table[guest_fd].generation == alloc_gen) {
         fd_table[guest_fd].linux_flags = linux_flags;
-        if (ds)
-            fd_table[guest_fd].dir = ds;
         if (have_proc_path)
             memcpy(fd_table[guest_fd].proc_path, proc_path_buf,
                    sizeof(proc_path_buf));
@@ -504,12 +560,8 @@ static int fd_alloc_opened_host(int host_fd,
             type == FD_URANDOM &&
             (linux_flags & LINUX_O_ACCMODE) != LINUX_O_WRONLY;
         shim_globals_mark_urandom_fd(guest_fd, readable_urandom);
-        installed = true;
     }
     pthread_mutex_unlock(&fd_lock);
-
-    if (!installed && ds)
-        dir_stream_discard(ds);
 
     return guest_fd;
 }
@@ -630,10 +682,8 @@ int64_t sys_openat_path(guest_t *g,
         }
         int guest_fd = fd_alloc_opened_host(host_fd, type, linux_flags, -1,
                                             NULL, NULL, NULL);
-        if (guest_fd < 0) {
-            close_keep_errno(host_fd);
+        if (guest_fd < 0)
             return linux_errno();
-        }
         return guest_fd;
     }
 
@@ -696,11 +746,8 @@ int64_t sys_openat_path(guest_t *g,
                 fd_alloc_opened_host(intercepted, type, linux_flags,
                                      min_guest_fd, fd_cleanup_for_type(type),
                                      tx.intercept_path, aliased ? &spec : NULL);
-            if (guest_fd < 0) {
-                proc_pty_forget_host_fd(intercepted);
-                close_keep_errno(intercepted);
+            if (guest_fd < 0)
                 return linux_errno();
-            }
             return guest_fd;
         }
         if (intercepted == -1) {
@@ -723,10 +770,8 @@ int64_t sys_openat_path(guest_t *g,
         }
         int guest_fd = fd_alloc_opened_host(host_fd, type, linux_flags, -1,
                                             NULL, NULL, NULL);
-        if (guest_fd < 0) {
-            close_keep_errno(host_fd);
+        if (guest_fd < 0)
             return linux_errno();
-        }
         return guest_fd;
     }
 
@@ -748,10 +793,8 @@ int64_t sys_openat_path(guest_t *g,
     }
     int guest_fd =
         fd_alloc_opened_host(host_fd, type, linux_flags, -1, NULL, NULL, NULL);
-    if (guest_fd < 0) {
-        close_keep_errno(host_fd);
+    if (guest_fd < 0)
         return linux_errno();
-    }
     return guest_fd;
 }
 
@@ -922,19 +965,14 @@ int64_t sys_close(int fd)
 
 /* dup/fcntl. */
 
-static void discard_allocated_fd(int guest_fd)
-{
-    fd_entry_t snap;
-    if (fd_snapshot_and_close(guest_fd, &snap))
-        fd_cleanup_entry(guest_fd, &snap);
-}
-
-/* Open a DIR stream over a dup of dst_host_fd if the source was an FD_DIR.
+/* Open a DIR stream over dst_host_fd if the source was an FD_DIR. The dup that
+ * produced dst_host_fd is the alias's own descriptor, and the stream adopts it:
+ * a second one, which is what this used to take, would give the guest fd two
+ * host descriptors for the rest of its life.
  *
- * Returns NULL on success-but-no-stream-needed (non-dir source) or on
- * dup/fdopendir/allocation failure with errno preserved. Pulled out of the
- * critical section in install_fd_alias_metadata_atomic because dup and
- * fdopendir are slow syscalls that must not hold fd_lock.
+ * Returns NULL on success-but-no-stream-needed (non-dir source) or on failure
+ * with errno preserved, distinguished by *out_failed. Runs outside fd_lock
+ * because fdopendir is a slow syscall.
  */
 static dir_stream_t *clone_dir_stream(const fd_entry_t *src_snap,
                                       int dst_host_fd,
@@ -944,27 +982,9 @@ static dir_stream_t *clone_dir_stream(const fd_entry_t *src_snap,
     if (src_snap->type != FD_DIR)
         return NULL;
 
-    int dir_fd = dup(dst_host_fd);
-    if (dir_fd < 0) {
+    dir_stream_t *ds = dir_stream_open(dst_host_fd);
+    if (!ds)
         *out_failed = true;
-        return NULL;
-    }
-    DIR *dir = fdopendir(dir_fd);
-    if (!dir) {
-        int saved_errno = errno;
-        close(dir_fd);
-        errno = saved_errno;
-        *out_failed = true;
-        return NULL;
-    }
-    dir_stream_t *ds = dir_stream_create(dir);
-    if (!ds) {
-        int saved_errno = errno;
-        closedir(dir);
-        errno = saved_errno;
-        *out_failed = true;
-        return NULL;
-    }
     return ds;
 }
 
@@ -973,15 +993,20 @@ static dir_stream_t *clone_dir_stream(const fd_entry_t *src_snap,
  * duplicate_guest_fd call; a sibling vCPU's pathological close + open between
  * the relaxed allocator's lock release and this call could otherwise clobber
  * the sibling's freshly-installed entry.
- * Returns true on successful install, false if the slot was reallocated (caller
- * must dir_stream_discard() any cloned ds to avoid a leak).
+ *
+ * The directory stream is not among the fields installed here: it is published
+ * by the allocator, in the window that creates the slot, because it owns the
+ * slot's host descriptor and a gap would leave that descriptor looking
+ * ownerless to a concurrent close.
+ *
+ * Returns true on successful install, false if the slot was reallocated, which
+ * leaves this side owning nothing.
  */
 static bool install_fd_alias_metadata_atomic(int dst_fd,
                                              int expected_type,
                                              int expected_host_fd,
                                              const fd_entry_t *src_snap,
                                              int linux_flags,
-                                             dir_stream_t *ds,
                                              uint64_t expected_gen)
 {
     bool installed = false;
@@ -1003,8 +1028,6 @@ static bool install_fd_alias_metadata_atomic(int dst_fd,
         fd_table[dst_fd].seals = src_snap->seals;
         memcpy(fd_table[dst_fd].proc_path, src_snap->proc_path,
                sizeof(fd_table[dst_fd].proc_path));
-        if (ds)
-            fd_table[dst_fd].dir = ds;
 
         /* Read the mode back from the slot the allocator published rather than
          * from a local copy of it, so there is one answer to what this fd's
@@ -1118,9 +1141,31 @@ static int duplicate_guest_fd(int src_fd,
      */
     fd_alias_spec_t spec = fd_alias_of(src_fd, &src_snap);
     spec.linux_flags |= linux_flags;
-    int guest_fd = fd_alloc_alias_relaxed(
-        &spec, fixed_slot ? fixed_guest_fd : -1, min_guest_fd, new_type,
-        new_host_fd, cleanup, &alloc_gen);
+
+    /* Open the alias's DIR stream before the slot exists, outside fd_lock
+     * because fdopendir is a slow syscall. It has to precede the allocation
+     * rather than follow it: the stream owns new_host_fd, and a slot published
+     * as FD_DIR before its stream exists is a slot whose descriptor a
+     * concurrent close would treat as plain and close underneath this call.
+     */
+    bool dir_clone_failed = false;
+    dir_stream_t *ds =
+        clone_dir_stream(&src_snap, new_host_fd, &dir_clone_failed);
+    if (dir_clone_failed) {
+        int saved_errno = errno;
+        proc_pty_forget_host_fd(new_host_fd);
+        close(new_host_fd);
+        errno = saved_errno;
+        return -1;
+    }
+
+    int guest_fd =
+        ds ? fd_alloc_alias_dir(&spec, fixed_slot ? fixed_guest_fd : -1,
+                                min_guest_fd, new_type, new_host_fd, cleanup,
+                                ds, spec.linux_flags, &alloc_gen)
+           : fd_alloc_alias_relaxed(&spec, fixed_slot ? fixed_guest_fd : -1,
+                                    min_guest_fd, new_type, new_host_fd,
+                                    cleanup, &alloc_gen);
     if (guest_fd < 0) {
         if (fixed_slot)
             errno = EBADF;
@@ -1131,39 +1176,26 @@ static int duplicate_guest_fd(int src_fd,
          * is about to be closed on the books, and the master would never see
          * its last slave go.
          */
-        proc_pty_forget_host_fd(new_host_fd);
-        close_keep_errno(new_host_fd);
-        return -1;
-    }
-
-    /* Clone the DIR stream outside fd_lock (dup + fdopendir would block other
-     * fd ops), then install everything atomically under fd_lock with a
-     * generation verification so a sibling close + reopen on the same guest_fd
-     * cannot make this install land on an unrelated slot.
-     */
-    bool dir_clone_failed = false;
-    dir_stream_t *ds =
-        clone_dir_stream(&src_snap, new_host_fd, &dir_clone_failed);
-    if (dir_clone_failed) {
         int saved_errno = errno;
-        discard_allocated_fd(guest_fd);
+        proc_pty_forget_host_fd(new_host_fd);
+        if (ds)
+            dir_stream_discard(ds); /* closes new_host_fd */
+        else
+            close(new_host_fd);
         errno = saved_errno;
         return -1;
     }
 
-    if (!install_fd_alias_metadata_atomic(guest_fd, new_type, new_host_fd,
-                                          &src_snap, linux_flags, ds,
-                                          alloc_gen)) {
-        /* Slot was reallocated by a sibling while metadata install was pending;
-         * the sibling's close path already cleaned up new_host_fd via
-         * fd_cleanup_entry, so the only resource this side still owns is the
-         * cloned DIR stream.
-         */
-        if (ds)
-            dir_stream_discard(ds);
-    } else if ((src_snap.linux_flags & LINUX_O_ASYNC) ||
-               (src_snap.type == FD_SOCKET &&
-                src_snap.fasync_owner_type != FASYNC_OWNER_NONE)) {
+    /* A false return means a sibling reallocated the slot while the metadata
+     * install was pending. Nothing to unwind: that sibling's close path already
+     * ran fd_cleanup_entry over new_host_fd, stream included, so this side owns
+     * nothing either way.
+     */
+    if (install_fd_alias_metadata_atomic(guest_fd, new_type, new_host_fd,
+                                         &src_snap, linux_flags, alloc_gen) &&
+        ((src_snap.linux_flags & LINUX_O_ASYNC) ||
+         (src_snap.type == FD_SOCKET &&
+          src_snap.fasync_owner_type != FASYNC_OWNER_NONE))) {
         /* dup shares O_ASYNC (per open-file-description); register the alias
          * with the readiness watcher. install only returns true when the slot
          * still carries alloc_gen, so arming with it drops any stale event from

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -343,7 +343,8 @@ int fd_alloc_alias_dir(const fd_alias_spec_t *spec,
                        int host_fd,
                        void (*cleanup)(int),
                        void *dir,
-                       int linux_flags);
+                       int linux_flags,
+                       uint64_t *out_gen);
 
 /* Allocate the lowest available FD and publish type, host_fd, dir, and
  * linux_flags in one fd_lock critical section, so the slot never becomes
@@ -368,13 +369,15 @@ int fd_alloc_dir_from(int minfd,
                       int host_fd,
                       void (*cleanup)(int),
                       void *dir,
-                      int linux_flags);
+                      int linux_flags,
+                      uint64_t *out_gen);
 int fd_alloc_dir_at(int fd,
                     int type,
                     int host_fd,
                     void (*cleanup)(int),
                     void *dir,
-                    int linux_flags);
+                    int linux_flags,
+                    uint64_t *out_gen);
 
 /* Allocate the lowest available FD >= minfd.
  *
@@ -759,15 +762,28 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap);
  * for FD_DIR entries (see syscall/fs.c). A raw DIR* would let a sibling's
  * close()/dup2()/fork-restore free it via closedir() while sys_getdents64() is
  * still mid-loop reading it; the wrapper defers the closedir() until every
- * acquirer -- the fd-table's own reference, plus any in-flight sys_getdents64
- * -- has released it. Guarded by fd_lock, mirroring poll.c's epoll_instance_t
- * refcount.
+ * acquirer has released it. Guarded by fd_lock, mirroring poll.c's
+ * epoll_instance_t refcount.
  *
- * dir_stream_create() takes ownership of dir and returns the wrapper, or NULL
- * on allocation failure (caller still owns dir and must closedir() it itself).
- * dir_stream_release() drops a reference and is a no-op when passed NULL.
+ * The wrapper also owns the host descriptor. fdopendir() adopts the descriptor
+ * it is handed and only closedir() gives it back, so an FD_DIR slot cannot also
+ * close its own host_fd -- that is what the descriptor doubling this replaced
+ * was paying for. (fdclosedir(3) would hand the descriptor back without closing
+ * it, but it is macOS 26.4+ and elfuse supports macOS 13+.) Everything that
+ * needs the descriptor to stay valid therefore holds a reference here:
+ *
+ *   - the fd-table slot          (released by fd_cleanup_entry)
+ *   - an in-flight getdents64    (dir_stream_acquire, syscall/fs.c)
+ *   - an fd_lifetime pin         (fdtable.c, which delegates its close here)
+ *
+ * dir_stream_open() takes ownership of host_fd and returns the wrapper, or NULL
+ * with errno set, in which case host_fd is untouched and still the caller's.
+ * dir_stream_ref_locked() takes an extra reference and requires fd_lock.
+ * dir_stream_release() drops a reference and is a no-op when passed NULL; it
+ * takes fd_lock itself, so no caller may hold it.
  */
-void *dir_stream_create(DIR *dir);
+void *dir_stream_open(int host_fd);
+void dir_stream_ref_locked(void *ds);
 void dir_stream_release(void *ds);
 
 /* Translation helpers. */

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1216,7 +1216,7 @@ int epoll_dup_fd(int src_fd,
     fd_alias_spec_t spec = fd_alias_identity(src_ofd_id, 0);
     int new_guest_fd = fd_alloc_alias_dir(
         &spec, fixed_slot ? fixed_guest_fd : -1, min_guest_fd, FD_EPOLL,
-        new_host_fd, NULL, inst, lflags);
+        new_host_fd, NULL, inst, lflags, NULL);
     if (new_guest_fd < 0) {
         /* fd_alloc_dir_at fails only when fixed_guest_fd is out of range or
          * over RLIMIT_NOFILE; dup2/dup3 report that as EBADF, not the EMFILE

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -26,8 +26,12 @@
 # which is a superset: it runs every one of these binaries too (via
 # elfuse-aarch64 mode), plus everything that used to be duplicated here.
 # Don't add a portable/cross-checkable test here; add it to test-matrix.sh
-# instead. Only add a test here if it is genuinely elfuse-internal, or if a
-# SANITIZER_SECTIONS section needs it.
+# instead. Only add a test here if it is genuinely elfuse-internal, if a
+# SANITIZER_SECTIONS section needs it, or if it needs a host_nofile
+# annotation: that annotation has no other home, and test-matrix.sh reads it
+# from this file for its own elfuse lane, so a cross-checkable test that only
+# means anything under a specific host descriptor limit is listed here as well
+# as there. test-dir-fd-budget is the one such entry today.
 
 [section] Assembly tests
 test-hello
@@ -80,6 +84,7 @@ test-ioctl-cloexec
 test-pty
 test-ioctl-fioasync
 test-getdents-refcount
+test-dir-fd-budget # host_nofile=elfuse-minimum
 test-dev-shm-paths
 test-fcntl-flags
 test-socket-shortwrite

--- a/tests/test-dir-fd-budget.c
+++ b/tests/test-dir-fd-budget.c
@@ -1,0 +1,313 @@
+/*
+ * A guest directory fd must cost exactly one host descriptor
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * elfuse sizes the host descriptor budget as FD_TABLE_SIZE guest fds plus
+ * HOST_FD_RESERVE for its own plumbing (src/elfuse-limits.h), which assumes one
+ * host descriptor per guest fd. Directories used to break that assumption:
+ * fd_alloc_opened_host() dup'd the descriptor so fdopendir() could adopt one
+ * copy while the fd table kept the other, and the duplicate lived as long as
+ * the guest fd. A guest that opened directories therefore ran out at half the
+ * table it was promised, and the overflow came out of the reserve, so the first
+ * casualty was elfuse's own fork IPC rather than the open that caused it.
+ *
+ * The stream now adopts the slot's own descriptor and owns it (see
+ * dir_stream_open / dir_stream_t in src/syscall/fs.c), so both tests below
+ * measure the same thing from two directions: how many directories fit, and
+ * whether dup'ing them fits too.
+ *
+ * Runs with host_nofile=elfuse-minimum, which is the point: with the host limit
+ * at exactly what elfuse asks for, the doubling has nowhere to hide. Before the
+ * fix the first test reached 636 of a promised 1021.
+ *
+ * Syscalls exercised: openat(56), dup(23), getdents64(61), lseek(62),
+ *                     fcntl(25), close(57)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* Every threshold below is derived from the guest's own RLIMIT_NOFILE, read at
+ * runtime, rather than written down. Under elfuse that limit is seeded from
+ * FD_TABLE_SIZE and the host budget is that plus HOST_FD_RESERVE, so a change
+ * to either constant moves these with it; a written-down 1000 would keep
+ * compiling and quietly stop discriminating the moment the table grew. Reading
+ * the limit rather than including src/elfuse-limits.h is also what lets the
+ * same binary mean something in the reference lane, where the host-side
+ * constants describe nothing.
+ *
+ * A few descriptors are already spoken for -- stdio, whatever the harness holds
+ * -- so the ceiling is approached, not hit exactly. SLACK is the room left for
+ * them.
+ */
+#define SLACK 24
+
+static int nofile_limit(void)
+{
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_NOFILE, &rl) < 0)
+        return -1;
+    return rl.rlim_cur > INT_MAX ? INT_MAX : (int) rl.rlim_cur;
+}
+
+/* Directory opens should stop on the guest table, the way a plain file does.
+ * The doubling stopped at roughly half of it.
+ */
+static int expect_at_least(int limit)
+{
+    return limit - SLACK;
+}
+
+/* Enough open+dup pairs that a directory costing two descriptors would need
+ * more than the whole host budget (4 * pairs > limit + HOST_FD_RESERVE), while
+ * the 2 * pairs guest fds still fit under the limit.
+ */
+static int dup_pairs(int limit)
+{
+    return limit / 2 - SLACK;
+}
+
+static char fixture_dir[] = "/tmp/elfuse-dir-budget-XXXXXX";
+static char fixture_file[256];
+
+static int open_fixture_dir(void)
+{
+    return open(fixture_dir, O_RDONLY | O_DIRECTORY);
+}
+
+typedef struct {
+    unsigned long long d_ino;
+    long long d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+} linux_dirent64_t;
+
+/* A stream that never reports its end would spin the walk below forever and
+ * reach the driver as a timeout rather than as a failure. The fixture holds
+ * three entries; this ceiling is about a broken stream, not about contents.
+ */
+#define MAX_ENTRIES 4096
+
+/* Read the whole stream through raw getdents64 and report whether the fixture
+ * file was read back. False covers an unreadable stream as well as an absent
+ * entry -- a failed lseek, a getdents64 error, a malformed record -- which is
+ * why the callers word their failures as not having read the entry rather than
+ * as the entry being gone. Deliberately spends no second descriptor -- these
+ * checks run while the guest fd table is deep into the budget the test just
+ * measured, and an fdopendir()/dup() here would fail with EMFILE for reasons
+ * that have nothing to do with what is under test.
+ *
+ * Every record is bounds-checked before any of it is read. The buffer is what a
+ * change to directory-stream ownership could plausibly corrupt, so this walk
+ * treats a malformed reclen as a failure to report rather than as something to
+ * step over -- and reading a name that does not terminate inside its own record
+ * would run strcmp off the end of buf.
+ */
+static bool dir_lists_fixture(int fd)
+{
+    if (lseek(fd, 0, SEEK_SET) < 0)
+        return false;
+
+    char buf[4096];
+    int seen = 0;
+    for (;;) {
+        long n = syscall(SYS_getdents64, fd, buf, sizeof(buf));
+        if (n <= 0)
+            return false;
+        const long header = (long) offsetof(linux_dirent64_t, d_name);
+        for (long off = 0; off < n;) {
+            /* The header has to fit before anything in it can be read. A
+             * malformed reclen walks off toward n rather than landing on it,
+             * and reading d_reclen out of a record that is not all there is
+             * itself the over-read this walk exists to avoid.
+             */
+            if (n - off < header)
+                return false;
+            linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
+            long reclen = de->d_reclen;
+            if (reclen <= header || reclen > n - off)
+                return false;
+            if (!memchr(de->d_name, '\0', (size_t) (reclen - header)))
+                return false;
+            if (!strcmp(de->d_name, "marker"))
+                return true;
+            if (++seen > MAX_ENTRIES)
+                return false;
+            off += reclen;
+        }
+    }
+}
+
+static void close_all(int *fds, int n)
+{
+    for (int i = 0; i < n; i++)
+        if (fds[i] >= 0)
+            close(fds[i]);
+}
+
+/* Sized from the limit at startup rather than declared, so the arrays cannot
+ * become the thing the open loop stops on.
+ */
+static int *fds;
+static int *dups;
+
+int main(void)
+{
+    printf("test-dir-fd-budget: one host descriptor per directory fd\n\n");
+
+    int limit = nofile_limit();
+    if (limit <= SLACK * 4) {
+        fprintf(stderr,
+                "guest RLIMIT_NOFILE is %d, too low to measure a "
+                "descriptor budget\n",
+                limit);
+        return 2;
+    }
+    const int want_open = expect_at_least(limit);
+    const int want_pairs = dup_pairs(limit);
+    const int slots = limit + SLACK;
+    printf("  RLIMIT_NOFILE %d: expecting >= %d directories, %d dup pairs\n\n",
+           limit, want_open, want_pairs);
+
+    fds = calloc((size_t) slots, sizeof(*fds));
+    dups = calloc((size_t) want_pairs, sizeof(*dups));
+    if (!fds || !dups) {
+        fprintf(stderr, "out of memory sizing the fd arrays\n");
+        return 2;
+    }
+
+    if (!mkdtemp(fixture_dir)) {
+        fprintf(stderr, "mkdtemp: %s\n", strerror(errno));
+        return 1;
+    }
+    snprintf(fixture_file, sizeof(fixture_file), "%s/marker", fixture_dir);
+    int marker = open(fixture_file, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (marker < 0) {
+        /* mkdtemp made a directory nobody else will ever name, so this is the
+         * only chance to take it back.
+         */
+        fprintf(stderr, "create marker: %s\n", strerror(errno));
+        rmdir(fixture_dir);
+        return 1;
+    }
+    close(marker);
+
+    TEST("directory fds reach the guest table");
+    int opened = 0;
+    for (; opened < slots; opened++) {
+        fds[opened] = open_fixture_dir();
+        if (fds[opened] < 0)
+            break;
+    }
+    if (opened >= want_open) {
+        PASS();
+    } else {
+        printf("FAIL: stopped at %d, expected >= %d (errno=%d)\n", opened,
+               want_open, errno);
+        fails++;
+    }
+
+    TEST("a directory fd still reads after that");
+    if (opened > 0 && dir_lists_fixture(fds[0]))
+        PASS();
+    else
+        FAIL("fixture entry missing from a surviving directory fd");
+    close_all(fds, opened);
+
+    TEST("dup'ing directory fds costs one each");
+    int paired = 0;
+    for (; paired < want_pairs; paired++) {
+        fds[paired] = open_fixture_dir();
+        if (fds[paired] < 0)
+            break;
+        dups[paired] = dup(fds[paired]);
+        if (dups[paired] < 0) {
+            /* Report the dup's errno, not the close's: the descriptor
+             * exhaustion this test exists to catch is what dup answered, and
+             * close is allowed to overwrite errno even when it succeeds.
+             */
+            int saved_errno = errno;
+            close(fds[paired]);
+            errno = saved_errno;
+            break;
+        }
+    }
+    if (paired == want_pairs) {
+        PASS();
+    } else {
+        printf("FAIL: only %d of %d pairs (errno=%d)\n", paired, want_pairs,
+               errno);
+        fails++;
+    }
+
+    close_all(fds, paired);
+    close_all(dups, paired);
+
+    /* The two fds hold separate streams over separate descriptors, so closing
+     * one must not take the other's descriptor with it. Checked by using the
+     * survivor as a directory rather than by reading it: a dup'd directory fd
+     * reports an empty stream on elfuse today, which predates this test and is
+     * a separate defect from the descriptor accounting under test here.
+     */
+    TEST("a dup outlives the fd it came from");
+    bool dup_ok = false;
+    int source = open_fixture_dir();
+    if (source >= 0) {
+        int alias = dup(source);
+        if (alias >= 0) {
+            close(source);
+            int through_alias = openat(alias, "marker", O_RDONLY);
+            dup_ok = through_alias >= 0;
+            if (through_alias >= 0)
+                close(through_alias);
+            close(alias);
+        } else {
+            close(source);
+        }
+    }
+    EXPECT_TRUE(dup_ok,
+                "the surviving dup stopped working as a directory "
+                "after the original closed");
+
+    /* fdopendir sets FD_CLOEXEC on the descriptor it adopts, which is now the
+     * guest fd's own. The guest's close-on-exec flag lives in elfuse's fd
+     * table, not on the host descriptor, so an open without O_CLOEXEC must
+     * still read back clear.
+     */
+    TEST("opening a directory does not set close-on-exec");
+    int plain = open_fixture_dir();
+    if (plain < 0) {
+        FAIL("could not open the fixture directory");
+    } else {
+        int fd_flags = fcntl(plain, F_GETFD);
+        if (fd_flags < 0)
+            FAIL("F_GETFD on the directory fd failed");
+        else
+            EXPECT_TRUE((fd_flags & FD_CLOEXEC) == 0,
+                        "directory fd came back with FD_CLOEXEC set");
+        close(plain);
+    }
+
+    unlink(fixture_file);
+    rmdir(fixture_dir);
+
+    SUMMARY("test-dir-fd-budget");
+    return fails ? 1 : 0;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -767,6 +767,7 @@ run_unit_tests()
     test_rc "$runner" "test-pty" 0 "$bindir/test-pty"
     test_rc "$runner" "test-ioctl-fioasync" 0 "$bindir/test-ioctl-fioasync"
     test_rc "$runner" "test-getdents-refcount" 0 "$bindir/test-getdents-refcount"
+    test_rc "$runner" "test-dir-fd-budget" 0 "$bindir/test-dir-fd-budget"
 
     printf "\n/proc and /dev\n"
     test_check "$runner" "test-proc" "0 failed" "$bindir/test-proc"


### PR DESCRIPTION
## Summary

The host descriptor budget in `src/elfuse-limits.h` is `FD_TABLE_SIZE` guest fds plus `HOST_FD_RESERVE` for elfuse's own plumbing, and that arithmetic assumes one host descriptor per guest fd. A directory took two. `fd_alloc_opened_host` dup'd the descriptor so `fdopendir` could adopt one copy while the fd table kept the other, and the duplicate lived as long as the guest fd rather than as long as a call.

Measured with the host limit at the minimum elfuse itself raises it to, which is what any launch from a lower soft limit gets:

| | before | after | Linux 6.12, `RLIMIT_NOFILE` 1024 |
|---|---|---|---|
| `open(dir, O_DIRECTORY)` until `EMFILE` | 636 | 1021 | 1021 |
| `open` a plain file until `EMFILE` | 1021 | 1021 | 1021 |
| 400 open + `dup` pairs on a directory | 318 pairs | 400 pairs | 400 pairs |

Overrunning the table is the visible half. The other half is that the overflow comes out of the reserve, so the first thing to break is not the open that caused it: with 636 directories held, `fork` failed inside `src/runtime/forkipc.c` with `socketpair` returning `EMFILE`, and the guest saw `ENOMEM` from a fork a real kernel completes. `HOST_NOFILE_MIN` is unchanged — this spends fewer descriptors rather than asking for more.

## Why the duplicate was there, and why it could not just go

`fdopendir` adopts the descriptor it is handed, and only `closedir` gives it back. A slot that also closed its own `host_fd` would close it twice, so two owners with independent lifetimes needed two descriptors. That is a real constraint, not an oversight: an in-flight `getdents64` must keep reading after a sibling closes the guest fd.

`fdclosedir(3)` returns the descriptor without closing it and would remove the need for a second owner outright. It is macOS 26.4, and this tree supports macOS 13, so it is not available.

So the ownership goes the other way instead. The stream owns the descriptor, and everything that needs it to stay valid holds a reference on the stream rather than a descriptor of its own. There are three such holders: the fd table slot, an in-flight `getdents64` (which already took one), and an `fd_lifetime` pin, which now delegates its close to the stream instead of calling `close` itself. The descriptor returns to the host at the stream's last release, so `dir_stream_release` is the single point where a directory fd is given back.

## Ordering, and why the stream is part of the slot's identity

Two steps in `fd_cleanup_entry` are keyed by the descriptor's number rather than by the slot: the pty side tables and the readiness watch. The slot's reference on the stream is therefore released after both, so the number cannot be recycled underneath them.

A slot published as `FD_DIR` before its stream exists is a slot whose descriptor looks plain to a concurrent close, which would close it and leave the opening thread's stream sitting on a number the next open can claim. Both creation paths — `openat` and `dup` — now build the stream first and publish it in the `fd_lock` window that creates the slot, which is what the `fd_alloc_dir` entry points already do for `FD_EPOLL`. The alias allocators hand back the allocation generation so the metadata install that follows can still prove the slot is its own, and `install_fd_alias_metadata_atomic` no longer installs the stream at all.

`fd_alloc_opened_host` now takes ownership of `host_fd` on every path including its failures, because for a directory that transfer is mandatory rather than tidy: once `fdopendir` has succeeded there is no way to hand the descriptor back. Its four callers no longer close on failure.

One host behaviour stops being invisible once the descriptor is shared: Darwin's `fdopendir` sets `FD_CLOEXEC` on the descriptor it adopts. That was harmless on a private duplicate. On the guest's own descriptor it flips a flag elfuse never asked for, so `dir_stream_open` clears it back — the guest's `O_CLOEXEC` lives in `fd_entry_t.linux_flags`, never on the host descriptor.

## Test

`tests/test-dir-fd-budget.c` pins the budget from both directions, how many directories fit and whether dup'ing them fits too, and runs at `host_nofile=elfuse-minimum` where the doubling has nowhere to hide. Against the parent commit it reports 636 of a promised 1021 and 318 of 400 pairs. It is registered in the matrix rather than exempted, because the reference kernel agrees with every number it asserts.

`tests/test-getdents-refcount.c` already covers the window this change makes load-bearing — `close`/`dup2` racing an in-flight `getdents64` — and passes unchanged.

## What this does not fix

A dup'd directory fd reads as an empty stream: `getdents64` on it returns 0 entries, not even `.` and `..`, where Linux lists the directory. This predates the change and is unrelated to descriptor accounting — verified by running the same probe against the parent commit, which behaves identically. The test above therefore checks the surviving dup by using it as an `openat` anchor rather than by reading it, so it pins ownership without depending on that defect.

`/dev/ptmx` is the other guest fd that costs two host descriptors, since elfuse holds a keepalive slave alongside the master. That one is bounded by the host's `kern.tty.ptmx_max` rather than by the descriptor budget, so it is a different problem and is left alone here.

## Checks

Based on `300bd1d`.

`make check`, rc=0: 90 in the manifest suite, 7/7, 82/84 (the two skips need a raw socket and an interactive terminal), 27/27, 4/4, 6/6, guardrail PASS.

`make test-matrix`, rc=0: elfuse-aarch64 271 passed, 0 failed; qemu-aarch64 250 passed, 0 failed. `test-dir-fd-budget` passes in both lanes.

`make lint`, rc=0, with no new clang-tidy warning on a touched line. `make check-format`, rc=0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spends one host descriptor per directory fd instead of two, so directory-heavy workloads reach the full guest fd table and stop draining the host descriptor reserve that fork and other elfuse plumbing depend on.

- The directory stream now owns the slot's descriptor and closes it at its last release; an in-flight `getdents64` or an `fd_lifetime` pin holds a stream reference instead of a duplicate descriptor, and fork restore adopts the received descriptor the same way.
- The stream is published in the slot's creation window so a concurrent close never sees a directory entry whose descriptor looks plain.
- Darwin's `fdopendir` sets `FD_CLOEXEC` on the descriptor it adopts, so `dir_stream_open` clears it back; the guest's `O_CLOEXEC` still lives only in `fd_entry_t.linux_flags`.
- Adds `tests/test-dir-fd-budget.c`, which pins the one-descriptor budget at the minimum host limit and reports 636 of a promised 1021 directories before the fix.

<sup>Written for commit 87321da93dc15859cc157d29dc1e3f97c28beaf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

