### PR TITLE
Stop tests claiming host-global names

### DIFF
--- a/tests/test-chown-overlay.c
+++ b/tests/test-chown-overlay.c
@@ -28,6 +28,7 @@
 
 int passes = 0, fails = 0;
 
+static char tmp_root[] = "/tmp/elfuse-chown-XXXXXX";
 static char tmp_file[256];
 static char tmp_link[256];
 static char tmp_target[256];
@@ -35,14 +36,14 @@ static char tmp_dir[256];
 
 static int setup_fixtures(void)
 {
-    snprintf(tmp_file, sizeof(tmp_file), "/tmp/elfuse-chown-%d.txt",
-             (int) getpid());
-    snprintf(tmp_target, sizeof(tmp_target), "/tmp/elfuse-chown-tgt-%d.txt",
-             (int) getpid());
-    snprintf(tmp_link, sizeof(tmp_link), "/tmp/elfuse-chown-link-%d",
-             (int) getpid());
-    snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/elfuse-chown-dir-%d",
-             (int) getpid());
+    if (!mkdtemp(tmp_root)) {
+        perror("setup: mkdtemp");
+        return -1;
+    }
+    snprintf(tmp_file, sizeof(tmp_file), "%s/file.txt", tmp_root);
+    snprintf(tmp_target, sizeof(tmp_target), "%s/target.txt", tmp_root);
+    snprintf(tmp_link, sizeof(tmp_link), "%s/link", tmp_root);
+    snprintf(tmp_dir, sizeof(tmp_dir), "%s/dir", tmp_root);
 
     int fd = open(tmp_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (fd < 0) {
@@ -63,7 +64,6 @@ static int setup_fixtures(void)
     }
     close(fd);
 
-    unlink(tmp_link);
     if (symlink(tmp_target, tmp_link) < 0) {
         perror("setup: symlink");
         return -1;
@@ -81,6 +81,7 @@ static void teardown_fixtures(void)
     unlink(tmp_link);
     unlink(tmp_target);
     rmdir(tmp_dir);
+    rmdir(tmp_root);
 }
 
 static void test_chown_then_stat(void)
@@ -267,6 +268,11 @@ int main(void)
 
     if (setup_fixtures() < 0) {
         printf("test-chown-overlay: fixture setup failed\n");
+
+        /* Safe on paths never created, and the only thing that removes tmp_root
+         * after a partial setup.
+         */
+        teardown_fixtures();
         return 1;
     }
     test_chown_then_stat();

--- a/tests/test-cross-fork-mapshared.c
+++ b/tests/test-cross-fork-mapshared.c
@@ -37,20 +37,9 @@ int passes = 0, fails = 0;
 #define MAP_ANONYMOUS 0x20
 #endif
 
-/* glibc 2.28 static: shm_open is broken; emulate via /dev/shm. */
-static int my_shm_open(const char *name, int oflag, int mode)
-{
-    char path[128];
-    snprintf(path, sizeof(path), "/dev/shm%s", name);
-    return open(path, oflag, mode);
-}
-
-static int my_shm_unlink(const char *name)
-{
-    char path[128];
-    snprintf(path, sizeof(path), "/dev/shm%s", name);
-    return unlink(path);
-}
+/* This test opens a /dev/shm path directly rather than calling shm_open, which
+ * returns ENOSYS without trying on glibc 2.28 static.
+ */
 
 /* IPC primitives between parent and child: a single byte over a pipe pair
  * signals "go ahead" each direction. Replaces a sleep-based synchronization
@@ -347,14 +336,13 @@ static void test_shm_cross_fork(void)
 {
     TEST("MAP_SHARED shm: cross-fork live coherence");
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-cf-shm-%ld", (long) getpid());
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[64] = "/dev/shm/elfuse-cf-shm-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("shm_open");
+        FAIL("mkstemp /dev/shm failed");
         return;
     }
-    my_shm_unlink(name);
+    unlink(name);
 
     if (ftruncate(fd, 4096) != 0) {
         FAIL("ftruncate");

--- a/tests/test-dev-shm-paths.c
+++ b/tests/test-dev-shm-paths.c
@@ -52,6 +52,7 @@ static char shm_fifo[128];
 static char shm_exec[128];
 static char victim_path[128];
 static char fixture_suffix[16];
+static char fixture_seed[] = "/tmp/elfuse-shm-seed-XXXXXX";
 
 /* Guest PIDs restart from the same value in each independent elfuse process.
  * Reserve a host-unique suffix so concurrent runtime jobs cannot unlink or
@@ -59,14 +60,15 @@ static char fixture_suffix[16];
  */
 static int name_fixtures(void)
 {
-    char seed[] = "/tmp/elfuse-shm-seed-XXXXXX";
-    int fd = mkstemp(seed);
+    int fd = mkstemp(fixture_seed);
     if (fd < 0)
         return -1;
     close(fd);
-    (void) unlink(seed);
 
-    const char *suffix = strrchr(seed, '-');
+    /* The seed stays until cleanup: mkstemp reserves a suffix only while the
+     * file exists, and the fixtures below are named after it.
+     */
+    const char *suffix = strrchr(fixture_seed, '-');
     if (suffix == NULL || suffix[1] == '\0')
         return -1;
     snprintf(fixture_suffix, sizeof(fixture_suffix), "%s", suffix + 1);
@@ -99,6 +101,16 @@ static void cleanup_fixtures(void)
     unlink(shm_exec);
     rmdir(shm_dir);
     unlink(victim_path);
+}
+
+/* Separate from cleanup_fixtures, which also runs once before the tests to
+ * sweep fixtures a killed run left in the shm backing dir. Releasing the seed
+ * there would free the suffix for another run to mint for the whole of this
+ * one.
+ */
+static void release_fixture_seed(void)
+{
+    unlink(fixture_seed);
 }
 
 /* The exact LTP setup_ipc() sequence: create via open, adjust via chmod. */
@@ -597,8 +609,8 @@ static void test_imported_symlink_contained(void)
 {
     TEST("symlink renamed into shm stays contained");
     char tmp_link[128];
-    snprintf(tmp_link, sizeof(tmp_link), "/tmp/elfuse-shm-implink-%d",
-             (int) getpid());
+    snprintf(tmp_link, sizeof(tmp_link), "/tmp/elfuse-shm-implink-%s",
+             fixture_suffix);
     if (make_victim() != 0) {
         FAIL("create victim");
         return;
@@ -804,6 +816,7 @@ int main(int argc, char **argv)
 
     if (name_fixtures() < 0) {
         FAIL("reserve unique fixture suffix");
+        release_fixture_seed();
         SUMMARY("test-dev-shm-paths");
         return 1;
     }
@@ -838,6 +851,7 @@ int main(int argc, char **argv)
     test_oversized_name();
 
     cleanup_fixtures();
+    release_fixture_seed();
 
     SUMMARY("test-dev-shm-paths");
     return fails == 0 ? 0 : 1;

--- a/tests/test-epoll-unsupported.c
+++ b/tests/test-epoll-unsupported.c
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <sys/epoll.h>
 #include <sys/stat.h>
@@ -244,22 +245,26 @@ int main(void)
     expect_op_errno("unregistered DEL", "/proc/self/mountinfo", EPOLL_CTL_DEL,
                     ENOENT);
 
-    /* Named after this process so two runs of the suite cannot collide on the
-     * unlink and see each other's fifo.
+    /* A private directory: guest pids restart at 1, so a pid-derived name was
+     * the same name in every concurrent run.
      */
-    char fifo_path[64];
-    snprintf(fifo_path, sizeof(fifo_path), "/tmp/elfuse-epoll-fifo-%d",
-             (int) getpid());
-    unlink(fifo_path);
+    char fifo_dir[] = "/tmp/elfuse-epoll-fifo-XXXXXX";
     TEST("fifo opened by path");
-    if (mkfifo(fifo_path, 0600) != 0) {
-        FAIL("mkfifo failed");
+    if (!mkdtemp(fifo_dir)) {
+        FAIL("mkdtemp failed");
     } else {
-        int ff = open(fifo_path, O_RDONLY | O_NONBLOCK);
-        EXPECT_EQ(add_to_fresh_epoll(ff, EPOLLIN), 0, "fifo was refused");
-        close(ff);
+        char fifo_path[128];
+        snprintf(fifo_path, sizeof(fifo_path), "%s/f", fifo_dir);
+        if (mkfifo(fifo_path, 0600) != 0) {
+            FAIL("mkfifo failed");
+        } else {
+            int ff = open(fifo_path, O_RDONLY | O_NONBLOCK);
+            EXPECT_EQ(add_to_fresh_epoll(ff, EPOLLIN), 0, "fifo was refused");
+            close(ff);
+        }
+        unlink(fifo_path);
+        rmdir(fifo_dir);
     }
-    unlink(fifo_path);
 
     /* Trees elfuse serves from ordinary host files. fstat calls every one of
      * them a plain file; Linux polls them, so the plain-file rule has to go by

--- a/tests/test-fchmodat-empty-path.c
+++ b/tests/test-fchmodat-empty-path.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -54,16 +55,14 @@ static int fchmodat2_supported(const char *probe_path)
 
 int passes = 0, fails = 0;
 
-static char tmp_file[256];
-static char tmp_dir[256];
+static char tmp_file[] = "/tmp/elfuse-fchmodat-empty-XXXXXX";
+static char tmp_dir[] = "/tmp/elfuse-fchmodat-empty-dir-XXXXXX";
 
 static int setup_fixtures(void)
 {
-    snprintf(tmp_file, sizeof(tmp_file), "/tmp/elfuse-fchmodat-empty-%d.txt",
-             (int) getpid());
-    int fd = open(tmp_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int fd = mkstemp(tmp_file);
     if (fd < 0) {
-        perror("setup: open tmp_file");
+        perror("setup: mkstemp tmp_file");
         return -1;
     }
     close(fd);
@@ -71,10 +70,18 @@ static int setup_fixtures(void)
     /* The AT_FDCWD case below needs a writable cwd; the process's inherited cwd
      * may not be (e.g. a read-only rootfs in a VM test image).
      */
-    snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/elfuse-fchmodat-empty-dir-%d",
-             (int) getpid());
-    if (mkdir(tmp_dir, 0755) < 0) {
-        perror("setup: mkdir tmp_dir");
+    if (!mkdtemp(tmp_dir)) {
+        perror("setup: mkdtemp tmp_dir");
+        return -1;
+    }
+
+    /* Off mkdtemp's 0700, because test_empty_path_at_fdcwd_targets_cwd chmods
+     * the cwd to 0700 and asserts it: starting there, that assertion would pass
+     * on a no-op. The sibling fchownat test reads no directory mode and needs
+     * no equivalent.
+     */
+    if (chmod(tmp_dir, 0755) < 0) {
+        perror("setup: chmod tmp_dir");
         return -1;
     }
     if (chdir(tmp_dir) < 0) {

--- a/tests/test-fchownat-empty-path.c
+++ b/tests/test-fchownat-empty-path.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -27,16 +28,14 @@
 
 int passes = 0, fails = 0;
 
-static char tmp_file[256];
-static char tmp_dir[256];
+static char tmp_file[] = "/tmp/elfuse-fchownat-empty-XXXXXX";
+static char tmp_dir[] = "/tmp/elfuse-fchownat-empty-dir-XXXXXX";
 
 static int setup_fixtures(void)
 {
-    snprintf(tmp_file, sizeof(tmp_file), "/tmp/elfuse-fchownat-empty-%d.txt",
-             (int) getpid());
-    int fd = open(tmp_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    int fd = mkstemp(tmp_file);
     if (fd < 0) {
-        perror("setup: open tmp_file");
+        perror("setup: mkstemp tmp_file");
         return -1;
     }
     close(fd);
@@ -44,10 +43,8 @@ static int setup_fixtures(void)
     /* The AT_FDCWD case below needs a writable cwd; the process's inherited cwd
      * may not be (e.g. a read-only rootfs in a VM test image).
      */
-    snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/elfuse-fchownat-empty-dir-%d",
-             (int) getpid());
-    if (mkdir(tmp_dir, 0755) < 0) {
-        perror("setup: mkdir tmp_dir");
+    if (!mkdtemp(tmp_dir)) {
+        perror("setup: mkdtemp tmp_dir");
         return -1;
     }
     if (chdir(tmp_dir) < 0) {

--- a/tests/test-fcntl-flags.c
+++ b/tests/test-fcntl-flags.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <signal.h>
 #include <stdint.h>
@@ -48,9 +49,6 @@ int passes = 0, fails = 0;
 #define O_PATH 010000000
 #endif
 
-/* Written where the guest can create it under either sysroot. */
-#define NOATIME_FILE "/tmp/fcntl-noatime.tmp"
-#define SYNC_FILE "/tmp/fcntl-sync.tmp"
 
 static void check_accmode(const char *what, int fd, int want)
 {
@@ -109,13 +107,26 @@ int main(void)
 {
     printf("test-fcntl-flags: status flags across fd types\n");
 
+    /* A directory private to this run, under /tmp so the guest can create it
+     * under either sysroot. The fixed names it replaces were unlinked mid-test
+     * by concurrent runs.
+     */
+    char tmpdir[] = "/tmp/elfuse-fcntl-flags-XXXXXX";
+    if (!mkdtemp(tmpdir)) {
+        perror("mkdtemp");
+        return 1;
+    }
+    char noatime_file[128], sync_file[128], regular_file[128];
+    snprintf(noatime_file, sizeof(noatime_file), "%s/noatime.tmp", tmpdir);
+    snprintf(sync_file, sizeof(sync_file), "%s/sync.tmp", tmpdir);
+    snprintf(regular_file, sizeof(regular_file), "%s/regular", tmpdir);
+
     /* Regular files, one per access mode. */
     int rd = open("/etc/hostname", O_RDONLY);
     if (rd < 0)
         rd = open("/proc/self/cmdline", O_RDONLY);
-    int wr =
-        open("/tmp/elfuse-fcntl-flags", O_WRONLY | O_CREAT | O_TRUNC, 0600);
-    int rw = open("/tmp/elfuse-fcntl-flags", O_RDWR);
+    int wr = open(regular_file, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    int rw = open(regular_file, O_RDWR);
 
     check_accmode("regular O_RDONLY", rd, O_RDONLY);
     check_accmode("regular O_WRONLY", wr, O_WRONLY);
@@ -324,7 +335,7 @@ int main(void)
      * open() recorded. Checked in both directions, since a shadow that is only
      * ever set looks correct until something clears it.
      */
-    int nafd = open(NOATIME_FILE, O_RDWR | O_CREAT, 0600);
+    int nafd = open(noatime_file, O_RDWR | O_CREAT, 0600);
     if (nafd >= 0) {
         TEST("O_NOATIME is not reported before it is set");
         EXPECT_EQ(fcntl(nafd, F_GETFL) & O_NOATIME, 0, "reported unset flag");
@@ -337,7 +348,7 @@ int main(void)
         TEST("F_SETFL clears O_NOATIME");
         EXPECT_EQ(fcntl(nafd, F_GETFL) & O_NOATIME, 0, "bit did not clear");
         close(nafd);
-        unlink(NOATIME_FILE);
+        unlink(noatime_file);
     }
 
     /* O_PATH and O_DIRECTORY have no macOS equivalent and are carried in the
@@ -457,7 +468,7 @@ int main(void)
         close(wr);
     if (rw >= 0)
         close(rw);
-    unlink("/tmp/elfuse-fcntl-flags");
+    unlink(regular_file);
 
     /* A raw openat may carry __O_SYNC without O_DSYNC. Linux normalizes it to
      * O_SYNC, while an O_DSYNC-only open remains weaker. Every F_GETFL result
@@ -465,7 +476,7 @@ int main(void)
      * satisfy every mask below, so testing the call inline would turn a failure
      * into a row of green checks. check_accmode above guards the same way.
      */
-    int sfd_sync = open(SYNC_FILE, O_RDWR | O_CREAT | O_SYNC, 0600);
+    int sfd_sync = open(sync_file, O_RDWR | O_CREAT | O_SYNC, 0600);
     if (sfd_sync >= 0) {
         int fl = fcntl(sfd_sync, F_GETFL);
         TEST("O_SYNC round trips through F_GETFL");
@@ -475,7 +486,7 @@ int main(void)
             EXPECT_EQ(fl & O_SYNC, O_SYNC, "flag was lost");
         close(sfd_sync);
     }
-    int sfd_raw_sync = syscall(SYS_openat, AT_FDCWD, SYNC_FILE,
+    int sfd_raw_sync = syscall(SYS_openat, AT_FDCWD, sync_file,
                                O_RDWR | O_CREAT | (O_SYNC & ~O_DSYNC), 0600);
     if (sfd_raw_sync >= 0) {
         int fl = fcntl(sfd_raw_sync, F_GETFL);
@@ -486,7 +497,7 @@ int main(void)
             EXPECT_EQ(fl & O_SYNC, O_SYNC, "flag was lost");
         close(sfd_raw_sync);
     }
-    int sfd_dsync = open(SYNC_FILE, O_RDWR | O_CREAT | O_DSYNC, 0600);
+    int sfd_dsync = open(sync_file, O_RDWR | O_CREAT | O_DSYNC, 0600);
     if (sfd_dsync >= 0) {
         int fl = fcntl(sfd_dsync, F_GETFL);
         TEST("O_DSYNC round trips through F_GETFL");
@@ -500,7 +511,8 @@ int main(void)
         }
         close(sfd_dsync);
     }
-    unlink(SYNC_FILE);
+    unlink(sync_file);
+    rmdir(tmpdir);
 
     SUMMARY("test-fcntl-flags");
     return fails > 0 ? 1 : 0;

--- a/tests/test-fd-pin-lock.c
+++ b/tests/test-fd-pin-lock.c
@@ -99,22 +99,32 @@ static void *sibling(void *arg)
  */
 static int child_can_lock(int go_wr, int rep_rd)
 {
-    if (write(go_wr, "x", 1) != 1)
-        return -1;
+    /* Every negative return is marked, not just one: the caller compares
+     * against 1 or 0, so an unmarked -1 reads as a child that was refused.
+     */
     int taken = -1;
-    if (read(rep_rd, &taken, sizeof(taken)) != (ssize_t) sizeof(taken))
+    if (write(go_wr, "x", 1) != 1 ||
+        read(rep_rd, &taken, sizeof(taken)) != (ssize_t) sizeof(taken)) {
+        printf("[child unreachable] ");
         return -1;
+    }
+    if (taken < 0)
+        printf("[child never tried] ");
     return taken;
 }
 
 int main(void)
 {
     int passes = 0, fails = 0;
-    const char *path = "/tmp/elfuse-test-fd-pin-lock";
 
-    lock_fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    /* Unique per invocation: record locks are held per (process, inode), so a
+     * fixed name shares one lock space with every concurrent run.
+     */
+    char path[] = "/tmp/elfuse-test-fd-pin-lock.XXXXXX";
+
+    lock_fd = mkstemp(path);
     if (lock_fd < 0) {
-        perror("open");
+        perror("mkstemp");
         return 1;
     }
 

--- a/tests/test-file-ops.c
+++ b/tests/test-file-ops.c
@@ -62,21 +62,29 @@ static int create_test_file(const char *path, const char *contents)
 int main(void)
 {
     int passes = 0, fails = 0;
-    const char *testfile = "/tmp/elfuse-test-file-ops.txt";
-    const char *symlink_path = "/tmp/elfuse-test-symlink";
-    const char *hardlink_path = "/tmp/elfuse-test-hardlink";
+
+    char tmpdir[] = "/tmp/elfuse-file-ops-XXXXXX";
+    if (!mkdtemp(tmpdir)) {
+        perror("mkdtemp");
+        return 1;
+    }
+    char testfile[256], symlink_path[256], hardlink_path[256];
+    char renamed_path[256], no_such_path[256], noreplace_dest[256];
+    snprintf(testfile, sizeof(testfile), "%s/file.txt", tmpdir);
+    snprintf(symlink_path, sizeof(symlink_path), "%s/symlink", tmpdir);
+    snprintf(hardlink_path, sizeof(hardlink_path), "%s/hardlink", tmpdir);
+    snprintf(renamed_path, sizeof(renamed_path), "%s/renamed.txt", tmpdir);
+    snprintf(no_such_path, sizeof(no_such_path), "%s/no-such.txt", tmpdir);
+    snprintf(noreplace_dest, sizeof(noreplace_dest), "%s/noreplace.txt",
+             tmpdir);
 
     printf("test-file-ops: Batch 1 file manipulation tests\n");
-
-    /* Clean up any leftover files */
-    unlink(testfile);
-    unlink(symlink_path);
-    unlink(hardlink_path);
 
     /* Create a test file */
     int fd;
     if (create_test_file(testfile, "hello\n") < 0) {
         printf("FATAL: cannot create %s\n", testfile);
+        rmdir(tmpdir);
         return 1;
     }
 
@@ -133,12 +141,12 @@ int main(void)
     TEST("readlinkat relative to dirfd");
     {
         char buf[256];
-        int dirfd = open("/tmp", O_RDONLY | O_DIRECTORY);
+        int dirfd = open(tmpdir, O_RDONLY | O_DIRECTORY);
         if (dirfd < 0) {
-            FAIL("open /tmp failed");
+            FAIL("open tmpdir failed");
         } else {
-            ssize_t len = syscall(SYS_readlinkat, dirfd, "elfuse-test-symlink",
-                                  buf, sizeof(buf));
+            ssize_t len =
+                syscall(SYS_readlinkat, dirfd, "symlink", buf, sizeof(buf));
             close(dirfd);
             EXPECT_TRUE(len == (ssize_t) strlen(testfile) &&
                             !memcmp(buf, testfile, (size_t) len),
@@ -157,8 +165,7 @@ int main(void)
     TEST("readlinkat invalid dirfd");
     {
         char buf[1];
-        EXPECT_ERRNO(syscall(SYS_readlinkat, -1, "elfuse-test-symlink", buf,
-                             sizeof(buf)),
+        EXPECT_ERRNO(syscall(SYS_readlinkat, -1, "symlink", buf, sizeof(buf)),
                      EBADF, "expected EBADF for invalid dirfd");
     }
 
@@ -271,9 +278,7 @@ int main(void)
 
     TEST("renameat2");
     {
-        const char *renamed_path = "/tmp/elfuse-test-file-ops-renamed.txt";
         struct stat renamed_st, old_st;
-        unlink(renamed_path);
         long r = syscall(SYS_renameat2, AT_FDCWD, testfile, AT_FDCWD,
                          renamed_path, 0);
         if (r == 0 && stat(renamed_path, &renamed_st) == 0 &&
@@ -296,23 +301,21 @@ int main(void)
 
     TEST("renameat2 conflicting flags EINVAL");
     EXPECT_ERRNO(syscall(SYS_renameat2, AT_FDCWD, testfile, AT_FDCWD,
-                         "/tmp/elfuse-test-no-such.txt",
-                         RENAME_NOREPLACE | RENAME_EXCHANGE),
+                         no_such_path, RENAME_NOREPLACE | RENAME_EXCHANGE),
                  EINVAL, "expected EINVAL for conflicting flags");
 
     TEST("renameat2 NOREPLACE with existing dest");
     {
-        const char *dest = "/tmp/elfuse-test-noreplace-dest.txt";
-        int dfd = open(dest, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        int dfd = open(noreplace_dest, O_WRONLY | O_CREAT | O_TRUNC, 0644);
         if (dfd >= 0)
             close(dfd);
-        long r = syscall(SYS_renameat2, AT_FDCWD, testfile, AT_FDCWD, dest,
-                         RENAME_NOREPLACE);
+        long r = syscall(SYS_renameat2, AT_FDCWD, testfile, AT_FDCWD,
+                         noreplace_dest, RENAME_NOREPLACE);
         bool ok = (r == -1 && errno == EEXIST);
         /* Verify source still exists */
         struct stat st;
         ok = ok && (stat(testfile, &st) == 0);
-        unlink(dest);
+        unlink(noreplace_dest);
         EXPECT_TRUE(ok, "NOREPLACE should fail with EEXIST");
     }
 
@@ -367,6 +370,7 @@ int main(void)
     unlink(hardlink_path);
     unlink(symlink_path);
     unlink(testfile);
+    rmdir(tmpdir);
 
     SUMMARY("test-file-ops");
     return fails > 0 ? 1 : 0;

--- a/tests/test-flock.c
+++ b/tests/test-flock.c
@@ -43,11 +43,15 @@ static int set_lock(int fd, short type, off_t start, off_t len)
 int main(void)
 {
     int passes = 0, fails = 0;
-    const char *path = "/tmp/elfuse-test-flock.db";
 
-    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    /* Unique per invocation: record locks are held per (process, inode), so a
+     * fixed name shares one lock space with every concurrent run.
+     */
+    char path[] = "/tmp/elfuse-test-flock.XXXXXX";
+
+    int fd = mkstemp(path);
     if (fd < 0) {
-        perror("open");
+        perror("mkstemp");
         return 1;
     }
 

--- a/tests/test-getdents-refcount.c
+++ b/tests/test-getdents-refcount.c
@@ -41,6 +41,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -56,7 +57,10 @@ static _Atomic int shared_fd = -1;
 static _Atomic int sibling_stop = 0;
 static char sibling_stack[32768] __attribute__((aligned(16)));
 
-#define STRESS_DIR "/tmp/test-getdents-refcount.d"
+/* Private to this run: a shared directory would have a concurrent run adding
+ * entries to the one this test is scanning.
+ */
+static char stress_dir[64];
 #define STRESS_FILE_COUNT 800
 
 /* Populate a directory with enough entries that a single getdents64() call
@@ -65,11 +69,12 @@ static char sibling_stack[32768] __attribute__((aligned(16)));
  */
 static int make_stress_dir(void)
 {
-    if (mkdir(STRESS_DIR, 0755) < 0 && errno != EEXIST)
+    snprintf(stress_dir, sizeof(stress_dir), "/tmp/elfuse-getdents-XXXXXX");
+    if (!mkdtemp(stress_dir))
         return -1;
     for (int i = 0; i < STRESS_FILE_COUNT; i++) {
         char path[128];
-        snprintf(path, sizeof(path), STRESS_DIR "/f%d", i);
+        snprintf(path, sizeof(path), "%s/f%d", stress_dir, i);
         int fd = open(path, O_CREAT | O_WRONLY, 0644);
         if (fd < 0)
             return -1;
@@ -127,7 +132,7 @@ int main(void)
     const int iterations = 4000;
     int completed = 0;
     for (int i = 0; i < iterations; i++) {
-        int fd = open(STRESS_DIR, O_RDONLY | O_DIRECTORY);
+        int fd = open(stress_dir, O_RDONLY | O_DIRECTORY);
         if (fd < 0)
             break;
 
@@ -152,7 +157,7 @@ int main(void)
              * without a close() syscall on fd itself -- the second chokepoint
              * dir_stream_release() must also cover.
              */
-            int replacement = open(STRESS_DIR, O_RDONLY | O_DIRECTORY);
+            int replacement = open(stress_dir, O_RDONLY | O_DIRECTORY);
             if (replacement >= 0) {
                 shared_fd = -1;
                 dup3(replacement, fd, 0);
@@ -174,7 +179,7 @@ int main(void)
      */
     TEST("getdents64 still functional after churn");
     {
-        int fd = open(STRESS_DIR, O_RDONLY | O_DIRECTORY);
+        int fd = open(stress_dir, O_RDONLY | O_DIRECTORY);
         int seen = 0;
         bool ok = fd >= 0;
         if (ok) {
@@ -201,6 +206,16 @@ int main(void)
         } ts = {0, 10000000}; /* 10ms */
         raw_syscall6(__NR_futex, (long) &child_tid, 0 /* FUTEX_WAIT */,
                      child_tid, (long) &ts, 0, 0);
+    }
+
+    /* 800 entries plus the directory. */
+    if (stress_dir[0]) {
+        for (int i = 0; i < STRESS_FILE_COUNT; i++) {
+            char path[128];
+            snprintf(path, sizeof(path), "%s/f%d", stress_dir, i);
+            unlink(path);
+        }
+        rmdir(stress_dir);
     }
 
     SUMMARY("test-getdents-refcount");

--- a/tests/test-inotify.c
+++ b/tests/test-inotify.c
@@ -74,8 +74,8 @@ static void test_modify_event(void)
 {
     TEST("detect IN_MODIFY event");
 
-    const char *path = "/tmp/elfuse-test-inotify-modify.txt";
-    int tfd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    char path[] = "/tmp/elfuse-inotify-modify-XXXXXX";
+    int tfd = mkstemp(path);
     if (tfd < 0) {
         FAIL("create temp file");
         return;
@@ -164,19 +164,31 @@ static void test_dir_create(void)
         return;
     }
 
-    int wd = inotify_add_watch(fd, "/tmp", IN_CREATE);
-    if (wd < 0) {
-        FAIL("inotify_add_watch /tmp");
+    /* A private directory, not all of /tmp, so a concurrent run's file
+     * creations stay out of this run's event stream.
+     */
+    char dir[] = "/tmp/elfuse-inotify-create-XXXXXX";
+    if (!mkdtemp(dir)) {
+        FAIL("mkdtemp");
         close(fd);
         return;
     }
 
-    const char *path = "/tmp/elfuse-test-inotify-create.txt";
-    unlink(path);
+    int wd = inotify_add_watch(fd, dir, IN_CREATE);
+    if (wd < 0) {
+        FAIL("inotify_add_watch");
+        close(fd);
+        rmdir(dir);
+        return;
+    }
+
+    char path[128];
+    snprintf(path, sizeof(path), "%s/child.txt", dir);
     int tfd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0644);
     if (tfd < 0) {
         FAIL("create file in watched dir");
         close(fd);
+        rmdir(dir);
         return;
     }
     close(tfd);
@@ -191,6 +203,7 @@ static void test_dir_create(void)
     unlink(path);
     inotify_rm_watch(fd, wd);
     close(fd);
+    rmdir(dir);
 }
 
 /* Drain events by reading (which drives elfuse's diff), retrying until a named

--- a/tests/test-io-opt.c
+++ b/tests/test-io-opt.c
@@ -20,20 +20,28 @@
 int main(void)
 {
     int passes = 0, fails = 0;
-    const char *src_path = "/tmp/elfuse-test-io-src.txt";
-    const char *dst_path = "/tmp/elfuse-test-io-dst.txt";
+
+    char tmpdir[] = "/tmp/elfuse-io-opt-XXXXXX";
+    if (!mkdtemp(tmpdir)) {
+        perror("mkdtemp");
+        return 1;
+    }
+    char src_path[256], dst_path[256];
+    char alloc_path[256], punch_path[256], cfr_dst[256];
+    snprintf(src_path, sizeof(src_path), "%s/src.txt", tmpdir);
+    snprintf(dst_path, sizeof(dst_path), "%s/dst.txt", tmpdir);
+    snprintf(alloc_path, sizeof(alloc_path), "%s/alloc.bin", tmpdir);
+    snprintf(punch_path, sizeof(punch_path), "%s/punch.bin", tmpdir);
+    snprintf(cfr_dst, sizeof(cfr_dst), "%s/cfr-dst.txt", tmpdir);
     const char *test_data = "Hello from sendfile test! This is test data.\n";
 
     printf("test-io-opt: Batch 3 I/O optimization tests\n");
-
-    /* Clean up */
-    unlink(src_path);
-    unlink(dst_path);
 
     /* Create source file */
     int src_fd = open(src_path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
     if (src_fd < 0) {
         printf("FATAL: cannot create %s\n", src_path);
+        rmdir(tmpdir);
         return 1;
     }
     write(src_fd, test_data, strlen(test_data));
@@ -94,8 +102,6 @@ int main(void)
     /* Test fallocate (via ftruncate fallback) */
     TEST("fallocate (extend)");
     {
-        const char *alloc_path = "/tmp/elfuse-test-alloc.bin";
-        unlink(alloc_path);
         int fd = open(alloc_path, O_CREAT | O_RDWR, 0644);
         if (fd >= 0) {
             /* fallocate mode=0 should extend the file */
@@ -113,8 +119,6 @@ int main(void)
 
     TEST("fallocate punch hole keeps size past EOF");
     {
-        const char *punch_path = "/tmp/elfuse-test-punch.bin";
-        unlink(punch_path);
         int fd = open(punch_path, O_CREAT | O_RDWR, 0644);
         if (fd >= 0) {
             const char data[] = "abc";
@@ -145,8 +149,6 @@ int main(void)
     /* Test copy_file_range (via off_t-based API) */
     TEST("copy_file_range");
     {
-        const char *cfr_dst = "/tmp/elfuse-test-cfr-dst.txt";
-        unlink(cfr_dst);
         int in_fd = open(src_path, O_RDONLY);
         int out_fd = open(cfr_dst, O_CREAT | O_WRONLY | O_TRUNC, 0644);
         if (in_fd >= 0 && out_fd >= 0) {
@@ -183,9 +185,12 @@ int main(void)
         unlink(cfr_dst);
     }
 
-    /* Cleanup */
+    /* Cleanup. The other three fixtures are unlinked by the blocks that make
+     * them, so only these two are left for rmdir to trip over.
+     */
     unlink(src_path);
     unlink(dst_path);
+    rmdir(tmpdir);
 
     SUMMARY("test-io-opt");
     return fails > 0 ? 1 : 0;

--- a/tests/test-large-io-boundary.c
+++ b/tests/test-large-io-boundary.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -82,15 +83,14 @@ static void test_large_write(void)
     for (size_t i = 0; i < IO_SIZE; i++)
         buf[i] = (unsigned char) (i * 131U + 17U);
 
-    char path[96];
-    snprintf(path, sizeof(path), "/tmp/elfuse-large-write-%d.tmp", getpid());
-    int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0600);
-    unlink(path);
+    char path[] = "/tmp/elfuse-large-write-XXXXXX";
+    int fd = mkstemp(path);
     if (fd < 0) {
         munmap(map, MAP_SIZE);
-        FAIL("open failed");
+        FAIL("mkstemp failed");
         return;
     }
+    unlink(path);
 
     ssize_t ret = write(fd, buf, IO_SIZE);
     int ok = (ret == (ssize_t) IO_SIZE);
@@ -143,15 +143,14 @@ static void test_large_read_from_split_block(void)
         return;
     }
 
-    char path[96];
-    snprintf(path, sizeof(path), "/tmp/elfuse-large-read-%d.tmp", getpid());
-    int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0600);
-    unlink(path);
+    char path[] = "/tmp/elfuse-large-read-XXXXXX";
+    int fd = mkstemp(path);
     if (fd < 0) {
         munmap(map, MAP_SIZE);
-        FAIL("open failed");
+        FAIL("mkstemp failed");
         return;
     }
+    unlink(path);
 
     unsigned char seed[4096];
     for (size_t i = 0; i < sizeof(seed); i++)

--- a/tests/test-mmap-shared-ro.c
+++ b/tests/test-mmap-shared-ro.c
@@ -53,8 +53,8 @@ static unsigned char page_marker(int page)
  */
 static int make_seed_file(char *out, size_t out_sz)
 {
-    snprintf(out, out_sz, "/tmp/elfuse-mmap-ro-%ld", (long) getpid());
-    int fd = open(out, O_CREAT | O_TRUNC | O_RDWR, 0600);
+    snprintf(out, out_sz, "/tmp/elfuse-mmap-ro-XXXXXX");
+    int fd = mkstemp(out);
     if (fd < 0)
         return -1;
     for (int p = 0; p < NPAGES; p++) {

--- a/tests/test-msync.c
+++ b/tests/test-msync.c
@@ -7,7 +7,7 @@
  *
  * Tests: MAP_SHARED write-back to shm backing files.
  *
- * Syscalls exercised: shm_open/openat, ftruncate, mmap, msync, pread64
+ * Syscalls exercised: openat, ftruncate, mmap, msync, pread64
  */
 
 #include <fcntl.h>
@@ -28,35 +28,21 @@
 
 int passes = 0, fails = 0;
 
-/* glibc 2.28 static: shm_open is broken (returns ENOSYS without trying).
- * Implement directly via openat on /dev/shm/.
+/* These tests open /dev/shm paths directly rather than calling shm_open, which
+ * returns ENOSYS without trying on glibc 2.28 static.
  */
-static int my_shm_open(const char *name, int oflag, int mode)
-{
-    char path[128];
-    snprintf(path, sizeof(path), "/dev/shm%s", name);
-    return open(path, oflag, mode);
-}
-
-static int my_shm_unlink(const char *name)
-{
-    char path[128];
-    snprintf(path, sizeof(path), "/dev/shm%s", name);
-    return unlink(path);
-}
 
 static void test_shared_msync_writes_file(void)
 {
     TEST("MAP_SHARED msync writes backing file");
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-msync-%ld", (long) getpid());
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[] = "/dev/shm/elfuse-msync-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("shm_open failed");
+        FAIL("mkstemp /dev/shm failed");
         return;
     }
-    my_shm_unlink(name);
+    unlink(name);
 
     if (ftruncate(fd, 4096) != 0) {
         FAIL("ftruncate failed");
@@ -98,14 +84,13 @@ static void test_shared_msync_refreshes_peer_mapping(void)
 {
     TEST("MAP_SHARED msync refreshes peer mapping");
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-msync-peer-%ld", (long) getpid());
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[] = "/dev/shm/elfuse-msync-peer-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("shm_open failed");
+        FAIL("mkstemp /dev/shm failed");
         return;
     }
-    my_shm_unlink(name);
+    unlink(name);
 
     if (ftruncate(fd, 4096) != 0) {
         FAIL("ftruncate failed");
@@ -143,14 +128,13 @@ static void test_shared_msync_preserves_alias_writes(void)
 {
     TEST("MAP_SHARED msync preserves peer alias writes");
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-msync-alias-%ld", (long) getpid());
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[] = "/dev/shm/elfuse-msync-alias-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("shm_open failed");
+        FAIL("mkstemp /dev/shm failed");
         return;
     }
-    my_shm_unlink(name);
+    unlink(name);
 
     if (ftruncate(fd, 4096) != 0) {
         FAIL("ftruncate failed");
@@ -194,24 +178,19 @@ static void test_shm_name_visible_after_fork(void)
 {
     TEST("/dev/shm name visible after fork");
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-msync-fork-%ld", (long) getpid());
-
-    /* Best-effort cleanup of stale shm objects from a previous run that was
-     * killed between create and the final unlink. macOS shm objects persist
-     * across process death, so without this O_EXCL fails with EEXIST and the
-     * test reports a spurious shm_open failure.
+    /* The name outlives the fork: it is not unlinked until the child has opened
+     * it.
      */
-    my_shm_unlink(name);
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[] = "/dev/shm/elfuse-msync-fork-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("parent shm_open failed");
+        FAIL("parent mkstemp /dev/shm failed");
         return;
     }
 
     if (ftruncate(fd, 4096) != 0) {
         FAIL("ftruncate failed");
-        my_shm_unlink(name);
+        unlink(name);
         close(fd);
         return;
     }
@@ -219,7 +198,7 @@ static void test_shm_name_visible_after_fork(void)
     char *p = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (p == MAP_FAILED) {
         FAIL("parent mmap failed");
-        my_shm_unlink(name);
+        unlink(name);
         close(fd);
         return;
     }
@@ -230,7 +209,7 @@ static void test_shm_name_visible_after_fork(void)
     if (child < 0) {
         FAIL("fork failed");
     } else if (child == 0) {
-        int cfd = my_shm_open(name, O_RDWR, 0600);
+        int cfd = open(name, O_RDWR);
         if (cfd < 0)
             _exit(2);
         char *cp = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, cfd, 0);
@@ -261,7 +240,7 @@ static void test_shm_name_visible_after_fork(void)
 
     munmap(p, 4096);
     close(fd);
-    my_shm_unlink(name);
+    unlink(name);
 }
 
 /* Real MAP_SHARED requires that host writes to the backing file are observable
@@ -273,14 +252,13 @@ static void test_shared_host_write_visible_without_msync(void)
 {
     TEST("MAP_SHARED host pwrite visible without msync");
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-msync-host-%ld", (long) getpid());
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[] = "/dev/shm/elfuse-msync-host-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("shm_open failed");
+        FAIL("mkstemp /dev/shm failed");
         return;
     }
-    my_shm_unlink(name);
+    unlink(name);
 
     if (ftruncate(fd, 4096) != 0) {
         FAIL("ftruncate failed");
@@ -348,14 +326,13 @@ static void test_shared_guest_write_lands_in_file(void)
 {
     TEST("MAP_SHARED guest write lands in file without msync");
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-msync-guest-%ld", (long) getpid());
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[] = "/dev/shm/elfuse-msync-guest-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("shm_open failed");
+        FAIL("mkstemp /dev/shm failed");
         return;
     }
-    my_shm_unlink(name);
+    unlink(name);
 
     if (ftruncate(fd, 4096) != 0) {
         FAIL("ftruncate failed");
@@ -398,14 +375,13 @@ static void test_shared_adjacent_fixed_mapping_does_not_alias_file(void)
     size_t hps = (size_t) sysconf(_SC_PAGESIZE);
     size_t file_len = hps > 8192 ? hps : 8192;
 
-    char name[64];
-    snprintf(name, sizeof(name), "/elfuse-msync-alias-%ld", (long) getpid());
-    int fd = my_shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    char name[] = "/dev/shm/elfuse-msync-neighbor-XXXXXX";
+    int fd = mkstemp(name);
     if (fd < 0) {
-        FAIL("shm_open failed");
+        FAIL("mkstemp /dev/shm failed");
         return;
     }
-    my_shm_unlink(name);
+    unlink(name);
 
     if (ftruncate(fd, (off_t) file_len) != 0) {
         FAIL("ftruncate failed");
@@ -460,8 +436,8 @@ static void test_shared_large_mapping_crosses_split_hvf_segments(void)
     const size_t reserve_len = 8u * 1024u * 1024u;
     const size_t large_len = 4u * 1024u * 1024u;
     const size_t split_offset = 2u * 1024u * 1024u;
-    char small_name[64];
-    char large_name[64];
+    char small_name[] = "/dev/shm/elfuse-msync-split-XXXXXX";
+    char large_name[] = "/dev/shm/elfuse-msync-large-XXXXXX";
     int small_fd = -1;
     int large_fd = -1;
     char *reserve;
@@ -479,19 +455,14 @@ static void test_shared_large_mapping_crosses_split_hvf_segments(void)
         return;
     }
 
-    snprintf(small_name, sizeof(small_name), "/elfuse-msync-split-%ld",
-             (long) getpid());
-    snprintf(large_name, sizeof(large_name), "/elfuse-msync-large-%ld",
-             (long) getpid());
-    my_shm_unlink(small_name);
-    my_shm_unlink(large_name);
-
-    small_fd = my_shm_open(small_name, O_CREAT | O_EXCL | O_RDWR, 0600);
-    large_fd = my_shm_open(large_name, O_CREAT | O_EXCL | O_RDWR, 0600);
-    my_shm_unlink(small_name);
-    my_shm_unlink(large_name);
+    small_fd = mkstemp(small_name);
+    large_fd = mkstemp(large_name);
+    if (small_fd >= 0)
+        unlink(small_name);
+    if (large_fd >= 0)
+        unlink(large_name);
     if (small_fd < 0 || large_fd < 0) {
-        FAIL("shm_open failed");
+        FAIL("mkstemp /dev/shm failed");
         goto out;
     }
     if (ftruncate(small_fd, 4096) != 0 ||

--- a/tests/test-negative.c
+++ b/tests/test-negative.c
@@ -11,6 +11,7 @@
  */
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <setjmp.h>
@@ -487,8 +488,8 @@ static void test_einval(void)
 
     TEST("open(O_PATH) metadata-only fd");
     {
-        const char *path = "/tmp/elfuse-negative-opath";
-        int wfd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        char path[] = "/tmp/elfuse-negative-opath-XXXXXX";
+        int wfd = mkstemp(path);
         if (wfd < 0) {
             FAIL("create test file failed");
         } else {

--- a/tests/test-netstat.c
+++ b/tests/test-netstat.c
@@ -169,34 +169,52 @@ int main(void)
     struct sockaddr_in taddr = {0};
     taddr.sin_family = AF_INET;
     taddr.sin_addr.s_addr = htonl(0x7f000001); /* 127.0.0.1 */
-    taddr.sin_port = htons(7777);
+    /* A fixed port is owned by the host, not by this process, so a concurrent
+     * run of this test took it first and every later one died on EADDRINUSE.
+     */
+    taddr.sin_port = htons(0);
     if (bind(tcp_fd, (struct sockaddr *) &taddr, sizeof(taddr)) < 0) {
         perror("bind(TCP)");
         return 1;
     }
+    socklen_t tlen = sizeof(taddr);
+    if (getsockname(tcp_fd, (struct sockaddr *) &taddr, &tlen) < 0) {
+        perror("getsockname(TCP)");
+        return 1;
+    }
+    unsigned tcp_port = ntohs(taddr.sin_port);
     if (listen(tcp_fd, 1) < 0) {
         perror("listen");
         return 1;
     }
 
-    /* UDP socket on 0.0.0.0:8888 */
     int udp_fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (udp_fd < 0) {
         perror("socket(UDP)");
         return 1;
     }
     struct sockaddr_in uaddr = {0};
-    uaddr.sin_family = AF_INET, uaddr.sin_port = htons(8888);
+    uaddr.sin_family = AF_INET;
+    uaddr.sin_port = htons(0);
     if (bind(udp_fd, (struct sockaddr *) &uaddr, sizeof(uaddr)) < 0) {
         perror("bind(UDP)");
         return 1;
     }
+    socklen_t ulen = sizeof(uaddr);
+    if (getsockname(udp_fd, (struct sockaddr *) &uaddr, &ulen) < 0) {
+        perror("getsockname(UDP)");
+        return 1;
+    }
+    unsigned udp_port = ntohs(uaddr.sin_port);
 
     /* 3. Verify /proc/net/tcp */
     if (read_proc_file("/proc/net/tcp", buf, sizeof(buf)) == 0) {
-        /* 7777 = 0x1E61, 127.0.0.1 = 0100007F in /proc/net format */
-        if (strstr(buf, "0100007F:1E61") && strstr(buf, " 0A ")) {
-            printf("PASS: /proc/net/tcp shows TCP LISTEN on 127.0.0.1:7777\n");
+        /* 127.0.0.1 is 0100007F in /proc/net format. */
+        char want[32];
+        snprintf(want, sizeof(want), "0100007F:%04X", tcp_port);
+        if (strstr(buf, want) && strstr(buf, " 0A ")) {
+            printf("PASS: /proc/net/tcp shows TCP LISTEN on 127.0.0.1:%u\n",
+                   tcp_port);
             pass++;
         } else {
             printf("FAIL: /proc/net/tcp missing TCP listener\n  got: %s", buf);
@@ -208,9 +226,10 @@ int main(void)
 
     /* 4. Verify /proc/net/udp */
     if (read_proc_file("/proc/net/udp", buf, sizeof(buf)) == 0) {
-        /* 8888 = 0x22B8 */
-        if (strstr(buf, "00000000:22B8")) {
-            printf("PASS: /proc/net/udp shows UDP on 0.0.0.0:8888\n");
+        char want[32];
+        snprintf(want, sizeof(want), "00000000:%04X", udp_port);
+        if (strstr(buf, want)) {
+            printf("PASS: /proc/net/udp shows UDP on 0.0.0.0:%u\n", udp_port);
             pass++;
         } else {
             printf("FAIL: /proc/net/udp missing UDP socket\n  got: %s", buf);

--- a/tests/test-ofd-lock.c
+++ b/tests/test-ofd-lock.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "test-harness.h"
@@ -47,11 +48,14 @@ static int ofd_lock_with_pid(int fd, int cmd, short type, pid_t pid)
 int main(void)
 {
     int passes = 0, fails = 0;
-    const char *path = "/tmp/elfuse-test-ofd-lock.db";
 
-    int fd1 = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    /* Unique per invocation: OFD locks contend across processes on one inode.
+     */
+    char path[] = "/tmp/elfuse-test-ofd-lock.XXXXXX";
+
+    int fd1 = mkstemp(path);
     if (fd1 < 0) {
-        perror("open fd1");
+        perror("mkstemp");
         return 1;
     }
 
@@ -59,9 +63,11 @@ int main(void)
      * taken on fd1 can conflict with a query made through fd2 even though both
      * fds live in the same process.
      */
-    int fd2 = open(path, O_RDWR, 0644);
+    int fd2 = open(path, O_RDWR);
     if (fd2 < 0) {
         perror("open fd2");
+        close(fd1);
+        unlink(path);
         return 1;
     }
 

--- a/tests/test-oom-proc.c
+++ b/tests/test-oom-proc.c
@@ -75,7 +75,6 @@ static void run_oom_copy_test(const char *label,
                               oom_copy_fn copy)
 {
     TEST(label);
-    unlink(dst);
     reset_oom_score_adj();
 
     int in_fd = open("/proc/self/oom_adj", O_RDONLY);
@@ -123,11 +122,26 @@ int main(void)
         "test-oom-proc: synthetic oom proc source sendfile/copy_file_range "
         "interception\n");
 
+    char sendfile_dst[] = "/tmp/elfuse-oom-sendfile-XXXXXX";
+    char cfr_dst[] = "/tmp/elfuse-oom-cfr-XXXXXX";
+    int seed = mkstemp(sendfile_dst);
+    if (seed < 0) {
+        perror("mkstemp");
+        return 1;
+    }
+    close(seed);
+    seed = mkstemp(cfr_dst);
+    if (seed < 0) {
+        perror("mkstemp");
+        unlink(sendfile_dst);
+        return 1;
+    }
+    close(seed);
+
     run_oom_copy_test("sendfile rereads synthetic oom proc source",
-                      "/tmp/elfuse-test-proc-sendfile.txt", copy_via_sendfile);
+                      sendfile_dst, copy_via_sendfile);
     run_oom_copy_test("copy_file_range rereads synthetic oom proc source",
-                      "/tmp/elfuse-test-proc-cfr.txt",
-                      copy_via_copy_file_range);
+                      cfr_dst, copy_via_copy_file_range);
 
     SUMMARY("test-oom-proc");
     return fails > 0 ? 1 : 0;

--- a/tests/test-opath.c
+++ b/tests/test-opath.c
@@ -35,27 +35,35 @@
 
 int passes = 0, fails = 0;
 
-static char tmp_file[256];
-static char tmp_dir[256];
+static char tmp_file[] = "/tmp/elfuse-opath-XXXXXX";
+static char tmp_dir[] = "/tmp/elfuse-opath-dir-XXXXXX";
 
-static void setup_fixtures(void)
+static int setup_fixtures(void)
 {
-    snprintf(tmp_file, sizeof(tmp_file), "/tmp/elfuse-opath-%d.txt",
-             (int) getpid());
-    snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/elfuse-opath-dir-%d",
-             (int) getpid());
-
-    int fd = open(tmp_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    if (fd >= 0) {
-        write(fd, "hello\n", 6);
-        close(fd);
+    /* Both failures are fatal rather than ignored: an unexpanded template is
+     * still a valid path, so carrying on would recreate the fixed shared name
+     * this replaced.
+     */
+    int fd = mkstemp(tmp_file);
+    if (fd < 0) {
+        perror("setup: mkstemp");
+        return -1;
     }
-    mkdir(tmp_dir, 0755);
+    write(fd, "hello\n", 6);
+    close(fd);
+
+    if (!mkdtemp(tmp_dir)) {
+        perror("setup: mkdtemp");
+        unlink(tmp_file);
+        return -1;
+    }
+
     char child[300];
     snprintf(child, sizeof(child), "%s/child", tmp_dir);
     fd = open(child, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (fd >= 0)
         close(fd);
+    return 0;
 }
 
 static void teardown_fixtures(void)
@@ -275,7 +283,10 @@ int main(void)
 {
     printf("test-opath: O_PATH semantics tests\n");
 
-    setup_fixtures();
+    if (setup_fixtures() < 0) {
+        printf("test-opath: fixture setup failed\n");
+        return 1;
+    }
 
     test_open_path_smoke();
     test_read_write_rejected();

--- a/tests/test-readv-writev.c
+++ b/tests/test-readv-writev.c
@@ -14,6 +14,7 @@
  */
 
 #include <fcntl.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -79,10 +80,10 @@ static void test_file_roundtrip(void)
 {
     TEST("writev->readv file roundtrip");
 
-    const char *path = "/tmp/elfuse-test-writev.txt";
-    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    char path[] = "/tmp/elfuse-writev-XXXXXX";
+    int fd = mkstemp(path);
     if (fd < 0) {
-        FAIL("open");
+        FAIL("mkstemp");
         return;
     }
 
@@ -239,10 +240,10 @@ static void test_pwritev2_append(void)
 {
     TEST("pwritev2 RWF_APPEND EOF");
 
-    const char *path = "/tmp/elfuse-test-pwritev2-append.txt";
-    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    char path[] = "/tmp/elfuse-pwritev2-app-XXXXXX";
+    int fd = mkstemp(path);
     if (fd < 0) {
-        FAIL("open");
+        FAIL("mkstemp");
         return;
     }
 
@@ -296,10 +297,10 @@ static void test_pwritev2_append_zero_iovcnt(void)
 {
     TEST("pwritev2 RWF_APPEND zero iovcnt");
 
-    const char *path = "/tmp/elfuse-test-pwritev2-append-zero.txt";
-    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    char path[] = "/tmp/elfuse-pwritev2-appz-XXXXXX";
+    int fd = mkstemp(path);
     if (fd < 0) {
-        FAIL("open");
+        FAIL("mkstemp");
         return;
     }
 
@@ -359,8 +360,8 @@ static long vec_zero_syscall(int op, int fd, long off, long flags)
 
 static void test_zero_iovcnt_validation(void)
 {
-    const char *path = "/tmp/elfuse-test-zero-iovcnt.txt";
-    int rw = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    char path[] = "/tmp/elfuse-zero-iovcnt-XXXXXX";
+    int rw = mkstemp(path);
     int ro = open(path, O_RDONLY);
     int wo = open(path, O_WRONLY);
     int opath = open(path, O_PATH);

--- a/tests/test-roundtrip.c
+++ b/tests/test-roundtrip.c
@@ -13,25 +13,36 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 int main(void)
 {
-    const char *path = "/tmp/elfuse-roundtrip-test.bin";
+    char path[] = "/tmp/elfuse-roundtrip-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        perror("mkstemp");
+        return 1;
+    }
+
     const int N = 1000;
 
     /* Generate test data: array of squares */
     int *data = malloc(N * sizeof(int));
     if (!data) {
         perror("malloc");
+        close(fd);
+        remove(path);
         return 1;
     }
     for (int i = 0; i < N; i++)
         data[i] = i * i;
 
     /* Write */
-    FILE *fp = fopen(path, "wb");
+    FILE *fp = fdopen(fd, "wb");
     if (!fp) {
-        perror("fopen(w)");
+        perror("fdopen(w)");
+        close(fd);
+        remove(path);
         return 1;
     }
     size_t nw = fwrite(data, sizeof(int), N, fp);

--- a/tests/test-scm-creds.c
+++ b/tests/test-scm-creds.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -83,10 +84,18 @@ static void test_accept_inherits_passcred(void)
     TEST("accept inherits SO_PASSCRED");
 
     int srv = -1, cli = -1, acc = -1;
+
+    /* A private directory rather than one name per pid: elfuse restarts guest
+     * pids at 1, so the unlink() that used to precede bind() removed the live
+     * socket of whatever concurrent run held the same name.
+     */
+    char dir[] = "/tmp/elfuse-scm-creds-XXXXXX";
     char path[sizeof(((struct sockaddr_un *) 0)->sun_path)];
-    snprintf(path, sizeof(path), "/tmp/elfuse-scm-creds-%ld.sock",
-             (long) getpid());
-    unlink(path);
+    if (!mkdtemp(dir)) {
+        FAIL("mkdtemp failed");
+        return;
+    }
+    snprintf(path, sizeof(path), "%s/s", dir);
 
     srv = socket(AF_UNIX, SOCK_STREAM, 0);
     if (srv < 0) {
@@ -145,6 +154,7 @@ done:
     if (srv >= 0)
         close(srv);
     unlink(path);
+    rmdir(dir);
 }
 
 static void test_blocked_accept_sees_passcred_toggle(void)
@@ -161,10 +171,13 @@ static void test_blocked_accept_sees_passcred_toggle(void)
         .lock = PTHREAD_MUTEX_INITIALIZER,
         .cond = PTHREAD_COND_INITIALIZER,
     };
+    char dir[] = "/tmp/elfuse-scm-creds-toggle-XXXXXX";
     char path[sizeof(((struct sockaddr_un *) 0)->sun_path)];
-    snprintf(path, sizeof(path), "/tmp/elfuse-scm-creds-toggle-%ld.sock",
-             (long) getpid());
-    unlink(path);
+    if (!mkdtemp(dir)) {
+        FAIL("mkdtemp failed");
+        return;
+    }
+    snprintf(path, sizeof(path), "%s/s", dir);
 
     srv = socket(AF_UNIX, SOCK_STREAM, 0);
     if (srv < 0) {
@@ -245,6 +258,7 @@ done:
     pthread_cond_destroy(&args.cond);
     pthread_mutex_destroy(&args.lock);
     unlink(path);
+    rmdir(dir);
 }
 
 int main(void)

--- a/tests/test-socket-accept-contended.c
+++ b/tests/test-socket-accept-contended.c
@@ -26,6 +26,7 @@
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -44,7 +45,6 @@ int passes = 0, fails = 0;
  * the harness's 60.
  */
 #define ACCEPT_DEADLINE_MS 10000
-#define SOCK_PATH "/tmp/elfuse-accept-contended.sock"
 
 static int lfd;
 static atomic_int eagains, accepted, stop;
@@ -70,15 +70,24 @@ int main(void)
     struct sockaddr_un sa;
     memset(&sa, 0, sizeof(sa));
     sa.sun_family = AF_UNIX;
-    strncpy(sa.sun_path, SOCK_PATH, sizeof(sa.sun_path) - 1);
-    unlink(SOCK_PATH);
+
+    /* A private directory per run: the fixed name it replaces was shared with
+     * every concurrent run, and the unlink() before bind() removed whichever
+     * listener got there first.
+     */
+    char sock_dir[] = "/tmp/elfuse-accept-contended-XXXXXX";
+    if (!mkdtemp(sock_dir)) {
+        FAIL("mkdtemp failed");
+        SUMMARY("test-socket-accept-contended");
+        return 1;
+    }
+    snprintf(sa.sun_path, sizeof(sa.sun_path), "%s/s", sock_dir);
 
     lfd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (lfd < 0 || bind(lfd, (struct sockaddr *) &sa, sizeof(sa)) != 0 ||
         listen(lfd, 64) != 0) {
         FAIL("listener setup failed");
-        SUMMARY("test-socket-accept-contended");
-        return 1;
+        goto fail;
     }
 
     int wake_fds[2];
@@ -88,10 +97,8 @@ int main(void)
             while (i > 0)
                 close(wake_fds[--i]);
             close(lfd);
-            unlink(SOCK_PATH);
             FAIL("wake socket setup failed");
-            SUMMARY("test-socket-accept-contended");
-            return 1;
+            goto fail;
         }
     }
 
@@ -99,8 +106,7 @@ int main(void)
     if (pthread_create(&a, NULL, acceptor, NULL) != 0 ||
         pthread_create(&b, NULL, acceptor, NULL) != 0) {
         FAIL("pthread_create failed");
-        SUMMARY("test-socket-accept-contended");
-        return 1;
+        goto fail;
     }
 
     /* Count what the client actually got onto the listener. The assertion below
@@ -167,7 +173,8 @@ int main(void)
     }
     pthread_join(a, NULL);
     pthread_join(b, NULL);
-    unlink(SOCK_PATH);
+    unlink(sa.sun_path);
+    rmdir(sock_dir);
 
     TEST("a blocking accept never reports EAGAIN to the guest");
     EXPECT_TRUE(atomic_load(&eagains) == 0,
@@ -181,4 +188,10 @@ int main(void)
     close(lfd);
     SUMMARY("test-socket-accept-contended");
     return fails ? 1 : 0;
+
+fail:
+    unlink(sa.sun_path);
+    rmdir(sock_dir);
+    SUMMARY("test-socket-accept-contended");
+    return 1;
 }

--- a/tests/test-xattr.c
+++ b/tests/test-xattr.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/syscall.h>
@@ -75,25 +76,36 @@ static long do_lgetxattr(const char *path,
     return syscall(NR_lgetxattr, path, name, out, cap);
 }
 
-static const char tmp_file[] = "/tmp/elfuse-xattr-target";
-static const char tmp_link[] = "/tmp/elfuse-xattr-link";
+static char tmp_dir[] = "/tmp/elfuse-xattr-XXXXXX";
+static char tmp_file[128];
+static char tmp_link[128];
 
-static void setup(void)
+static int setup(void)
 {
-    unlink(tmp_link);
-    unlink(tmp_file);
+    if (!mkdtemp(tmp_dir)) {
+        perror("setup: mkdtemp");
+        return -1;
+    }
+    snprintf(tmp_file, sizeof(tmp_file), "%s/target", tmp_dir);
+    snprintf(tmp_link, sizeof(tmp_link), "%s/link", tmp_dir);
+
     int fd = open(tmp_file, O_WRONLY | O_CREAT | O_TRUNC, 0600);
-    if (fd < 0)
-        return;
+    if (fd < 0) {
+        perror("setup: open");
+        rmdir(tmp_dir);
+        return -1;
+    }
     (void) !write(fd, "hello\n", 6);
     close(fd);
     symlink(tmp_file, tmp_link);
+    return 0;
 }
 
 static void teardown(void)
 {
     unlink(tmp_link);
     unlink(tmp_file);
+    rmdir(tmp_dir);
 }
 
 static void test_lgetxattr_regular_file(void)
@@ -162,7 +174,10 @@ int main(void)
 {
     printf("test-xattr: lgetxattr / getxattr / setxattr semantics\n");
 
-    setup();
+    if (setup() < 0) {
+        printf("test-xattr: fixture setup failed\n");
+        return 1;
+    }
 
     test_lgetxattr_regular_file();
     test_lgetxattr_symlink_no_follow();


### PR DESCRIPTION
CI is red on test-fd-pin-lock. The Runtime job runs four legs at once on one
self-hosted runner, and its per-job concurrency group is keyed on the sanitizer,
so the legs never serialize against each other and all four share one host
`/tmp`.

Two legs of run 33405194184 landed 14 ms apart:

```
Runtime (ASAN)     test-fd-pin-lock  [ OK ]    14:54:30.7900
Runtime (Release)  test-fd-pin-lock  [ FAIL ]  14:54:30.7762
```

Release's own `F_SETLK F_WRLCK` returned EAGAIN, the errno for a conflicting
lock held by another process, while it held none. POSIX record locks are held
per (process, inode), so a fixed filename is a shared lock space.

## Reproduction

Four concurrent copies of the pre-change binary:

```
for i in 1 2 3 4; do ./build/elfuse build/test-fd-pin-lock & done; wait

  the region starts unlocked     FAIL: child could not take a free lock (errno=0)
  F_SETLK on a multi-threaded guest FAIL: F_SETLK F_WRLCK rejected (errno=11)
  the lock survives a fork       FAIL: forking released this process's lock (errno=11)
test-fd-pin-lock: 5 passed, 4 failed - FAIL
```

Identical to the CI log, down to the errnos. The same command passes 4 of 4
after the first commit.

## The rest of the suite

Sweeping every test the same way found twenty-two more that are green only by
timing. Eleven of them built a name from `getpid()`, which supplies no
uniqueness here: guest pids are virtualized and restart per invocation, so
every concurrently running guest is pid 1.

```
guest pid=1
guest pid=1
guest pid=1
guest pid=1
```

The defense read as present, which is why it survived review. test-dev-shm-paths
had already written the diagnosis into a comment and fixed its own `/dev/shm`
fixtures, yet left one site on `getpid()`, and test-epoll-unsupported promised
per-process naming its code did not deliver.

## Verification

Against the 147 test binaries that pass when run alone, four concurrent
full-suite legs report no failures, each running all 147. Reverting one file
alone puts three of those four legs back to failing, so the zero measures
coverage rather than a harness that ran nothing.

test-pty is deliberately unchanged. It exhausts the host pty pool at eight
concurrent legs and is clean at four, which is a capacity ceiling rather than a
shared name, and no test change should hide it.

Host: macOS 26.6.2 (25G83), SDK 26.5, Apple M1, 8 cores.
`make check`: 81 passed, 0 failed, 3 skipped in the runtime lane, every other
lane green, guardrail PASS.

`.ci/check-format.sh` could not run here: it requires clang-format-22 and this
machine has 23.1.0. As a substitute check, clang-format 23 `--dry-run --Werror`
over all 375 tracked C and H files under `src/` and `tests/` reports zero
disagreements, including the 350 this branch does not touch, so the two versions
agree on this tree. CI enforces the pinned version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tests claiming host-global names, so concurrent CI legs on the same self-hosted runner no longer collide on shared files, locks, sockets, or ports. Guest pids restart at 1 per invocation, so `getpid()`-derived names were never unique, and fixed paths and ports were owned by the host, not the test — `test-fd-pin-lock` failed on a lock it never took because record locks are held per inode.

- 26 test files now claim per-run names: `mkdtemp`/`mkstemp` for files, `mkstemp` on the `/dev/shm` path for shm objects (replacing the `O_EXCL` probe loop and the `shm_open` wrappers with no callers left), and `bind(0)` + `getsockname` for ports.
- Dropped the `unlink`-before-create that deleted another leg's live socket or shm object.
- The `test-dev-shm-paths` seed suffix is now held for the whole run, and setup-failure paths no longer leak created fixtures or run against unset paths.
- `test-pty` is deliberately unchanged: it exhausts the host pty pool at eight concurrent legs and is clean at four, a capacity ceiling rather than a shared name.
- Verified with four concurrent full-suite legs, each running all 147 test binaries, with zero failures; reverting any one fix puts three of four legs back to failing.

<sup>Written for commit 51cdf0067657f99b74d162bb0ad5f49a3d4b8620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

