### PR TITLE
Improve skill to reduce excessive comment generation by LLM

### DIFF
--- a/.claude/skills/elfuse-conventions/SKILL.md
+++ b/.claude/skills/elfuse-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elfuse-conventions
-description: elfuse conventions that CONTRIBUTING.md does not carry: the register a comment or commit message is written in, comment brevity, the type and return conventions at the ABI boundary, how shared mutable state is declared and which memory order a site states, PR etiquette, the untracked root working docs, and the rule that a tool checked out for evaluation never becomes a build dependency. Use when drafting a commit message or PR description, adding a new file or a new type, touching an atomic or a lock-free access, or wiring the build to anything a fresh clone would not have.
+description: elfuse conventions outside CONTRIBUTING.md. Use when adding, reviewing, or reducing prose in source comments, docstrings, README.md, or docs/*.md; drafting a commit message, PR description, or review reply; adding a file or type; touching an atomic or lock-free access; handling untracked working docs; or wiring the build to a tool absent from a fresh clone.
 ---
 
 # elfuse conventions
@@ -87,6 +87,10 @@ prompt echo, effort claims, inflation words, coined vocabulary, trailing
 `references/prose-register.md` before writing a comment block, a commit body,
 a PR reply, or a paragraph of `docs/`, and treat it as the one place those
 classes are defined.
+
+When a prose task extends beyond a local sentence, read
+`references/prose-reduction.md` to decide what survives and where it belongs.
+The register reference above still settles how each survivor is written.
 
 Comments and commit messages are third-person: name the subject (the caller,
 this function) or use imperative phrasing.
@@ -269,14 +273,15 @@ block and rewrite what no longer reads cleanly.
 Mechanics: `/* */` only in `.c`, `.h`, and `.S`, no `//`, no Doxygen tags;
 multi-line blocks align on ` * `, close with `*/` on its own line, indented
 to the body; American English; `@name` references a parameter in prose. A
-new file opens with title, copyright, SPDX identifier, a blank `*` line,
-then one prose paragraph on what the module is for (`src/syscall/signal.h`
-is the model). `#` comments in shell, Python, and Make obey the same rules.
-Update or delete a comment in the commit that changes its code: a stale
-comment is worse than none, because it is believed. A comment asserting a
-number or a guarantee is the case that rots silently, so recompute it before
-carrying it into an edit; `elfuse-refactor` reads the same rule from the
-reviewer's side.
+new file follows the surrounding legal-header form. Omit a title or synopsis
+when the filename, module name, primary type, or entry point already states
+it. Keep one short module paragraph only for a stable file-wide constraint
+with no narrower owner. `#` comments in shell, Python, and Make obey the same
+content rules. Update or delete a comment in the commit that changes its code:
+a stale comment is worse than none, because it is believed. A comment
+asserting a number or a guarantee is the case that rots silently, so recompute
+it before carrying it into an edit; `elfuse-refactor` reads the same rule from
+the reviewer's side.
 
 ## docs/
 

--- a/.claude/skills/elfuse-conventions/references/prose-reduction.md
+++ b/.claude/skills/elfuse-conventions/references/prose-reduction.md
@@ -1,0 +1,85 @@
+# Reducing prose
+
+This reference decides what survives and which surface owns it. The sibling
+`references/prose-register.md` decides how a survivor is written. Apply both
+when a task changes more than a local sentence.
+
+## The deletion pass
+
+1. Read the names, types, control flow, tests, and neighboring documentation
+   without relying on the prose.
+2. Delete prose that only translates those surfaces into English.
+3. Identify the facts that would be lost: rationale, invariants, boundaries,
+   units, citations, and compatibility constraints.
+4. Put each fact beside its narrowest stable owner. Shared contracts live once
+   at the interface or type that owns them.
+5. Rewrite each survivor as the shortest cause, constraint, or consequence
+   that remains accurate.
+6. Recompute numbers and guarantees, check citations, and run the
+   surface-specific checks below.
+7. Measure the reduction as evidence. No percentage can justify deleting a
+   load-bearing fact.
+
+Editing one sentence reopens its paragraph. A sentence left untouched inside a
+rewritten block still reads as newly verified.
+
+## Surface ownership
+
+| Surface | Delete | Keep |
+| --- | --- | --- |
+| File or module header | A filename restatement, feature inventory, or execution tour | Legal text and one file-wide constraint with no narrower owner |
+| Function or method docstring | A signature paraphrase, obvious return shape, or implementation sequence | A caller-visible contract, surprising side effect, or failure meaning |
+| Inline or block comment | Statement narration, branch paraphrase, or implementation history | Rationale, invariant, boundary, unit, citation, or dangerous alternative |
+| Test | Setup, action, and assertion narration | Why a fixture has an unusual shape or an obvious oracle is insufficient |
+| JSONC, build, or workflow file | Generic purpose, visible syntax, schema inventory, or list count | Exclusion rationale, required-check behavior, or compatibility constraint |
+| README | Repeated reference material | Navigation, entry points, and a concise capability statement |
+| Usage document | Internal implementation detail | Copyable commands, inputs, outputs, and stable failure behavior |
+| Domain reference | Repeated command catalogs and source-file inventories | Current contracts, ownership, architecture, and cross-component invariants |
+| Commit body | Diff walkthrough, file inventory, moved source narration, or generic test log | Short what and why, the rejected obvious alternative, and claim-specific verification |
+| PR or review text | A restated diff, walkthrough, status summary, or closing verdict | Intent, reproduction, correction, or measurement |
+| Skill | A section summary, case-study transcript, or duplicated trigger | A routing branch, consequence, authority, and task-specific judgment |
+
+Two copies of one fact eventually disagree. The second surface links to the
+first instead of copying it.
+
+## Checks before deletion
+
+A Python docstring is runtime data. Search for consumers before deleting one:
+
+```sh
+git grep -n -E '__doc__|inspect\.getdoc|pydoc|help\(' -- '*.py'
+```
+
+Keep or replace it when argument parsing, help generation, introspection,
+tests, or another runtime path consumes it.
+
+Poor naming does not make narration valuable. Rename within the requested
+scope when a better identifier makes the comment redundant. Retain a needed
+explanation when the rename or restructuring would expand the task.
+
+Legal notices, tool directives, generated-file notices, and externally
+required annotations are outside this reduction rule. Vendored prose is not
+rewritten as project style.
+
+Documentation replaces copies with links and collapses adjacent sections that
+state the same contract. Examples stay when they are copyable or distinguish
+two behaviors. Preserve externally visible states, command syntax, error
+semantics, and safety boundaries.
+
+Deleting source narration does not move it into a commit body. Keep an obvious
+alternative there only when its failure would attract a future rewrite.
+
+## Calibration
+
+These transformations distinguish deletion from shortening:
+
+```text
+# Cleanup takes 12 seconds, the runner adds 25, and transport adds 30.
+rewrite: Keep supervisor cleanup below the channel deadline.
+
+# Remove stale binds before recursive removal can enter the real device tree.
+keep: the destructive alternative is invisible in the command itself
+```
+
+The result is allowed to be longer when the hidden contract is longer. The
+test is what a reader loses after deletion, not how much text remains.

