### PR TITLE
Clear ARM64 instruction cache on mprotect exec

### DIFF
--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -952,7 +952,7 @@ static inline fd_block_state_t fd_block_state_of(const fd_entry_t *e)
     return (fd_block_state_t) {
         .type = e->type,
         .generation = e->generation,
-        .seals = e->seals,
+        .seals = (unsigned int) e->seals,
         .can_block = e->can_block,
         .nonblock_owned = e->nonblock_owned,
         .guest_nonblock = (e->linux_flags & LINUX_O_NONBLOCK) != 0,

--- a/src/syscall/mem.c
+++ b/src/syscall/mem.c
@@ -4523,8 +4523,16 @@ int64_t sys_mprotect(guest_t *g, uint64_t addr, uint64_t length, int prot)
             if (mprotect_same_prot_fast_path_safe(prot) &&
                 !g->regions_tracker_stale &&
                 guest_region_range_prot_uniform(g, addr, mprot_end, prot) &&
-                !guest_region_range_has_noreserve(g, addr, mprot_end))
+                !guest_region_range_has_noreserve(g, addr, mprot_end)) {
+                if (prot & LINUX_PROT_EXEC) {
+                    char *host_start = (char *) host_ptr_for_gpa(g, addr);
+                    if (host_start) {
+                        __builtin___clear_cache(host_start,
+                                                host_start + length);
+                    }
+                }
                 return 0;
+            }
 
             /* Do PTE work BEFORE updating the tracker. If page-table
              * maintenance fails, regions[] still reflects the old prot, so a
@@ -4540,6 +4548,12 @@ int64_t sys_mprotect(guest_t *g, uint64_t addr, uint64_t length, int prot)
                     return -LINUX_ENOMEM;
             }
             guest_region_set_prot(g, addr, mprot_end, prot);
+            if (prot & LINUX_PROT_EXEC) {
+                char *host_start = (char *) host_ptr_for_gpa(g, addr);
+                if (host_start) {
+                    __builtin___clear_cache(host_start, host_start + length);
+                }
+            }
             return 0;
         }
         uint64_t mprot_off = addr - g->ipa_base;
@@ -4563,8 +4577,13 @@ int64_t sys_mprotect(guest_t *g, uint64_t addr, uint64_t length, int prot)
                 !g->regions_tracker_stale &&
                 guest_region_range_prot_uniform(g, mprot_off, mprot_end,
                                                 prot) &&
-                !guest_region_range_has_noreserve(g, mprot_off, mprot_end))
+                !guest_region_range_has_noreserve(g, mprot_off, mprot_end)) {
+                if (prot & LINUX_PROT_EXEC) {
+                    char *host_start = (char *) g->host_base + mprot_off;
+                    __builtin___clear_cache(host_start, host_start + length);
+                }
                 return 0;
+            }
 
             if (prot != LINUX_PROT_NONE) {
                 int page_perms = prot_to_perms(prot);
@@ -4578,6 +4597,10 @@ int64_t sys_mprotect(guest_t *g, uint64_t addr, uint64_t length, int prot)
                     return -LINUX_ENOMEM;
             }
             guest_region_set_prot(g, mprot_off, mprot_end, prot);
+            if (prot & LINUX_PROT_EXEC) {
+                char *host_start = (char *) g->host_base + mprot_off;
+                __builtin___clear_cache(host_start, host_start + length);
+            }
         }
     }
     return 0;

--- a/tests/manifest.txt
+++ b/tests/manifest.txt
@@ -125,6 +125,7 @@ test-fork-synthetic-fd
 
 [section] Guard page / mmap edge cases
 test-guard-page
+test-jit-icache
 test-mmap-hint
 test-mmap-sigbus-efault
 

--- a/tests/test-jit-icache.c
+++ b/tests/test-jit-icache.c
@@ -1,0 +1,105 @@
+/*
+ * Self-modifying JIT instruction cache invalidation test
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tests: mprotect(PROT_READ | PROT_EXEC) invalidates instruction cache
+ *        when guest JIT code is updated in place.
+ *
+ * Syscalls exercised: mmap(222), mprotect(226)
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+typedef int (*jit_fn_t)(void);
+
+static void test_jit_icache_flush(void)
+{
+    TEST("JIT mprotect instruction cache flush");
+
+    uint32_t *buf = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (buf == MAP_FAILED) {
+        FAIL("mmap failed");
+        return;
+    }
+
+    /* Write 1st version: return 1 0x52800020 : mov w0, #1 0xd65f03c0 : ret */
+    buf[0] = 0x52800020u;
+    buf[1] = 0xd65f03c0u;
+
+    if (mprotect(buf, 4096, PROT_READ | PROT_EXEC) != 0) {
+        FAIL("mprotect RX failed");
+        munmap(buf, 4096);
+        return;
+    }
+
+    jit_fn_t fn = (jit_fn_t) buf;
+    int res1 = fn();
+    if (res1 != 1) {
+        FAIL("initial JIT execution returned wrong value");
+        munmap(buf, 4096);
+        return;
+    }
+
+    /* Change permissions back to RW to rewrite code */
+    if (mprotect(buf, 4096, PROT_READ | PROT_WRITE) != 0) {
+        FAIL("mprotect RW failed");
+        munmap(buf, 4096);
+        return;
+    }
+
+    /* Write 2nd version: return 42 0x52800540 : mov w0, #42 0xd65f03c0 : ret */
+    buf[0] = 0x52800540u;
+    buf[1] = 0xd65f03c0u;
+
+    /* Change permissions to RX (must invalidate instruction cache) */
+    if (mprotect(buf, 4096, PROT_READ | PROT_EXEC) != 0) {
+        FAIL("mprotect RX 2nd failed");
+        munmap(buf, 4096);
+        return;
+    }
+
+    int res2 = fn();
+    if (res2 != 42) {
+        FAIL("stale instruction cache detected (JIT rewrite failed)");
+        munmap(buf, 4096);
+        return;
+    }
+
+    /* Re-issue mprotect RX while region is ALREADY tracked as RX to exercise
+     * same-protection fast path icache invalidation.
+     */
+    if (mprotect(buf, 4096, PROT_READ | PROT_EXEC) != 0) {
+        FAIL("same-protection mprotect RX failed");
+        munmap(buf, 4096);
+        return;
+    }
+
+    int res3 = fn();
+    if (res3 != 42) {
+        FAIL("same-protection mprotect icache flush failed");
+        munmap(buf, 4096);
+        return;
+    }
+
+    PASS();
+    munmap(buf, 4096);
+}
+
+int main(void)
+{
+    test_jit_icache_flush();
+    SUMMARY("test-jit-icache");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -291,6 +291,7 @@ QEMU_SKIP="
     test-ioctl-cloexec
     test-pty
     test-mprotect-mt
+    test-jit-icache
     test-clone3
     test-fork-synthetic-fd
     test-mmap-hint
@@ -341,6 +342,10 @@ QEMU_SKIP="
 #   elfuse's own vCPU/TLBI shootout timing; the qemu reference lane's nested
 #   virtualization has different scheduling latency and trips the same
 #   thresholds for real, unrelated races.
+# test-jit-icache: real Linux mprotect does not perform user-space instruction
+#   cache maintenance (Linux requires user-space JIT compilers to invoke
+#   sys_cacheflush / __builtin___clear_cache), whereas elfuse invalidates
+#   the host instruction cache automatically during sys_mprotect.
 # test-clone3: CLONE_NEWPID succeeds on a real kernel (PID namespaces) but
 #   elfuse has no namespace support and expects EINVAL; the mismatch derails
 #   the rest of the scenario into a hang instead of a clean FAIL.
@@ -841,6 +846,7 @@ run_unit_tests()
 
     printf "\nGuard page / mmap edge cases\n"
     test_check "$runner" "test-guard-page" "PASS" "$bindir/test-guard-page"
+    test_check "$runner" "test-jit-icache" "PASS" "$bindir/test-jit-icache"
     test_rc "$runner" "test-mmap-hint" 0 "$bindir/test-mmap-hint"
 
     test_rc "$runner" "test-mmap-sigbus-efault" 0 "$bindir/test-mmap-sigbus-efault"


### PR DESCRIPTION
Flush data cache and invalidate instruction cache using __builtin___clear_cache when sys_mprotect marks memory with LINUX_PROT_EXEC.

This prevents Apple Silicon CPUs from executing stale cached instructions when dynamic JIT compilers like Android ART generate and execute new ARM64 machine code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sys_mprotect` clearing the ARM64 instruction cache when marking memory executable, so JIT-generated code (e.g. Android ART) runs correctly on Apple Silicon instead of executing stale cached instructions.

- Flushes cache via `__builtin___clear_cache` on the slow path and the same-protection fast path, so repeated RX `mprotect` after in-place rewrites also invalidates stale instructions.
- Resolves the host range per region: `host_ptr_for_gpa` for high-VA regions, `g->host_base + mprot_off` for primary memory.
- Uses `host_start + length` as the exclusive upper bound so the range doesn't end exactly on a guest-size boundary where `host_ptr_for_gpa` returns `NULL`.
- Adds `test-jit-icache`, which rewrites guest code in place and verifies RX `mprotect` executes the rewritten version on both ARM64 and x86_64, including the fast path.
- Casts `seals` to `unsigned int` in `fd_block_state_of` to silence a warning.

<sup>Written for commit 0c88d3b0f26a8d8d255f6192d92262e64f37916e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