--- a/.claude/skills/elfuse-refactor/SKILL.md
+++ b/.claude/skills/elfuse-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elfuse-refactor
-description: Judging and cleaning elfuse C code that already works - which Refactoring smells carry weight in a Linux ABI reimplementation, which ones are false alarms in this tree, and what has to stay green before a change counts as behavior-preserving. Use when asked to clean up, simplify, deduplicate, or restructure, when reviewing a diff for maintainability rather than for bugs, or on the symptom alone: an over-long function, the same cleanup block repeated at many failure exits, a helper that returns 0 or -1 and is read with a < 0 test, a comment asserting a number. Not for adding a syscall (elfuse-syscall), for naming and commit style (elfuse-conventions), or for chasing a live failure (elfuse-debug).
+description: Behavior-preserving cleanup of elfuse code, calibrated for C-specific smells and false alarms. Use when simplifying, deduplicating, or restructuring working code; reviewing maintainability; or facing an over-long function, repeated cleanup, a 0/-1 helper used as a boolean, or prose that narrates code or asserts a number. Not for syscall implementation (elfuse-syscall), naming or commit style (elfuse-conventions), or live failures (elfuse-debug).
 ---
 
 # Refactoring elfuse code
@@ -109,15 +109,12 @@ Three cases where "I only moved code" is wrong:
   `src/syscall/abi.h` with a name, and the domain file uses the name.
 - A helper that returns 0 or -1 and is only ever read with `< 0`. That is a
   `bool` wearing an `int`, and `elfuse-conventions` says which is which.
-- A comment that asserts a number or a guarantee. Both rot silently and both
-  read as checked. A comment saying a buffer is "~100KiB" when the type it
-  sizes has since grown, or saying a check "has to be declared in the diff"
-  when `WarningsAsErrors` is empty and the CI job logs rather than gates, is
-  worse than no comment: the next reader trusts it instead of measuring. When
-  a refactor moves a comment, its claims move with it unverified, so recompute
-  the number and re-read the config the sentence describes. This is the same
-  failure `scripts/check-skill-refs.py` exists to catch in the skills, and
-  nothing catches it in `src/`.
+- A comment or docstring that narrates working code or asserts a number or
+  guarantee. Restatements hide rationale, and unchecked claims rot. Recompute
+  the claim, then apply the deletion pass in
+  `.claude/skills/elfuse-conventions/references/prose-reduction.md`. A Python
+  docstring is runtime data, so rule out introspection consumers before
+  deleting it.
 
 ## Smells that are false alarms in this tree
 

--- a/.claude/skills/elfuse-skills/SKILL.md
+++ b/.claude/skills/elfuse-skills/SKILL.md
@@ -55,6 +55,9 @@ The shape the tree already uses, and the reason for it:
 
 `elfuse-conventions` binds this prose the same as any other surface in the
 tree: no em dash, third person, and no register the machine writes in.
+When the task reduces a skill rather than adding one, read
+`.claude/skills/elfuse-conventions/references/prose-reduction.md`; keep
+reusable decisions and omit case-specific evidence.
 
 ## Authoritative sources
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Teaches the skill files to prefer deleting generated prose instead of adding more, so comments, docs, and commit bodies carry only facts the code cannot state.

**Refactors**
- Adds `references/prose-reduction.md` as the single owner for deletion passes, surface ownership, and calibration examples.
- Points `elfuse-conventions`, `elfuse-refactor`, and `elfuse-skills` to the reference so prose questions resolve to one place.
- Changes file and module headers to omit titles or synopses the filename already states, with a short module paragraph only for a file-wide stable constraint.
- Extends refactor's comment smell to cover narration and runtime-visible Python docstrings; removal is behavior-preserving only after ruling out introspection consumers.

<sup>Written for commit f274c7d6352d0557c8ee0c7cd1e4d71c4afd9edd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

