### PR TITLE
Stop the USB layer shadowing the sysroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,13 @@ $(BUILD_DIR)/test-signal-in-shim: tests/test-signal-in-shim.c | $(BUILD_DIR)
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
 
+# test-dir-union-fd-reuse closes the walked directory fd from a second thread
+# while the first is inside the widened union backing-lookup window.
+$(BUILD_DIR)/test-dir-union-fd-reuse: \
+		tests/test-dir-union-fd-reuse.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
+
 # test-fd-pin-lock keeps a sibling thread live so the fd syscalls under test
 # take the multi-threaded pin path rather than the single-active fast path.
 $(BUILD_DIR)/test-fd-pin-lock: \

--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,13 @@ $(BUILD_DIR)/test-dir-union-fd-reuse: \
 	@echo "  CROSS   $< (with -lpthread)"
 	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
 
+# test-fstatfs-fd-identity replaces the slot from a second thread while the
+# first is inside the widened fd-identity window.
+$(BUILD_DIR)/test-fstatfs-fd-identity: \
+		tests/test-fstatfs-fd-identity.c | $(BUILD_DIR)
+	@echo "  CROSS   $< (with -lpthread)"
+	$(Q)$(CROSS_COMPILE)gcc $(CROSS_TEST_CFLAGS) -o $@ $< -lpthread
+
 # test-fd-pin-lock keeps a sibling thread live so the fd syscalls under test
 # take the multi-threaded pin path rather than the single-active fast path.
 $(BUILD_DIR)/test-fd-pin-lock: \

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1043,6 +1043,46 @@ that string on Linux and shows nothing here.
 Related implementation: `src/runtime/procemu.c`, `src/syscall/path.c`,
 `src/syscall/fs.c`, `src/syscall/proc-state.c`, `src/runtime/usb-sysfs.c`.
 
+### Ownership Of `/sys` And `/dev/bus` Names
+
+The layer synthesizes exactly one subtree on each side, `/sys/bus/usb` and
+`/dev/bus/usb`, on top of a `/sys` and a `/dev/bus` that a sysroot supplies.
+Which of the two answers a name is one decision, taken once in
+`classify_and_normalize`, and every entry point -- `open`, `stat`, `lstat`,
+`readlink`, `access`, `getdents64`, `statfs`, `chdir` -- answers from it.
+An entry point that re-derives the decision is how four regressions arrived,
+each one a shadow: the layer claiming a name it does not serve and reporting
+`ENOENT` for a file the sysroot really has.
+
+The classes and who answers them:
+
+| Class | Path | Answered by |
+|-------|------|-------------|
+| `USB_PATH_SYS` | `/sys[/suffix]` | the layer, if the folded suffix resolves in the scratch tree; otherwise the backing, unless the suffix is under `bus/usb`, where an absence is authoritative |
+| `USB_PATH_DEV_BUS` | `/dev/bus` | both: a union listing, synthetic `usb` plus the backing's names |
+| `USB_PATH_DEV_USB` | `/dev/bus/usb` | the layer |
+| `USB_PATH_DEV_BUSNUM` | `/dev/bus/usb/BBB` | the layer |
+| `USB_PATH_DEV_NODE` | `/dev/bus/usb/BBB/DDD` | the layer |
+| `USB_PATH_DEV_NODE_SUB` | a node used as a directory | the layer (`ENOTDIR` once the node exists) |
+| `USB_PATH_DEV_ABSENT` | under `/dev/bus/usb`, no such device | the layer, `ENOENT` |
+| `USB_PATH_DEV_FOREIGN` | under `/dev/bus`, a bus we do not model | the backing |
+| `USB_PATH_NONE` | anything else, and a name that folds above its root | the backing |
+
+Only `PROC_NOT_INTERCEPTED` means "ask the backing". A name the layer claims
+and then fails to serve is an answer, not a fall-through: taking the failure
+for one let `access(2)`, and then `statfs(2)`, answer from the backing while
+`open` and `stat` reported `ENOENT` for the same path.
+
+`.` and `..` are folded lexically before ownership is decided, on both halves.
+The fold is the ours/not-ours gate and nothing else -- the served path is built
+by `usb_sys_resolve_suffix`, which resolves symlinks and applies each `..` to
+what the previous component resolved to, the way the kernel does, so
+`<dev>/subsystem/..` names `/sys/bus`. Deciding ownership on the guest's
+spelling instead splits the two halves apart in both directions:
+`/dev/bus/usb/../other/f` reads as a malformed device number and is claimed,
+and `/dev/bus/other/../usb/001/002` reads as a foreign bus and is disowned.
+A suffix that folds away above its own root leaves as `USB_PATH_NONE`.
+
 ### Limits Of The IOKit Mapping
 
 This tree enumerates devices; the pieces that follow open them and

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1122,6 +1122,57 @@ The stamp and the descriptor are read in one `fd_lock` window
 and read separately a close and reopen between them gives the stamp of one and
 the descriptor of another.
 
+### Union Directory Listings
+
+A directory that exists on both sides -- `/sys`, `/dev/bus` -- lists the union.
+`sys_getdents64` walks the synthetic (primary) stream first and then the names
+drained out of the backing; the drain opens the backing directory and closes it
+before returning, so elfuse keeps its promise of one host descriptor per guest
+fd and a union directory costs no more than a plain one.
+
+What the guest is told when part of the listing cannot be delivered is the
+contract that matters, because the failure mode is silent: a listing that lost
+a name and still ends at `0` is an end-of-directory the guest cannot tell from
+a real one, and having read it, it never asks again.
+
+- A failure that costs the stream names it can never produce again -- a drain
+  that failed part-way, a primary `readdir` that stopped -- is recorded in
+  `listing_errno`. It is sticky: every later call on that fd fails the same
+  way. Linux has no case that re-delivers an error on a directory stream, so
+  there is no shape to copy; clearing it would put the next call back on the
+  silent path, and the stream has nothing truthful left to return.
+- Linux's two-part shape is followed for reporting one: a call that has already
+  written entries returns their count and leaves the error for the next call; a
+  call that has written nothing returns `-1` with the errno.
+- A buffer too small to hold one entry is `EINVAL`, not `0`. Measured on Linux
+  over a directory holding a twelve-byte name: `getdents64` with 8- and
+  16-byte buffers returns `EINVAL` immediately, and with 24 bytes it delivers
+  the names that fit and then reports.
+- No exit from the walk may consume an entry without putting it back. The
+  entry-does-not-fit path and the guest-write fault path both rewind the
+  primary with `seekdir`; the backing side rewinds by not advancing its cursor.
+- A host name too long for Linux `NAME_MAX` is skipped, and the rest of the
+  stream is delivered. This is an elfuse compatibility policy with no Linux
+  counterpart: Linux enforces `NAME_MAX` at the filesystem layer, so no
+  oversize entry ever reaches `getdents64` there. macOS APFS accepts them, and
+  aborting the stream truncated `ls` / `find` listings against APFS trees.
+
+`dir_stream_t` is the wrapper around the `DIR*`. It is refcounted and carries
+its own lock, so an in-flight `getdents64` pins it against a sibling's
+`close()`; `dup`, `dup2` and `F_DUPFD` share one wrapper rather than opening a
+second, which is what makes two guest fds on one open file description share
+one position and one union state. A forked child's inherited fds share one
+wrapper per inherited open file description for the same reason. The wrapper
+owns the descriptor it was opened on -- only `closedir()` gives it back -- so
+an alias names the descriptor the shared wrapper holds and the redundant one is
+closed.
+
+A stream built for an inherited descriptor has `backing_private` set: the
+primary is shared with the parent through the description and must be read, and
+the backing belongs to whichever stream first ran out of primary and must not
+be drained twice. `docs/testing.md` records the one state this cannot deliver
+whole.
+
 ### Limits Of The IOKit Mapping
 
 This tree enumerates devices; the pieces that follow open them and

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1083,6 +1083,45 @@ spelling instead splits the two halves apart in both directions:
 and `/dev/bus/other/../usb/001/002` reads as a foreign bus and is disowned.
 A suffix that folds away above its own root leaves as `USB_PATH_NONE`.
 
+### Filesystem Identity Of A Descriptor
+
+Two questions have one answer here: what `statfs` reports for a name, and what
+`fstatfs` reports for a descriptor opened by that name. systemd's `sd-device`
+gates every enumerated syspath on `fstatfs(fd) == SYSFS_MAGIC` and libusb gates
+on `statfs("/sys")`, so a build where the two disagree is one where a device
+enumerates through one library and not the other.
+
+The rules:
+
+- `/sys`, whichever side served it, reports `SYSFS_MAGIC` (`0x62656572`). That
+  covers the scratch-dir backed names, where the host `fstatfs` would leak the
+  `/tmp` filesystem's magic, and the ones that fell through to a sysroot's own
+  `/sys`, where it would leak the sysroot's.
+- `/dev/bus` reports devtmpfs, on both entry points.
+- `..` is folded and a relative name is resolved against the cwd before either
+  entry point decides, so the two cannot be handed different spellings of one
+  object.
+
+A descriptor's identity comes from the virtual path stamped on its slot when
+this layer served the open, and from the descriptor's own host path mapped back
+through the sysroot when there is no stamp -- a fall-through open stamps
+nothing, which is exactly the case that used to make `statfs("/sys/class")`
+report `SYSFS_MAGIC` while `fstatfs` on the fd it had just opened reported the
+sysroot's filesystem.
+
+`fstat` answers from the stamp for `O_PATH` descriptors and for `/sys` and
+`/dev/bus` names, because the object behind a `/dev/bus/usb/BBB/DDD` node is a
+placeholder file: libusb `fstat`s the node it just opened and refuses anything
+that is not a character device, so the descriptor has to report the character
+device the path side described. `/proc` stays `O_PATH`-only there: its
+descriptors are real host files whose contents are the answer, and stamping
+their type would misdescribe the object the guest is reading.
+
+The stamp and the descriptor are read in one `fd_lock` window
+(`host_fd_ref_open_entry`). They are two facts about one open file description,
+and read separately a close and reopen between them gives the stamp of one and
+the descriptor of another.
+
 ### Limits Of The IOKit Mapping
 
 This tree enumerates devices; the pieces that follow open them and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -436,6 +436,56 @@ Example:
 bash tests/driver.sh -f test-proc
 ```
 
+## Fault Injection And Recorded Rows
+
+Three failures the directory and identity lanes have to pin cannot be provoked
+from a test: a `malloc` coming back NULL part-way through a backing listing, a
+`readdir` that fails part-way through a directory elfuse itself materialized,
+and a slot replaced inside a window that is sub-microsecond wide unaided. Each
+has an environment hook, read once and with no effect at all when unset:
+
+| Variable | Effect | Driven by |
+|----------|--------|-----------|
+| `ELFUSE_DIR_BACKING_FAULT=N` | the union drain fails with `ENOMEM` once it has buffered N names | `test-dir-backing-drain-error` |
+| `ELFUSE_DIR_PRIMARY_READ_FAULT=N` | `readdir` on the synthetic stream fails with `EIO` after N entries | `test-dir-primary-read-error` |
+| `ELFUSE_DIR_UNION_BACKING_DELAY_US=N` | widens the window between pinning a directory stream and looking its backing up | `test-dir-union-fd-reuse` |
+| `ELFUSE_FD_IDENTITY_WINDOW_US=N` | widens the window between reading a descriptor's stamp and pinning its host fd | `test-fstatfs-fd-identity` |
+
+`ELFUSE_USB_FIXTURE` is the same shape pointing at enumeration rather than
+failure: it stands a deterministic synthetic USB tree up in place of whatever
+IOKit reports, so the lanes below have devices to walk on any host.
+`ELFUSE_USB_FIXTURE=overflow` stands up 129 address-less devices on one bus for
+the `devnum` cap.
+
+The lanes these drive:
+
+| Lane | Property |
+|------|----------|
+| `test-usb-sysfs-matrix` | every entry point against every class of name `/sys` and `/dev/bus` can hold |
+| `test-getdents64-small-buf` | a buffer that cannot take the next entry reports rather than ending, and the entry it could not take comes back |
+| `test-dir-backing-drain-error` | a union listing that lost its backing half is reported, not ended |
+| `test-dir-primary-read-error` | the same on the synthetic half |
+| `test-dir-union-fd-reuse` | a walk answers for the directory it pinned, not for the fd number |
+| `test-dir-union-alias` | every route to a second fd on one description shares one position and one union state |
+| `test-dir-fd-budget-union` | a union directory fd costs one host descriptor, like a plain one |
+| `test-fstatfs-fd-identity` | `fstatfs` answers for the descriptor it pinned, not for the fd number |
+
+Two lanes carry rows that are recorded rather than asserted, and print as
+`XFAIL`. An `XFAIL` row is a measured Linux value the build knowingly does not
+meet: it is neither a pass nor a failure, it does not turn the lane red, and the
+value elfuse gives today is carried beside it so that a departure from either
+number shows up as a diff in the lane's output. The alternative -- deleting the
+row -- is what lets a known divergence become an unknown one.
+
+`test-usb-sysfs-matrix` records its `escape-syn` column that way: a `..` chain
+walking through the synthetic subtree and back out cannot be resolved here,
+because the host walk has to traverse a `/sys/bus/usb` that exists only inside
+the layer. `test-dir-union-alias` records its fork cross-close rows: a child
+whose parent closes its copy of the fd before the backing has been drained
+answers with its primary alone, because the backing half belongs to a stream
+that has gone. Both rows are load-bearing in pairs -- neither number alone
+separates the answers the site could give -- so both are printed.
+
 ## Validation Strategy By Change Type
 
 Suggested minimum validation:

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -43,8 +43,10 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-nosysroot-literal-names test-sysroot-outside-names \
         test-sysroot-root test-usb-sysfs test-usb-sysfs-sysroot \
         test-usb-sysfs-matrix \
-        test-usb-sysfs-overflow test-dir-union-fd-reuse \
+        test-usb-sysfs-overflow test-dir-fd-budget-union \
+        test-dir-backing-drain-error test-dir-union-fd-reuse \
         test-fstatfs-fd-identity \
+        test-dir-union-alias test-dir-primary-read-error \
         test-sysroot-symlink-target \
         test-sysroot-name-i18n test-sysroot-name-length \
         test-sysroot-name-staged test-sysroot-name-race \
@@ -258,8 +260,12 @@ $(call run-lane,test-usb-sysfs,synthetic USB tree contract)
 $(call run-lane,test-usb-sysfs-sysroot,synthetic USB /sys sharing a populated sysroot)
 $(call run-lane,test-usb-sysfs-matrix,every /sys and /dev/bus entry point against every path class)
 $(call run-lane,test-usb-sysfs-overflow,per-bus devnum cap under 127-device overflow)
+$(call run-lane,test-dir-fd-budget-union,a union directory fd costs one host descriptor)
+$(call run-lane,test-dir-backing-drain-error,a lost union listing is reported not truncated)
 $(call run-lane,test-dir-union-fd-reuse,a union walk answers for the directory it pinned)
 $(call run-lane,test-fstatfs-fd-identity,fstatfs answers for the descriptor it pinned)
+$(call run-lane,test-dir-union-alias,a dup shares one listing position and one union)
+$(call run-lane,test-dir-primary-read-error,a failed synthetic read is reported not ended)
 $(call run-lane,test-fstatat-empty-path,AT_EMPTY_PATH stat by fd under a sysroot)
 $(call run-lane,test-sysroot-name-unique,one on-disk name per guest name)
 $(call run-lane,test-sysroot-name-relative,relative and dirfd-relative names)
@@ -1670,6 +1676,110 @@ test-fstatfs-fd-identity: $(ELFUSE_BIN) $(TEST_DIR)/test-fstatfs-fd-identity
 	ELFUSE_FD_IDENTITY_WINDOW_US=120000 ELFUSE_USB_FIXTURE=1 \
 		$(ELFUSE_BIN) --sysroot "$$sysroot" \
 		$(TEST_DIR)/test-fstatfs-fd-identity /etc/hostname /sys/kernel
+## A union directory fd must cost one host descriptor, like a plain one
+# The measurement only means something with the host limit at exactly what
+# elfuse asks for -- the same squeeze tests/manifest.txt puts on
+# test-dir-fd-budget -- and only if /sys really is a union here, which needs a
+# sysroot that carries one. The skeleton is the same shape the other /sys lanes
+# stage, plus a marker directory the synthetic tree has no name for: the test
+# refuses to pass without seeing it, so the lane cannot go quietly vacuous if
+# the sysroot ever stops being planted.
+test-dir-fd-budget-union: $(ELFUSE_BIN) $(TEST_DIR)/test-dir-fd-budget-union
+	@$(SYSROOT_SCRATCH); \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot/sys/class/net/eth0" \
+		"$$sysroot/sys/kernel/mm/transparent_hugepage" \
+		"$$sysroot/sys/devices/system/node" \
+		"$$sysroot/sys/elfuse-union-marker"; \
+	printf '02:42:ac:11:00:02\n' > "$$sysroot/sys/class/net/eth0/address"; \
+	printf 'always [madvise] never\n' \
+		> "$$sysroot/sys/kernel/mm/transparent_hugepage/enabled"; \
+	printf '0-3\n' > "$$sysroot/sys/devices/system/node/online"; \
+	ulimit -n $(ELFUSE_HOST_NOFILE_MIN); \
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-fd-budget-union
+
+## A union listing that cannot be delivered whole must be reported
+# Three runs over one staged sysroot, because the thing under test is what the
+# guest is told and each answer needs its own conditions. The drain-failure run
+# needs a failure that will not happen by itself -- a malloc coming back NULL
+# part-way through the backing -- so ELFUSE_DIR_BACKING_FAULT drives it after
+# two names, against a backing that has more than two to give. The unreadable
+# run needs no hook: chmod 000 on the sysroot's /sys makes the drain's own open
+# fail. The no-fault run is the control, and it is also what keeps the other
+# two honest: it refuses to pass unless the marker directory -- present in the
+# sysroot and nowhere in the synthetic tree -- comes back in the listing, so
+# the lane cannot go quietly vacuous if /sys ever stops being a union here.
+# chmod 000 outlives the scratch trap on some filesystems, so the mode goes
+# back before the shell exits.
+test-dir-backing-drain-error: $(ELFUSE_BIN) $(TEST_DIR)/test-dir-backing-drain-error
+	@$(SYSROOT_SCRATCH); \
+	sysroot="$$tmpdir/sysroot"; \
+	trap 'chmod -R u+rwX "$$tmpdir" 2>/dev/null; rm -rf "$$tmpdir"' EXIT; \
+	mkdir -p "$$sysroot/sys/class/net" \
+		"$$sysroot/sys/kernel" \
+		"$$sysroot/sys/devices" \
+		"$$sysroot/sys/elfuse-union-marker" \
+		"$$sysroot/sys/extra-one" "$$sysroot/sys/extra-two"; \
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-backing-drain-error complete; \
+	ELFUSE_DIR_BACKING_FAULT=2 ELFUSE_USB_FIXTURE=1 \
+		$(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-backing-drain-error fault; \
+	chmod 000 "$$sysroot/sys"; \
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-backing-drain-error unreadable
+
+## A dup'd directory fd must share one listing position and one union state
+# Both directories the lane walks are staged several hundred names wide, and
+# that width is the lane. macOS reads one host block ahead when it opens a
+# directory, so a three-name fixture -- what this staged before -- fits inside
+# that block: a stream that never reads its primary loses nothing, and the loss
+# only becomes visible once the listing outruns the block. Measured over this
+# staging, an unread fork on the 403-name plain directory: 403 names across the
+# pair when the sharing is right, 340 when the child skips its primary. The
+# union side is staged wide for the mirror-image reason -- a backing delivered a
+# second time is 809 names where 405 are wanted. 400 a side is several times the
+# block and costs one mkdir.
+test-dir-union-alias: $(ELFUSE_BIN) $(TEST_DIR)/test-dir-union-alias
+	@$(SYSROOT_SCRATCH); \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot/sys/class/net" "$$sysroot/sys/class/tty" \
+		"$$sysroot/sys/class/block" \
+		"$$sysroot/sys/kernel" \
+		"$$sysroot/sys/devices" \
+		"$$sysroot/sys/elfuse-union-marker" \
+		"$$sysroot/plain-alias"; \
+	i=0; wide=""; \
+	while [ $$i -lt 403 ]; do \
+		wide="$$wide $$sysroot/plain-alias/plain-w$$i"; \
+		i=$$((i + 1)); \
+	done; \
+	i=0; \
+	while [ $$i -lt 400 ]; do \
+		wide="$$wide $$sysroot/sys/union-w$$i"; \
+		i=$$((i + 1)); \
+	done; \
+	mkdir -p $$wide; \
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-union-alias
+
+## A synthetic listing that failed part-way must be reported, not ended
+# Two runs over one staged sysroot: the control proves the union works at all,
+# and the fault run drives a readdir failure on the primary after one entry,
+# which is a failure that cannot happen by itself on a tree elfuse owns.
+test-dir-primary-read-error: $(ELFUSE_BIN) $(TEST_DIR)/test-dir-primary-read-error
+	@$(SYSROOT_SCRATCH); \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot/sys/class/net" \
+		"$$sysroot/sys/kernel" \
+		"$$sysroot/sys/devices" \
+		"$$sysroot/sys/elfuse-union-marker"; \
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-primary-read-error complete; \
+	ELFUSE_DIR_PRIMARY_READ_FAULT=1 ELFUSE_USB_FIXTURE=1 \
+		$(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-primary-read-error fault
 
 ## A union walk must answer for the directory it pinned, not the fd number
 # The window between pinning the stream and looking the backing up is far too

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1620,8 +1620,12 @@ test-usb-sysfs-sysroot: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-sysroot
 ## Every entry point that can name something under /sys or /dev/bus, against
 ## every class of name those trees can hold. The layer synthesizes one subtree
 ## on each side and the rest belongs to the sysroot, so the sysroot has to carry
-## the other side of each column: a /sys skeleton, a foreign /dev/bus, and an
-## /etc file for the '..' chain that leaves the tree. Expected values are the
+## the other side of each column: a /sys skeleton, a foreign /dev/bus, an /etc
+## file for the '..' chain that leaves the tree, and one name planted inside
+## /dev/bus/usb, which the layer owns and the backing must not reach into.
+## Nothing is planted under the sysroot's /sys/bus: a Linux rootfs image carries
+## an empty /sys, and its not having a `bus` is the shape the escape-syn column
+## records. Expected values are the
 ## ones recorded on Linux; see tests/usb-sysfs-matrix-vectors.h.
 test-usb-sysfs-matrix: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-matrix
 	@$(SYSROOT_SCRATCH); \
@@ -1631,7 +1635,7 @@ test-usb-sysfs-matrix: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-matrix
 		"$$sysroot/sys/devices/system/node" \
 		"$$sysroot/sys/fs/cgroup" \
 		"$$sysroot/sys/bus/pci/devices" \
-		"$$sysroot/dev/bus/other" \
+		"$$sysroot/dev/bus/other" "$$sysroot/dev/bus/usb/099" \
 		"$$sysroot/etc"; \
 	printf '02:42:ac:11:00:02\n' > "$$sysroot/sys/class/net/eth0/address"; \
 	printf 'always [madvise] never\n' \
@@ -1639,6 +1643,7 @@ test-usb-sysfs-matrix: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-matrix
 	printf '0-3\n' > "$$sysroot/sys/devices/system/node/online"; \
 	: > "$$sysroot/sys/fs/cgroup/g"; \
 	: > "$$sysroot/dev/bus/other/f"; \
+	: > "$$sysroot/dev/bus/usb/099/001"; \
 	printf 'elfuse\n' > "$$sysroot/etc/hostname"; \
 	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
 		$(TEST_DIR)/test-usb-sysfs-matrix

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -47,6 +47,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-dir-backing-drain-error test-dir-union-fd-reuse \
         test-fstatfs-fd-identity \
         test-dir-union-alias test-dir-primary-read-error \
+        test-getdents64-small-buf \
         test-sysroot-symlink-target \
         test-sysroot-name-i18n test-sysroot-name-length \
         test-sysroot-name-staged test-sysroot-name-race \
@@ -266,6 +267,7 @@ $(call run-lane,test-dir-union-fd-reuse,a union walk answers for the directory i
 $(call run-lane,test-fstatfs-fd-identity,fstatfs answers for the descriptor it pinned)
 $(call run-lane,test-dir-union-alias,a dup shares one listing position and one union)
 $(call run-lane,test-dir-primary-read-error,a failed synthetic read is reported not ended)
+$(call run-lane,test-getdents64-small-buf,a getdents64 buffer too small for one entry)
 $(call run-lane,test-fstatat-empty-path,AT_EMPTY_PATH stat by fd under a sysroot)
 $(call run-lane,test-sysroot-name-unique,one on-disk name per guest name)
 $(call run-lane,test-sysroot-name-relative,relative and dirfd-relative names)
@@ -1075,6 +1077,18 @@ test-getdents64-overlong: $(ELFUSE_BIN) $(BUILD_DIR)/test-getdents64-overlong
 		: > "$$tmpdir/fixture/$$overlong"; \
 	done; \
 	$(ELFUSE_BIN) $(BUILD_DIR)/test-getdents64-overlong "$$tmpdir/fixture"
+
+## Verify a getdents64 buffer too small for one entry reports EINVAL
+test-getdents64-small-buf: $(ELFUSE_BIN) $(BUILD_DIR)/test-getdents64-small-buf
+	@$(SYSROOT_SCRATCH); \
+	mkdir -p "$$tmpdir/fixture" "$$tmpdir/wide"; \
+	: > "$$tmpdir/fixture/aaaaaaaaaaaa"; \
+	: > "$$tmpdir/fixture/bb"; \
+	i=0; while [ $$i -lt 96 ]; do \
+		printf '' > "$$tmpdir/wide/name-that-is-fairly-long-$$i"; \
+		i=$$((i + 1)); \
+	done; \
+	$(ELFUSE_BIN) $(BUILD_DIR)/test-getdents64-small-buf "$$tmpdir/fixture" "$$tmpdir/wide" 96
 
 test-sysroot-create-paths: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-create-paths
 	@set -e; \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -42,7 +42,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-sysroot-name-relative \
         test-nosysroot-literal-names test-sysroot-outside-names \
         test-sysroot-root test-usb-sysfs test-usb-sysfs-sysroot \
-        test-usb-sysfs-overflow \
+        test-usb-sysfs-overflow test-dir-union-fd-reuse \
         test-sysroot-symlink-target \
         test-sysroot-name-i18n test-sysroot-name-length \
         test-sysroot-name-staged test-sysroot-name-race \
@@ -255,6 +255,7 @@ $(call run-host-unit,test-elf-headers-host,ELF header validation unit test)
 $(call run-lane,test-usb-sysfs,synthetic USB tree contract)
 $(call run-lane,test-usb-sysfs-sysroot,synthetic USB /sys sharing a populated sysroot)
 $(call run-lane,test-usb-sysfs-overflow,per-bus devnum cap under 127-device overflow)
+$(call run-lane,test-dir-union-fd-reuse,a union walk answers for the directory it pinned)
 $(call run-lane,test-fstatat-empty-path,AT_EMPTY_PATH stat by fd under a sysroot)
 $(call run-lane,test-sysroot-name-unique,one on-disk name per guest name)
 $(call run-lane,test-sysroot-name-relative,relative and dirfd-relative names)
@@ -1617,6 +1618,24 @@ test-usb-sysfs-sysroot: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-sysroot
 ## whole model is synthetic here.
 test-usb-sysfs-overflow: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-overflow
 	ELFUSE_USB_FIXTURE=overflow $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-overflow
+
+## A union walk must answer for the directory it pinned, not the fd number
+# The window between pinning the stream and looking the backing up is far too
+# narrow to reach unaided, so ELFUSE_DIR_UNION_BACKING_DELAY_US widens it and
+# the guest closes the walked fd inside it. MARKER is planted in the sysroot's
+# /sys and nowhere in the synthetic tree, so its absence from a listing that
+# reported success is exactly the silent half-listing under test.
+test-dir-union-fd-reuse: $(ELFUSE_BIN) $(TEST_DIR)/test-dir-union-fd-reuse
+	@$(SYSROOT_SCRATCH); \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot/sys/class/net" \
+		"$$sysroot/sys/kernel" \
+		"$$sysroot/sys/devices" \
+		"$$sysroot/sys/elfuse-union-marker"; \
+	ELFUSE_DIR_UNION_BACKING_DELAY_US=20000 ELFUSE_USB_FIXTURE=1 \
+		$(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-dir-union-fd-reuse
+
 
 ## Run the absock derived-name unit test natively on the host
 test-absock-names-host: $(BUILD_DIR)/test-absock-names-host

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -42,6 +42,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-sysroot-name-relative \
         test-nosysroot-literal-names test-sysroot-outside-names \
         test-sysroot-root test-usb-sysfs test-usb-sysfs-sysroot \
+        test-usb-sysfs-matrix \
         test-usb-sysfs-overflow test-dir-union-fd-reuse \
         test-fstatfs-fd-identity \
         test-sysroot-symlink-target \
@@ -255,6 +256,7 @@ $(call run-host-unit,test-usb-desc-host,USB descriptor blob walk unit test)
 $(call run-host-unit,test-elf-headers-host,ELF header validation unit test)
 $(call run-lane,test-usb-sysfs,synthetic USB tree contract)
 $(call run-lane,test-usb-sysfs-sysroot,synthetic USB /sys sharing a populated sysroot)
+$(call run-lane,test-usb-sysfs-matrix,every /sys and /dev/bus entry point against every path class)
 $(call run-lane,test-usb-sysfs-overflow,per-bus devnum cap under 127-device overflow)
 $(call run-lane,test-dir-union-fd-reuse,a union walk answers for the directory it pinned)
 $(call run-lane,test-fstatfs-fd-identity,fstatfs answers for the descriptor it pinned)
@@ -1614,6 +1616,32 @@ test-usb-sysfs-sysroot: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-sysroot
 	printf '0-3\n' > "$$sysroot/sys/devices/system/node/online"; \
 	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
 		$(TEST_DIR)/test-usb-sysfs-sysroot
+
+## Every entry point that can name something under /sys or /dev/bus, against
+## every class of name those trees can hold. The layer synthesizes one subtree
+## on each side and the rest belongs to the sysroot, so the sysroot has to carry
+## the other side of each column: a /sys skeleton, a foreign /dev/bus, and an
+## /etc file for the '..' chain that leaves the tree. Expected values are the
+## ones recorded on Linux; see tests/usb-sysfs-matrix-vectors.h.
+test-usb-sysfs-matrix: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-matrix
+	@$(SYSROOT_SCRATCH); \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot/sys/class/net/eth0" \
+		"$$sysroot/sys/kernel/mm/transparent_hugepage" \
+		"$$sysroot/sys/devices/system/node" \
+		"$$sysroot/sys/fs/cgroup" \
+		"$$sysroot/sys/bus/pci/devices" \
+		"$$sysroot/dev/bus/other" \
+		"$$sysroot/etc"; \
+	printf '02:42:ac:11:00:02\n' > "$$sysroot/sys/class/net/eth0/address"; \
+	printf 'always [madvise] never\n' \
+		> "$$sysroot/sys/kernel/mm/transparent_hugepage/enabled"; \
+	printf '0-3\n' > "$$sysroot/sys/devices/system/node/online"; \
+	: > "$$sysroot/sys/fs/cgroup/g"; \
+	: > "$$sysroot/dev/bus/other/f"; \
+	printf 'elfuse\n' > "$$sysroot/etc/hostname"; \
+	ELFUSE_USB_FIXTURE=1 $(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-usb-sysfs-matrix
 
 ## The devnum cap needs more than 127 address-less devices on one bus, which
 ## the overflow fixture injects through the real fallback path. No sysroot: the

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -43,6 +43,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-nosysroot-literal-names test-sysroot-outside-names \
         test-sysroot-root test-usb-sysfs test-usb-sysfs-sysroot \
         test-usb-sysfs-overflow test-dir-union-fd-reuse \
+        test-fstatfs-fd-identity \
         test-sysroot-symlink-target \
         test-sysroot-name-i18n test-sysroot-name-length \
         test-sysroot-name-staged test-sysroot-name-race \
@@ -256,6 +257,7 @@ $(call run-lane,test-usb-sysfs,synthetic USB tree contract)
 $(call run-lane,test-usb-sysfs-sysroot,synthetic USB /sys sharing a populated sysroot)
 $(call run-lane,test-usb-sysfs-overflow,per-bus devnum cap under 127-device overflow)
 $(call run-lane,test-dir-union-fd-reuse,a union walk answers for the directory it pinned)
+$(call run-lane,test-fstatfs-fd-identity,fstatfs answers for the descriptor it pinned)
 $(call run-lane,test-fstatat-empty-path,AT_EMPTY_PATH stat by fd under a sysroot)
 $(call run-lane,test-sysroot-name-unique,one on-disk name per guest name)
 $(call run-lane,test-sysroot-name-relative,relative and dirfd-relative names)
@@ -1618,6 +1620,23 @@ test-usb-sysfs-sysroot: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-sysroot
 ## whole model is synthetic here.
 test-usb-sysfs-overflow: $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-overflow
 	ELFUSE_USB_FIXTURE=overflow $(ELFUSE_BIN) $(TEST_DIR)/test-usb-sysfs-overflow
+
+## fstatfs answers for the descriptor it pinned, not for the fd number
+# The identity is decided from the slot's stamp and from the descriptor itself,
+# and those used to be two lookups with a window between them. The window is far
+# too narrow to reach unaided, so ELFUSE_FD_IDENTITY_WINDOW_US widens it and the
+# test swaps the slot inside it. The sysroot carries both sides the test needs:
+# a plain file, and a /sys directory this layer does not synthesize, so the
+# descriptor falls through to the sysroot and still has to answer sysfs.
+test-fstatfs-fd-identity: $(ELFUSE_BIN) $(TEST_DIR)/test-fstatfs-fd-identity
+	@$(SYSROOT_SCRATCH); \
+	sysroot="$$tmpdir/sysroot"; \
+	mkdir -p "$$sysroot/sys/class/net" "$$sysroot/sys/kernel" \
+		"$$sysroot/sys/devices" "$$sysroot/etc"; \
+	printf 'elfuse\n' > "$$sysroot/etc/hostname"; \
+	ELFUSE_FD_IDENTITY_WINDOW_US=120000 ELFUSE_USB_FIXTURE=1 \
+		$(ELFUSE_BIN) --sysroot "$$sysroot" \
+		$(TEST_DIR)/test-fstatfs-fd-identity /etc/hostname /sys/kernel
 
 ## A union walk must answer for the directory it pinned, not the fd number
 # The window between pinning the stream and looking the backing up is far too

--- a/src/runtime/fork-state.c
+++ b/src/runtime/fork-state.c
@@ -439,7 +439,15 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
         return -1;
     }
 
+    /* One row per open file description the parent had, so the slots that
+     * aliased it in the parent alias it in the child too. The directory stream
+     * and the descriptor it owns are carried alongside the identity because a
+     * repeat has to reuse them rather than build a second set; see the FD_DIR
+     * arm below.
+     */
     uint64_t parent_ofds[FD_TABLE_SIZE], child_ofds[FD_TABLE_SIZE];
+    void *ofd_dirs[FD_TABLE_SIZE];
+    int ofd_dir_hosts[FD_TABLE_SIZE];
     uint32_t ofd_maps = 0;
 
     for (uint32_t i = 0; i < num_fds; i++) {
@@ -455,9 +463,13 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
         }
 
         uint64_t child_ofd = 0;
+        void *shared_dir = NULL;
+        int shared_dir_host = -1;
         for (uint32_t j = 0; j < ofd_maps; j++) {
             if (parent_ofds[j] == fd_entries[i].ofd_id) {
                 child_ofd = child_ofds[j];
+                shared_dir = ofd_dirs[j];
+                shared_dir_host = ofd_dir_hosts[j];
                 break;
             }
         }
@@ -489,6 +501,29 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
         } else {
             void (*cleanup)(int) = fd_cleanup_for_type(fd_entries[i].type);
 
+            /* A second slot on a description whose directory stream this loop
+             * has already built shares that stream, the way dup/dup2/F_DUPFD
+             * share one in-process (fd_snapshot_and_dup_or_share_dir). The
+             * sharing did not use to survive a fork: each inherited descriptor
+             * arrives on its own over SCM_RIGHTS, and a wrapper per descriptor
+             * gave the child two locks, two DIR* read-ahead buffers and two
+             * positions over one description, so its two aliases split the
+             * listing at a host buffer boundary and the first ended at a clean
+             * 0 with names only the second could still reach.
+             *
+             * The redundant descriptor goes back here rather than to the slot:
+             * a stream owns the descriptor it was opened on and only closedir()
+             * gives it back (see dir_stream_t in syscall/internal.h), so the
+             * alias has to name the one the shared stream holds. That is also
+             * what keeps the fork side to one host descriptor per guest fd,
+             * which tests/test-dir-fd-budget-union asserts.
+             */
+            int host_fd = host_fds[i];
+            if (fd_entries[i].type == FD_DIR && shared_dir) {
+                close(host_fds[i]);
+                host_fd = shared_dir_host;
+            }
+
             /* Every descriptor here aliases a description the parent already
              * had, so the allocator takes the parent's answers rather than
              * probing: a slot that aliases the launcher's stdio must not have
@@ -497,8 +532,8 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
             fd_alias_spec_t spec =
                 fd_alias_carried(fd_entries[i].foreign_description != 0,
                                  fd_entries[i].nonblock_owned != 0);
-            fd_alloc_alias_at(&spec, gfd, fd_entries[i].type, host_fds[i],
-                              cleanup, NULL);
+            fd_alloc_alias_at(&spec, gfd, fd_entries[i].type, host_fd, cleanup,
+                              NULL);
             fd_table[gfd].linux_flags = fd_entries[i].linux_flags;
             fd_refresh_urandom_bitmap(gfd);
             memcpy(fd_table[gfd].proc_path, fd_entries[i].proc_path,
@@ -525,14 +560,33 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
                  * fd_retire_published close it -- and it must, because a slot
                  * left published as FD_DIR with a NULL dir owns its descriptor
                  * the ordinary way (see fd_cleanup_entry).
+                 *
+                 * The inherited form, not dir_stream_open: the parent's stream
+                 * has already read this description to its end, so the child's
+                 * listing is over before it starts and its union state has to
+                 * say so too. A fresh one re-drained the backing and handed the
+                 * child names the parent still owed. See internal.h.
                  */
-                void *ds = dir_stream_open(host_fds[i]);
-                if (!ds) {
-                    log_error(
-                        "fork-child: dir_stream_open failed for gfd %d: %s",
-                        gfd, strerror(errno));
-                    fd_retire_published(gfd, host_fds[i]);
-                    continue;
+                void *ds;
+                if (shared_dir) {
+                    /* No fd_lock: the child is the only thread alive at this
+                     * point in the rebuild, so nothing can be releasing the
+                     * stream underneath this reference. Every other caller of
+                     * dir_stream_ref_locked takes the lock because a sibling
+                     * close could.
+                     */
+                    dir_stream_ref_locked(shared_dir);
+                    ds = shared_dir;
+                } else {
+                    ds = dir_stream_open_inherited(host_fd);
+                    if (!ds) {
+                        log_error(
+                            "fork-child: dir_stream_open_inherited failed for "
+                            "gfd %d: %s",
+                            gfd, strerror(errno));
+                        fd_retire_published(gfd, host_fd);
+                        continue;
+                    }
                 }
                 fd_table[gfd].dir = ds;
             }
@@ -541,6 +595,9 @@ int fork_ipc_recv_fd_table(int ipc_fd, guest_t *g)
         if (!child_ofd && fd_entries[i].ofd_id) {
             child_ofd = fd_table[gfd].ofd_id;
             parent_ofds[ofd_maps] = fd_entries[i].ofd_id;
+            ofd_dirs[ofd_maps] =
+                fd_entries[i].type == FD_DIR ? fd_table[gfd].dir : NULL;
+            ofd_dir_hosts[ofd_maps] = fd_table[gfd].host_fd;
             child_ofds[ofd_maps++] = child_ofd;
         }
         if (child_ofd)

--- a/src/runtime/usb-sysfs.c
+++ b/src/runtime/usb-sysfs.c
@@ -1048,7 +1048,8 @@ typedef enum {
     USB_PATH_DEV_BUSNUM,   /* /dev/bus/usb/BBB    */
     USB_PATH_DEV_NODE,     /* /dev/bus/usb/BBB/DDD */
     USB_PATH_DEV_NODE_SUB, /* the node used as a directory: BBB/DDD/ or /x */
-    USB_PATH_DEV_ABSENT,   /* under /dev/bus but nothing we model */
+    USB_PATH_DEV_ABSENT,   /* under /dev/bus/usb but no such device */
+    USB_PATH_DEV_FOREIGN,  /* under /dev/bus but on no bus we model */
     USB_PATH_SYS,          /* /sys[/suffix] (whole sysfs view) */
 } usb_path_kind_t;
 
@@ -1094,7 +1095,7 @@ static usb_path_kind_t classify_path(const char *path,
     if (!*p)
         return USB_PATH_DEV_BUS;
     if (strncmp(p, "usb", 3) != 0 || (p[3] != '\0' && p[3] != '/'))
-        return USB_PATH_DEV_ABSENT;
+        return USB_PATH_DEV_FOREIGN;
     p = skip_slashes(p + 3);
     if (!*p)
         return USB_PATH_DEV_USB;
@@ -1286,6 +1287,7 @@ static void usb_canon_path(usb_path_kind_t kind,
         snprintf(out, outsz, "/dev/bus/usb/%03d/%03d", bus, dev);
         break;
     case USB_PATH_DEV_ABSENT:
+    case USB_PATH_DEV_FOREIGN:
     case USB_PATH_NONE:
         str_copy_trunc(out, "/dev/bus", outsz);
         break;
@@ -1378,13 +1380,24 @@ static int usb_blob_fd(const usb_dev_t *d)
 
 /* intercept entry points */
 
-/* Shared entry-point preamble: classify, and for the /sys view apply the
- * ours/not-ours fold before any lock is taken.
+/* Shared entry-point preamble: fold the name, then decide whose it is, before
+ * any lock is taken. Both halves fold; see the /dev/bus arm below and
+ * usb_suffix_normalize for what the fold is and is not.
  *
- * *sfx_out receives the suffix as the guest spelled it -- unfolded, because
- * usb_sys_resolve_suffix has to see the '..' in their original positions to
- * order them against the symlinks they follow. `norm` holds the folded
- * spelling, which is used only to decide whether the name is ours at all.
+ * *sfx_out receives the /sys suffix as the guest spelled it -- unfolded,
+ * because usb_sys_resolve_suffix has to see the '..' in their original
+ * positions to order them against the symlinks they follow. `norm` holds the
+ * folded spelling, which decides only whether the name is ours.
+ *
+ * Every name whose spelling alone settles ownership is settled here, so that no
+ * entry point re-derives it: a /sys name that folds above /sys, a /dev/bus name
+ * that folds above /dev/bus, and a /dev/bus name on a bus we do not model all
+ * leave as USB_PATH_NONE, and every caller reports PROC_NOT_INTERCEPTED. See
+ * docs/internals.md, "Ownership Of `/sys` And `/dev/bus` Names", for why a name
+ * we do not serve must fall through rather than answer ENOENT.
+ *
+ * The one ours/not-ours question this cannot answer is the /sys name that has
+ * to be resolved first; usb_resolve_or_disown owns that half.
  *
  * Returns the kind, or USB_PATH_NONE when the folded path is not ours; *err_out
  * non-zero means classify itself failed (ENAMETOOLONG) and the caller must
@@ -1399,7 +1412,53 @@ static usb_path_kind_t classify_and_normalize(const char *path,
                                               int *err_out)
 {
     *err_out = 0;
+
+    /* Fold the /dev/bus suffix before classify_path reads it, so both halves of
+     * the layer reach ownership the same way. The /sys half has always folded
+     * first and decided after; the /dev half used to classify the guest's
+     * spelling as written, and a '..' crossing the boundary then went wrong in
+     * both directions. /dev/bus/usb/../other/f reached parse_ddd's failure arm
+     * and came back USB_PATH_DEV_ABSENT, so the layer claimed the name and
+     * answered ENOENT for a file the sysroot really has;
+     * /dev/bus/other/../usb/001/002 classified as USB_PATH_DEV_FOREIGN, fell
+     * through, and missed the synthetic node because no sysroot carries a
+     * /dev/bus/usb. Both spellings are matrix columns now (dev-fold-out and
+     * dev-fold-in).
+     *
+     * The fold is lexical, and that is the right walk here: every component of
+     * /dev/bus this layer serves is a plain directory it materialized itself,
+     * so there is no symlink for a kernel-order walk to resolve differently.
+     * The result is written into `norm`, which the /sys arm below would use for
+     * its own folded suffix -- the two never both run -- and classify_path's
+     * sys_suffix_out is only set on the /sys arm, so it keeps pointing into
+     * live storage either way.
+     *
+     * A suffix that folds away above /dev/bus leaves as USB_PATH_NONE, the same
+     * answer the /sys arm gives a name that climbs above /sys: the layer serves
+     * nothing there and the caller reports PROC_NOT_INTERCEPTED.
+     */
+    if (path_prefix_match(path, "/dev/bus", 8)) {
+        char folded[LINUX_PATH_MAX];
+        int frc = usb_suffix_normalize(skip_slashes(path + 8), folded,
+                                       sizeof(folded));
+        if (frc < 0) {
+            *err_out = ENAMETOOLONG;
+            return USB_PATH_NONE;
+        }
+        if (frc == 0)
+            return USB_PATH_NONE; /* climbed above /dev/bus; not ours */
+        int n = folded[0] ? snprintf(norm, normsz, "/dev/bus/%s", folded)
+                          : snprintf(norm, normsz, "/dev/bus");
+        if (n < 0 || (size_t) n >= normsz) {
+            *err_out = ENAMETOOLONG;
+            return USB_PATH_NONE;
+        }
+        path = norm;
+    }
+
     usb_path_kind_t kind = classify_path(path, bus_out, dev_out, sfx_out);
+    if (kind == USB_PATH_DEV_FOREIGN)
+        return USB_PATH_NONE; /* another bus's /dev/bus subtree; not ours */
     if (kind != USB_PATH_SYS)
         return kind;
     int rc = usb_suffix_normalize(*sfx_out, norm, normsz);
@@ -1415,30 +1474,20 @@ static usb_path_kind_t classify_and_normalize(const char *path,
 /* Resolve a host path inside the sysfs scratch tree and prove the result is
  * still inside it, so the caller can open it with symlinks followed.
  *
- * Why following is safe here, and why O_NOFOLLOW was the wrong belt: the links
- * this tree carries are ours, written by emit_* with fixed relative targets,
- * and the tree is read-only to the guest (every mutating open under /sys is
- * refused before this point, and no mkdir/symlink/rename intercept reaches it),
- * so the procemu.c rationale "do not follow symlinks the guest created inside
- * the scratch dir" has nothing to bite on. What replaces it is a positive check
- * rather than a blanket refusal.
+ * Following is safe because the links are ours -- emit_* writes them with fixed
+ * relative targets into a tree the guest cannot write -- so procemu.c's "do not
+ * follow symlinks the guest created" has nothing to bite on, and a positive
+ * containment check replaces the blanket refusal.
  *
- * The escape guarantee, unchanged: the suffix reaching us has already had '.'
- * and '..' folded lexically by usb_suffix_normalize, so host_path is
- * usb_sys_dir followed by plain components and cannot climb out on its own; a
- * symlink is therefore the only way out, and realpath() resolves every one of
- * them -- in the leaf and in each intermediate component alike -- before we
- * test the fully canonical result against the canonical root. A path that
- * resolved outside is reported as absent instead of opened. The open then still
- * passes O_NOFOLLOW: the resolved leaf is by construction not a symlink, so the
- * flag changes nothing on the intended path and closes the swap window on the
- * final component only -- open(2) re-walks by the resolved path string, not
- * against a root fd retained from realpath(), so a symlink spun into an
- * intermediate directory between the resolve and the open would still be
- * followed. That residual TOCTOU is not reachable here: a sysrooted guest
- * cannot name the host scratch tree to plant such a link, and a sysroot-less
- * guest already has the host filesystem. Closing it for real would mean an
- * fd-relative reopen the read-only tree does not justify.
+ * The escape guarantee: the suffix arrives lexically folded, so host_path
+ * cannot climb out on its own and a symlink is the only way out; realpath()
+ * resolves every one of them, leaf and intermediate alike, and the canonical
+ * result is tested against the canonical root. A path that resolved outside is
+ * reported absent. The open still passes O_NOFOLLOW, which closes the swap
+ * window on the final component; a symlink spun into an intermediate directory
+ * between the resolve and the open would still be followed, and that residual
+ * TOCTOU is unreachable -- a sysrooted guest cannot name the host scratch tree
+ * to plant one, and a sysroot-less guest already has the host filesystem.
  *
  * Returns 0 with `out` filled, or -1 with errno set (realpath's errno, or
  * ENOENT for a path that resolved outside the tree).
@@ -1478,17 +1527,14 @@ static int usb_sys_resolve(const char *host_path, char *out, size_t outsz)
  *
  * realpath() performs the whole walk -- symlinks in the leaf and in every
  * intermediate component, and '..' in kernel order -- and its canonical result
- * is then tested against the canonical root. That containment test is the sole
- * escape authority: nothing above it is trusted to have kept the path inside,
- * which is why the raw, unfolded suffix can be handed to it safely.
+ * is tested against the canonical root. That containment test is the sole
+ * escape authority, which is why the raw, unfolded suffix is safe to hand it.
  *
  * `nofollow` keeps the semantics O_NOFOLLOW and lstat need: everything up to
- * the final component is resolved and contained as above, and the leaf is then
- * appended without being followed, so a symlink leaf stays a symlink -- and
- * contained again afterwards, because the append is the one step that happens
- * after a containment test. A '.' or '..' leaf is not held back at all: it
- * cannot be a symlink, so nothing is protected by withholding it, and it is the
- * one leaf whose reattachment can move the name (see below).
+ * the final component is resolved and contained, and the leaf is appended
+ * without being followed and contained again afterwards. A '.' or '..' leaf is
+ * not held back -- it cannot be a symlink, and it is the one leaf whose
+ * reattachment can move the name (see below).
  *
  * *canon_out receives the resolved location as a /sys-relative suffix, so the
  * synthetic identity is keyed on the object rather than on the spelling.
@@ -1576,6 +1622,24 @@ static int usb_sys_resolve_suffix(const char *raw_sfx,
             errno = ENOENT;
             return -1;
         }
+
+        /* Probe the leaf that was reattached without being walked. Without this
+         * the nofollow resolve succeeds for every name whose *parent* exists --
+         * the scratch /sys root exists, so "/sys/class" resolved -- and the
+         * caller's ours/not-ours escape hatch, which only the failure path
+         * consults, was never reached. The lstat that followed then failed
+         * ENOENT and that became the answer, shadowing a populated sysroot for
+         * lstat, open(O_NOFOLLOW) and readlink while stat and plain open (which
+         * resolve the leaf too, and so fail here) fell through correctly.
+         *
+         * lstat, not stat: a symlink leaf is the object the caller named.
+         */
+        struct stat leaf_st;
+        if (lstat(resolved, &leaf_st) < 0) {
+            if (!errno)
+                errno = ENOENT;
+            return -1;
+        }
     }
 
     if (str_copy_trunc(host_out, resolved, host_sz) >= host_sz) {
@@ -1594,6 +1658,38 @@ static int usb_sys_resolve_suffix(const char *raw_sfx,
         return -1;
     }
     return 0;
+}
+
+/* Resolve a /sys name and settle, in one place, whether this layer answers for
+ * it at all -- the resolve half of the fall-through decision classify_and_
+ * normalize makes for every other name. Every /sys entry point goes through
+ * here so none of them can disagree about which names are ours.
+ *
+ * Returns true with @host_out and @canon_out filled.
+ *
+ * Returns false with *err_out set to 0 when the name is not ours (the caller
+ * reports PROC_NOT_INTERCEPTED so the sysroot backing answers), or to an errno
+ * when the name is ours and the resolve genuinely failed. An absence under
+ * /sys/bus/usb is authoritative -- that subtree is the one thing this layer
+ * synthesizes -- so it comes back as ENOENT rather than as a fall-through.
+ */
+static bool usb_resolve_or_disown(const char *raw_sfx,
+                                  const char *norm,
+                                  bool nofollow,
+                                  char *host_out,
+                                  size_t host_sz,
+                                  char *canon_out,
+                                  size_t canon_sz,
+                                  int *err_out)
+{
+    if (usb_sys_resolve_suffix(raw_sfx, nofollow, host_out, host_sz, canon_out,
+                               canon_sz) == 0) {
+        *err_out = 0;
+        return true;
+    }
+    int reserr = errno;
+    *err_out = (reserr == ENOENT && !usb_sys_suffix_owned(norm)) ? 0 : reserr;
+    return false;
 }
 
 int usb_sysfs_guest_path_for_fd(int host_fd, char *out, size_t outsz)
@@ -1658,16 +1754,14 @@ int usb_sysfs_intercept_open(const char *path, int linux_flags, int mode)
         /* Resolve in kernel order first: '..' after a symlink has to pop the
          * target's parent before anything is decided about the name.
          */
-        if (usb_sys_resolve_suffix(sfx, nofollow, host_path, sizeof(host_path),
-                                   canon_sfx, sizeof(canon_sfx)) < 0) {
-            int reserr = errno;
-
-            /* A /sys name we do not synthesize resolved to nothing here: hand
-             * it back to the sysroot backing instead of shadowing it with
-             * ENOENT. Only the /sys/bus/usb subtree we own answers for its own
-             * absences.
+        int reserr = 0;
+        if (!usb_resolve_or_disown(sfx, norm, nofollow, host_path,
+                                   sizeof(host_path), canon_sfx,
+                                   sizeof(canon_sfx), &reserr)) {
+            /* Not ours: hand it back to the sysroot backing instead of
+             * shadowing it with ENOENT.
              */
-            if (reserr == ENOENT && !usb_sys_suffix_owned(norm)) {
+            if (!reserr) {
                 pthread_mutex_unlock(&usb_lock);
                 return PROC_NOT_INTERCEPTED;
             }
@@ -1792,8 +1886,9 @@ int usb_sysfs_intercept_open(const char *path, int linux_flags, int mode)
     case USB_PATH_DEV_ABSENT:
         err = ENOENT;
         goto out;
+    case USB_PATH_DEV_FOREIGN:
     case USB_PATH_NONE:
-        break;
+        break; /* folded to USB_PATH_NONE by classify_and_normalize */
     }
 
 out:
@@ -1838,16 +1933,14 @@ int usb_sysfs_intercept_stat(const char *path, struct stat *st, bool follow)
          * lstat() (follow == false) still reports the link itself.
          */
         char host_path[PATH_MAX], canon_sfx[PATH_MAX];
-        if (usb_sys_resolve_suffix(sfx, !follow, host_path, sizeof(host_path),
-                                   canon_sfx, sizeof(canon_sfx)) < 0) {
-            int reserr = errno;
-
-            /* A /sys name we do not synthesize resolved to nothing: let the
-             * sysroot backing answer rather than shadow it with ENOENT, so stat
-             * and open agree on it (see usb_sysfs_intercept_open). Only the
-             * /sys/bus/usb subtree we own reports its own absences.
+        int reserr = 0;
+        if (!usb_resolve_or_disown(sfx, norm, !follow, host_path,
+                                   sizeof(host_path), canon_sfx,
+                                   sizeof(canon_sfx), &reserr)) {
+            /* Not ours: let the sysroot backing answer rather than shadow it
+             * with ENOENT, so stat and open agree on it.
              */
-            if (reserr == ENOENT && !usb_sys_suffix_owned(norm)) {
+            if (!reserr) {
                 pthread_mutex_unlock(&usb_lock);
                 return PROC_NOT_INTERCEPTED;
             }
@@ -1906,8 +1999,9 @@ int usb_sysfs_intercept_stat(const char *path, struct stat *st, bool follow)
     case USB_PATH_DEV_ABSENT:
         err = ENOENT;
         goto out;
+    case USB_PATH_DEV_FOREIGN:
     case USB_PATH_NONE:
-        break;
+        break; /* folded to USB_PATH_NONE by classify_and_normalize */
     }
 
 out:
@@ -1953,16 +2047,13 @@ int usb_sysfs_intercept_readlink(const char *path, char *buf, size_t bufsiz)
              * object behind it.
              */
             char host_path[PATH_MAX], canon_sfx[PATH_MAX];
-            if (usb_sys_resolve_suffix(sfx, true, host_path, sizeof(host_path),
-                                       canon_sfx, sizeof(canon_sfx)) < 0) {
-                err = errno;
-
-                /* A /sys name we do not synthesize resolved to nothing: fall
-                 * through to the sysroot backing rather than shadow it, as the
-                 * open and stat paths do. Only /sys/bus/usb answers its own
-                 * absences.
+            if (!usb_resolve_or_disown(sfx, norm, true, host_path,
+                                       sizeof(host_path), canon_sfx,
+                                       sizeof(canon_sfx), &err)) {
+                /* Not ours: fall through to the sysroot backing rather than
+                 * shadow it, as the open and stat paths do.
                  */
-                if (err == ENOENT && !usb_sys_suffix_owned(norm)) {
+                if (!err) {
                     pthread_mutex_unlock(&usb_lock);
                     return PROC_NOT_INTERCEPTED;
                 }
@@ -1989,6 +2080,132 @@ int usb_sysfs_intercept_readlink(const char *path, char *buf, size_t bufsiz)
     /* The /dev/bus tree holds real dirs and device nodes, never symlinks. */
     errno = EINVAL;
     return -1;
+}
+
+/* True when @sfx (a /sys-relative spelling) names one of the `subsystem`
+ * symlinks this layer materializes. Caller holds usb_lock and has run
+ * ensure_usb_tree().
+ *
+ * The name alone is not enough: /sys/bus/usb/devices/9-9/subsystem names no
+ * link at all when there is no device 9-9, and rewriting a walk through a link
+ * that does not exist would turn a Linux ENOENT into a successful lookup
+ * somewhere else entirely.
+ */
+static bool usb_sys_is_subsystem_link(const char *sfx)
+{
+    char host[PATH_MAX];
+    int n = snprintf(host, sizeof(host), "%s/%s", usb_sys_dir, sfx);
+    if (n < 0 || (size_t) n >= sizeof(host))
+        return false;
+    struct stat st;
+    return lstat(host, &st) == 0 && S_ISLNK(st.st_mode);
+}
+
+int usb_sysfs_resolve_guest_path(const char *guest_path,
+                                 char *out,
+                                 size_t outsz)
+{
+    /* Every `subsystem` link this layer plants sits under /sys/bus/usb/devices,
+     * so nothing else can move a walk, and a path that cannot contain one is
+     * rejected before the tree is touched.
+     */
+    if (strncmp(guest_path, "/sys/bus/usb/devices/", 21) != 0 ||
+        !strstr(guest_path, "/subsystem"))
+        return 0;
+
+    pthread_mutex_lock(&usb_lock);
+    int rc = 0;
+    if (ensure_usb_tree() < 0)
+        goto out;
+
+    char rel[LINUX_PATH_MAX];
+    size_t len = 0;
+    size_t marks[64];
+    size_t depth = 0;
+    bool rewrote = false;
+    rel[0] = '\0';
+
+    for (const char *p = guest_path + 5; *p;) {
+        const char *seg = p;
+        while (*p && *p != '/')
+            p++;
+        size_t seglen = (size_t) (p - seg);
+        const char *after = p;
+        while (*after == '/')
+            after++;
+        p = after;
+
+        if (seglen == 0 || (seglen == 1 && seg[0] == '.'))
+            continue;
+        if (seglen == 2 && seg[0] == '.' && seg[1] == '.') {
+            if (depth == 0)
+                goto out; /* above /sys; not a name this layer can place */
+            len = marks[--depth];
+            rel[len] = '\0';
+            continue;
+        }
+        if (depth >= ARRAY_SIZE(marks))
+            goto out;
+        marks[depth++] = len;
+        if (len + (len ? 1 : 0) + seglen + 1 > sizeof(rel))
+            goto out;
+        if (len)
+            rel[len++] = '/';
+        memcpy(rel + len, seg, seglen);
+        len += seglen;
+        rel[len] = '\0';
+
+        /* A `subsystem` link with nothing after it is the object the caller
+         * named, and lstat/readlink/O_NOFOLLOW have to keep seeing the link
+         * itself, so only a link the walk continues through is substituted.
+         * What it is substituted with is where it points -- every one of them
+         * points at /sys/bus/usb -- so the components that follow are applied
+         * to the target, which is what makes `subsystem/..` name /sys/bus the
+         * way the kernel does.
+         */
+        if (*p && seglen == 9 && !memcmp(seg, "subsystem", 9)) {
+            if (!usb_sys_is_subsystem_link(rel))
+                goto out;
+            memcpy(rel, "bus/usb", 8);
+            len = 7;
+            depth = 2;
+            marks[0] = 0;
+            marks[1] = 3;
+            rewrote = true;
+        }
+    }
+
+    if (!rewrote)
+        goto out;
+
+    /* A trailing slash survives: it is what makes a non-directory named as a
+     * directory report ENOTDIR, and the rewrite must not answer that question.
+     */
+    const char *tail = guest_path[strlen(guest_path) - 1] == '/' ? "/" : "";
+    int n = snprintf(out, outsz, "/sys%s%s%s", len ? "/" : "", rel, tail);
+    rc = (n > 0 && (size_t) n < outsz) ? 1 : 0;
+
+out:
+    pthread_mutex_unlock(&usb_lock);
+    return rc;
+}
+
+bool usb_sysfs_dir_unions_backing(const char *guest_path)
+{
+    int bus = 0, dev = 0, cerr = 0;
+    const char *sfx = NULL;
+    char norm[LINUX_PATH_MAX];
+    usb_path_kind_t kind = classify_and_normalize(guest_path, &bus, &dev, &sfx,
+                                                  norm, sizeof(norm), &cerr);
+    if (kind == USB_PATH_DEV_BUS)
+        return true;
+    if (kind != USB_PATH_SYS)
+        return false;
+
+    /* The same ownership test the lookup path uses, so the listing and the
+     * lookups can never disagree about which names this layer answers for.
+     */
+    return !usb_sys_suffix_owned(norm);
 }
 
 uint8_t *usb_sysfs_descriptors_dup(int busnum, int devnum, size_t *len_out)

--- a/src/runtime/usb-sysfs.h
+++ b/src/runtime/usb-sysfs.h
@@ -34,6 +34,47 @@ int usb_sysfs_intercept_open(const char *path, int linux_flags, int mode);
 int usb_sysfs_intercept_stat(const char *path, struct stat *st, bool follow);
 int usb_sysfs_intercept_readlink(const char *path, char *buf, size_t bufsiz);
 
+/* True when @guest_path names a directory this layer serves but does not own,
+ * so its listing has to be the union of the synthetic entries and whatever the
+ * host/sysroot backing carries under the same name.
+ *
+ * /sys and /dev/bus exist on both sides: a Linux sysroot has class/, devices/,
+ * kernel/ under /sys and other buses under /dev/bus, while this layer adds only
+ * bus/usb and usb. Serving the synthetic directory alone made getdents64
+ * replace that listing rather than extend it, so `ls /sys` saw an almost-empty
+ * sysfs while every hidden name stayed openable by its exact path --
+ * enumeration and direct access disagreed.
+ *
+ * False for the one subtree this layer does own, /sys/bus/usb and /dev/bus/usb:
+ * there an absence is authoritative (lookup answers ENOENT rather than falling
+ * through), so the listing has to be authoritative too.
+ */
+bool usb_sysfs_dir_unions_backing(const char *guest_path);
+
+/* Rewrite @guest_path into the canonical guest spelling of the object it names,
+ * when its walk passes *through* one of the synthetic `subsystem` symlinks this
+ * layer plants and continues past it.
+ *
+ * Those links are the only way a /sys walk can leave this layer's subtree
+ * without saying so lexically: `<dev>/subsystem` points at /sys/bus/usb, so
+ * `<dev>/subsystem/../pci` names /sys/bus/pci, exactly as the kernel resolves
+ * it. Deciding ownership on the lexical fold instead reads that name as
+ * `<dev>/pci`, claims it as ours because it starts with bus/usb, and answers
+ * ENOENT -- shadowing a populated backing /sys/bus/pci that the *listing* of
+ * `<dev>/subsystem/..` had just offered. Resolving first, once, in the path
+ * layer, is what keeps the listing and every lookup answering from the same
+ * name.
+ *
+ * A link named as the final component is left alone: it is the object the
+ * caller asked for, and lstat, readlink and O_NOFOLLOW must keep seeing it.
+ *
+ * Returns 1 with @out filled, or 0 when no rewrite applies (including when the
+ * link named does not exist, so a missing device stays ENOENT).
+ */
+int usb_sysfs_resolve_guest_path(const char *guest_path,
+                                 char *out,
+                                 size_t outsz);
+
 /* Malloc'd copy of the usbfs descriptors blob (18-byte little-endian device
  * descriptor followed by every raw configuration descriptor in index order) for
  * the device at busnum/devnum. This is the exact byte sequence read() returns

--- a/src/syscall/fdtable.c
+++ b/src/syscall/fdtable.c
@@ -1215,6 +1215,36 @@ int fd_snapshot_and_dup(int guest_fd, fd_entry_t *out)
     return host;
 }
 
+int fd_snapshot_and_dup_or_share_dir(int guest_fd,
+                                     fd_entry_t *out,
+                                     bool *out_shared_dir)
+{
+    *out_shared_dir = false;
+    out->type = FD_CLOSED;
+    if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))
+        return -1;
+    pthread_mutex_lock(&fd_lock);
+    if (!fd_snapshot_locked(guest_fd, out, false)) {
+        pthread_mutex_unlock(&fd_lock);
+        return -1;
+    }
+
+    /* Reference and descriptor are taken in the one window that proved the slot
+     * is still this directory, so a sibling close cannot free the stream
+     * between the snapshot and the reference that keeps it alive.
+     */
+    int host;
+    if (out->type == FD_DIR && out->dir) {
+        dir_stream_ref_locked(out->dir);
+        *out_shared_dir = true;
+        host = out->host_fd;
+    } else {
+        host = (out->host_fd >= 0) ? dup(out->host_fd) : -1;
+    }
+    pthread_mutex_unlock(&fd_lock);
+    return host;
+}
+
 int fd_get_type(int guest_fd)
 {
     if (!RANGE_CHECK(guest_fd, 0, FD_TABLE_SIZE))

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -5,10 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <fcntl.h>
+#include <limits.h>
+#include <stdatomic.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include "debug/log.h"
 
@@ -146,6 +151,19 @@ static int write_linux_statx(guest_t *g,
     return guest_write_small(g, statx_gva, &sx, sizeof(sx));
 }
 
+/* Whether a descriptor's identity comes from the stamp rather than from the
+ * host object underneath it: O_PATH, /sys and /dev/bus do, /proc does not. See
+ * docs/internals.md, "Filesystem Identity Of A Descriptor", for why.
+ */
+static bool fd_stat_answers_from_stamp(const fd_entry_t *snap)
+{
+    if (snap->proc_path[0] == '\0')
+        return false;
+    return snap->type == FD_PATH ||
+           path_prefix_match(snap->proc_path, "/sys", 4) ||
+           path_prefix_match(snap->proc_path, "/dev/bus", 8);
+}
+
 static void translate_statfs(const struct statfs *mac, linux_statfs_t *lin)
 {
     memset(lin, 0, sizeof(*lin));
@@ -223,7 +241,7 @@ static int64_t stat_empty_path_fd(int dirfd, struct stat *mac_st)
     }
 
     int64_t rc = 0;
-    if (snap.type == FD_PATH && snap.proc_path[0] != '\0') {
+    if (fd_stat_answers_from_stamp(&snap)) {
         /* The descriptor already names one object: an O_PATH open that followed
          * refers to the target, one made with O_NOFOLLOW to the link itself, so
          * the open's flag is what selects here.
@@ -490,17 +508,10 @@ static void fill_proc_statfs(linux_statfs_t *lin)
 /* Boundary-checked "/sys or under it", applied to the folded name, which is
  * also published so the caller can act on the same spelling it classified.
  *
- * Linux resolves the path before deciding which filesystem answers it, so
- * statfs("/sys/../etc") reports the filesystem behind /etc and not sysfs. The
- * intercept path arrives here unnormalized, so testing the "/sys" prefix as
- * spelled would hand SYSFS_MAGIC to every name that merely starts inside /sys
- * and then climbs back out of it. Fold '.' and '..' first and test what the
- * name actually resolves to.
- *
- * A relative name resolves the same way, against the cwd -- statfs("sys") from
- * / is statfs("/sys") to the kernel, and sd-device and libusb both reach sysfs
- * through relative walks. Refusing every name that did not start with '/' left
- * those on the pass-through, which on a host with no /sys is ENOENT.
+ * Fold before deciding, and resolve a relative name against the cwd first: the
+ * kernel decides which filesystem answers a path after resolving it, so
+ * statfs("/sys/../etc") is /etc's filesystem and statfs("sys") from / is
+ * /sys's. See docs/internals.md, "Filesystem Identity Of A Descriptor".
  *
  * path_openat2_normalize_in_root clamps '..' at the root, which is what the
  * kernel does with a leading "/..", and yields a root-relative spelling --
@@ -531,6 +542,36 @@ static bool statfs_path_is_sysfs(const char *path, char *abs, size_t abssz)
         return false;
     int n = snprintf(abs, abssz, "/%s", folded);
     return n > 0 && (size_t) n < abssz;
+}
+
+/* True for a /dev/bus name the synthetic USB tree serves.
+ *
+ * That tree has no host backing, so the pass-through statfs reported ENOENT for
+ * a node stat() and open() both answer for, while fstatfs on the descriptor
+ * open() handed back reported the filesystem of elfuse's staging file. Linux
+ * serves usbfs nodes from the devtmpfs that carries the rest of /dev and
+ * reports TMPFS_MAGIC for them (0x01021994, measured on 6.x alongside /dev and
+ * /dev/null, which report the same). Both entry points ask this one question so
+ * they agree on every /dev/bus name either can reach.
+ *
+ * A /dev/bus name the layer does not claim -- another bus's subtree, which the
+ * sysroot may well carry -- answers false and keeps the host statfs.
+ */
+static bool statfs_name_is_synthetic_dev_bus(const char *path)
+{
+    if (!path || !path_prefix_match(path, "/dev/bus", 8))
+        return false;
+    struct stat st;
+    return proc_intercept_stat_at(path, &st, true) == 0;
+}
+
+static void fill_dev_statfs(linux_statfs_t *lin)
+{
+    memset(lin, 0, sizeof(*lin));
+    lin->f_type = 0x01021994; /* TMPFS_MAGIC, what devtmpfs reports */
+    lin->f_bsize = 4096;
+    lin->f_namelen = 255;
+    lin->f_frsize = 4096;
 }
 
 static void fill_sysfs_statfs(linux_statfs_t *lin)
@@ -637,6 +678,14 @@ static int64_t sys_statfs_impl(guest_t *g,
         return 0;
     }
 
+    if (statfs_name_is_synthetic_dev_bus(tx.intercept_path)) {
+        linux_statfs_t lin_st;
+        fill_dev_statfs(&lin_st);
+        if (guest_write_small(g, buf_gva, &lin_st, sizeof(lin_st)) < 0)
+            return -LINUX_EFAULT;
+        return 0;
+    }
+
     /* glibc's posix_openpt() opens /dev/ptmx and then confirms devpts is
      * mounted before handing the master back (sysdeps/unix/sysv/linux/getpt.c).
      * /dev/pts has no host backing here, so a pass-through statfs fails and
@@ -701,16 +750,56 @@ int64_t sys_statfs(guest_t *g, uint64_t path_gva, uint64_t buf_gva)
     return sys_statfs_impl(g, path, buf_gva, 0);
 }
 
+/* Widen the window between reading a descriptor's stamp and pinning the host fd
+ * it names, off unless ELFUSE_FD_IDENTITY_WINDOW_US is set to a positive
+ * microsecond count.
+ *
+ * The window is real and far too narrow to reach from a test: unaided, over 160
+ * runs at four delays, a sibling close-and-reopen between the two lookups was
+ * never distinguishable in the answer. What lives in it is a guest fd number
+ * whose slot can be replaced while this call is deciding what filesystem to
+ * report for it, so the identity would come from one description and the
+ * descriptor from another. tests/test-fstatfs-fd-identity drives it. Same shape
+ * and the same reasoning as dir_backing_window_delay in syscall/fs.c; no effect
+ * at all when unset.
+ */
+static void fd_identity_window_delay(void)
+{
+    static _Atomic long cached = -1; /* -1 = unread */
+    long v = atomic_load_explicit(&cached, memory_order_relaxed);
+    if (v < 0) {
+        const char *env = getenv("ELFUSE_FD_IDENTITY_WINDOW_US");
+        long long n = env ? strtoll(env, NULL, 10) : 0;
+        v = (n > 0 && n < 1000000) ? (long) n : 0;
+        atomic_store_explicit(&cached, v, memory_order_relaxed);
+    }
+    if (v > 0)
+        usleep((useconds_t) v);
+}
+
 int64_t sys_fstatfs(guest_t *g, int fd, uint64_t buf_gva)
 {
     /* Deliberately no devpts case for a pty master fd: Linux answers from
      * whatever filesystem provides /dev/ptmx, which is devpts only when it is
      * the bind-mounted /dev/pts/ptmx and tmpfs or devtmpfs otherwise. There is
-     * no single correct value to report, and nothing needs one.
+     * no single correct value to report, and nothing needs one. The stamp and
+     * the descriptor come out of one fd_lock window. They are two facts about
+     * one open file description, and read separately a close and reopen between
+     * them gave the stamp of the description the caller named and the
+     * descriptor of whatever took the number afterwards -- so every branch
+     * below, /proc included, could answer for an object this call is not
+     * holding. Measured with the window widened: a plain sysroot file whose
+     * slot was replaced mid-call by a /sys descriptor was reported as sysfs.
      */
     fd_entry_t snap;
-    memset(&snap, 0, sizeof(snap));
-    if (fd_snapshot(fd, &snap) && statfs_path_is_proc(snap.proc_path)) {
+    host_fd_ref_t host_ref;
+    int64_t ref_err = host_fd_ref_open_entry(fd, &host_ref, &snap);
+    if (ref_err < 0)
+        return ref_err;
+    fd_identity_window_delay();
+
+    if (statfs_path_is_proc(snap.proc_path)) {
+        host_fd_ref_close(&host_ref);
         linux_statfs_t proc_st;
         fill_proc_statfs(&proc_st);
         if (guest_write_small(g, buf_gva, &proc_st, sizeof(proc_st)) < 0)
@@ -718,14 +807,27 @@ int64_t sys_fstatfs(guest_t *g, int fd, uint64_t buf_gva)
         return 0;
     }
 
-    /* Descriptors opened under /sys are scratch-dir backed; the host fstatfs
-     * would leak the /tmp filesystem's magic. systemd's sd-device gates every
-     * enumerated syspath on fstatfs(fd) == SYSFS_MAGIC, so answer as sysfs
-     * exactly like path statfs("/sys") does.
+    /* Descriptors under /sys are sysfs whichever side served them, and the
+     * spelling to test comes from the stamp when the fd carries one and from
+     * the descriptor's own host path otherwise -- a fall-through open stamps
+     * nothing. Both go to statfs_path_is_sysfs, the test the path side uses.
+     * See docs/internals.md, "Filesystem Identity Of A Descriptor".
      */
+    char fd_guest[LINUX_PATH_MAX];
+    const char *fd_name = NULL;
+    if (snap.proc_path[0]) {
+        fd_name = snap.proc_path;
+    } else {
+        char fd_host[PATH_MAX];
+        if (fcntl(host_ref.fd, F_GETPATH, fd_host) == 0 &&
+            path_host_to_guest(fd_host, fd_guest, sizeof(fd_guest)) == 0)
+            fd_name = fd_guest;
+    }
+
     char fd_sys_abs[LINUX_PATH_MAX];
-    if (snap.proc_path[0] &&
-        statfs_path_is_sysfs(snap.proc_path, fd_sys_abs, sizeof(fd_sys_abs))) {
+    if (fd_name &&
+        statfs_path_is_sysfs(fd_name, fd_sys_abs, sizeof(fd_sys_abs))) {
+        host_fd_ref_close(&host_ref);
         linux_statfs_t sys_st;
         fill_sysfs_statfs(&sys_st);
         if (guest_write_small(g, buf_gva, &sys_st, sizeof(sys_st)) < 0)
@@ -733,10 +835,14 @@ int64_t sys_fstatfs(guest_t *g, int fd, uint64_t buf_gva)
         return 0;
     }
 
-    host_fd_ref_t host_ref;
-    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
-    if (ref_err < 0)
-        return ref_err;
+    if (fd_name && statfs_name_is_synthetic_dev_bus(fd_name)) {
+        host_fd_ref_close(&host_ref);
+        linux_statfs_t dev_st;
+        fill_dev_statfs(&dev_st);
+        if (guest_write_small(g, buf_gva, &dev_st, sizeof(dev_st)) < 0)
+            return -LINUX_EFAULT;
+        return 0;
+    }
 
     struct statfs mac_st;
     if (fstatfs(host_ref.fd, &mac_st) < 0) {

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -544,9 +544,11 @@ static bool statfs_path_is_sysfs(const char *path, char *abs, size_t abssz)
     return n > 0 && (size_t) n < abssz;
 }
 
-/* True for a /dev/bus name the synthetic USB tree serves.
+/* What the synthetic USB tree answers for a /dev/bus name: 0 when it serves the
+ * name, -1 with errno set when it owns the name and the lookup failed, and
+ * PROC_NOT_INTERCEPTED when the name is not ours at all.
  *
- * That tree has no host backing, so the pass-through statfs reported ENOENT for
+ * The tree has no host backing, so the pass-through statfs reported ENOENT for
  * a node stat() and open() both answer for, while fstatfs on the descriptor
  * open() handed back reported the filesystem of elfuse's staging file. Linux
  * serves usbfs nodes from the devtmpfs that carries the rest of /dev and
@@ -554,15 +556,18 @@ static bool statfs_path_is_sysfs(const char *path, char *abs, size_t abssz)
  * /dev/null, which report the same). Both entry points ask this one question so
  * they agree on every /dev/bus name either can reach.
  *
- * A /dev/bus name the layer does not claim -- another bus's subtree, which the
- * sysroot may well carry -- answers false and keeps the host statfs.
+ * The last two answers stay distinct because collapsing them is the bug
+ * sys_faccessat had: a sysroot carrying a name inside /dev/bus/usb -- on a bus
+ * number no device has -- would otherwise have its file answer statfs while
+ * open, stat and access all report ENOENT for the same path. Only
+ * PROC_NOT_INTERCEPTED means "ask the backing".
  */
-static bool statfs_name_is_synthetic_dev_bus(const char *path)
+static int statfs_dev_bus_class(const char *path)
 {
     if (!path || !path_prefix_match(path, "/dev/bus", 8))
-        return false;
+        return PROC_NOT_INTERCEPTED;
     struct stat st;
-    return proc_intercept_stat_at(path, &st, true) == 0;
+    return proc_intercept_stat_at(path, &st, true);
 }
 
 static void fill_dev_statfs(linux_statfs_t *lin)
@@ -678,7 +683,10 @@ static int64_t sys_statfs_impl(guest_t *g,
         return 0;
     }
 
-    if (statfs_name_is_synthetic_dev_bus(tx.intercept_path)) {
+    int dev_bus = statfs_dev_bus_class(tx.intercept_path);
+    if (dev_bus == -1)
+        return linux_errno();
+    if (dev_bus == 0) {
         linux_statfs_t lin_st;
         fill_dev_statfs(&lin_st);
         if (guest_write_small(g, buf_gva, &lin_st, sizeof(lin_st)) < 0)
@@ -835,7 +843,11 @@ int64_t sys_fstatfs(guest_t *g, int fd, uint64_t buf_gva)
         return 0;
     }
 
-    if (fd_name && statfs_name_is_synthetic_dev_bus(fd_name)) {
+    /* Only the "we serve it" answer applies here: an open descriptor stays a
+     * valid one whatever became of its name, so a claimed-and-failed lookup is
+     * no reason to fail fstatfs, and the host answers as it did before.
+     */
+    if (fd_name && statfs_dev_bus_class(fd_name) == 0) {
         host_fd_ref_close(&host_ref);
         linux_statfs_t dev_st;
         fill_dev_statfs(&dev_st);

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -348,6 +348,19 @@ static const char *proc_virtual_dir_path(const char *path,
     return NULL;
 }
 
+/* One entry read out of a union directory's backing, held after that
+ * directory's stream has been closed. The name is the host spelling, not yet
+ * put through path_translate_dirent_name: translation depends on the backing's
+ * escape policy, which is recorded once per drain, and a host name may be
+ * longer than Linux NAME_MAX -- the emit path is where that is already
+ * diagnosed, and keeping it there keeps one copy of the rule.
+ */
+typedef struct {
+    uint64_t ino;
+    unsigned char type;
+    char name[]; /* NUL-terminated */
+} backing_name_t;
+
 /* Reference-counted wrapper around a directory stream. See the declaration in
  * syscall/internal.h for why this exists: a raw DIR* stored in fd_table[fd].dir
  * would let a sibling close()/dup2()/fork-restore free it via closedir() while
@@ -358,16 +371,66 @@ static const char *proc_virtual_dir_path(const char *path,
 typedef struct {
     DIR *dir;
 
-    /* Second stream, over the host/sysroot directory that backs the same guest
-     * name, for the synthetic directories that must extend their backing rather
-     * than replace it (see usb_sysfs_dir_unions_backing). Opened lazily, once,
-     * when the primary stream runs out, so a directory that is never read to
-     * the end never pays for it and a directory that has no backing never opens
-     * one. Guarded by `lock` along with the walk itself.
+    /* The tail of the listing for a synthetic directory that must extend its
+     * backing rather than replace it (see usb_sysfs_dir_unions_backing): the
+     * names of the host/sysroot directory that backs the same guest name, read
+     * out of it in one pass and held here as data.
+     *
+     * Names rather than a second open stream, because a stream would be a
+     * second host descriptor charged to one guest fd for as long as the fd
+     * lives, and elfuse sizes its host budget as one descriptor per guest fd
+     * (FD_TABLE_SIZE + HOST_FD_RESERVE, src/elfuse-limits.h). The backing
+     * stream is opened and closed inside the single getdents64 call that first
+     * needs it -- see dir_backing_drain -- so the extra descriptor is transient
+     * and never spans a return to the guest.
+     *
+     * Filled lazily, when the primary stream runs out, so a directory that is
+     * never read to the end never pays for it and a directory that has no
+     * backing never opens one. Guarded by `lock` along with the walk itself.
      */
-    DIR *overlay;
-    bool overlay_tried; /* the lazy open has run; do not retry */
-    bool on_overlay;    /* the walk has moved to the overlay stream */
+    backing_name_t **backing; /* NULL until the drain has run */
+    size_t backing_count;
+    size_t backing_pos;   /* how much of `backing` the walk has emitted */
+    bool backing_drained; /* the one-shot drain has run; do not retry */
+    bool backing_private; /* this stream may not read a backing of its own:
+                           * another stream on the same open file description
+                           * owns the backing half of this listing. Set only on
+                           * the stream a forked child builds over an inherited
+                           * descriptor -- see dir_stream_open_inherited. It
+                           * stops the drain and nothing else; the primary walk
+                           * runs exactly as it does on any other stream,
+                           * because the primary position IS shared through the
+                           * description and splitting it is the one part of
+                           * Linux's answer this can give.
+                           */
+    bool backing_escapes; /* path_dirent_dir_holds_escapes for the backing,
+                           * recorded while its descriptor still existed
+                           */
+    int listing_errno;    /* non-zero when this listing is incomplete and can
+                           * never be completed. Sticky: set once and never
+                           * cleared, because the stream has lost names it can
+                           * no longer produce. sys_getdents64 reads it at the
+                           * top of every call and returns it, so the failure
+                           * outlives the call that hit it instead of being
+                           * swallowed by that call's partial return.
+                           *
+                           * Set from either half of the walk. The drain sets it
+                           * when the backing could not be read; the primary
+                           * walk sets it when readdir() on the synthetic stream
+                           * fails. Both are the same defect from the guest's
+                           * side -- names that exist and were not delivered --
+                           * so they answer through one field and one delivery
+                           * point rather than one being reported and the other
+                           * spelled as an end of directory.
+                           */
+
+    size_t primary_seen; /* Entries readdir() has returned from the synthetic
+                          * stream over this stream's whole life. Only the
+                          * fault hook reads it (see dir_primary_fault_after);
+                          * the walk itself needs no count, because the primary
+                          * side keeps its position in the DIR* rather than in
+                          * an index. Guarded by `lock` with the walk.
+                          */
 
     pthread_mutex_t lock; /* Serializes the telldir/readdir/seekdir walk in
                            * sys_getdents64. The refcount below only pins the
@@ -380,12 +443,25 @@ typedef struct {
                            * never destroyed while held.
                            */
     int refcount;         /* Guarded by fd_lock. Starts at 1 (the fd-table's
-                           * own reference) and gains one per in-flight
-                           * sys_getdents64 that pinned it via
+                           * own reference), gains one per guest fd that dup'd
+                           * its way onto the same open file description, and
+                           * one per in-flight sys_getdents64 that pinned it via
                            * dir_stream_acquire(). Freed only when the count
                            * reaches zero.
                            */
 } dir_stream_t;
+
+/* Release the drained backing names. Safe on a stream that never drained one.
+ */
+static void dir_backing_free(dir_stream_t *ds)
+{
+    for (size_t i = 0; i < ds->backing_count; i++)
+        free(ds->backing[i]);
+    free((void *) ds->backing);
+    ds->backing = NULL;
+    ds->backing_count = 0;
+    ds->backing_pos = 0;
+}
 
 /* Open a stream over host_fd and take ownership of the descriptor.
  *
@@ -395,7 +471,7 @@ typedef struct {
  * DIR* and nothing short of closedir() -- which closes it -- gets it back, so
  * there must be no failure left after that point.
  */
-void *dir_stream_open(int host_fd)
+static dir_stream_t *dir_stream_new(int host_fd)
 {
     dir_stream_t *ds = malloc(sizeof(*ds));
     if (!ds) {
@@ -432,11 +508,37 @@ void *dir_stream_open(int host_fd)
     }
 
     ds->dir = dir;
-    ds->overlay = NULL;
-    ds->overlay_tried = false;
-    ds->on_overlay = false;
+    ds->backing = NULL;
+    ds->backing_count = 0;
+    ds->backing_pos = 0;
+    ds->backing_drained = false;
+    ds->backing_private = false;
+    ds->backing_escapes = false;
+    ds->listing_errno = 0;
+    ds->primary_seen = 0;
     pthread_mutex_init(&ds->lock, NULL);
     ds->refcount = 1;
+    return ds;
+}
+
+void *dir_stream_open(int host_fd)
+{
+    return dir_stream_new(host_fd);
+}
+
+/* A stream for an inherited descriptor: the same wrapper, forbidden to read a
+ * backing of its own. See internal.h for which half of the listing the child
+ * shares with its parent and which half it must leave alone.
+ *
+ * Only the backing half is suppressed. The primary is read normally, because
+ * the primary lives in the shared open file description and reading it is what
+ * splits the listing between the two processes instead of losing part of it.
+ */
+void *dir_stream_open_inherited(int host_fd)
+{
+    dir_stream_t *ds = dir_stream_new(host_fd);
+    if (ds)
+        ds->backing_private = true;
     return ds;
 }
 
@@ -458,8 +560,7 @@ void dir_stream_ref_locked(void *ds_ptr)
 static void dir_stream_discard(void *ds_ptr)
 {
     dir_stream_t *ds = ds_ptr;
-    if (ds->overlay)
-        closedir(ds->overlay);
+    dir_backing_free(ds);
     closedir(ds->dir);
     pthread_mutex_destroy(&ds->lock);
     free(ds);
@@ -475,9 +576,10 @@ static void dir_stream_discard(void *ds_ptr)
  * the descriptor's identity therefore travels with the pinned stream instead of
  * being re-read from fd_table[fd] later: a sibling's close()+open() can put a
  * different file behind that number while this walk still holds the original
- * stream, and a re-read would then union some other directory's backing into it
+ * stream, and a re-read would then drain some other directory's backing into it
  * -- or, when the number is merely closed, find no stamp at all and end the
- * listing early with the backing half silently missing and success reported.
+ * union listing early with the backing half silently missing and success
+ * reported.
  *
  * @proc_path_out receives that stamp, empty when the slot carried none.
  *
@@ -522,8 +624,7 @@ void dir_stream_release(void *ds_ptr)
     bool last = --ds->refcount == 0;
     pthread_mutex_unlock(&fd_lock);
     if (last) {
-        if (ds->overlay)
-            closedir(ds->overlay);
+        dir_backing_free(ds);
         closedir(ds->dir);
         pthread_mutex_destroy(&ds->lock);
         free(ds);
@@ -1107,29 +1208,6 @@ int64_t sys_close(int fd)
 
 /* dup/fcntl. */
 
-/* Open a DIR stream over dst_host_fd if the source was an FD_DIR. The dup that
- * produced dst_host_fd is the alias's own descriptor, and the stream adopts it:
- * a second one, which is what this used to take, would give the guest fd two
- * host descriptors for the rest of its life.
- *
- * Returns NULL on success-but-no-stream-needed (non-dir source) or on failure
- * with errno preserved, distinguished by *out_failed. Runs outside fd_lock
- * because fdopendir is a slow syscall.
- */
-static dir_stream_t *clone_dir_stream(const fd_entry_t *src_snap,
-                                      int dst_host_fd,
-                                      bool *out_failed)
-{
-    *out_failed = false;
-    if (src_snap->type != FD_DIR)
-        return NULL;
-
-    dir_stream_t *ds = dir_stream_open(dst_host_fd);
-    if (!ds)
-        *out_failed = true;
-    return ds;
-}
-
 /* Install dup-alias metadata atomically with the slot identity. Uses the (type,
  * host_fd) tuple as proof that the slot still belongs to the in-flight
  * duplicate_guest_fd call; a sibling vCPU's pathological close + open between
@@ -1207,7 +1285,9 @@ static int duplicate_guest_fd(int src_fd,
      */
     proc_pty_lock_for_dup();
     fd_entry_t src_snap;
-    int new_host_fd = fd_snapshot_and_dup(src_fd, &src_snap);
+    bool shared_dir = false;
+    int new_host_fd =
+        fd_snapshot_and_dup_or_share_dir(src_fd, &src_snap, &shared_dir);
     if (new_host_fd < 0 && src_snap.type == FD_CLOSED) {
         proc_pty_unlock_for_dup();
         errno = EBADF;
@@ -1253,20 +1333,28 @@ static int duplicate_guest_fd(int src_fd,
         return -1;
     }
 
-    /* Mirror any /dev/ptmx keepalive BEFORE fd_alloc publishes guest_fd. Once
-     * the guest fd exists, a sibling thread can close it; that runs
-     * fd_cleanup_entry which calls proc_pty_close_keepalive(new_host_fd). For
-     * that cleanup to drop the freshly-duped keepalive, the keepalive entry
-     * must already be in the table; registering after fd_alloc would lose the
-     * race and leak the slave fd. No-op when the source has no keepalive.
+    /* Not for a shared directory descriptor: source and alias are the one
+     * descriptor there, so there is no second reference for either table to
+     * record, and registering a descriptor as its own duplicate would count it
+     * twice. A directory is never a pty either way.
      */
-    proc_pty_dup_keepalive_locked(src_snap.host_fd, new_host_fd);
+    if (!shared_dir) {
+        /* Mirror any /dev/ptmx keepalive BEFORE fd_alloc publishes guest_fd.
+         * Once the guest fd exists, a sibling thread can close it; that runs
+         * fd_cleanup_entry which calls proc_pty_close_keepalive(new_host_fd).
+         * For that cleanup to drop the freshly-duped keepalive, the keepalive
+         * entry must already be in the table; registering after fd_alloc would
+         * lose the race and leak the slave fd. No-op when the source has no
+         * keepalive.
+         */
+        proc_pty_dup_keepalive_locked(src_snap.host_fd, new_host_fd);
 
-    /* Same reasoning for the slave side: the alias is a live reference to the
-     * pty and must be on the books before the guest fd is published, or the
-     * source's close will retire the only counted reference.
-     */
-    proc_pty_dup_guest_slave_locked(src_snap.host_fd, new_host_fd);
+        /* Same reasoning for the slave side: the alias is a live reference to
+         * the pty and must be on the books before the guest fd is published, or
+         * the source's close will retire the only counted reference.
+         */
+        proc_pty_dup_guest_slave_locked(src_snap.host_fd, new_host_fd);
+    }
     proc_pty_unlock_for_dup();
 
     int new_type = (src_snap.type == FD_STDIO) ? FD_REGULAR : src_snap.type;
@@ -1284,22 +1372,13 @@ static int duplicate_guest_fd(int src_fd,
     fd_alias_spec_t spec = fd_alias_of(src_fd, &src_snap);
     spec.linux_flags |= linux_flags;
 
-    /* Open the alias's DIR stream before the slot exists, outside fd_lock
-     * because fdopendir is a slow syscall. It has to precede the allocation
-     * rather than follow it: the stream owns new_host_fd, and a slot published
-     * as FD_DIR before its stream exists is a slot whose descriptor a
-     * concurrent close would treat as plain and close underneath this call.
+    /* A directory alias publishes the source's own stream, referenced in the
+     * window that snapshotted the slot. Nothing is opened here: the alias is
+     * the same open file description as the source, so it must be the same
+     * position, the same union state, and the same descriptor -- which is also
+     * why a dup costs no second host descriptor, as it does not on Linux.
      */
-    bool dir_clone_failed = false;
-    dir_stream_t *ds =
-        clone_dir_stream(&src_snap, new_host_fd, &dir_clone_failed);
-    if (dir_clone_failed) {
-        int saved_errno = errno;
-        proc_pty_forget_host_fd(new_host_fd);
-        close(new_host_fd);
-        errno = saved_errno;
-        return -1;
-    }
+    dir_stream_t *ds = shared_dir ? (dir_stream_t *) src_snap.dir : NULL;
 
     int guest_fd =
         ds ? fd_alloc_alias_dir(&spec, fixed_slot ? fixed_guest_fd : -1,
@@ -1319,11 +1398,15 @@ static int duplicate_guest_fd(int src_fd,
          * its last slave go.
          */
         int saved_errno = errno;
-        proc_pty_forget_host_fd(new_host_fd);
-        if (ds)
-            dir_stream_discard(ds); /* closes new_host_fd */
-        else
+        if (shared_dir) {
+            /* The descriptor is the source's and stays open with it; only this
+             * side's reference on the shared stream is given back.
+             */
+            dir_stream_release(ds);
+        } else {
+            proc_pty_forget_host_fd(new_host_fd);
             close(new_host_fd);
+        }
         errno = saved_errno;
         return -1;
     }
@@ -2029,9 +2112,8 @@ int64_t sys_close_range(unsigned int first,
  * used to name -- and the outcome that has to be pinned is that the walk keeps
  * answering for the directory it pinned, rather than reading someone else's
  * backing into it or quietly returning a listing missing its backing half.
- * tests/test-dir-union-fd-reuse drives it. Read from the environment, with no
- * effect at all when unset, like the ELFUSE_USB_FIXTURE hook in
- * src/runtime/usb-sysfs.c.
+ * tests/test-dir-union-fd-reuse drives it. Same shape and the same reasoning as
+ * the drain's fault hook; no effect at all when unset.
  */
 static void dir_backing_window_delay(void)
 {
@@ -2049,26 +2131,32 @@ static void dir_backing_window_delay(void)
 
 /* Open the host/sysroot directory that backs the same guest name as @fd, for a
  * synthetic directory whose listing has to extend its backing instead of
- * replacing it.
+ * replacing it. See docs/internals.md, "Union Directory Listings".
  *
- * The backing is found from the descriptor's stamped guest path rather than
- * remembered at open time, so a dup'd or fork-restored directory fd -- which
- * gets a fresh stream over the same host descriptor and would otherwise lose
- * the union -- resolves it the same way the original did.
+ * @guest_path is the stamp as dir_stream_acquire read it, not as fd_table holds
+ * it now: the stream was pinned by fd number and can outlive the slot that
+ * number names, so the number must never be consulted again.
  *
- * @guest_path is that stamp as dir_stream_acquire read it, not as fd_table
- * holds it now. The distinction is the whole point: the stream this extends was
- * pinned by fd number and can outlive the slot that number names, so the number
- * must never be consulted again once the walk owns the stream.
+ * Returns the stream, or NULL when there is no backing listing to add. NULL
+ * splits two ways and *@hard_errno tells them apart. Left at 0, no readable
+ * backing was ever there to lose -- no union here, the guest path does not
+ * translate, the backing is behind FUSE, ENOENT, or ENOTDIR. ENOENT covers the
+ * backing being unlinked between the guest's open and this drain, which is a
+ * name vanishing mid-walk: POSIX leaves that unspecified and Linux does not
+ * report it either.
  *
- * Returns the stream, or NULL when this directory has no union to do, when the
- * backing does not exist (no sysroot, or a sysroot with no such directory), or
- * when it cannot be opened. Every one of those is "nothing to add", so the
- * caller simply finishes with the entries it already has.
+ * Set, the backing exists and could not be read -- EACCES, EMFILE/ENFILE, ELOOP
+ * -- and the caller must report rather than hand back a listing quietly missing
+ * those names. Linux never answers that case short: measured in docker (gcc:13,
+ * Linux 6.19 aarch64), an unprivileged open() of a chmod 000 directory fails
+ * EACCES outright. elfuse cannot refuse the open, because the synthetic half
+ * opened fine and the guest already holds the fd, so it reports on the read.
  */
-static DIR *dir_backing_stream(const char *guest_path)
+static DIR *dir_backing_stream(const char *guest_path, int *hard_errno)
 {
+    *hard_errno = 0;
     dir_backing_window_delay();
+
     if (guest_path[0] != '/')
         return NULL;
     if (!usb_sysfs_dir_unions_backing(guest_path))
@@ -2081,12 +2169,189 @@ static DIR *dir_backing_stream(const char *guest_path)
         return NULL;
 
     int host_fd = open(tx.host_path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-    if (host_fd < 0)
+    if (host_fd < 0) {
+        if (errno != ENOENT && errno != ENOTDIR)
+            *hard_errno = errno;
         return NULL;
+    }
     DIR *dir = fdopendir(host_fd);
-    if (!dir)
+    if (!dir) {
+        *hard_errno = errno;
         close_keep_errno(host_fd);
+    }
     return dir;
+}
+
+/* Fault-injection hook for the drain, off unless ELFUSE_DIR_BACKING_FAULT is
+ * set to a positive count: the drain then fails with ENOMEM once it has
+ * buffered that many names. It exists because the failure it drives -- a
+ * malloc/realloc that comes back NULL part-way through a real backing listing
+ * -- cannot be provoked on demand, and the behavior on that path (the guest is
+ * told, and never handed a short listing it reads as complete) is exactly what
+ * regressed once already and so has to be pinned by a test rather than argued
+ * about. tests/test-dir-backing-drain-error drives it. Same shape as the
+ * ELFUSE_USB_FIXTURE hook in src/runtime/usb-sysfs.c: read from the
+ * environment, no effect at all when unset.
+ */
+static size_t dir_backing_fault_after(void)
+{
+    static _Atomic size_t cached = 0; /* 0 = unread, SIZE_MAX = off */
+    size_t v = atomic_load_explicit(&cached, memory_order_relaxed);
+    if (v != 0)
+        return v;
+
+    const char *env = getenv("ELFUSE_DIR_BACKING_FAULT");
+    long long n = env ? strtoll(env, NULL, 10) : -1;
+    v = (n > 0) ? (size_t) n : SIZE_MAX;
+    atomic_store_explicit(&cached, v, memory_order_relaxed);
+    return v;
+}
+
+/* Fault-injection hook for the primary (synthetic) stream, off unless
+ * ELFUSE_DIR_PRIMARY_READ_FAULT is set to a positive count: readdir() on the
+ * primary then fails with EIO once it has returned that many entries.
+ *
+ * Same reason the drain has one, and the same shape: a readdir() that fails
+ * part-way through a directory elfuse itself materialized cannot be provoked
+ * from a test, and the behavior on that path -- the guest is told, and is never
+ * handed a listing that stops early but reads as complete -- is exactly what
+ * regressed on the backing side and has to be pinned rather than argued about.
+ * tests/test-dir-primary-read-error drives it. No effect at all when unset.
+ */
+static size_t dir_primary_fault_after(void)
+{
+    static _Atomic size_t cached = 0; /* 0 = unread, SIZE_MAX = off */
+    size_t v = atomic_load_explicit(&cached, memory_order_relaxed);
+    if (v != 0)
+        return v;
+
+    const char *env = getenv("ELFUSE_DIR_PRIMARY_READ_FAULT");
+    long long n = env ? strtoll(env, NULL, 10) : -1;
+    v = (n > 0) ? (size_t) n : SIZE_MAX;
+    atomic_store_explicit(&cached, v, memory_order_relaxed);
+    return v;
+}
+
+/* Read the whole backing listing for @fd into @ds and close the backing stream
+ * before returning, so the second host descriptor exists only for the duration
+ * of this call and never spans a return to the guest. That is the whole point:
+ * elfuse promises one host descriptor per guest fd (tests/test-dir-fd-budget),
+ * and a resident second stream would charge union directories two.
+ *
+ * Names already present in the primary (synthetic) directory are dropped here
+ * rather than at emit time, which is both the deduplication the union needs --
+ * synthetic wins, and "." / ".." therefore appear once -- and what keeps the
+ * buffer to the names that will actually be emitted. Asking the primary
+ * directory itself rather than remembering the names already emitted keeps that
+ * state out of the stream: the backing is only ever read once the primary is
+ * exhausted, so a name that is in the primary has already been offered.
+ *
+ * There is no ceiling on what this buffers. A cap invents a failure Linux never
+ * returns -- getdents64 on a directory of any size succeeds -- and spells it
+ * ENOMEM, which is a lie about what went wrong. The memory is not the memory
+ * that matters either: this buffer replaced a host descriptor held for the
+ * whole life of the guest fd, and the widest sysfs directory on a real Linux
+ * host (/sys/kernel/slab, 496 names, 5883 bytes of them) is a few tens of KiB,
+ * freed at close. Grow until the allocator says no, and let a real ENOMEM be
+ * the only ENOMEM.
+ *
+ * Always marks the drain as done, so it runs at most once per stream. Sets
+ * ds->listing_errno when it could not deliver the whole backing listing -- a
+ * failed allocation, a readdir that errored part-way, or a backing that exists
+ * but could not be opened. The caller turns that into an error return rather
+ * than a short one. A backing that was never there is not a failure: it means
+ * there is nothing to add (see dir_backing_stream).
+ */
+static void dir_backing_drain(dir_stream_t *ds, const char *guest_path, int fd)
+{
+    ds->backing_drained = true;
+
+    int open_failed = 0;
+    DIR *backing = dir_backing_stream(guest_path, &open_failed);
+    if (!backing) {
+        ds->listing_errno = open_failed;
+        if (open_failed)
+            log_warn(
+                "getdents64: the backing directory for fd %d exists but "
+                "could not be read (%s); reporting the listing as "
+                "incomplete rather than dropping its names",
+                fd, strerror(open_failed));
+        return;
+    }
+
+    ds->backing_escapes = path_dirent_dir_holds_escapes(dirfd(backing));
+
+    size_t cap = 0, count = 0;
+    backing_name_t **names = NULL;
+    int failed = 0;
+    const size_t fault_after = dir_backing_fault_after();
+
+    for (;;) {
+        /* readdir returns NULL for both end-of-stream and error, and only errno
+         * separates them. Left unread, a readdir that failed part-way would end
+         * the drain as if the backing had simply run out and the names past the
+         * failure would go missing with nothing said -- the same silent
+         * truncation the ceiling used to cause.
+         */
+        errno = 0;
+        struct dirent *de = readdir(backing);
+        if (!de) {
+            failed = errno; /* 0 on a genuine end of stream */
+            break;
+        }
+
+        struct stat dup_st;
+        if (fstatat(dirfd(ds->dir), de->d_name, &dup_st, AT_SYMLINK_NOFOLLOW) ==
+            0)
+            continue;
+
+        if (count >= fault_after) {
+            failed = ENOMEM;
+            break;
+        }
+
+        size_t len = strlen(de->d_name);
+
+        if (count == cap) {
+            size_t want = cap ? cap * 2 : 16;
+            backing_name_t **grown = (backing_name_t **) realloc(
+                (void *) names, want * sizeof(*grown));
+            if (!grown) {
+                failed = ENOMEM;
+                break;
+            }
+            names = grown;
+            cap = want;
+        }
+
+        backing_name_t *entry = malloc(sizeof(*entry) + len + 1);
+        if (!entry) {
+            failed = ENOMEM;
+            break;
+        }
+        entry->ino = de->d_ino;
+        entry->type = de->d_type;
+        memcpy(entry->name, de->d_name, len + 1);
+        names[count++] = entry;
+    }
+
+    closedir(backing); /* the transient descriptor goes back here */
+
+    if (failed) {
+        log_warn(
+            "getdents64: the backing directory for fd %d could not be read "
+            "to the end (%s) after %zu names; reporting the listing as "
+            "incomplete rather than truncating it",
+            fd, strerror(failed), count);
+        for (size_t i = 0; i < count; i++)
+            free(names[i]);
+        free((void *) names);
+        ds->listing_errno = failed;
+        return;
+    }
+
+    ds->backing = names;
+    ds->backing_count = count;
 }
 
 /* getdents64: read directory entries from a guest directory fd. Uses the
@@ -2128,6 +2393,18 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         goto out;
     }
 
+    /* A stream that lost names it can never produce again fails here, before
+     * the walk, and goes on failing: the errno is sticky. Without this the
+     * stream came back with nothing buffered and returned 0, an end of
+     * directory the guest cannot tell from a real one. See docs/internals.md,
+     * "Union Directory Listings", for the contract and why it is not one-shot.
+     */
+    if (ds->listing_errno) {
+        errno = ds->listing_errno;
+        ret = linux_errno();
+        goto out;
+    }
+
     size_t guest_pos = 0;
     struct dirent *de;
 
@@ -2144,54 +2421,119 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
     uint8_t entry_buf[DIRENT64_MAX_RECLEN];
 
     /* The walk runs over the primary stream and then, for a synthetic directory
-     * that has a backing, over the backing's own stream. `cur` is whichever one
-     * is being read; every telldir/readdir/seekdir below uses it, so a rewind
-     * always rewinds the stream the entry came from.
+     * that has a backing, over the names drained out of the backing. Which side
+     * it is on survives the return to the guest, in the stream: the drain is
+     * what exhausts the primary, so a stream that has drained is a stream whose
+     * remaining entries are all on the backing side.
      */
-    DIR *cur = ds->on_overlay && ds->overlay ? ds->overlay : ds->dir;
+    bool on_backing = ds->backing_drained;
 
     /* One answer per stream, not per entry: which side of the sysroot boundary
-     * the stream reads from is a property of the directory.
+     * the stream reads from is a property of the directory. The backing's
+     * answer was recorded by the drain, while its descriptor still existed.
      */
-    bool dir_holds_escapes = path_dirent_dir_holds_escapes(dirfd(cur));
+    bool dir_holds_escapes =
+        on_backing ? ds->backing_escapes
+                   : path_dirent_dir_holds_escapes(dirfd(ds->dir));
 
     while (1) {
-        /* Save position BEFORE readdir so getdents emulation can rewind if the
-         * entry does not fit. macOS telldir returns an opaque cookie --
-         * arithmetic on it (e.g. telldir()-1) is undefined.
-         */
-        long saved_pos = telldir(cur);
-        de = readdir(cur);
-        if (!de) {
-            if (ds->on_overlay || ds->overlay_tried)
-                break;
-            ds->overlay_tried = true;
-            ds->overlay = dir_backing_stream(walk_path);
-            if (!ds->overlay)
-                break;
-            ds->on_overlay = true;
-            cur = ds->overlay;
-            dir_holds_escapes = path_dirent_dir_holds_escapes(dirfd(cur));
-            continue;
-        }
+        const char *host_name;
+        uint64_t entry_ino;
+        unsigned char entry_type;
+        int64_t entry_off = 0; /* backing side only; the primary asks telldir */
+        long saved_pos = 0;
 
-        /* Deduplicate by name with the synthetic side winning, which is also
-         * what makes "." and ".." appear once. Asking the primary directory
-         * itself rather than remembering the names already emitted keeps the
-         * state out of the stream: the overlay is only ever read after the
-         * primary is exhausted, so a name that is in the primary has already
-         * been offered to the guest.
-         */
-        if (ds->on_overlay) {
-            struct stat dup_st;
-            if (fstatat(dirfd(ds->dir), de->d_name, &dup_st,
-                        AT_SYMLINK_NOFOLLOW) == 0)
+        if (on_backing) {
+            if (ds->backing_pos >= ds->backing_count)
+                break;
+            const backing_name_t *bn = ds->backing[ds->backing_pos];
+            host_name = bn->name;
+            entry_ino = bn->ino;
+            entry_type = bn->type;
+
+            /* The backing side numbers its entries from one. d_off is an opaque
+             * cookie the guest may only hand back, so the primary's telldir
+             * cookies and these indices share one space, exactly as the two
+             * streams' separate cookie spaces did before.
+             */
+            entry_off = (int64_t) (ds->backing_pos + 1);
+        } else {
+            /* Save position BEFORE readdir so getdents emulation can rewind if
+             * the entry does not fit. macOS telldir returns an opaque cookie --
+             * arithmetic on it (e.g. telldir()-1) is undefined.
+             */
+            saved_pos = telldir(ds->dir);
+
+            /* readdir() reports end-of-stream and failure the same way -- NULL
+             * -- and only errno separates them, so errno has to be cleared
+             * first or a value left by an earlier call would read as this one's
+             * failure. Left unchecked, a primary readdir that failed part-way
+             * was taken for exhaustion: the walk unioned the backing in as if
+             * the synthetic half were finished, dropped every synthetic name
+             * past the failure, and handed the result back as a clean end of
+             * directory. That is the same silent truncation the drain side was
+             * repaired for, on the other half of the union.
+             */
+            errno = 0;
+            de = readdir(ds->dir);
+            if (de && ++ds->primary_seen > dir_primary_fault_after()) {
+                de = NULL;
+                errno = EIO;
+            }
+            if (!de && errno) {
+                int primary_errno = errno;
+                ds->listing_errno = primary_errno;
+                log_warn(
+                    "getdents64: the directory behind fd %d could not be read "
+                    "to the end (%s); reporting the listing as incomplete "
+                    "rather than ending it early",
+                    fd, strerror(primary_errno));
+
+                /* Linux's two-part shape, the same one the drain failure uses:
+                 * a call that has already written entries returns their count
+                 * and leaves the error for the next call, which the sticky
+                 * listing_errno delivers at the top of this function; a call
+                 * that has written nothing returns -1 with the errno.
+                 */
+                errno = primary_errno;
+                ret = guest_pos > 0 ? (int64_t) guest_pos : linux_errno();
+                goto out;
+            }
+            if (!de) {
+                if (ds->backing_drained || ds->backing_private)
+                    break;
+
+                /* Primary exhausted: pull in the backing's names. The drain
+                 * opens the backing directory and closes it before returning,
+                 * so the second descriptor does not outlive this call.
+                 */
+                dir_backing_drain(ds, walk_path, fd);
+                if (ds->listing_errno) {
+                    /* Linux's two-part shape: a call that has written entries
+                     * returns their count and leaves the error for the next
+                     * call, which the sticky listing_errno delivers at the top
+                     * of this function; a call that has written nothing is the
+                     * guest_pos == 0 arm here and returns -1. Measured before
+                     * the repair, with the drain failed after two names against
+                     * a backing of six: the guest got 3 of 9 names and errno 0
+                     * at every buffer size from 24 bytes to 32KiB.
+                     */
+                    errno = ds->listing_errno;
+                    ret = guest_pos > 0 ? (int64_t) guest_pos : linux_errno();
+                    goto out;
+                }
+                on_backing = true;
+                dir_holds_escapes = ds->backing_escapes;
                 continue;
+            }
+            host_name = de->d_name;
+            entry_ino = de->d_ino;
+            entry_type = de->d_type;
         }
 
         char guest_name[NAME_MAX + 1];
         int name_rc = path_translate_dirent_name(
-            dir_holds_escapes, de->d_name, guest_name, sizeof(guest_name));
+            dir_holds_escapes, host_name, guest_name, sizeof(guest_name));
         if (name_rc < 0) {
             /* macOS APFS accepts UTF-8 filenames whose byte length exceeds
              * Linux NAME_MAX (255). A guest libc cannot represent such a name
@@ -2214,7 +2556,9 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
                         "getdents64: skipping host dirent whose name "
                         "exceeds Linux NAME_MAX (%u); first hit was "
                         "%zu bytes on fd %d",
-                        NAME_MAX, strlen(de->d_name), fd);
+                        NAME_MAX, strlen(host_name), fd);
+                if (on_backing)
+                    ds->backing_pos++;
                 continue;
             }
             ret = guest_pos > 0 ? (int64_t) guest_pos : linux_errno();
@@ -2229,16 +2573,19 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
 
         if (!dirent_record_bounds(name_len, guest_pos, count, &reclen,
                                   &pad_start)) {
-            /* Entry does not fit; rewind so next call gets it */
-            seekdir(cur, saved_pos);
+            /* Entry does not fit; rewind so next call gets it. The backing side
+             * rewinds by simply not advancing its cursor.
+             */
+            if (!on_backing)
+                seekdir(ds->dir, saved_pos);
             break;
         }
 
         linux_dirent64_t lde;
-        lde.d_ino = de->d_ino;
-        lde.d_off = telldir(cur);
+        lde.d_ino = entry_ino;
+        lde.d_off = on_backing ? entry_off : telldir(ds->dir);
         lde.d_reclen = (uint16_t) reclen;
-        lde.d_type = de->d_type;
+        lde.d_type = entry_type;
 
         /* Serialize entry into temp buffer, then copy to guest via
          * guest_write() which handles 2MiB block boundary crossings.
@@ -2253,6 +2600,8 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
             goto out;
         }
 
+        if (on_backing)
+            ds->backing_pos++;
         guest_pos += reclen;
     }
 

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -224,7 +224,21 @@ static bool resolve_virtual_path(const char *path, char *out, size_t out_size)
      */
     if (path_prefix_match(path, "/sys", 4) ||
         path_prefix_match(path, "/dev/bus", 8)) {
-        str_copy_trunc(out, path, out_size);
+        /* Refuse a name that does not fit rather than stamp a truncated one.
+         * The stamp is FD_VIRTUAL_PATH_MAX bytes and str_copy_trunc cuts
+         * silently, which for a long spelling ends the stamp mid-component --
+         * and every consumer then acts on that name as if it were whole: the
+         * relative-walk rebase resolves off a directory the guest never named,
+         * and getcwd and /proc/self/fd/N report it. No spelling the synthetic
+         * tree produces reaches the cap today (the longest canonical one is 47
+         * bytes for an interface attribute, and a deep hub chain adds a few),
+         * so this is the guard for the day one does: an unstamped descriptor
+         * loses an identity, a mis-stamped one invents a different one, and
+         * sys_fstatfs already recovers the sysfs answer from the descriptor
+         * itself when the stamp is absent.
+         */
+        if (str_copy_trunc(out, path, out_size) >= out_size)
+            return false;
         return true;
     }
 
@@ -343,6 +357,18 @@ static const char *proc_virtual_dir_path(const char *path,
  */
 typedef struct {
     DIR *dir;
+
+    /* Second stream, over the host/sysroot directory that backs the same guest
+     * name, for the synthetic directories that must extend their backing rather
+     * than replace it (see usb_sysfs_dir_unions_backing). Opened lazily, once,
+     * when the primary stream runs out, so a directory that is never read to
+     * the end never pays for it and a directory that has no backing never opens
+     * one. Guarded by `lock` along with the walk itself.
+     */
+    DIR *overlay;
+    bool overlay_tried; /* the lazy open has run; do not retry */
+    bool on_overlay;    /* the walk has moved to the overlay stream */
+
     pthread_mutex_t lock; /* Serializes the telldir/readdir/seekdir walk in
                            * sys_getdents64. The refcount below only pins the
                            * wrapper's lifetime; two guest threads issuing
@@ -406,6 +432,9 @@ void *dir_stream_open(int host_fd)
     }
 
     ds->dir = dir;
+    ds->overlay = NULL;
+    ds->overlay_tried = false;
+    ds->on_overlay = false;
     pthread_mutex_init(&ds->lock, NULL);
     ds->refcount = 1;
     return ds;
@@ -429,27 +458,47 @@ void dir_stream_ref_locked(void *ds_ptr)
 static void dir_stream_discard(void *ds_ptr)
 {
     dir_stream_t *ds = ds_ptr;
+    if (ds->overlay)
+        closedir(ds->overlay);
     closedir(ds->dir);
     pthread_mutex_destroy(&ds->lock);
     free(ds);
 }
 
 /* Pin fd's directory stream against a concurrent close()/dup2() so
- * sys_getdents64 can safely walk it.
+ * sys_getdents64 can safely walk it, and stamp the walk with the guest path
+ * that slot carried at the moment it was pinned.
+ *
+ * The stamp is copied out here, under the same fd_lock that proved the slot is
+ * this stream's, because it is the only moment at which the fd number and the
+ * stream are known to belong together. Everything the walk needs to know about
+ * the descriptor's identity therefore travels with the pinned stream instead of
+ * being re-read from fd_table[fd] later: a sibling's close()+open() can put a
+ * different file behind that number while this walk still holds the original
+ * stream, and a re-read would then union some other directory's backing into it
+ * -- or, when the number is merely closed, find no stamp at all and end the
+ * listing early with the backing half silently missing and success reported.
+ *
+ * @proc_path_out receives that stamp, empty when the slot carried none.
  *
  * Returns the pinned wrapper, or NULL if fd is not (or no longer) an open
  * FD_DIR. Balance every non-NULL return with dir_stream_release().
  */
-static dir_stream_t *dir_stream_acquire(int fd)
+static dir_stream_t *dir_stream_acquire(int fd,
+                                        char *proc_path_out,
+                                        size_t proc_path_sz)
 {
+    proc_path_out[0] = '\0';
     if (!RANGE_CHECK(fd, 0, FD_TABLE_SIZE))
         return NULL;
     pthread_mutex_lock(&fd_lock);
     dir_stream_t *ds = NULL;
     if (fd_table[fd].type == FD_DIR) {
         ds = (dir_stream_t *) fd_table[fd].dir;
-        if (ds)
+        if (ds) {
             ds->refcount++;
+            str_copy_trunc(proc_path_out, fd_table[fd].proc_path, proc_path_sz);
+        }
     }
     pthread_mutex_unlock(&fd_lock);
     return ds;
@@ -473,6 +522,8 @@ void dir_stream_release(void *ds_ptr)
     bool last = --ds->refcount == 0;
     pthread_mutex_unlock(&fd_lock);
     if (last) {
+        if (ds->overlay)
+            closedir(ds->overlay);
         closedir(ds->dir);
         pthread_mutex_destroy(&ds->lock);
         free(ds);
@@ -1967,6 +2018,77 @@ int64_t sys_close_range(unsigned int first,
 
 /* directory operations. */
 
+/* Widen the window between pinning the stream and looking the backing up, off
+ * unless ELFUSE_DIR_UNION_BACKING_DELAY_US is set to a positive microsecond
+ * count.
+ *
+ * The window is real but far too narrow to reach from a test: two threads
+ * hammering close and dup2 on the walked fd produced no cross-listing in 353k
+ * walks. What lives in it is a guest fd number that can be closed, or reopened
+ * onto a different file, while this walk still holds the stream that number
+ * used to name -- and the outcome that has to be pinned is that the walk keeps
+ * answering for the directory it pinned, rather than reading someone else's
+ * backing into it or quietly returning a listing missing its backing half.
+ * tests/test-dir-union-fd-reuse drives it. Read from the environment, with no
+ * effect at all when unset, like the ELFUSE_USB_FIXTURE hook in
+ * src/runtime/usb-sysfs.c.
+ */
+static void dir_backing_window_delay(void)
+{
+    static _Atomic long cached = -1; /* -1 = unread */
+    long v = atomic_load_explicit(&cached, memory_order_relaxed);
+    if (v < 0) {
+        const char *env = getenv("ELFUSE_DIR_UNION_BACKING_DELAY_US");
+        long long n = env ? strtoll(env, NULL, 10) : 0;
+        v = (n > 0 && n < 1000000) ? (long) n : 0;
+        atomic_store_explicit(&cached, v, memory_order_relaxed);
+    }
+    if (v > 0)
+        usleep((useconds_t) v);
+}
+
+/* Open the host/sysroot directory that backs the same guest name as @fd, for a
+ * synthetic directory whose listing has to extend its backing instead of
+ * replacing it.
+ *
+ * The backing is found from the descriptor's stamped guest path rather than
+ * remembered at open time, so a dup'd or fork-restored directory fd -- which
+ * gets a fresh stream over the same host descriptor and would otherwise lose
+ * the union -- resolves it the same way the original did.
+ *
+ * @guest_path is that stamp as dir_stream_acquire read it, not as fd_table
+ * holds it now. The distinction is the whole point: the stream this extends was
+ * pinned by fd number and can outlive the slot that number names, so the number
+ * must never be consulted again once the walk owns the stream.
+ *
+ * Returns the stream, or NULL when this directory has no union to do, when the
+ * backing does not exist (no sysroot, or a sysroot with no such directory), or
+ * when it cannot be opened. Every one of those is "nothing to add", so the
+ * caller simply finishes with the entries it already has.
+ */
+static DIR *dir_backing_stream(const char *guest_path)
+{
+    dir_backing_window_delay();
+    if (guest_path[0] != '/')
+        return NULL;
+    if (!usb_sysfs_dir_unions_backing(guest_path))
+        return NULL;
+
+    path_translation_t tx;
+    if (path_translate_at(LINUX_AT_FDCWD, guest_path, PATH_TR_NONE, &tx) < 0)
+        return NULL;
+    if (tx.fuse_path)
+        return NULL;
+
+    int host_fd = open(tx.host_path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (host_fd < 0)
+        return NULL;
+    DIR *dir = fdopendir(host_fd);
+    if (!dir)
+        close_keep_errno(host_fd);
+    return dir;
+}
+
 /* getdents64: read directory entries from a guest directory fd. Uses the
  * persistent DIR* stored in fd_table (created by openat).
  */
@@ -1989,10 +2111,10 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
     /* Pin the directory stream so a concurrent close()/dup2() cannot free it
      * while this call is still walking it -- see dir_stream_t in fs.c.
      */
-    dir_stream_t *ds = dir_stream_acquire(fd);
+    char walk_path[FD_VIRTUAL_PATH_MAX];
+    dir_stream_t *ds = dir_stream_acquire(fd, walk_path, sizeof(walk_path));
     if (!ds)
         return -LINUX_ENOTDIR;
-    DIR *dir = ds->dir;
 
     /* Serialize the walk against a concurrent getdents64 pinning the same
      * stream -- see the lock field in dir_stream_t.
@@ -2021,20 +2143,51 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
      */
     uint8_t entry_buf[DIRENT64_MAX_RECLEN];
 
-    /* One answer per call, not per entry: which side of the sysroot boundary
+    /* The walk runs over the primary stream and then, for a synthetic directory
+     * that has a backing, over the backing's own stream. `cur` is whichever one
+     * is being read; every telldir/readdir/seekdir below uses it, so a rewind
+     * always rewinds the stream the entry came from.
+     */
+    DIR *cur = ds->on_overlay && ds->overlay ? ds->overlay : ds->dir;
+
+    /* One answer per stream, not per entry: which side of the sysroot boundary
      * the stream reads from is a property of the directory.
      */
-    const bool dir_holds_escapes = path_dirent_dir_holds_escapes(dirfd(dir));
+    bool dir_holds_escapes = path_dirent_dir_holds_escapes(dirfd(cur));
 
     while (1) {
         /* Save position BEFORE readdir so getdents emulation can rewind if the
          * entry does not fit. macOS telldir returns an opaque cookie --
          * arithmetic on it (e.g. telldir()-1) is undefined.
          */
-        long saved_pos = telldir(dir);
-        de = readdir(dir);
-        if (!de)
-            break;
+        long saved_pos = telldir(cur);
+        de = readdir(cur);
+        if (!de) {
+            if (ds->on_overlay || ds->overlay_tried)
+                break;
+            ds->overlay_tried = true;
+            ds->overlay = dir_backing_stream(walk_path);
+            if (!ds->overlay)
+                break;
+            ds->on_overlay = true;
+            cur = ds->overlay;
+            dir_holds_escapes = path_dirent_dir_holds_escapes(dirfd(cur));
+            continue;
+        }
+
+        /* Deduplicate by name with the synthetic side winning, which is also
+         * what makes "." and ".." appear once. Asking the primary directory
+         * itself rather than remembering the names already emitted keeps the
+         * state out of the stream: the overlay is only ever read after the
+         * primary is exhausted, so a name that is in the primary has already
+         * been offered to the guest.
+         */
+        if (ds->on_overlay) {
+            struct stat dup_st;
+            if (fstatat(dirfd(ds->dir), de->d_name, &dup_st,
+                        AT_SYMLINK_NOFOLLOW) == 0)
+                continue;
+        }
 
         char guest_name[NAME_MAX + 1];
         int name_rc = path_translate_dirent_name(
@@ -2077,13 +2230,13 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         if (!dirent_record_bounds(name_len, guest_pos, count, &reclen,
                                   &pad_start)) {
             /* Entry does not fit; rewind so next call gets it */
-            seekdir(dir, saved_pos);
+            seekdir(cur, saved_pos);
             break;
         }
 
         linux_dirent64_t lde;
         lde.d_ino = de->d_ino;
-        lde.d_off = telldir(dir);
+        lde.d_off = telldir(cur);
         lde.d_reclen = (uint16_t) reclen;
         lde.d_type = de->d_type;
 
@@ -2179,6 +2332,44 @@ int64_t sys_chdir(guest_t *g, uint64_t path_gva)
             return linux_errno();
         proc_cwd_set_virtual(tx.guest_path);
         return 0;
+    }
+
+    /* The synthetic /sys and /dev/bus directories are reached by an intercept,
+     * never by the host walk: chdir(tx.host_path) looks for them in the sysroot
+     * or on the host, neither of which carries the tree, so chdir answered
+     * ENOENT for every directory open() and fchdir() both reach -- and reported
+     * ENOENT rather than ENOTDIR for the attributes and device nodes inside it.
+     * Route it through the same open the descriptor path uses so the three
+     * agree, and publish the descriptor's own guest spelling as the virtual
+     * cwd, which is what makes a chdir onto a `subsystem` link land where Linux
+     * lands rather than in the directory the link sits in.
+     *
+     * A name the intercept does not claim falls through to the host chdir
+     * below, unchanged.
+     */
+    if (tx.intercept_path &&
+        (path_prefix_match(tx.intercept_path, "/sys", 4) ||
+         path_prefix_match(tx.intercept_path, "/dev/bus", 8))) {
+        int host_fd =
+            proc_intercept_open(g, tx.intercept_path, LINUX_O_DIRECTORY, 0);
+        if (host_fd >= 0) {
+            char virt_buf[LINUX_PATH_MAX];
+            const char *virt_path = tx.intercept_path;
+            if (usb_sysfs_guest_path_for_fd(host_fd, virt_buf,
+                                            sizeof(virt_buf)) > 0)
+                virt_path = virt_buf;
+            int chdir_rc = fchdir(host_fd);
+            int saved_errno = errno;
+            close_keep_errno(host_fd);
+            if (chdir_rc < 0) {
+                errno = saved_errno;
+                return linux_errno();
+            }
+            proc_cwd_set_virtual(virt_path);
+            return 0;
+        }
+        if (host_fd == -1)
+            return linux_errno();
     }
 
     if (chdir(tx.host_path) < 0)
@@ -2950,13 +3141,27 @@ int64_t sys_faccessat(guest_t *g,
      * mode bits, not just path existence.
      */
     struct stat intercepted_st;
-    if (path_might_use_stat_intercept(tx.intercept_path) &&
-        proc_intercept_stat_at(tx.intercept_path, &intercepted_st,
-                               !(flags & LINUX_AT_SYMLINK_NOFOLLOW)) == 0) {
-        host_fd_ref_close(&dir_ref);
-        if (path_check_intercept_access(&intercepted_st, mode, flags) < 0)
+    if (path_might_use_stat_intercept(tx.intercept_path)) {
+        int intercepted =
+            proc_intercept_stat_at(tx.intercept_path, &intercepted_st,
+                                   !(flags & LINUX_AT_SYMLINK_NOFOLLOW));
+        if (intercepted == 0) {
+            host_fd_ref_close(&dir_ref);
+            if (path_check_intercept_access(&intercepted_st, mode, flags) < 0)
+                return linux_errno();
+            return 0;
+        }
+
+        /* An intercept that claimed the name and then failed is the answer.
+         * Only PROC_NOT_INTERCEPTED means "ask the backing": treating the
+         * failure as one too let access(2) answer OK from the host for a name
+         * whose open and stat both said ENOENT, so the three disagreed about
+         * the same path.
+         */
+        if (intercepted == -1) {
+            host_fd_ref_close(&dir_ref);
             return linux_errno();
-        return 0;
+        }
     }
 
     int mac_flags =

--- a/src/syscall/fs.c
+++ b/src/syscall/fs.c
@@ -2535,18 +2535,17 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
         int name_rc = path_translate_dirent_name(
             dir_holds_escapes, host_name, guest_name, sizeof(guest_name));
         if (name_rc < 0) {
-            /* macOS APFS accepts UTF-8 filenames whose byte length exceeds
-             * Linux NAME_MAX (255). A guest libc cannot represent such a name
-             * in its 256-byte dirent buffer at all, so elfuse silently skips
-             * the unrepresentable entry and keeps the rest of the stream
-             * intact. This is an elfuse compatibility policy, not Linux kernel
-             * behavior: real getdents64 has no equivalent skip path because
-             * Linux NAME_MAX is enforced at the filesystem layer, so no
-             * oversize entry ever reaches verify_dirent_name. Aborting the
-             * whole stream the way the pre-fix code did truncated ls / find /
-             * coreutils listings against APFS-mounted source trees. Skip on
-             * ENAMETOOLONG; keep the existing partial-return path for any other
-             * translation failure so genuine errors are not silently dropped.
+            /* A host name a guest libc cannot represent is skipped and the rest
+             * of the stream delivered -- an elfuse policy with no Linux
+             * counterpart; see docs/internals.md, "Union Directory Listings".
+             *
+             * ENAMETOOLONG is the only failure the translator can raise here:
+             * its other arm is an EINVAL guarding null arguments and a
+             * zero-sized output, and this call site passes the entry's own name
+             * and a NAME_MAX + 1 array with its own sizeof. The exit below is
+             * therefore unreachable rather than a second policy, and it rewinds
+             * the way the does-not-fit path does, so that no exit from this
+             * walk can consume an entry without putting it back.
              */
             if (errno == ENAMETOOLONG) {
                 static _Atomic bool overlong_warned;
@@ -2561,6 +2560,8 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
                     ds->backing_pos++;
                 continue;
             }
+            if (!on_backing)
+                seekdir(ds->dir, saved_pos);
             ret = guest_pos > 0 ? (int64_t) guest_pos : linux_errno();
             goto out;
         }
@@ -2578,6 +2579,22 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
              */
             if (!on_backing)
                 seekdir(ds->dir, saved_pos);
+
+            /* Nothing written yet means the buffer is too small for this one
+             * entry, and no larger call will ever be made on a stream the guest
+             * believes has ended. Linux answers EINVAL -- measured in docker
+             * (gcc 14.4, Linux 6.19 aarch64) over a directory holding one
+             * twelve-byte name and one two-byte name: 8 and 16 bytes report at
+             * once, and 24 bytes delivers the three names a 24-byte record can
+             * hold, one to a call, and then reports. Returning the count, zero
+             * here, is an end of directory the guest cannot tell from a real
+             * one. A call that has already written entries keeps the other half
+             * of the shape and returns their count -- the break below.
+             */
+            if (guest_pos == 0) {
+                ret = -LINUX_EINVAL;
+                goto out;
+            }
             break;
         }
 
@@ -2596,6 +2613,29 @@ int64_t sys_getdents64(guest_t *g, int fd, uint64_t buf_gva, uint64_t count)
             memset(entry_buf + pad_start, 0, reclen - pad_start);
 
         if (guest_write(g, buf_gva + guest_pos, entry_buf, reclen) < 0) {
+            /* readdir has already handed this entry over, so leaving now
+             * without putting it back resumes the next call past it: the guest
+             * gets a listing one name short that still ends at 0, which is the
+             * silent truncation this walk was repaired for on its other paths.
+             *
+             * Rewind, the shape the does-not-fit path above uses, rather than
+             * setting ds->listing_errno. The two shapes answer different
+             * questions. listing_errno is for a name the stream can never
+             * produce again -- a failed drain, a primary that stopped reading
+             * -- and it is sticky, so every later call on the fd fails. Nothing
+             * is lost here: the guest buffer could not take one entry, which is
+             * the same thing the record-does-not-fit break says, and Linux
+             * answers it the same way, by returning the short count and
+             * delivering the entry on the following call. Measured over a
+             * 96-name directory read through a buffer whose tail is unmapped,
+             * at gaps of 120, 410 and 700 bytes: Linux (docker gcc:14, 6.19
+             * aarch64) delivers all 96 names at every gap, and elfuse before
+             * this rewind lost the entry at the fault -- 97 of the 98 names the
+             * directory holds, errno 0, ending at a clean 0. The backing side
+             * rewinds by not advancing backing_pos, which it has not done yet.
+             */
+            if (!on_backing)
+                seekdir(ds->dir, saved_pos);
             ret = guest_pos > 0 ? (int64_t) guest_pos : -LINUX_EFAULT;
             goto out;
         }

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -461,6 +461,31 @@ uint64_t fd_current_generation(int guest_fd);
  */
 int fd_snapshot_and_dup(int guest_fd, fd_entry_t *out);
 
+/* The dup(2) form of the above: snapshot an fd entry and take, in the same
+ * fd_lock critical section, whatever the duplicate has to own.
+ *
+ * A directory is duplicated by sharing its stream rather than by duplicating
+ * its descriptor. dup(2) gives the alias the same open file description, so the
+ * two guest fds share one listing position -- and, because the union state a
+ * synthetic directory carries lives in that same wrapper, one union state as
+ * well. Handing the alias its own fdopendir() over a duplicated descriptor gave
+ * it a second position and a second, empty union state instead, which is how a
+ * dup'd union directory came to re-emit the backing names the source had
+ * already delivered.
+ *
+ * On a shared return the host descriptor is the source's own, already owned by
+ * the stream, so the caller must neither close it nor hand it to
+ * dir_stream_open(); it installs *out's `dir` pointer as the alias's stream and
+ * balances the reference taken here with dir_stream_release().
+ *
+ * Returns the host fd the duplicate is to be installed with -- a fresh dup for
+ * every other type, the source's own when *out_shared_dir is set -- or -1 on
+ * failure.
+ */
+int fd_snapshot_and_dup_or_share_dir(int guest_fd,
+                                     fd_entry_t *out,
+                                     bool *out_shared_dir);
+
 /* Read just the fd type under fd_lock.
  *
  * Returns FD_CLOSED for out-of-range or closed slots. Cheaper than fd_snapshot
@@ -774,6 +799,10 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap);
  * needs the descriptor to stay valid therefore holds a reference here:
  *
  *   - the fd-table slot          (released by fd_cleanup_entry)
+ *   - every other fd-table slot  (a dup shares the source's stream rather than
+ *     that aliases it           opening one, so the alias is one more slot
+ *                               reference on the same wrapper -- see
+ *                               fd_snapshot_and_dup_or_share_dir)
  *   - an in-flight getdents64    (dir_stream_acquire, syscall/fs.c)
  *   - an fd_lifetime pin         (fdtable.c, which delegates its close here)
  *
@@ -786,6 +815,65 @@ void fd_cleanup_entry(int guest_fd, const fd_entry_t *snap);
 void *dir_stream_open(int host_fd);
 void dir_stream_ref_locked(void *ds);
 void dir_stream_release(void *ds);
+
+/* The same, for the directory fds a forked child inherits.
+ *
+ * The child receives the parent's descriptor over SCM_RIGHTS, so the two
+ * processes hold one open file description, and the two halves of a union
+ * listing are worth different things across it.
+ *
+ * The primary is shared and must be read. Darwin's fdopendir() reads one host
+ * block ahead as it builds the stream and leaves the description just past it,
+ * so what the parent's open() took is in the parent's memory and the rest of
+ * the directory is still in the description for the child to read: measured
+ * over the 403-name sysroot directory tests/test-dir-union-alias stages (macOS
+ * 15.6, APFS), the parent's open takes 49 names and the child's stream reads
+ * the remaining 354. A five-name directory fits inside that one block, which is
+ * the whole reason a five-name measurement reads as all-or-nothing; it is not
+ * what a directory of any width does. So the child's stream is built like any
+ * other and walks its primary normally, and the split that falls out is real --
+ * not Linux's split, but a partition, with nothing counted twice and nothing
+ * dropped.
+ *
+ * The backing is not shared and must not be re-read. It is drained into
+ * whichever stream first runs out of primary and held there as names, so a
+ * child that drained one of its own would emit every backing name a second time
+ * -- names the parent's stream still holds and goes on to deliver.
+ * dir_stream_open() would do exactly that. This wrapper comes back with the
+ * backing half marked private instead: the drain is skipped, the walk ends when
+ * the primary does, and the parent delivers the backing once.
+ *
+ * The gap this leaves is a child whose parent closes its copy of the fd before
+ * the backing is ever drained: nobody is left holding the half the parent owns,
+ * and the child answers with its primary alone. Measured over the same two
+ * fixtures, forking and closing the parent's fd at once gives the child 354 of
+ * the plain directory's 403 names -- the 49 the parent's open had taken go with
+ * it, which is the loss any inherited stream takes -- and 0 of the union's 405,
+ * because that tree's synthetic half fits inside the block that open consumed.
+ * Linux gives the child all 403. Closing it would mean keeping the position and
+ * the union state in the description rather than in a DIR* one process owns,
+ * which is a rewrite of every directory read and is not attempted here.
+ *
+ * Suppressing the whole walk rather than just the drain is the mistake this
+ * interface exists to avoid, and it is not a small one. A stream created
+ * already at the end of its listing never reads the primary at all, so the
+ * block its own fdopendir() consumed is lost to both sides: measured over that
+ * same 403-name directory, an unread fork came back with 352 names across the
+ * pair instead of 403, with no error at either end.
+ *
+ * Linux keeps the position in the description and splits the listing there --
+ * measured in docker (gcc 14.4, Linux 6.19 aarch64) over the same fork sequence
+ * that lane runs, an unread directory fd forked and drained by the child gives
+ * the child all 403 names and the parent 0, and draining the parent first gives
+ * the parent all 403 and the child 0. elfuse cannot reproduce which side
+ * delivers, because the block the open read ahead lives in a DIR* the opener
+ * owns rather than in the description; what it can do, and what this preserves,
+ * is deliver each name exactly once across the pair. Measured over that lane's
+ * fixtures in all four states a parent can fork in -- unread, part-read, read
+ * to the end, and forked then read by the parent first -- the plain 403-name
+ * directory and the 405-name union each come back whole and without a repeat.
+ */
+void *dir_stream_open_inherited(int host_fd);
 
 /* Translation helpers. */
 

--- a/src/syscall/internal.h
+++ b/src/syscall/internal.h
@@ -918,6 +918,45 @@ static inline int64_t host_fd_ref_open_state(guest_fd_t guest_fd,
     return 0;
 }
 
+/* Pin the host fd and take the slot's whole entry together, for a caller that
+ * decides something from the slot's own record -- its stamped virtual path, say
+ * -- as well as from the descriptor. Two separate lookups of one guest fd let a
+ * close and reopen between them answer from the record of one open file
+ * description and the descriptor of another.
+ *
+ * The same shape as host_fd_ref_open_state, and the same reasoning: with one
+ * active thread there is no mutator, and with siblings alive both come from the
+ * fd_lock window inside fd_host_ref_acquire.
+ */
+static inline int64_t host_fd_ref_open_entry(guest_fd_t guest_fd,
+                                             host_fd_ref_t *ref,
+                                             fd_entry_t *snap_out)
+{
+    ref->fd = -1;
+    ref->lifetime = NULL;
+
+    /* Settle the entry before anything can fail, so a caller that reads it
+     * after a refused open reads a closed slot rather than its own stack.
+     */
+    *snap_out = (fd_entry_t) {.type = FD_CLOSED};
+
+    if (thread_is_single_active()) {
+        int host_fd = fd_to_host(guest_fd);
+        if (host_fd < 0)
+            return -LINUX_EBADF;
+        if (!fd_snapshot(guest_fd, snap_out))
+            return -LINUX_EBADF;
+        ref->fd = host_fd;
+        return 0;
+    }
+
+    int host_fd = fd_host_ref_acquire(guest_fd, snap_out, &ref->lifetime);
+    if (host_fd < 0)
+        return linux_errno();
+    ref->fd = host_fd;
+    return 0;
+}
+
 static inline void host_fd_ref_close(host_fd_ref_t *ref)
 {
     /* Preserve errno across close(2). Callers commonly invoke this on the

--- a/src/syscall/path.c
+++ b/src/syscall/path.c
@@ -18,6 +18,7 @@
 #include "utils.h"
 
 #include "runtime/procemu.h"
+#include "runtime/usb-sysfs.h"
 #include "syscall/linux-wire.h"
 #include "syscall/casefold-walk.h"
 #include "syscall/fuse.h"
@@ -530,6 +531,34 @@ int path_translate_at(guest_fd_t dirfd,
             tx->guest_path = tx->guest_buf;
             tx->intercept_path = tx->guest_buf;
             tx->fuse_path = true;
+        }
+    }
+
+    /* A /sys walk that passes through one of the synthetic USB `subsystem`
+     * symlinks is rewritten to the canonical guest spelling of where it lands,
+     * before anything decides whose name it is. The links exist only in the
+     * synthetic tree, so no other layer can resolve them: the sysroot has no
+     * such link, and a lexical fold puts the walk back in the device directory
+     * it had just left. Doing it here, once, is what makes open, stat, lstat,
+     * readlink and getdents64 answer from one name -- the union listing of
+     * `<dev>/subsystem/..` offered /sys/bus/pci while every lookup of
+     * `<dev>/subsystem/../pci` denied it, because each entry point folded the
+     * name for itself.
+     *
+     * Cheap for everything else: the prefix test rejects every path that cannot
+     * contain such a link before the USB layer is called at all.
+     */
+    if (!strncmp(tx->guest_path, "/sys/bus/usb/devices/", 21)) {
+        /* Through a local buffer, not straight into guest_buf: guest_path may
+         * already be guest_buf (the FUSE resolver above puts it there), and the
+         * rewrite reads its input while writing its output.
+         */
+        char resolved[LINUX_PATH_MAX];
+        if (usb_sysfs_resolve_guest_path(tx->guest_path, resolved,
+                                         sizeof(resolved)) == 1) {
+            str_copy_trunc(tx->guest_buf, resolved, sizeof(tx->guest_buf));
+            tx->guest_path = tx->guest_buf;
+            tx->intercept_path = tx->guest_buf;
         }
     }
 

--- a/src/syscall/poll.c
+++ b/src/syscall/poll.c
@@ -1395,6 +1395,21 @@ static bool epoll_target_pollable(int kq, int host_fd)
     return true;
 }
 
+/* A directory takes no knote on Linux whatever it is mounted from: kernfs
+ * installs its poll method on sysfs *attributes*, and sysfs_dir_operations has
+ * none, so epoll_ctl(ADD) on /sys, /sys/class or /sys/bus/usb/devices is EPERM
+ * while the attributes under them are accepted (measured on 6.x). The
+ * path-based capability answer is a per-subtree one and cannot see that
+ * distinction, so it is asked only after the object has been ruled out as a
+ * directory -- otherwise every synthetic /sys directory was accepted while the
+ * sysroot-backed directory beside it was refused, for the same guest name.
+ */
+static bool epoll_target_is_dir(int host_fd)
+{
+    struct stat st;
+    return fstat(host_fd, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
 /* Whether Linux would take this target at all. A plain file has no poll method
  * and kqueue does not mind, so that refusal originates here; fstat answers it
  * rather than the fd type, since FD_REGULAR also covers a fifo or a tty opened
@@ -1406,6 +1421,9 @@ static bool epoll_target_pollable(int kq, int host_fd)
  */
 static bool epoll_target_supported(int kq, const fd_entry_t *snap)
 {
+    if (epoll_target_is_dir(snap->host_fd))
+        return false;
+
     /* A settled path answers for itself. The kqueue probe would veto
      * /dev/random, which Linux polls and macOS refuses a knote on.
      */
@@ -1442,6 +1460,8 @@ static void epoll_undo_changes(int kq, const struct kevent *changes, int n)
  */
 static bool epoll_target_supported_standalone(const fd_entry_t *snap)
 {
+    if (epoll_target_is_dir(snap->host_fd))
+        return false;
     if (snap->path_poll_capable)
         return true;
     struct stat st;
@@ -1503,6 +1523,19 @@ int64_t sys_epoll_ctl(guest_t *g, int epfd, int op, int fd, uint64_t event_gva)
     if (!fd_snapshot(fd, &target_snap)) {
         host_fd_ref_close(&epoll_ref);
         return -LINUX_EBADF;
+    }
+
+    /* do_epoll_ctl tests file_can_poll on the target before it looks at the op,
+     * at the instance, or at whether a registration already exists, so a
+     * directory answers EPERM for every call whatever the mask says. Only the
+     * empty-mask path used to ask, which left the ordinary ADD to kqueue -- and
+     * kqueue does take an EVFILT_READ knote on a directory, which is how every
+     * synthetic /sys directory came to be accepted while the sysroot-backed
+     * directory next to it was refused.
+     */
+    if (epoll_target_is_dir(target_snap.host_fd)) {
+        host_fd_ref_close(&epoll_ref);
+        return -LINUX_EPERM;
     }
 
     /* Pin the instance so a concurrent close(epfd) cannot free it under us.

--- a/tests/test-dir-backing-drain-error.c
+++ b/tests/test-dir-backing-drain-error.c
@@ -1,0 +1,231 @@
+/*
+ * A union listing that loses names must say so, never end quietly
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Code under test: dir_backing_drain and sys_getdents64 in src/syscall/fs.c.
+ *
+ * A synthetic /sys that extends its backing drains the backing's names into the
+ * stream when the primary runs out (see usb_sysfs_dir_unions_backing). If that
+ * drain cannot deliver the whole listing -- an allocation that fails, a readdir
+ * that errors, a backing that exists but cannot be opened -- the guest must be
+ * told. The one outcome that is not acceptable is a listing that comes back
+ * short with errno 0, because the guest cannot tell it from a complete one and
+ * there is nothing it can do about what it never saw.
+ *
+ * The first drain implementation produced exactly that. It reported the error
+ * only from the call that hit it, and that call had usually already written
+ * entries, so it returned their count instead; the recorded errno was never
+ * read again, and the next call found the backing side empty and returned 0.
+ * Measured before the fix, with the drain failed after two names against a
+ * six-name backing: 3 of 9 names and errno 0, at every buffer size from 24
+ * bytes to 32KiB. Never an error.
+ *
+ * The failure is driven rather than waited for. A real ENOMEM from malloc is
+ * not something a test can arrange on demand, so ELFUSE_DIR_BACKING_FAULT makes
+ * the drain fail after a set number of names; the lane in mk/tests.mk sets it.
+ * The unreadable-backing mode needs no hook: the lane chmods the sysroot's /sys
+ * to 000 and the drain's open fails for real.
+ *
+ * Modes, one per lane invocation:
+ *   complete    no fault: the whole union listing arrives and ends at EOF.
+ *   fault       the drain fails part-way: every walk must end in an error.
+ *   unreadable  the backing cannot be opened: the walk must end in an error.
+ *
+ * Syscalls exercised: openat(56), getdents64(61), close(57)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* The union root: a /sys the USB layer synthesizes and the sysroot also has. */
+#define UNION_DIR "/sys"
+
+/* Planted in the sysroot's /sys by the lane, absent from the synthetic tree.
+ * Seeing it is what proves the union is live and this test is measuring
+ * something; the "complete" mode refuses to pass without it.
+ */
+#define MARKER "elfuse-union-marker"
+
+/* Buffer sizes the walk is repeated at. The defect was invisible to a size
+ * sweep -- it reported the same wrong answer at every one of these -- so the
+ * sweep is here to show the fix is not a single-size accident. 24 is one dirent
+ * record; 32768 takes the whole listing in one call.
+ */
+static const size_t kBufSizes[] = {24, 32, 48, 72, 96, 4096, 32768};
+#define NBUFSIZES (sizeof(kBufSizes) / sizeof(kBufSizes[0]))
+
+/* A stream that never reports its end would spin this walk forever and reach
+ * the driver as a timeout rather than as a failure.
+ */
+#define MAX_CALLS 512
+
+typedef struct {
+    unsigned long long d_ino;
+    long long d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+} linux_dirent64_t;
+
+typedef struct {
+    int names;     /* names handed to the guest before the walk ended */
+    int end_errno; /* errno the walk ended with; 0 means it ended at EOF */
+    bool saw_marker;
+    bool runaway;
+} walk_t;
+
+/* Walk UNION_DIR to its end with a @bufsz-byte buffer, reporting how it ended.
+ */
+static walk_t walk_union(size_t bufsz)
+{
+    walk_t w = {0};
+    char buf[32768];
+
+    int fd = open(UNION_DIR, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        w.end_errno = errno;
+        return w;
+    }
+
+    for (int call = 0; call < MAX_CALLS; call++) {
+        errno = 0;
+        long rc = syscall(SYS_getdents64, fd, buf, bufsz);
+        if (rc < 0) {
+            w.end_errno = errno ? errno : EIO;
+            close(fd);
+            return w;
+        }
+        if (rc == 0) { /* clean end of directory */
+            close(fd);
+            return w;
+        }
+        for (long off = 0; off < rc;) {
+            linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
+            if (!strcmp(de->d_name, MARKER))
+                w.saw_marker = true;
+            w.names++;
+            off += de->d_reclen;
+        }
+    }
+
+    w.runaway = true;
+    close(fd);
+    return w;
+}
+
+/* The longest name the fixture stages is MARKER, whose dirent record is 40
+ * bytes. A buffer under that cannot carry it however the walk behaves, so the
+ * completeness assertions below start at the first sweep size that can. What
+ * elfuse does with a buffer too small for the next record is a separate
+ * question about getdents64 itself, not about the union drain, and it is the
+ * same on a plain directory: measured here, the walk ends at EOF, where Linux
+ * (docker, gcc:13, Linux 6.10 aarch64) returns EINVAL. Untouched by this change
+ * and not asserted either way.
+ */
+#define COMPLETE_MIN_BUFSIZE 48
+
+/* The whole listing arrives, ends at EOF, and carries the sysroot's marker. */
+static void mode_complete(void)
+{
+    int full = -1;
+
+    for (size_t i = 0; i < NBUFSIZES; i++) {
+        if (kBufSizes[i] < COMPLETE_MIN_BUFSIZE)
+            continue;
+
+        char label[64];
+        snprintf(label, sizeof(label), "complete listing at %zu bytes",
+                 kBufSizes[i]);
+        TEST(label);
+
+        walk_t w = walk_union(kBufSizes[i]);
+        if (w.runaway) {
+            FAIL("walk never ended");
+            continue;
+        }
+        if (w.end_errno) {
+            errno = w.end_errno;
+            FAIL("walk failed with no fault injected");
+            continue;
+        }
+        if (!w.saw_marker) {
+            /* Without the marker the sysroot is not backing /sys here and every
+             * other assertion in this file would be vacuous.
+             */
+            FAIL("sysroot marker missing: the union is not live");
+            continue;
+        }
+
+        /* Every size that can carry the listing must agree with every other on
+         * how many names it carried.
+         */
+        if (full < 0)
+            full = w.names;
+        else if (w.names != full) {
+            fprintf(stderr, "  %d names here, %d at the previous size\n",
+                    w.names, full);
+            FAIL("buffer size changed the number of names");
+            continue;
+        }
+        PASS();
+    }
+}
+
+/* A drain that failed part-way is reported, at every buffer size, and is never
+ * allowed to look like the end of the directory.
+ */
+static void mode_error(const char *what, int want_errno)
+{
+    for (size_t i = 0; i < NBUFSIZES; i++) {
+        char label[64];
+        snprintf(label, sizeof(label), "%s reported at %zu bytes", what,
+                 kBufSizes[i]);
+        TEST(label);
+
+        walk_t w = walk_union(kBufSizes[i]);
+        if (w.runaway) {
+            FAIL("walk never ended");
+        } else if (w.end_errno == 0) {
+            /* The defect, exactly: a short listing that ends at EOF. */
+            fprintf(stderr, "  walk ended at EOF after %d names\n", w.names);
+            FAIL("truncated listing ended cleanly instead of reporting");
+        } else if (w.end_errno != want_errno) {
+            errno = w.end_errno;
+            FAIL("walk reported the wrong errno");
+        } else {
+            PASS();
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    const char *mode = argc > 1 ? argv[1] : "";
+
+    printf("test-dir-backing-drain-error: a lost union listing is reported\n");
+
+    if (!strcmp(mode, "complete")) {
+        mode_complete();
+    } else if (!strcmp(mode, "fault")) {
+        mode_error("drain failure", ENOMEM);
+    } else if (!strcmp(mode, "unreadable")) {
+        mode_error("unreadable backing", EACCES);
+    } else {
+        TEST("mode argument");
+        FAIL("expected one of: complete, fault, unreadable");
+    }
+
+    SUMMARY("test-dir-backing-drain-error");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-dir-backing-drain-error.c
+++ b/tests/test-dir-backing-drain-error.c
@@ -184,9 +184,22 @@ static void mode_complete(void)
 
 /* A drain that failed part-way is reported, at every buffer size, and is never
  * allowed to look like the end of the directory.
+ *
+ * EINVAL is the one other answer a size may legitimately give. A buffer too
+ * small to hold one record of the directory's own names ends the walk there,
+ * before the primary is exhausted and so before the drain runs at all, and
+ * Linux answers that with EINVAL (tests/test-getdents64-small-buf). The
+ * synthetic tree's widest name decides which sizes that covers, so it is a
+ * property of the build under test rather than of this fixture, and the sizes
+ * it swallows are counted rather than asserted on. What is asserted at every
+ * size regardless is the thing this lane exists for: the walk never ends at
+ * EOF. And at least one size must reach the drain, or the lane has measured
+ * nothing.
  */
 static void mode_error(const char *what, int want_errno)
 {
+    int reached_drain = 0;
+
     for (size_t i = 0; i < NBUFSIZES; i++) {
         char label[64];
         snprintf(label, sizeof(label), "%s reported at %zu bytes", what,
@@ -200,13 +213,25 @@ static void mode_error(const char *what, int want_errno)
             /* The defect, exactly: a short listing that ends at EOF. */
             fprintf(stderr, "  walk ended at EOF after %d names\n", w.names);
             FAIL("truncated listing ended cleanly instead of reporting");
+        } else if (w.end_errno == EINVAL && want_errno != EINVAL) {
+            fprintf(stderr,
+                    "  buffer too small for this tree's own names; the walk "
+                    "reported EINVAL before reaching the drain\n");
+            PASS();
         } else if (w.end_errno != want_errno) {
             errno = w.end_errno;
             FAIL("walk reported the wrong errno");
         } else {
+            reached_drain++;
             PASS();
         }
     }
+
+    TEST("some buffer size actually reached the drain");
+    if (!reached_drain)
+        FAIL("every size stopped short of the drain; nothing was measured");
+    else
+        PASS();
 }
 
 int main(int argc, char **argv)

--- a/tests/test-dir-fd-budget-union.c
+++ b/tests/test-dir-fd-budget-union.c
@@ -1,0 +1,228 @@
+/*
+ * A union directory fd must cost one host descriptor, the way a plain one does
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * test-dir-fd-budget asserts the invariant elfuse's host budget is sized on:
+ * FD_TABLE_SIZE guest fds plus HOST_FD_RESERVE, one host descriptor per guest
+ * fd (src/elfuse-limits.h). It measures that on a plain directory, which is why
+ * it could not see the one directory shape that broke the invariant.
+ *
+ * A synthetic directory that extends its backing instead of replacing it -- a
+ * /sys or /dev/bus name the USB layer does not own, see
+ * usb_sysfs_dir_unions_backing -- lists two directories through one guest fd.
+ * The first implementation held the backing open as a second stream for the
+ * lifetime of the guest fd, so such a directory cost two host descriptors as
+ * soon as anything read it to the end. Nothing caught it: the budget test never
+ * opens a union directory, and a union directory that is opened but not read
+ * never reaches the backing at all.
+ *
+ * The measurement here is therefore a difference, not an absolute: how many
+ * union directory fds the guest can hold when it only opens them, against how
+ * many it can hold when it also reads each one to the end. Driving the listing
+ * is what makes the backing appear, so a descriptor charged for the backing
+ * shows up as capacity lost between the two numbers and nowhere else. A plain
+ * sysroot directory is measured the same way as the control: it has no backing
+ * to union in, so its two numbers are what "costs nothing to read" looks like
+ * on this host.
+ *
+ * Both absolute capacities are left to the runtime rather than written down.
+ * The union root and a plain directory do not reach the same ceiling -- the
+ * synthetic tree has its own costs at open time -- so a test that compared them
+ * to each other, or to a constant, would be measuring the wrong difference.
+ *
+ * Runs with the host limit at exactly what elfuse asks for, so the extra
+ * descriptor has nowhere to hide, against a sysroot that populates /sys (see
+ * the lane in mk/tests.mk). MARKER is planted there and nowhere in the
+ * synthetic tree, so its presence in the listing proves the union is live and
+ * this lane is measuring something.
+ *
+ * Syscalls exercised: openat(56), getdents64(61), close(57)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* The union root: a /sys the USB layer synthesizes and the sysroot also has. */
+#define UNION_DIR "/sys"
+
+/* A sysroot directory under /sys with nothing synthetic in it. Reading it is
+ * the plain-directory control.
+ */
+#define PLAIN_DIR "/sys/class/net"
+
+/* Planted in the sysroot's /sys by the lane, absent from the synthetic tree. */
+#define MARKER "elfuse-union-marker"
+
+/* Descriptors already spoken for -- stdio, whatever the harness holds -- plus
+ * room for run-to-run jitter in where the ceiling lands. It cannot hide the
+ * defect this test exists to catch: a second descriptor per handle costs a
+ * fraction of the whole capacity (nearly a third, measured), not a fixed few.
+ */
+#define SLACK 24
+
+typedef struct {
+    unsigned long long d_ino;
+    long long d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+} linux_dirent64_t;
+
+/* A stream that never reports its end would spin this walk forever and reach
+ * the driver as a timeout rather than as a failure.
+ */
+#define MAX_ENTRIES 4096
+
+/* Read fd's whole listing through raw getdents64.
+ *
+ * Returns false on an unreadable or malformed stream; sets *saw_marker when
+ * MARKER was listed.
+ *
+ * Spends no second descriptor of its own -- these walks run while the guest fd
+ * table is deep into the budget being measured, and an fdopendir() here would
+ * fail with EMFILE for reasons that have nothing to do with what is under test.
+ *
+ * Every record is bounds-checked before any of it is read: reading a name that
+ * does not terminate inside its own record would run strcmp off the end of buf.
+ */
+static bool drain_dir(int fd, bool *saw_marker)
+{
+    char buf[4096];
+    int seen = 0;
+    for (;;) {
+        long n = syscall(SYS_getdents64, fd, buf, sizeof(buf));
+        if (n < 0)
+            return false;
+        if (n == 0)
+            return true;
+        const long header = (long) offsetof(linux_dirent64_t, d_name);
+        for (long off = 0; off < n;) {
+            if (n - off < header)
+                return false;
+            linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
+            long reclen = de->d_reclen;
+            if (reclen <= header || reclen > n - off)
+                return false;
+            if (!memchr(de->d_name, '\0', (size_t) (reclen - header)))
+                return false;
+            if (saw_marker && !strcmp(de->d_name, MARKER))
+                *saw_marker = true;
+            if (++seen > MAX_ENTRIES)
+                return false;
+            off += reclen;
+        }
+    }
+}
+
+static int *fds;
+static int slots;
+
+/* How many fds on @path the guest can hold at once. With @drive, each one is
+ * also read to its end before the next is opened, which is what pulls a union
+ * directory's backing into the picture.
+ *
+ * Returns -1 when a listing came back broken; a capacity of zero is reported as
+ * zero and left for the caller to judge.
+ */
+static int capacity(const char *path, bool drive, bool *saw_marker)
+{
+    int held = 0;
+    bool ok = true;
+
+    for (; held < slots; held++) {
+        fds[held] = open(path, O_RDONLY | O_DIRECTORY);
+        if (fds[held] < 0)
+            break;
+        if (drive && !drain_dir(fds[held], saw_marker)) {
+            ok = false;
+            held++;
+            break;
+        }
+    }
+
+    for (int i = 0; i < held; i++)
+        close(fds[i]);
+    return ok ? held : -1;
+}
+
+int main(void)
+{
+    printf(
+        "test-dir-fd-budget-union: a union directory costs one "
+        "host descriptor\n\n");
+
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_NOFILE, &rl) < 0) {
+        fprintf(stderr, "getrlimit: %s\n", strerror(errno));
+        return 2;
+    }
+    int limit = rl.rlim_cur > INT_MAX ? INT_MAX : (int) rl.rlim_cur;
+    if (limit <= SLACK * 4) {
+        fprintf(stderr,
+                "guest RLIMIT_NOFILE is %d, too low to measure a "
+                "descriptor budget\n",
+                limit);
+        return 2;
+    }
+
+    slots = limit + SLACK;
+    fds = calloc((size_t) slots, sizeof(*fds));
+    if (!fds) {
+        fprintf(stderr, "out of memory sizing the fd array\n");
+        return 2;
+    }
+
+    bool saw_marker = false;
+    int union_open = capacity(UNION_DIR, false, NULL);
+    int union_read = capacity(UNION_DIR, true, &saw_marker);
+    int plain_open = capacity(PLAIN_DIR, false, NULL);
+    int plain_read = capacity(PLAIN_DIR, true, NULL);
+
+    printf("  RLIMIT_NOFILE %d\n", limit);
+    printf("  %-16s open-only %5d   open+read %5d\n", UNION_DIR, union_open,
+           union_read);
+    printf("  %-16s open-only %5d   open+read %5d\n\n", PLAIN_DIR, plain_open,
+           plain_read);
+
+    /* Without this the rest of the lane would pass on a host where the union
+     * never happens, and say nothing while doing it.
+     */
+    TEST("the union is live in this lane");
+    EXPECT_TRUE(saw_marker,
+                "the sysroot's " MARKER " is missing from " UNION_DIR
+                ", so nothing here measured a union");
+
+    TEST("a plain directory reads for free");
+    EXPECT_TRUE(plain_open > SLACK && plain_read >= plain_open - SLACK,
+                "reading a plain directory cost capacity, so the "
+                "measurement itself is unsound");
+
+    TEST("a union directory reads for free");
+    if (union_open <= SLACK) {
+        FAIL("too few union directory fds to measure");
+    } else {
+        EXPECT_TRUE(union_read >= union_open - SLACK,
+                    "reading union directories cost host descriptors: "
+                    "the backing stream is being held across the "
+                    "getdents64 return");
+    }
+
+    free(fds);
+    SUMMARY("test-dir-fd-budget-union");
+    return fails ? 1 : 0;
+}

--- a/tests/test-dir-fd-budget.c
+++ b/tests/test-dir-fd-budget.c
@@ -18,6 +18,15 @@
  * measure the same thing from two directions: how many directories fit, and
  * whether dup'ing them fits too.
  *
+ * A dup costs nothing at all, which is the stronger form of the same invariant.
+ * dup(2) gives the alias the source's open file description, so the alias
+ * shares the source's stream -- one descriptor, one listing position, one union
+ * state, given back when the last of the two guest fds closes. The bound
+ * asserted below is therefore a ceiling the dup half can only come in under,
+ * and it is left as a ceiling on purpose: what must never happen is a dup
+ * costing more, and pinning it at exactly zero would make this test fail for a
+ * future dup that legitimately needed a descriptor of its own.
+ *
  * Runs with host_nofile=elfuse-minimum, which is the point: with the host limit
  * at exactly what elfuse asks for, the doubling has nowhere to hide. Before the
  * fix the first test reached 636 of a promised 1021.
@@ -76,7 +85,10 @@ static int expect_at_least(int limit)
 
 /* Enough open+dup pairs that a directory costing two descriptors would need
  * more than the whole host budget (4 * pairs > limit + HOST_FD_RESERVE), while
- * the 2 * pairs guest fds still fit under the limit.
+ * the 2 * pairs guest fds still fit under the limit. A shared alias spends no
+ * descriptor of its own, so the pairs cost half of this; the count is what a
+ * regression to a descriptor per alias would fail at, not what today's cost
+ * predicts.
  */
 static int dup_pairs(int limit)
 {
@@ -231,7 +243,7 @@ int main(void)
         FAIL("fixture entry missing from a surviving directory fd");
     close_all(fds, opened);
 
-    TEST("dup'ing directory fds costs one each");
+    TEST("dup'ing directory fds costs no more than one each");
     int paired = 0;
     for (; paired < want_pairs; paired++) {
         fds[paired] = open_fixture_dir();
@@ -260,11 +272,13 @@ int main(void)
     close_all(fds, paired);
     close_all(dups, paired);
 
-    /* The two fds hold separate streams over separate descriptors, so closing
-     * one must not take the other's descriptor with it. Checked by using the
-     * survivor as a directory rather than by reading it: a dup'd directory fd
-     * reports an empty stream on elfuse today, which predates this test and is
-     * a separate defect from the descriptor accounting under test here.
+    /* The two fds share one stream over one descriptor, held by a reference
+     * count, so closing either must not give the descriptor back while the
+     * other still names it. Checked by using the survivor as a directory rather
+     * than by reading it: the shared position means the source's own reads
+     * would have consumed the listing, and what is under test here is the
+     * descriptor's lifetime, not the listing. tests/test-dir-union-alias covers
+     * the sharing itself.
      */
     TEST("a dup outlives the fd it came from");
     bool dup_ok = false;

--- a/tests/test-dir-primary-read-error.c
+++ b/tests/test-dir-primary-read-error.c
@@ -1,0 +1,207 @@
+/*
+ * A synthetic listing that failed part-way is reported, not ended
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The union walk has two halves: the synthetic (primary) directory elfuse
+ * materialized, and the backing directory the sysroot carries under the same
+ * name. test-dir-backing-drain-error pins what the guest is told when the
+ * second half cannot be delivered. This pins the first.
+ *
+ * readdir() reports end-of-stream and failure the same way -- NULL -- and only
+ * errno separates them. The primary walk did not look: a readdir that failed
+ * part-way was taken for exhaustion, so the walk moved on to the backing as if
+ * the synthetic half were finished, dropped every synthetic name past the
+ * failure, and returned the result with a success code and errno 0. The guest
+ * saw a shorter directory, not a broken one -- which is the same silent
+ * truncation the backing half was repaired for, re-made on the other side.
+ *
+ * The failure cannot be provoked from a guest -- the primary is a scratch tree
+ * elfuse owns and readdir does not fail on it -- so ELFUSE_DIR_PRIMARY_READ_
+ * FAULT drives it after a chosen number of entries, exactly as the drain's
+ * fault hook does. Linux's shape is the one being matched: a call that has
+ * written entries returns their count and the error arrives on the next call; a
+ * call that has written nothing returns -1 with the errno; and the error is
+ * sticky, because the stream has lost names it can no longer produce.
+ *
+ * Syscalls exercised: openat(56), getdents64(61), close(57)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* The union root: a /sys the USB layer synthesizes and the sysroot also has. */
+#define UNION_DIR "/sys"
+
+/* Planted in the sysroot's /sys and nowhere in the synthetic tree. Its arrival
+ * is what "the walk went on to the backing" looks like from the guest.
+ */
+#define MARKER "elfuse-union-marker"
+
+typedef struct {
+    unsigned long long d_ino;
+    long long d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+} linux_dirent64_t;
+
+#define MAX_CALLS 256
+
+typedef struct {
+    int names;       /* names delivered before the walk stopped */
+    bool saw_marker; /* a backing name reached the guest */
+    long end_ret;    /* what the call that ended the walk returned */
+    int end_errno;   /* and with what errno */
+    bool sticky;     /* a further call answered the same way */
+    bool malformed;
+} walk_t;
+
+/* Walk UNION_DIR to whatever end it reaches, then ask once more.
+ *
+ * The buffer is the size handed to the syscall, and every record is
+ * bounds-checked before its name is read.
+ */
+static void walk(walk_t *w)
+{
+    char buf[4096];
+    memset(w, 0, sizeof(*w));
+
+    int fd = open(UNION_DIR, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        w->malformed = true;
+        return;
+    }
+
+    long n = 0;
+    for (int calls = 0; calls <= MAX_CALLS; calls++) {
+        errno = 0;
+        n = syscall(SYS_getdents64, fd, buf, sizeof(buf));
+        if (n <= 0)
+            break;
+        const long header = (long) offsetof(linux_dirent64_t, d_name);
+        for (long off = 0; off < n;) {
+            if (n - off < header) {
+                w->malformed = true;
+                close(fd);
+                return;
+            }
+            linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
+            long reclen = de->d_reclen;
+            if (reclen <= header || reclen > n - off) {
+                w->malformed = true;
+                close(fd);
+                return;
+            }
+            if (!memchr(de->d_name, '\0', (size_t) (reclen - header))) {
+                w->malformed = true;
+                close(fd);
+                return;
+            }
+            if (!strcmp(de->d_name, MARKER))
+                w->saw_marker = true;
+            w->names++;
+            off += reclen;
+        }
+    }
+    w->end_ret = n;
+    w->end_errno = n < 0 ? errno : 0;
+
+    /* Ask again. A stream that has lost names must keep saying so rather than
+     * fall through to an end of directory the guest cannot tell from a real
+     * one.
+     */
+    errno = 0;
+    long again = syscall(SYS_getdents64, fd, buf, sizeof(buf));
+    w->sticky = again < 0 && errno == w->end_errno;
+    close(fd);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s complete|fault\n", argv[0]);
+        return 2;
+    }
+    bool fault = !strcmp(argv[1], "fault");
+
+    printf(
+        "test-dir-primary-read-error: a failed synthetic read is reported "
+        "(%s)\n\n",
+        argv[1]);
+
+    walk_t w;
+    walk(&w);
+    if (w.malformed) {
+        TEST("the walk ran on a well-formed stream");
+        FAIL("the listing was malformed or the directory would not open");
+        SUMMARY("test-dir-primary-read-error");
+        return 1;
+    }
+
+    if (!fault) {
+        /* The control. Without it, the assertions below would also hold for a
+         * union that never worked.
+         */
+        TEST("an undisturbed union listing ends cleanly and is whole");
+        if (w.end_ret != 0 || w.end_errno != 0) {
+            fprintf(stderr, "  names=%d ret=%ld errno=%d\n", w.names, w.end_ret,
+                    w.end_errno);
+            FAIL("a complete union listing did not end cleanly");
+        } else if (!w.saw_marker) {
+            FAIL("the backing half never reached the guest");
+        } else if (w.names < 4) {
+            fprintf(stderr, "  names=%d\n", w.names);
+            FAIL("the union listing was too short to be the whole thing");
+        } else {
+            PASS();
+        }
+        SUMMARY("test-dir-primary-read-error");
+        return fails == 0 ? 0 : 1;
+    }
+
+    TEST("a failed synthetic read is not spelled as an end of directory");
+    if (w.end_ret != -1) {
+        fprintf(stderr, "  names=%d ret=%ld errno=%d marker=%d\n", w.names,
+                w.end_ret, w.end_errno, (int) w.saw_marker);
+        FAIL("the walk ended with success over a listing that lost names");
+    } else if (w.end_errno != EIO) {
+        fprintf(stderr, "  errno=%d\n", w.end_errno);
+        FAIL("the walk reported an errno other than the one that happened");
+    } else {
+        PASS();
+    }
+
+    /* The specific harm: with the primary mistaken for exhausted, the walk went
+     * on to the backing and handed its names over as if the synthetic half had
+     * finished. The backing must not appear in a listing whose synthetic half
+     * failed.
+     */
+    TEST("a failed synthetic read does not fall through to the backing");
+    if (w.saw_marker) {
+        FAIL("the backing was unioned in after the synthetic half failed");
+    } else {
+        PASS();
+    }
+
+    TEST("the failure outlives the call that hit it");
+    if (!w.sticky) {
+        FAIL("a later call on the same fd no longer reported the failure");
+    } else {
+        PASS();
+    }
+
+    SUMMARY("test-dir-primary-read-error");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-dir-union-alias.c
+++ b/tests/test-dir-union-alias.c
@@ -1,0 +1,566 @@
+/*
+ * An aliased directory fd shares one listing position and one union
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * dup(2) gives the alias the source's open file description, so the two guest
+ * fds share one directory position: whatever one of them reads, the other does
+ * not read again. Linux is unambiguous here -- measured in docker (gcc:14): an
+ * unread source dup'd and then drained through the alias yields the whole
+ * listing on the alias and nothing at all on the source.
+ *
+ * elfuse gave the alias a stream of its own over a duplicated descriptor. On a
+ * plain directory that made the alias come back empty, because the duplicate
+ * shares the file offset and the source's stream had already read the host
+ * directory to its end. On a *union* directory -- a /sys name the USB layer
+ * serves but does not own, whose listing is the synthetic entries followed by
+ * the backing's -- it did something worse than empty: the alias's fresh stream
+ * carried a fresh, undrained union state, so it skipped the synthetic half it
+ * had no position for and then drained and emitted the backing half a second
+ * time. The alias returned a plausible listing that was neither the whole one
+ * nor the remainder.
+ *
+ * Every route to an alias is walked, because they are four spellings of one
+ * operation and only one of them was ever exercised: dup, dup2, F_DUPFD and
+ * F_DUPFD_CLOEXEC. Closing one alias mid-listing is walked too -- the shared
+ * stream must outlive it and the survivor must deliver the remainder -- since
+ * sharing an object is what makes premature release possible.
+ *
+ * fork(2) is the fifth route. The child receives the descriptor over
+ * SCM_RIGHTS, so on Linux the position is shared for real: measured in docker
+ * (gcc 14.4, Linux 6.19 aarch64) over this same sequence on a 403-name
+ * directory, an unread fd forked and drained by the child gives the child all
+ * 403 names and the parent 0, and the parent-drains-first order gives the
+ * parent all 403 and the child 0. macOS shares the position too, but only as
+ * far as the block boundary: fdopendir() reads one host block ahead into the
+ * stream's own memory and leaves the description there, so the names already
+ * buffered go to whoever buffered them and the rest of the directory is still
+ * in the description for the other side to read. Over the 403-name plain
+ * fixture below elfuse answers the unread fork with 354 names on the child and
+ * 49 on the parent -- 49 being the block the parent's own open had already
+ * taken -- a real split at a place Linux would not have split, and one that
+ * adds up to the same 403.
+ *
+ * So what is asserted is the property, not an order and not a split: across the
+ * pair, every name of the directory appears exactly once, and the pair's total
+ * is the directory's. That is what Linux satisfies in every state, it is what a
+ * shared position means, and it fails both ways -- on a name emitted twice and
+ * on a name lost -- which is what the defect did on the two halves of the union
+ * at once. The fork routes failed it for a second reason: a fork-restored fd
+ * was given a fresh, undrained union state over a primary it also re-read, so
+ * the child drained the backing and emitted names the parent still held.
+ *
+ * Both fixtures are several hundred names wide, and that is load-bearing. An
+ * earlier revision of this lane staged three names a side, and scored 22 of 22
+ * on a build that loses a whole host block: at three names the whole listing
+ * fits inside the one block the open reads ahead, so a stream that never
+ * touches its primary has nothing left to lose. Measured on the fixtures this
+ * lane stages, an unread fork: the 403-name plain directory comes back 403
+ * across the pair here and 352 on that build -- 51 names gone, with no error --
+ * and the 405-name union comes back 405 here and 809, with 404 of its names
+ * delivered twice, on the build whose child drains the backing again. Those two
+ * builds score 20 of 22 and 10 of 22 against this lane, and 22 of 22 against
+ * the three-name one.
+ *
+ * Syscalls exercised: openat(56), dup(23), dup3(24), fcntl(25), clone(220),
+ * getdents64(61), close(57)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* The union root: a /sys the USB layer synthesizes and the sysroot also has.
+ * Staged several hundred names wide on the sysroot side, so the backing half is
+ * what dominates the listing and delivering it twice is unmissable.
+ */
+#define UNION_DIR "/sys"
+
+/* A sysroot directory with nothing synthetic in it: the plain-directory case,
+ * where the same sharing must hold for the same reason. Staged just as wide,
+ * because this is the side where a lost host block shows and the union side is
+ * where a repeated backing shows -- the two builds this lane separates are each
+ * broken on only one of them.
+ *
+ * It sits outside /sys deliberately. A directory under /sys is only plain until
+ * some later commit decides to synthesize a name in it, and this lane's whole
+ * plain half then stops measuring what it says it measures: a stream whose
+ * primary is synthetic hands a forked child nothing, so the fixture can no
+ * longer split at a host block boundary and the row that needs the split
+ * reports the fixture rather than the build. Outside /sys nothing in this layer
+ * can claim it.
+ */
+#define PLAIN_DIR "/plain-alias"
+
+typedef struct {
+    unsigned long long d_ino;
+    long long d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+} linux_dirent64_t;
+
+/* Both fixtures are several hundred names wide on purpose -- see the header
+ * comment -- so the capacity here has to clear that with room to spare, and has
+ * to hold a listing delivered twice without silently clipping it back to the
+ * right size. NAME_CAP is 64 because that is what one 64-byte getdents64 buffer
+ * can carry in a single record, which is the widest name partial_read below can
+ * ever be handed.
+ */
+#define MAX_NAMES 1024
+#define NAME_CAP 64
+#define MAX_CALLS 256
+
+/* The listing must be wider than one host directory block, or the whole class
+ * of defect this lane exists for is invisible. Measured on this fixture (macOS
+ * 15.6, APFS, elfuse over a 403-name sysroot directory): the open reads 49 of
+ * the 403 names ahead, so a stream that skips its primary loses 51 names and a
+ * three-name fixture loses none. The floor is set below the fixture's width
+ * rather than at it, so adding a name to the staging does not fail the lane,
+ * and far above one block, so removing the width does.
+ */
+#define MIN_REFERENCE_NAMES 300
+
+typedef struct {
+    char name[MAX_NAMES][NAME_CAP];
+    int count;
+    bool overflow;
+} names_t;
+
+static void names_add(names_t *ns, const char *name)
+{
+    if (ns->count >= MAX_NAMES) {
+        ns->overflow = true;
+        return;
+    }
+    snprintf(ns->name[ns->count++], NAME_CAP, "%s", name);
+}
+
+static int names_count_of(const names_t *ns, const char *name)
+{
+    int n = 0;
+    for (int i = 0; i < ns->count; i++)
+        if (!strcmp(ns->name[i], name))
+            n++;
+    return n;
+}
+
+/* Append one getdents64 call's worth of names. The buffer is the size handed to
+ * the syscall, and every record is bounds-checked before its name is read.
+ *
+ * Returns the call's return value.
+ */
+static long drain_call(int fd, size_t bufsz, names_t *ns, bool *malformed)
+{
+    char buf[4096];
+    if (bufsz > sizeof(buf)) {
+        *malformed = true;
+        return -1;
+    }
+    errno = 0;
+    long n = syscall(SYS_getdents64, fd, buf, bufsz);
+    if (n <= 0)
+        return n;
+    const long header = (long) offsetof(linux_dirent64_t, d_name);
+    for (long off = 0; off < n;) {
+        if (n - off < header) {
+            *malformed = true;
+            return n;
+        }
+        linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
+        long reclen = de->d_reclen;
+        if (reclen <= header || reclen > n - off) {
+            *malformed = true;
+            return n;
+        }
+        if (!memchr(de->d_name, '\0', (size_t) (reclen - header))) {
+            *malformed = true;
+            return n;
+        }
+        names_add(ns, de->d_name);
+        off += reclen;
+    }
+    return n;
+}
+
+/* Read fd to the end, appending every name. */
+static bool drain(int fd, names_t *ns)
+{
+    bool malformed = false;
+    for (int calls = 0; calls <= MAX_CALLS; calls++) {
+        long n = drain_call(fd, 4096, ns, &malformed);
+        if (malformed)
+            return false;
+        if (n < 0)
+            return false;
+        if (n == 0)
+            return true;
+    }
+    return false;
+}
+
+/* Every name of @want appears exactly once in @got, and @got holds nothing
+ * else. Order is never consulted.
+ *
+ * The total across the pair is checked first and reported whether or not it is
+ * the thing that broke, because it is the one number that catches both halves
+ * of the defect at once and the one number a narrow fixture cannot show: a
+ * listing that loses a host block and a listing that delivers the backing twice
+ * are both a wrong total, and at three names neither is. The per-name counts
+ * follow, and say which names, so a total that is right by cancellation -- a
+ * name lost and another duplicated -- is still caught.
+ *
+ * At several hundred names a single offending name is not a useful report, so
+ * the counts are summarized and one example of each kind is named.
+ */
+static bool same_names_once(const names_t *want,
+                            const names_t *got,
+                            char *why,
+                            size_t whysz)
+{
+    if (want->overflow || got->overflow) {
+        snprintf(why, whysz, "listing larger than the test's capacity");
+        return false;
+    }
+
+    int lost = 0, twice = 0, foreign = 0;
+    const char *lost_eg = NULL, *twice_eg = NULL, *foreign_eg = NULL;
+    for (int i = 0; i < want->count; i++) {
+        int n = names_count_of(got, want->name[i]);
+        if (n == 0) {
+            lost++;
+            if (!lost_eg)
+                lost_eg = want->name[i];
+        } else if (n > 1) {
+            twice++;
+            if (!twice_eg)
+                twice_eg = want->name[i];
+        }
+    }
+    for (int i = 0; i < got->count; i++) {
+        if (names_count_of(want, got->name[i]) == 0) {
+            foreign++;
+            if (!foreign_eg)
+                foreign_eg = got->name[i];
+        }
+    }
+
+    if (!lost && !twice && !foreign && got->count == want->count)
+        return true;
+
+    snprintf(why, whysz,
+             "%d names across the pair, want %d: %d lost (%s), %d delivered "
+             "more than once (%s), %d not in the directory at all (%s)",
+             got->count, want->count, lost, lost_eg ? lost_eg : "-", twice,
+             twice_eg ? twice_eg : "-", foreign, foreign_eg ? foreign_eg : "-");
+    return false;
+}
+
+/* The listing a single untouched fd delivers: the reference every case below is
+ * compared against.
+ */
+static bool reference(const char *dir, names_t *ns)
+{
+    int fd = open(dir, O_RDONLY | O_DIRECTORY);
+    if (fd < 0)
+        return false;
+    bool ok = drain(fd, ns);
+    close(fd);
+    return ok;
+}
+
+/* The routes an alias can arrive by. Each is the same operation -- a second
+ * guest fd on one open file description -- and the lane walks all of them
+ * because only dup() was ever walked before.
+ */
+typedef enum {
+    ROUTE_DUP,
+    ROUTE_DUP2,
+    ROUTE_DUPFD,
+    ROUTE_DUPFD_CLOEXEC,
+    ROUTE_FORK,
+} route_t;
+
+/* Slots dup2/F_DUPFD are aimed at, chosen high enough that the harness's own
+ * descriptors cannot be sitting in them.
+ */
+#define DUP2_SLOT 40
+#define DUPFD_FLOOR 50
+
+static int make_alias(route_t route, int src)
+{
+    switch (route) {
+    case ROUTE_DUP:
+        return dup(src);
+    case ROUTE_DUP2:
+        return dup2(src, DUP2_SLOT);
+    case ROUTE_DUPFD:
+        return fcntl(src, F_DUPFD, DUPFD_FLOOR);
+    case ROUTE_DUPFD_CLOEXEC:
+        return fcntl(src, F_DUPFD_CLOEXEC, DUPFD_FLOOR);
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+/* Read one small call off @src so the source has consumed part of the listing
+ * and no more. A 64-byte buffer holds a name of up to 44 bytes; nothing in the
+ * fixture is close to that, so a short call here is a real partial read rather
+ * than the entry-too-large refusal.
+ *
+ * Returns false when the partial read delivered nothing to continue from.
+ */
+static bool partial_read(int src, names_t *ns)
+{
+    bool malformed = false;
+    int before = ns->count;
+    long first = drain_call(src, 64, ns, &malformed);
+    return !malformed && first > 0 && ns->count > before;
+}
+
+/* The child half of the fork route: drain the inherited fd and report the names
+ * back one per line, then a status line the parent reads as the walk's verdict.
+ *
+ * Written with write(2) rather than stdio because the child leaves through
+ * _exit and an unflushed buffer would report an empty listing as a real one.
+ */
+static void fork_child_report(int src, int out) __attribute__((noreturn));
+static void fork_child_report(int src, int out)
+{
+    names_t got = {0};
+    bool ok = drain(src, &got);
+    for (int i = 0; i < got.count; i++) {
+        dprintf(out, "%s\n", got.name[i]);
+    }
+    dprintf(out, "%s\n", ok && !got.overflow ? "#ok" : "#broke");
+    _exit(0);
+}
+
+/* Collect the child's report into @ns.
+ *
+ * Returns false if the child's own walk did not end on a well-formed stream, or
+ * said nothing at all.
+ */
+static bool fork_collect(int in, names_t *ns)
+{
+    FILE *f = fdopen(in, "r");
+    if (!f) {
+        close(in);
+        return false;
+    }
+    char line[NAME_CAP + 8];
+    bool verdict = false, spoke = false;
+    while (fgets(line, sizeof(line), f)) {
+        line[strcspn(line, "\n")] = '\0';
+        if (!strcmp(line, "#ok")) {
+            verdict = true;
+            spoke = true;
+            continue;
+        }
+        if (!strcmp(line, "#broke")) {
+            spoke = true;
+            continue;
+        }
+        names_add(ns, line);
+    }
+    fclose(f);
+    return spoke && verdict;
+}
+
+/* One case: put @src in the state @half_read asks for, alias it by @route, and
+ * check that the pair together delivers the directory once.
+ *
+ * The two sides are drained in a fixed order -- alias (or child) first, then
+ * source -- because a shared position makes the order irrelevant to what the
+ * pair delivers, which is the whole claim.
+ */
+static void case_alias(const char *dir,
+                       route_t route,
+                       bool half_read,
+                       const char *what)
+{
+    TEST(what);
+    names_t ref = {0};
+    if (!reference(dir, &ref)) {
+        FAIL("could not read the reference listing");
+        return;
+    }
+    if (ref.count < MIN_REFERENCE_NAMES) {
+        fprintf(stderr, "  %d names, want at least %d\n", ref.count,
+                MIN_REFERENCE_NAMES);
+        FAIL("the fixture is too narrow to show a lost host block");
+        return;
+    }
+
+    int src = open(dir, O_RDONLY | O_DIRECTORY);
+    if (src < 0) {
+        FAIL("could not open the directory");
+        return;
+    }
+
+    names_t got = {0};
+    if (half_read && !partial_read(src, &got)) {
+        close(src);
+        FAIL("the partial read delivered nothing to continue from");
+        return;
+    }
+
+    bool ok;
+    if (route == ROUTE_FORK) {
+        int pipefd[2];
+        if (pipe(pipefd) < 0) {
+            close(src);
+            FAIL("could not open the pipe the child reports over");
+            return;
+        }
+        pid_t child = fork();
+        if (child < 0) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            close(src);
+            FAIL("could not fork");
+            return;
+        }
+        if (child == 0) {
+            close(pipefd[0]);
+            fork_child_report(src, pipefd[1]);
+        }
+        close(pipefd[1]);
+        bool child_ok = fork_collect(pipefd[0], &got);
+        int status = 0;
+        waitpid(child, &status, 0);
+        ok = child_ok && drain(src, &got);
+        close(src);
+    } else {
+        int alias = make_alias(route, src);
+        if (alias < 0) {
+            close(src);
+            FAIL("could not alias the directory fd");
+            return;
+        }
+        ok = drain(alias, &got) && drain(src, &got);
+        close(alias);
+        close(src);
+    }
+
+    if (!ok) {
+        FAIL("a walk over the pair did not end on a well-formed stream");
+        return;
+    }
+
+    char why[192];
+    if (same_names_once(&ref, &got, why, sizeof(why))) {
+        PASS();
+    } else {
+        fprintf(stderr, "  %s\n", why);
+        FAIL("the pair did not deliver the directory exactly once");
+    }
+}
+
+/* Closing one alias must not disturb the other. The two guest fds share one
+ * refcounted stream, so a close that took the stream down with it would leave
+ * the survivor walking freed memory -- or, if the close simply dropped the
+ * union state, restart the survivor's listing. What is asserted is the same
+ * property: the survivor delivers the remainder and the pair adds up once.
+ */
+static void case_cross_close(const char *dir, const char *what)
+{
+    TEST(what);
+    names_t ref = {0};
+    if (!reference(dir, &ref)) {
+        FAIL("could not read the reference listing");
+        return;
+    }
+    if (ref.count < MIN_REFERENCE_NAMES) {
+        fprintf(stderr, "  %d names, want at least %d\n", ref.count,
+                MIN_REFERENCE_NAMES);
+        FAIL("the fixture is too narrow to show a lost host block");
+        return;
+    }
+
+    int src = open(dir, O_RDONLY | O_DIRECTORY);
+    if (src < 0) {
+        FAIL("could not open the directory");
+        return;
+    }
+    int alias = dup(src);
+    if (alias < 0) {
+        close(src);
+        FAIL("could not dup the directory fd");
+        return;
+    }
+
+    names_t got = {0};
+    if (!partial_read(alias, &got)) {
+        close(alias);
+        close(src);
+        FAIL("the alias's partial read delivered nothing to continue from");
+        return;
+    }
+    close(alias); /* the alias goes away mid-listing */
+
+    bool ok = drain(src, &got);
+    close(src);
+    if (!ok) {
+        FAIL("the source did not survive the alias's close");
+        return;
+    }
+
+    char why[192];
+    if (same_names_once(&ref, &got, why, sizeof(why))) {
+        PASS();
+    } else {
+        fprintf(stderr, "  %s\n", why);
+        FAIL("the surviving fd did not continue the shared listing");
+    }
+}
+
+typedef struct {
+    route_t route;
+    const char *name;
+} route_desc_t;
+
+static const route_desc_t routes[] = {
+    {ROUTE_DUP, "dup"},       {ROUTE_DUP2, "dup2"},
+    {ROUTE_DUPFD, "F_DUPFD"}, {ROUTE_DUPFD_CLOEXEC, "F_DUPFD_CLOEXEC"},
+    {ROUTE_FORK, "fork"},
+};
+
+static void run_dir(const char *dir, const char *kind)
+{
+    for (size_t i = 0; i < sizeof(routes) / sizeof(routes[0]); i++) {
+        char what[64];
+        snprintf(what, sizeof(what), "%s %s unread", kind, routes[i].name);
+        case_alias(dir, routes[i].route, false, what);
+        snprintf(what, sizeof(what), "%s %s part-read", kind, routes[i].name);
+        case_alias(dir, routes[i].route, true, what);
+    }
+    char what[64];
+    snprintf(what, sizeof(what), "%s cross-close", kind);
+    case_cross_close(dir, what);
+}
+
+int main(void)
+{
+    printf(
+        "test-dir-union-alias: an alias shares one position and one union\n\n");
+
+    run_dir(PLAIN_DIR, "plain");
+    run_dir(UNION_DIR, "union");
+
+    SUMMARY("test-dir-union-alias");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-dir-union-alias.c
+++ b/tests/test-dir-union-alias.c
@@ -51,6 +51,13 @@
  * was given a fresh, undrained union state over a primary it also re-read, so
  * the child drained the backing and emitted names the parent still held.
  *
+ * One fork state is not asserted, because this cannot deliver it: a parent that
+ * closes its copy of the fd before the backing has been drained takes the
+ * backing half with it, and the child answers with its primary alone. That row
+ * is measured and printed as an XFAIL carrying both values -- Linux's and this
+ * build's -- rather than left out of the lane; see case_fork_cross_close for
+ * why it is recorded in both directions and what the two rows separate.
+ *
  * Both fixtures are several hundred names wide, and that is load-bearing. An
  * earlier revision of this lane staged three names a side, and scored 22 of 22
  * on a build that loses a whole host block: at three names the whole listing
@@ -81,6 +88,12 @@
 #include "test-harness.h"
 
 int passes = 0, fails = 0;
+
+/* Cases that neither passed nor failed: a measured divergence from Linux this
+ * build knowingly keeps, printed with both values. Counted so the summary says
+ * one is there instead of leaving a row that only reads as absent.
+ */
+static int xfails = 0;
 
 /* The union root: a /sys the USB layer synthesizes and the sysroot also has.
  * Staged several hundred names wide on the sysroot side, so the backing half is
@@ -337,9 +350,21 @@ static bool partial_read(int src, names_t *ns)
  * Written with write(2) rather than stdio because the child leaves through
  * _exit and an unflushed buffer would report an empty listing as a real one.
  */
-static void fork_child_report(int src, int out) __attribute__((noreturn));
-static void fork_child_report(int src, int out)
+static void fork_child_report(int src, int out, int gate)
+    __attribute__((noreturn));
+static void fork_child_report(int src, int out, int gate)
 {
+    /* When a gate is given, the case being walked is one whose state the parent
+     * establishes after the fork, so the child must not read before it is told.
+     * A byte on the gate is that permission; a closed gate (EOF) means the
+     * parent gave up, and the child reads anyway rather than hanging.
+     */
+    if (gate >= 0) {
+        char go;
+        read(gate, &go, 1);
+        close(gate);
+    }
+
     names_t got = {0};
     bool ok = drain(src, &got);
     for (int i = 0; i < got.count; i++) {
@@ -436,7 +461,7 @@ static void case_alias(const char *dir,
         }
         if (child == 0) {
             close(pipefd[0]);
-            fork_child_report(src, pipefd[1]);
+            fork_child_report(src, pipefd[1], -1);
         }
         close(pipefd[1]);
         bool child_ok = fork_collect(pipefd[0], &got);
@@ -528,6 +553,255 @@ static void case_cross_close(const char *dir, const char *what)
     }
 }
 
+/* The one state this cannot deliver whole, recorded rather than asserted.
+ *
+ * A child whose parent closes its copy of the fd before either side has drained
+ * the backing answers with its primary alone: the backing half belongs to the
+ * parent's stream (see dir_stream_open_inherited in src/syscall/internal.h) and
+ * that stream is gone, while the block the parent's own open() read ahead went
+ * with it. Linux keeps position and listing in the open file description, so
+ * the close costs the child nothing and it reads the directory whole.
+ *
+ * It is reported the way tests/usb-sysfs-matrix-vectors.h reports its
+ * escape-syn column: the measured Linux value is carried here as data and
+ * printed as an XFAIL beside what elfuse answers, rather than deleted from the
+ * lane. So a change in either direction shows up as a diff in the lane's output
+ * -- a child that started draining its own backing would move the elfuse number
+ * up, a widening loss would move it down -- while neither counts as a pass nor
+ * turns the lane red. The value elfuse gives today is carried too, and a
+ * departure from it is called out on the same line; nothing else in this lane
+ * holds that side.
+ *
+ * Both rows are load-bearing, because neither number alone separates the three
+ * answers. Measured here by putting each of the other two back at the one site
+ * that chooses between them, dir_stream_open_inherited: with the child allowed
+ * to drain a backing of its own -- what 54cd91e does -- the plain row still
+ * reads 354 and the union row moves to 404; with the child's stream handed back
+ * already at the end of its listing -- what 27ee83a does -- the union row still
+ * reads 0 and the plain row moves to 0. So the pair, plain 354 with union 0, is
+ * this build's answer and neither other's, and the two rows together pin the
+ * middle course between delivering the backing twice and delivering nothing.
+ *
+ * Linux side measured in docker (gcc 14.4, Linux 6.19 aarch64) over this same
+ * sequence on directories staged with this lane's two widths: the child gets
+ * all 403 names of the plain fixture and all 405 of the union's. elfuse side
+ * measured on macOS 15.6, APFS.
+ */
+static void case_fork_cross_close(const char *dir,
+                                  int linux_names,
+                                  int recorded,
+                                  const char *what)
+{
+    TEST(what);
+    names_t ref = {0};
+    if (!reference(dir, &ref)) {
+        FAIL("could not read the reference listing");
+        return;
+    }
+    if (ref.count < MIN_REFERENCE_NAMES) {
+        fprintf(stderr, "  %d names, want at least %d\n", ref.count,
+                MIN_REFERENCE_NAMES);
+        FAIL("the fixture is too narrow to show a lost host block");
+        return;
+    }
+
+    int src = open(dir, O_RDONLY | O_DIRECTORY);
+    if (src < 0) {
+        FAIL("could not open the directory");
+        return;
+    }
+    int pipefd[2], gate[2];
+    if (pipe(pipefd) < 0) {
+        close(src);
+        FAIL("could not open the pipe the child reports over");
+        return;
+    }
+    if (pipe(gate) < 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        close(src);
+        FAIL("could not open the gate the child waits on");
+        return;
+    }
+    pid_t child = fork();
+    if (child < 0) {
+        close(gate[0]);
+        close(gate[1]);
+        close(pipefd[0]);
+        close(pipefd[1]);
+        close(src);
+        FAIL("could not fork");
+        return;
+    }
+    if (child == 0) {
+        close(pipefd[0]);
+        close(gate[1]);
+        fork_child_report(src, pipefd[1], gate[0]);
+    }
+    close(pipefd[1]);
+    close(gate[0]);
+
+    /* The state being measured: the parent's copy is gone before the child has
+     * read anything, and the gate is what makes that an order rather than a
+     * race.
+     */
+    close(src);
+    ssize_t told = write(gate[1], "g", 1);
+    close(gate[1]);
+
+    names_t got = {0};
+    bool child_ok = fork_collect(pipefd[0], &got);
+    int status = 0;
+    waitpid(child, &status, 0);
+    if (told != 1 || !child_ok || got.overflow) {
+        FAIL("the child's walk did not end on a well-formed stream");
+        return;
+    }
+
+    xfails++;
+    printf("XFAIL: Linux %d, elfuse %d%s\n", linux_names, got.count,
+           got.count == recorded ? "" : " -- the recorded value moved");
+    if (got.count != recorded)
+        fprintf(stderr, "  recorded %d, now %d\n", recorded, got.count);
+}
+
+/* Two aliases inside the child, which is the dimension every case above misses:
+ * they all put the second fd on one side of the fork or the other, and this one
+ * carries a pair of aliases across it together.
+ *
+ * The parent opens the directory and dups it, so both descriptors name one open
+ * file description before the fork. The child inherits both. Nothing about
+ * elfuse's fork rebuild makes that pair share a wrapper on its own -- each
+ * inherited descriptor arrives over SCM_RIGHTS on its own, and building a
+ * stream for each gives the child two locks, two DIR* read-ahead buffers and
+ * two positions over one description -- so the child's second alias came back
+ * holding names the first had never delivered, and the first had ended at a
+ * clean 0 before them.
+ *
+ * What is asserted is the alias property, not a count: after the child has
+ * drained the first alias to its end, the second delivers nothing, and no name
+ * arrives twice. Both halves hold on Linux for any pair of fds on one
+ * description, so neither needs measuring; the count the child reaches is the
+ * inherited-stream loss the fork cross-close row already records, and is
+ * deliberately not asserted here.
+ *
+ * The plain fixture only. The union fixture's child answers with nothing at all
+ * (see case_fork_cross_close), so both halves would hold vacuously there.
+ */
+static void case_child_aliases(const char *dir, const char *what)
+{
+    TEST(what);
+    int src = open(dir, O_RDONLY | O_DIRECTORY);
+    if (src < 0) {
+        FAIL("could not open the directory");
+        return;
+    }
+    int alias = dup(src);
+    if (alias < 0) {
+        close(src);
+        FAIL("could not dup the directory fd");
+        return;
+    }
+    int pipefd[2];
+    if (pipe(pipefd) < 0) {
+        close(alias);
+        close(src);
+        FAIL("could not open the pipe the child reports over");
+        return;
+    }
+    pid_t child = fork();
+    if (child < 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        close(alias);
+        close(src);
+        FAIL("could not fork");
+        return;
+    }
+    if (child == 0) {
+        close(pipefd[0]);
+
+        /* First alias to its end, then the second. The marker between them is
+         * what lets the parent tell which side a name came from; a name after
+         * it is a name the first alias's end-of-listing had already denied.
+         */
+        names_t first = {0}, second = {0};
+        bool ok = drain(src, &first);
+        ok = drain(alias, &second) && ok;
+        for (int i = 0; i < first.count; i++)
+            dprintf(pipefd[1], "%s\n", first.name[i]);
+        dprintf(pipefd[1], "#split\n");
+        for (int i = 0; i < second.count; i++)
+            dprintf(pipefd[1], "%s\n", second.name[i]);
+        dprintf(pipefd[1], "%s\n",
+                ok && !first.overflow && !second.overflow ? "#ok" : "#broke");
+        _exit(0);
+    }
+    close(pipefd[1]);
+
+    /* The parent's copies go away: it never reads, and holding them would leave
+     * the child's answer depending on when they closed.
+     */
+    close(alias);
+    close(src);
+
+    names_t first = {0}, second = {0};
+    FILE *f = fdopen(pipefd[0], "r");
+    if (!f) {
+        close(pipefd[0]);
+        FAIL("could not read the child's report");
+        return;
+    }
+    char line[NAME_CAP + 8];
+    bool split = false, verdict = false, spoke = false;
+    while (fgets(line, sizeof(line), f)) {
+        line[strcspn(line, "\n")] = '\0';
+        if (!strcmp(line, "#split")) {
+            split = true;
+            continue;
+        }
+        if (!strcmp(line, "#ok")) {
+            verdict = true;
+            spoke = true;
+            continue;
+        }
+        if (!strcmp(line, "#broke")) {
+            spoke = true;
+            continue;
+        }
+        names_add(split ? &second : &first, line);
+    }
+    fclose(f);
+    int status = 0;
+    waitpid(child, &status, 0);
+
+    if (!spoke || !verdict || !split || first.overflow || second.overflow) {
+        FAIL("the child's walk over the pair did not end well-formed");
+        return;
+    }
+    if (first.count < MIN_REFERENCE_NAMES) {
+        fprintf(stderr, "  the child's first alias delivered %d names\n",
+                first.count);
+        FAIL("the fixture is too narrow to split at a host block boundary");
+        return;
+    }
+
+    const char *twice = NULL;
+    for (int i = 0; i < second.count && !twice; i++)
+        if (names_count_of(&first, second.name[i]))
+            twice = second.name[i];
+    if (second.count) {
+        fprintf(stderr,
+                "  the first alias ended at 0 with %d names, then the second "
+                "delivered %d more (%s%s)\n",
+                first.count, second.count, second.name[0],
+                twice ? ", and repeated one" : "");
+        FAIL("the child's two aliases split one listing between them");
+    } else {
+        PASS();
+    }
+}
+
 typedef struct {
     route_t route;
     const char *name;
@@ -539,7 +813,10 @@ static const route_desc_t routes[] = {
     {ROUTE_FORK, "fork"},
 };
 
-static void run_dir(const char *dir, const char *kind)
+static void run_dir(const char *dir,
+                    const char *kind,
+                    int linux_names,
+                    int recorded)
 {
     for (size_t i = 0; i < sizeof(routes) / sizeof(routes[0]); i++) {
         char what[64];
@@ -551,6 +828,8 @@ static void run_dir(const char *dir, const char *kind)
     char what[64];
     snprintf(what, sizeof(what), "%s cross-close", kind);
     case_cross_close(dir, what);
+    snprintf(what, sizeof(what), "%s fork cross-close", kind);
+    case_fork_cross_close(dir, linux_names, recorded, what);
 }
 
 int main(void)
@@ -558,9 +837,18 @@ int main(void)
     printf(
         "test-dir-union-alias: an alias shares one position and one union\n\n");
 
-    run_dir(PLAIN_DIR, "plain");
-    run_dir(UNION_DIR, "union");
+    /* The two numbers each row carries: what Linux answers, and what this build
+     * answers. Both measured -- see case_fork_cross_close.
+     */
+    run_dir(PLAIN_DIR, "plain", 403, 354);
+    run_dir(UNION_DIR, "union", 405, 0);
+    case_child_aliases(PLAIN_DIR, "plain two aliases inside the child");
 
     SUMMARY("test-dir-union-alias");
+    if (xfails)
+        printf(
+            "%d expected failure%s printed above, neither passed nor "
+            "failed\n",
+            xfails, xfails == 1 ? "" : "s");
     return fails == 0 ? 0 : 1;
 }

--- a/tests/test-dir-union-fd-reuse.c
+++ b/tests/test-dir-union-fd-reuse.c
@@ -1,0 +1,227 @@
+/*
+ * A union walk answers for the directory it pinned, not for the fd number
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * getdents64 pins the directory stream for the length of the call, so a sibling
+ * thread's close() -- or a close() and reopen that lands on the same number --
+ * cannot free it underneath the walk. The stream survived that; the
+ * descriptor's *identity* did not. The backing half of a union listing was
+ * looked up by re-reading fd_table[fd] part-way through the call, which is a
+ * different question from the one the pin answered: by then the number could
+ * name nothing at all, or a different file.
+ *
+ * Both outcomes were silent. With the number closed, the backing lookup found
+ * no stamped path, contributed nothing, and the walk ended -- handing back the
+ * synthetic entries alone, with a success return and errno 0, which the guest
+ * reads as a complete listing. With the number reused, the walk would have
+ * drained some other directory's names into this one.
+ *
+ * The window is real and far too narrow to reach unaided (measured: no
+ * cross-listing in 353k walks with two threads hammering close and dup2 on the
+ * walked fd), so the lane widens it with ELFUSE_DIR_UNION_BACKING_DELAY_US and
+ * closes the fd inside it. What is asserted is not the timing but the answer:
+ * the walk must deliver the whole union -- synthetic names and the backing's
+ * MARKER alike -- or say it could not. A short listing reported as success is
+ * the one result that must never appear.
+ *
+ * Syscalls exercised: openat(56), getdents64(61), close(57), clone(220)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* The union root: a /sys the USB layer synthesizes and the sysroot also has. */
+#define UNION_DIR "/sys"
+
+/* Planted in the sysroot's /sys by the lane, absent from the synthetic tree, so
+ * its presence proves the backing half of the union was delivered.
+ */
+#define MARKER "elfuse-union-marker"
+
+/* Synthesized by the USB layer and absent from the sysroot: the other half. */
+#define SYNTH "bus"
+
+typedef struct {
+    unsigned long long d_ino;
+    long long d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+} linux_dirent64_t;
+
+/* A stream that never reports its end would spin this walk forever. */
+#define MAX_CALLS 256
+
+typedef struct {
+    int fd;
+    int delay_us;
+    bool reopen;
+} disturb_t;
+
+/* Close the walked fd from under the walk, once the walk is inside the widened
+ * drain window. With `reopen`, claim the freed number with a different
+ * directory as well, which is the other half of the same defect.
+ */
+static void *disturb(void *arg)
+{
+    disturb_t *d = arg;
+    usleep((useconds_t) (d->delay_us / 2));
+    close(d->fd);
+    if (d->reopen) {
+        int other = open("/", O_RDONLY | O_DIRECTORY);
+        if (other >= 0 && other != d->fd) {
+            dup2(other, d->fd);
+            close(other);
+        }
+    }
+    return NULL;
+}
+
+/* Walk @fd to the end, recording what was seen and how it ended.
+ *
+ * The buffer is the size passed to the syscall, so a full call cannot write
+ * past it. Every record is bounds-checked before its name is read.
+ */
+static bool walk(int fd,
+                 bool *saw_marker,
+                 bool *saw_synth,
+                 long *end_ret,
+                 int *end_errno)
+{
+    char buf[4096];
+    int calls = 0;
+    long n;
+    *saw_marker = *saw_synth = false;
+    for (;;) {
+        if (++calls > MAX_CALLS)
+            return false;
+        errno = 0;
+        n = syscall(SYS_getdents64, fd, buf, sizeof(buf));
+        if (n <= 0)
+            break;
+        const long header = (long) offsetof(linux_dirent64_t, d_name);
+        for (long off = 0; off < n;) {
+            if (n - off < header)
+                return false;
+            linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
+            long reclen = de->d_reclen;
+            if (reclen <= header || reclen > n - off)
+                return false;
+            if (!memchr(de->d_name, '\0', (size_t) (reclen - header)))
+                return false;
+            if (!strcmp(de->d_name, MARKER))
+                *saw_marker = true;
+            if (!strcmp(de->d_name, SYNTH))
+                *saw_synth = true;
+            off += reclen;
+        }
+    }
+    *end_ret = n;
+    *end_errno = n < 0 ? errno : 0;
+    return true;
+}
+
+static void one_case(const char *what, bool reopen, int delay_us)
+{
+    TEST(what);
+    int fd = open(UNION_DIR, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        FAIL("could not open the union directory");
+        return;
+    }
+
+    disturb_t d = {.fd = fd, .delay_us = delay_us, .reopen = reopen};
+    pthread_t th;
+    if (pthread_create(&th, NULL, disturb, &d) != 0) {
+        close(fd);
+        FAIL("could not start the disturbing thread");
+        return;
+    }
+
+    bool saw_marker, saw_synth;
+    long rc = 0;
+    int err = 0;
+    bool ok = walk(fd, &saw_marker, &saw_synth, &rc, &err);
+    pthread_join(th, NULL);
+
+    if (!ok) {
+        FAIL("the walk did not terminate on a well-formed stream");
+        return;
+    }
+
+    /* Two answers are allowed, and only two. Either the walk delivered the
+     * whole union -- it pinned the directory before the number went away, so
+     * this is what the fixed path does -- or it reported a failure. What must
+     * never happen is a clean end of directory over a listing that lost a half.
+     */
+    if (rc < 0) {
+        PASS();
+        return;
+    }
+    if (saw_marker && saw_synth) {
+        PASS();
+        return;
+    }
+    fprintf(stderr, "  rc=%ld errno=%d marker=%d synthetic=%d\n", rc, err,
+            (int) saw_marker, (int) saw_synth);
+    FAIL("a listing that lost a half was reported as a clean end of directory");
+}
+
+int main(void)
+{
+    const char *env = getenv("ELFUSE_DIR_UNION_BACKING_DELAY_US");
+    int delay_us = env ? atoi(env) : 0;
+    if (delay_us <= 0) {
+        fprintf(
+            stderr,
+            "ELFUSE_DIR_UNION_BACKING_DELAY_US must be set for this lane\n");
+        return 2;
+    }
+
+    printf(
+        "test-dir-union-fd-reuse: a union walk answers for what it pinned\n\n");
+
+    /* A control first: undisturbed, the same walk must deliver both halves, or
+     * the two cases below would pass on a listing that was never whole.
+     */
+    TEST("an undisturbed union walk delivers both halves");
+    int fd = open(UNION_DIR, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        FAIL("could not open the union directory");
+    } else {
+        bool saw_marker, saw_synth;
+        long rc = 0;
+        int err = 0;
+        bool ok = walk(fd, &saw_marker, &saw_synth, &rc, &err);
+        close(fd);
+        if (!ok || rc != 0 || !saw_marker || !saw_synth) {
+            fprintf(stderr, "  rc=%ld errno=%d marker=%d synthetic=%d\n", rc,
+                    err, (int) saw_marker, (int) saw_synth);
+            FAIL("the control listing was not whole");
+        } else {
+            PASS();
+        }
+    }
+
+    one_case("a close during the drain does not shorten the listing", false,
+             delay_us);
+    one_case("a close and reuse during the drain does not divert the listing",
+             true, delay_us);
+
+    SUMMARY("test-dir-union-fd-reuse");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-fstatfs-fd-identity.c
+++ b/tests/test-fstatfs-fd-identity.c
@@ -1,0 +1,180 @@
+/*
+ * fstatfs answers for the descriptor it pinned, not for the fd number
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Code under test: sys_fstatfs in src/syscall/fs-stat.c.
+ *
+ * A descriptor's filesystem identity is decided from two things: the virtual
+ * path stamped on its slot when this layer served the open, and, when there is
+ * no stamp, the host path the descriptor itself resolves to. Those used to be
+ * two separate lookups of the same guest fd -- fd_snapshot for the stamp, then
+ * host_fd_ref_open for the descriptor -- so a close and reopen in between gave
+ * the stamp of one open file description and the descriptor of another, and the
+ * answer belonged to neither.
+ *
+ * The lane drives it in the direction that shows: a plain sysroot file, whose
+ * slot carries no stamp, is replaced during the window by a descriptor on a
+ * /sys directory that fell through to the sysroot. Split, the call reads "no
+ * stamp" off the plain file and then resolves the /sys descriptor that took the
+ * number, and reports SYSFS_MAGIC for a call that latched onto a plain file.
+ * Taken together, the two agree and it reports the sysroot's own filesystem.
+ *
+ * The window is far too narrow to reach unaided -- over 160 runs at four
+ * delays, a sibling swap between the two lookups was never distinguishable in
+ * the answer -- so the lane widens it with ELFUSE_FD_IDENTITY_WINDOW_US and
+ * swaps the slot inside it. What is asserted is not the timing: whichever
+ * description the call latches, the filesystem it names has to be that one's.
+ * The control run, with no sibling at all, pins both answers this file relies
+ * on being different.
+ *
+ * The paths are passed by the lane in mk/tests.mk: argv[1] is a plain file in
+ * the sysroot, argv[2] a /sys directory the sysroot supplies and this layer
+ * does not synthesize.
+ *
+ * Syscalls exercised: openat(56), fstatfs(44), dup3(24), clone(220)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+#define SYSFS_MAGIC 0x62656572
+
+/* Long enough that the swap lands inside the widened window with room on both
+ * sides, and short enough that the lane stays quick. The lane sets the delay to
+ * WINDOW_US; the sibling waits SWAP_AFTER_US into it.
+ */
+#define SWAP_AFTER_US 40000
+
+typedef struct {
+    const char *sys_dir; /* opened and dup2'd onto the target */
+    int target_fd;       /* the guest fd number being answered for */
+    volatile int go;     /* raised by the main thread just before the call */
+    int swapped;         /* the sibling's dup2 result */
+} swap_arg_t;
+
+static void *swapper(void *p)
+{
+    swap_arg_t *a = p;
+    while (!a->go)
+        usleep(1000);
+    usleep(SWAP_AFTER_US);
+    int n = open(a->sys_dir, O_RDONLY | O_DIRECTORY);
+    if (n < 0) {
+        a->swapped = -1;
+        return NULL;
+    }
+    a->swapped = dup2(n, a->target_fd);
+    close(n);
+    return NULL;
+}
+
+/* The filesystem fstatfs reports for @fd: 1 for sysfs, 0 for anything else, -1
+ * when the call failed.
+ */
+static int fs_is_sysfs(int fd)
+{
+    struct statfs sf;
+    if (fstatfs(fd, &sf) < 0)
+        return -1;
+    return (unsigned long) sf.f_type == SYSFS_MAGIC ? 1 : 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s <plain-file> <sys-dir>\n", argv[0]);
+        return 2;
+    }
+    const char *plain = argv[1];
+    const char *sys_dir = argv[2];
+
+    /* The control. Neither answer is assumed: the lane is only meaningful if a
+     * plain sysroot file and a fallen-through /sys directory report different
+     * filesystems, so both are measured here before anything is raced.
+     */
+    TEST("a plain sysroot file is not sysfs");
+    int fd = open(plain, O_RDONLY);
+    if (fd < 0) {
+        FAIL("could not open the plain file");
+        return 1;
+    }
+    int plain_fs = fs_is_sysfs(fd);
+    close(fd);
+    if (plain_fs != 0) {
+        fprintf(stderr, "  fstatfs said %d\n", plain_fs);
+        FAIL("the plain file did not report an ordinary filesystem");
+    } else {
+        PASS();
+    }
+
+    TEST("a /sys directory the sysroot supplies is sysfs");
+    fd = open(sys_dir, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        FAIL("could not open the /sys directory");
+        return 1;
+    }
+    int sys_fs = fs_is_sysfs(fd);
+    close(fd);
+    if (sys_fs != 1) {
+        fprintf(stderr, "  fstatfs said %d\n", sys_fs);
+        FAIL("the /sys directory did not report sysfs");
+    } else {
+        PASS();
+    }
+
+    /* The race. The descriptor the call latches is the plain file, because the
+     * swap happens after it has entered the call; whatever it reports has to be
+     * that file's filesystem and not the one that took the number afterwards.
+     */
+    TEST("a swap inside the window does not decide the answer");
+    int target = open(plain, O_RDONLY);
+    if (target < 0) {
+        FAIL("could not open the plain file");
+        return 1;
+    }
+    swap_arg_t arg = {
+        .sys_dir = sys_dir, .target_fd = target, .go = 0, .swapped = -2};
+    pthread_t th;
+    if (pthread_create(&th, NULL, swapper, &arg) != 0) {
+        close(target);
+        FAIL("could not start the swapping thread");
+        return 1;
+    }
+    arg.go = 1;
+    int raced = fs_is_sysfs(target);
+    pthread_join(th, NULL);
+
+    /* The swap has to have happened, or the run proves nothing. */
+    bool swapped = arg.swapped == target;
+    int after = fs_is_sysfs(target);
+    close(target);
+
+    if (!swapped) {
+        fprintf(stderr, "  the sibling's dup2 returned %d\n", arg.swapped);
+        FAIL("the slot was never replaced, so the window was not exercised");
+    } else if (after != 1) {
+        fprintf(stderr, "  after the swap fstatfs said %d\n", after);
+        FAIL("the slot does not hold the /sys descriptor after the swap");
+    } else if (raced != 0) {
+        fprintf(stderr, "  the raced call said %d, the plain file is %d\n",
+                raced, plain_fs);
+        FAIL("fstatfs reported the filesystem of the slot's replacement");
+    } else {
+        PASS();
+    }
+
+    SUMMARY("test-fstatfs-fd-identity");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-getdents64-small-buf.c
+++ b/tests/test-getdents64-small-buf.c
@@ -1,0 +1,371 @@
+/*
+ * A getdents64 buffer too small for one entry reports, it does not end
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Code under test: sys_getdents64 in src/syscall/fs.c.
+ *
+ * A dirent64 record is a 19-byte header plus the name and its NUL, rounded up,
+ * so a 24-byte buffer holds a name of four bytes and nothing longer. Asked for
+ * a listing in a buffer that cannot hold its next name, sys_getdents64 used to
+ * break out of the walk with nothing written and return 0. The guest reads 0 as
+ * the end of the directory, so every name too long for the buffer disappeared
+ * with nothing said, and no larger call was ever made because the stream looked
+ * finished.
+ *
+ * Linux answers that call with EINVAL. Measured in docker (gcc:13, Linux 6.19
+ * aarch64) over a directory holding one twelve-byte name and one two-byte name:
+ * getdents64 with a 24-byte buffer returns the short name and then -1 EINVAL,
+ * and buffers of 8 and 16 return -1 EINVAL immediately, while a buffer large
+ * enough for the longest name delivers the whole listing.
+ *
+ * The two halves of the shape are both pinned here: a call that has already
+ * written entries returns their count and leaves the error for the next call,
+ * and a call that writes nothing returns -1 with the errno.
+ *
+ * The buffer that stops the walk part-way is pinned here too. A guest buffer
+ * whose tail is unmapped takes the entries that fit and faults on the next one,
+ * and the entry that could not be written has already been read off the host
+ * stream. Linux delivers it on the following call; elfuse used to leave it
+ * behind, so the guest saw a listing one name short that ended at 0 -- the
+ * silent truncation this file's other cases exist to close, reached through the
+ * one exit from the walk that never rewound.
+ *
+ * The fixture directory is passed as argv[1] by the lane in mk/tests.mk.
+ *
+ * Syscalls exercised: openat(56), getdents64(61), close(57)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+#ifndef SYS_getdents64
+#define SYS_getdents64 61
+#endif
+
+int passes = 0, fails = 0;
+
+typedef struct {
+    unsigned long long d_ino;
+    long long d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[];
+} linux_dirent64_t;
+
+/* The lane plants exactly these two names beside "." and ".." */
+#define LONG_NAME "aaaaaaaaaaaa" /* 12 bytes: needs 32, not 24 */
+#define SHORT_NAME "bb"          /* 2 bytes: fits 24 */
+
+/* A stream that never reports its end would spin this walk forever. */
+#define MAX_CALLS 256
+
+/* The walk buffer is the largest request any caller below makes, and the walk
+ * refuses anything larger. getdents64 writes up to the size it is given, so a
+ * buffer smaller than that size is a buffer the guest kernel is invited to
+ * overrun -- which stayed invisible only because the fixture was small enough
+ * that no call ever filled it. The wide fixture makes it visible.
+ */
+#define WALK_BUF_MAX 4096
+
+
+/* Names delivered by a walk, so two walks can be compared by name rather than
+ * by count: an entry dropped at a fault and an entry never reached both lower
+ * the count, and only the names say which happened.
+ */
+#define NAME_CAP 64
+#define NAMES_MAX 256
+
+typedef struct {
+    char name[NAMES_MAX][NAME_CAP];
+    int count;
+    int overflow;
+} names_t;
+
+static void names_add(names_t *ns, const char *name)
+{
+    if (ns->count >= NAMES_MAX) {
+        ns->overflow = 1;
+        return;
+    }
+    snprintf(ns->name[ns->count++], NAME_CAP, "%s", name);
+}
+
+static int names_has(const names_t *ns, const char *name)
+{
+    for (int i = 0; i < ns->count; i++)
+        if (!strcmp(ns->name[i], name))
+            return 1;
+    return 0;
+}
+
+/* Collect one getdents64 result into @ns. */
+static void names_collect(names_t *ns, const char *buf, long rc)
+{
+    for (long off = 0; off < rc;) {
+        const linux_dirent64_t *de = (const linux_dirent64_t *) (buf + off);
+        names_add(ns, de->d_name);
+        off += de->d_reclen;
+    }
+}
+
+/* Walk @dir with @bufsz-byte calls.
+ *
+ * Returns the number of names delivered, and writes how the walk ended into
+ * *@end_ret / *@end_errno.
+ */
+static int walk(const char *dir,
+                size_t bufsz,
+                long *end_ret,
+                int *end_errno,
+                int *saw_long)
+{
+    char buf[WALK_BUF_MAX];
+
+    /* Never hand the syscall a length this buffer cannot absorb. */
+    if (bufsz > sizeof(buf)) {
+        *end_ret = -1;
+        *end_errno = 0;
+        return -1;
+    }
+
+    int fd = (int) syscall(SYS_openat, -100, dir, O_RDONLY | O_DIRECTORY, 0);
+    if (fd < 0) {
+        *end_ret = -1;
+        *end_errno = errno;
+        return -1;
+    }
+
+    int names = 0, calls = 0;
+    long rc;
+    *saw_long = 0;
+    for (;;) {
+        if (++calls > MAX_CALLS) {
+            close(fd);
+            *end_ret = -1;
+            *end_errno = 0;
+            return -1;
+        }
+        errno = 0;
+        rc = syscall(SYS_getdents64, fd, buf, bufsz);
+        if (rc <= 0)
+            break;
+        for (long off = 0; off < rc;) {
+            linux_dirent64_t *de = (linux_dirent64_t *) (buf + off);
+            names++;
+            if (!strcmp(de->d_name, LONG_NAME))
+                *saw_long = 1;
+            off += de->d_reclen;
+        }
+    }
+    *end_ret = rc;
+    *end_errno = rc < 0 ? errno : 0;
+    close(fd);
+    return names;
+}
+
+
+/* Read @dir into @ns through a buffer whose tail is not mapped.
+ *
+ * Two pages are mapped and the second one dropped, so the buffer handed to the
+ * kernel starts @gap bytes before a hole. The call writes the entries that fit
+ * and faults on the first one that crosses; the rest of the listing is then
+ * read through a buffer that is entirely mapped, which is what a guest does
+ * after a short return. What must survive is the entry the faulting call read
+ * off the host stream and could not place.
+ *
+ * Returns 0, or -1 when the fixture could not be set up.
+ */
+static int walk_faulting(const char *dir, size_t gap, names_t *ns)
+{
+    long pagesz = sysconf(_SC_PAGESIZE);
+    if (pagesz <= 0 || gap >= (size_t) pagesz)
+        return -1;
+
+    char *m = mmap(NULL, (size_t) pagesz * 2, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (m == MAP_FAILED)
+        return -1;
+    if (munmap(m + pagesz, (size_t) pagesz) < 0) {
+        munmap(m, (size_t) pagesz * 2);
+        return -1;
+    }
+    char *buf = m + pagesz - gap;
+
+    int fd = (int) syscall(SYS_openat, -100, dir, O_RDONLY | O_DIRECTORY, 0);
+    if (fd < 0) {
+        munmap(m, (size_t) pagesz);
+        return -1;
+    }
+
+    errno = 0;
+    long rc = syscall(SYS_getdents64, fd, buf, (size_t) pagesz);
+    if (rc > 0)
+        names_collect(ns, buf, rc);
+    munmap(m, (size_t) pagesz);
+
+    /* Whatever the faulting call answered, the guest reads on. */
+    if (rc > 0) {
+        char safe[WALK_BUF_MAX];
+        int calls = 0;
+        for (;;) {
+            if (++calls > MAX_CALLS)
+                break;
+            errno = 0;
+            rc = syscall(SYS_getdents64, fd, safe, sizeof(safe));
+            if (rc <= 0)
+                break;
+            names_collect(ns, safe, rc);
+        }
+    }
+    close(fd);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 4) {
+        fprintf(stderr, "usage: %s <fixture-dir> <wide-dir> <wide-names>\n",
+                argv[0]);
+        return 2;
+    }
+    const char *dir = argv[1];
+
+    /* A second fixture, wide enough that one full-size call writes more than a
+     * few hundred bytes. The narrow fixture cannot serve here: it is sized so
+     * that exactly one of its names fails to fit a 24-byte record, and adding
+     * names to it would put that one name at a host-chosen position in the
+     * listing and make the 24-byte count below depend on enumeration order.
+     */
+    const char *wide_dir = argv[2];
+    const int wide_names = atoi(argv[3]);
+    long rc;
+    int err, names, saw_long;
+
+    /* A buffer smaller than any record: the very first call writes nothing. */
+    for (size_t bufsz = 8; bufsz <= 16; bufsz += 8) {
+        TEST("a buffer too small for any entry reports EINVAL");
+        names = walk(dir, bufsz, &rc, &err, &saw_long);
+        if (names != 0 || rc != -1 || err != EINVAL) {
+            fprintf(stderr, "  bufsz=%zu names=%d ret=%ld errno=%d\n", bufsz,
+                    names, rc, err);
+            FAIL("did not report EINVAL on an entry-sized-buffer failure");
+        } else {
+            PASS();
+        }
+    }
+
+    /* 24 bytes holds ".", "..", "bb" and not LONG_NAME. The calls that wrote
+     * those entries returned their counts; the call that can write nothing
+     * reports.
+     */
+    TEST("a listing cut short by the buffer reports rather than ending");
+    names = walk(dir, 24, &rc, &err, &saw_long);
+    if (rc != -1 || err != EINVAL) {
+        fprintf(stderr, "  names=%d ret=%ld errno=%d saw_long=%d\n", names, rc,
+                err, saw_long);
+        FAIL("truncated listing ended cleanly instead of reporting");
+    } else if (saw_long) {
+        FAIL("the long name fitted a 24-byte buffer; fixture is wrong");
+    } else if (names < 3) {
+        fprintf(stderr, "  names=%d\n", names);
+        FAIL("the entries that did fit were not delivered before the error");
+    } else {
+        PASS();
+    }
+
+    /* The other half of the shape: room for the longest name, whole listing. */
+    TEST("a buffer that fits every entry delivers the whole listing");
+    names = walk(dir, WALK_BUF_MAX, &rc, &err, &saw_long);
+    if (rc != 0 || err != 0) {
+        fprintf(stderr, "  names=%d ret=%ld errno=%d\n", names, rc, err);
+        FAIL("a listing that fits did not end cleanly");
+    } else if (!saw_long) {
+        FAIL("the long name is missing from a listing with room for it");
+    } else if (names != 4) {
+        fprintf(stderr, "  names=%d\n", names);
+        FAIL("unexpected visible entry count");
+    } else {
+        PASS();
+    }
+
+    /* A full-size call over a directory whose listing needs more than a few
+     * hundred bytes. The count is order-independent -- every name is delivered
+     * whatever order the host enumerates them in -- and what it pins is that
+     * the walk survives writing a full buffer at all.
+     */
+    TEST("a full-size call absorbs a listing that fills its buffer");
+    names = walk(wide_dir, WALK_BUF_MAX, &rc, &err, &saw_long);
+    if (rc != 0 || err != 0) {
+        fprintf(stderr, "  names=%d ret=%ld errno=%d\n", names, rc, err);
+        FAIL("a wide listing did not end cleanly");
+    } else if (names != wide_names + 2) {
+        fprintf(stderr, "  names=%d want=%d\n", names, wide_names + 2);
+        FAIL("the wide listing lost or gained entries");
+    } else {
+        PASS();
+    }
+
+
+    /* A buffer that faults part-way. The entry the call could not place was
+     * already taken off the host stream, so unless the walk rewinds, the next
+     * call resumes past it and the name is gone from a listing that still ends
+     * at 0. The gap is swept because where the hole falls decides which entry
+     * is the one that cannot be written, and a single gap could land on "."
+     * where the loss is easy to miss.
+     */
+    for (size_t gap = 120; gap <= 700; gap += 290) {
+        TEST("an entry a faulting buffer could not take is delivered later");
+        names_t whole = {0}, faulted = {0};
+        int fd = (int) syscall(SYS_openat, -100, wide_dir,
+                               O_RDONLY | O_DIRECTORY, 0);
+        if (fd < 0) {
+            FAIL("could not open the wide fixture");
+            continue;
+        }
+        char big[WALK_BUF_MAX];
+        long r;
+        while ((r = syscall(SYS_getdents64, fd, big, sizeof(big))) > 0)
+            names_collect(&whole, big, r);
+        close(fd);
+
+        if (walk_faulting(wide_dir, gap, &faulted) < 0) {
+            FAIL("could not stage a buffer that ends in an unmapped page");
+            continue;
+        }
+        if (whole.overflow || faulted.overflow) {
+            FAIL("the fixture holds more names than the lane can record");
+            continue;
+        }
+        const char *lost = NULL;
+        for (int i = 0; i < whole.count; i++) {
+            if (!names_has(&faulted, whole.name[i])) {
+                lost = whole.name[i];
+                break;
+            }
+        }
+        if (whole.count != wide_names + 2) {
+            fprintf(stderr, "  reference names=%d want=%d\n", whole.count,
+                    wide_names + 2);
+            FAIL("the reference listing is not the whole fixture");
+        } else if (lost) {
+            fprintf(stderr, "  gap=%zu delivered %d of %d, first missing %s\n",
+                    gap, faulted.count, whole.count, lost);
+            FAIL("the entry the faulting call could not write was dropped");
+        } else {
+            PASS();
+        }
+    }
+
+    SUMMARY("test-getdents64-small-buf");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-usb-sysfs-matrix.c
+++ b/tests/test-usb-sysfs-matrix.c
@@ -1,0 +1,762 @@
+/*
+ * Entry-point x path-class matrix for the synthetic /sys and /dev/bus views
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Code under test: the ours/not-ours decision in src/runtime/usb-sysfs.c
+ * (classify_and_normalize + usb_resolve_or_disown), the getdents64 union in
+ * src/syscall/fs.c, the access arm of sys_faccessat, and the fd-side sysfs
+ * identity in sys_fstatfs (src/syscall/fs-stat.c).
+ *
+ * The layer synthesizes exactly one subtree on each side, /sys/bus/usb and
+ * /dev/bus/usb, on top of a backing /sys and /dev/bus that a sysroot supplies.
+ * Its contract is not per-syscall: a name is this layer's or it is not, and
+ * every entry point has to answer from that one decision. Four regressions all
+ * came from an entry point re-deriving it -- lstat/open(O_NOFOLLOW)/readlink
+ * shadowed the backing because their resolve succeeded where stat's failed,
+ * getdents64 replaced the backing listing instead of extending it, /dev/bus had
+ * no fall-through arm at all while access(2) fell through anyway, and fstatfs
+ * never saw the sysfs identity statfs was handing out. Pinning them one
+ * assertion at a time is what let them appear, so this is a matrix instead:
+ * every entry point against every path class, so a fix that unifies one pair
+ * and splits another cannot pass.
+ *
+ * EXPECTED VALUES ARE MEASURED, NOT ASSUMED. Every cell below was recorded by
+ * running this same binary natively on Linux (docker gcc:14, aarch64, kernel
+ * 6.x) with MATRIX_RECORD=1, over a /sys that is a real sysfs and a /dev/bus
+ * carrying a mknod'd usb node next to a foreign bus directory. Re-record with:
+ *
+ *   docker run --rm -v "$PWD:/w" -w /w gcc:14 sh -c \
+ *     'mkdir -p /dev/bus/usb/001 /dev/bus/other && : > /dev/bus/other/f && \
+ *      mknod /dev/bus/usb/001/001 c 189 0 && \
+ *      gcc -D MATRIX_STANDALONE -o /tmp/m tests/test-usb-sysfs-matrix.c && \
+ *      MATRIX_RECORD=1 /tmp/m'
+ *
+ * Cells the guest cannot match byte-for-byte are recorded per class rather than
+ * per spelling; see the notes on COL_SUBSYS and COL_NODE.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/stat.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+
+#ifdef MATRIX_STANDALONE
+/* Recording build: runs natively on Linux with no elfuse harness. */
+#include <sys/syscall.h>
+static int passes, fails;
+#define EXPECT_TRUE(cond, msg)                    \
+    do {                                          \
+        if (cond)                                 \
+            passes++;                             \
+        else                                      \
+            (fails++, printf("FAIL: %s\n", msg)); \
+    } while (0)
+#else
+#include "test-harness.h"
+int passes = 0, fails = 0;
+#endif
+
+#define SYSFS_MAGIC 0x62656572
+#define CELL_MAX 24
+
+/* path classes (columns) */
+enum {
+    COL_SYNTH_DIR,  /* a directory this layer synthesizes */
+    COL_BACK_SYS,   /* a /sys name the backing owns and we do not */
+    COL_BACK_DEV,   /* a /dev/bus name the backing owns and we do not */
+    COL_SUBSYS,     /* a subsystem symlink inside a device directory */
+    COL_ESCAPE,     /* a '..' chain that leaves the tree entirely */
+    COL_ESCAPE_SYN, /* the same, but transiting the synthetic subtree */
+    COL_NODE,       /* a /dev/bus/usb device node */
+    COL_ABSENT,     /* a name absent on both sides */
+    COL_LONG,       /* a /sys spelling longer than the 63-byte fd stamp */
+    COL_SYS_ROOT,   /* /sys itself: synthetic and backed at once */
+    COL_DEV_BUS,    /* /dev/bus itself: synthetic and backed at once */
+    COL_SUBSYS_OUT, /* a walk through the subsystem link and back out of usb */
+    COL_COUNT,
+};
+
+static const char *col_name[COL_COUNT] = {
+    "synth-dir", "back-sys", "back-dev", "subsys",   "escape",  "escape-syn",
+    "usb-node",  "absent",   "long-sys", "sys-root", "dev-bus", "subsys-out",
+};
+
+/* COL_SUBSYS is the one spelling that cannot be shared: the recording host's
+ * bus carries whatever devices it has, and the guest's carries the fixture's.
+ * Both are "the subsystem link of some /sys/bus/usb/devices/<dev>", which is
+ * the class under test, so the spelling is discovered rather than hardcoded.
+ */
+static char subsys_path[512];
+
+/* COL_SUBSYS_OUT is the same link walked *through* rather than named: the
+ * kernel applies the '..' after it to what the link resolved to, so
+ * <dev>/subsystem/.. is /sys/bus and <dev>/subsystem/../pci is /sys/bus/pci --
+ * a bus this layer does not model, which only the backing has.
+ *
+ * It is the column that catches ownership being decided on the lexical fold.
+ * That fold reads the same name as <dev>/pci, which starts with bus/usb and so
+ * looks like ours, and an absence under our own subtree is authoritative: every
+ * lookup answered ENOENT while the *listing* of <dev>/subsystem/.. was offering
+ * `pci` from the backing in the same breath. Derived from subsys_path so it
+ * follows whichever device the host actually has.
+ */
+static char subsys_out_path[512];
+
+/* COL_LONG is a >63-byte spelling of a synthetic sysfs *attribute*, not of a
+ * backing file: the 63-byte virtual-path stamp a descriptor carries is only
+ * written for the names this layer serves, so that is where a truncation would
+ * cut a component in half. It is built by repeating "<dev>/.." until the
+ * spelling passes the stamp's width, which also puts a '..' behind the
+ * devices/<dev> symlink -- Linux applies it to what the link resolved to, and
+ * the same object has to come back out. The device name differs between the
+ * recording host and the guest fixture, so it is discovered too.
+ */
+static char long_path[512];
+
+static const char *col_path(int c)
+{
+    switch (c) {
+    case COL_SYNTH_DIR:
+        return "/sys/bus/usb/devices";
+    case COL_BACK_SYS:
+        return "/sys/class";
+    case COL_BACK_DEV:
+        return "/dev/bus/other/f";
+    case COL_SUBSYS:
+        return subsys_path;
+    case COL_ESCAPE:
+        return "/sys/class/../../etc/hostname";
+    case COL_ESCAPE_SYN:
+        return "/sys/bus/usb/../../../etc/hostname";
+    case COL_NODE:
+        return "/dev/bus/usb/001/001";
+    case COL_ABSENT:
+        return "/sys/no-such-name-here";
+    case COL_LONG:
+        return long_path;
+    case COL_SYS_ROOT:
+        return "/sys";
+    case COL_SUBSYS_OUT:
+        return subsys_out_path;
+    default:
+        return "/dev/bus";
+    }
+}
+
+/* Names that must be listed by the union directories, one comma-free name per
+ * entry, NULL-terminated. Empty for the columns where enumeration is not the
+ * property under test.
+ */
+static const char *col_union_names[COL_COUNT][5] = {
+    [COL_SYS_ROOT] = {"bus", "class", "kernel", "devices", NULL},
+    [COL_DEV_BUS] = {"usb", "other", NULL},
+};
+
+
+static void discover_long(void)
+{
+    strcpy(long_path, "/sys/bus/usb/devices/@none@/bInterfaceNumber");
+    DIR *d = opendir("/sys/bus/usb/devices");
+    if (!d)
+        return;
+    struct dirent *e;
+    while ((e = readdir(d))) {
+        if (e->d_name[0] == '.')
+            continue;
+        char cand[512];
+        struct stat st;
+        snprintf(cand, sizeof(cand), "/sys/bus/usb/devices/%s/bInterfaceNumber",
+                 e->d_name);
+        if (stat(cand, &st) != 0 || !S_ISREG(st.st_mode))
+            continue;
+        char acc[512];
+        snprintf(acc, sizeof(acc), "/sys/bus/usb/devices/%s", e->d_name);
+        while (strlen(acc) + strlen(e->d_name) + 21 <= 63) {
+            char next[512];
+            snprintf(next, sizeof(next), "%s/../%s", acc, e->d_name);
+            strcpy(acc, next);
+        }
+        snprintf(long_path, sizeof(long_path), "%s/../%s/bInterfaceNumber", acc,
+                 e->d_name);
+        break;
+    }
+    closedir(d);
+}
+
+static void discover_subsys(void)
+{
+    strcpy(subsys_path, "/sys/bus/usb/devices/@none@/subsystem");
+    DIR *d = opendir("/sys/bus/usb/devices");
+    if (!d)
+        return;
+    struct dirent *e;
+    while ((e = readdir(d))) {
+        if (e->d_name[0] == '.')
+            continue;
+        char cand[512];
+        struct stat st;
+        snprintf(cand, sizeof(cand), "/sys/bus/usb/devices/%s/subsystem",
+                 e->d_name);
+        if (lstat(cand, &st) == 0 && S_ISLNK(st.st_mode)) {
+            strcpy(subsys_path, cand);
+            break;
+        }
+    }
+    closedir(d);
+    snprintf(subsys_out_path, sizeof(subsys_out_path), "%s/../pci",
+             subsys_path);
+}
+
+/* cell encodings */
+
+static void enc_rc(char *out, int rc)
+{
+    if (rc >= 0)
+        snprintf(out, CELL_MAX, "ok");
+    else
+        snprintf(out, CELL_MAX, "E%d", errno);
+}
+
+static char type_char(mode_t m)
+{
+    if (S_ISDIR(m))
+        return 'd';
+    if (S_ISLNK(m))
+        return 'l';
+    if (S_ISCHR(m))
+        return 'c';
+    if (S_ISREG(m))
+        return 'f';
+    return '?';
+}
+
+static void enc_stat(char *out, int rc, const struct stat *st)
+{
+    if (rc < 0)
+        snprintf(out, CELL_MAX, "E%d", errno);
+    else
+        snprintf(out, CELL_MAX, "ok:%c", type_char(st->st_mode));
+}
+
+static void enc_fs(char *out, int rc, const struct statfs *sf)
+{
+    if (rc < 0)
+        snprintf(out, CELL_MAX, "E%d", errno);
+    else
+        snprintf(out, CELL_MAX, "%s",
+                 (unsigned long) sf->f_type == SYSFS_MAGIC ? "sysfs" : "other");
+}
+
+/* Split a path into a parent directory fd and the trailing component, for the
+ * *at() rows: they must reach the same answer through a relative walk that the
+ * absolute spelling reaches directly.
+ */
+static int parent_fd(const char *path, char *base, size_t basesz)
+{
+    const char *slash = strrchr(path, '/');
+    if (!slash || slash == path)
+        return -1;
+    char dir[512];
+    size_t n = (size_t) (slash - path);
+    if (n >= sizeof(dir) || strlen(slash + 1) >= basesz)
+        return -1;
+    memcpy(dir, path, n);
+    dir[n] = '\0';
+    snprintf(base, basesz, "%s", slash + 1);
+    return open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+}
+
+/* rows */
+
+typedef void (*row_fn)(const char *path, char *out);
+
+static void r_open(const char *p, char *out)
+{
+    int fd = open(p, O_RDONLY);
+    enc_rc(out, fd);
+    if (fd >= 0)
+        close(fd);
+}
+
+static void r_open_nofollow(const char *p, char *out)
+{
+    int fd = open(p, O_RDONLY | O_NOFOLLOW);
+    enc_rc(out, fd);
+    if (fd >= 0)
+        close(fd);
+}
+
+static void r_openat(const char *p, char *out)
+{
+    char base[256];
+    int dfd = parent_fd(p, base, sizeof(base));
+    if (dfd < 0) {
+        snprintf(out, CELL_MAX, "skip");
+        return;
+    }
+    int fd = openat(dfd, base, O_RDONLY);
+    enc_rc(out, fd);
+    if (fd >= 0)
+        close(fd);
+    close(dfd);
+}
+
+static void r_stat(const char *p, char *out)
+{
+    struct stat st;
+    enc_stat(out, stat(p, &st), &st);
+}
+
+static void r_lstat(const char *p, char *out)
+{
+    struct stat st;
+    enc_stat(out, lstat(p, &st), &st);
+}
+
+static void r_fstatat_nofollow(const char *p, char *out)
+{
+    struct stat st;
+    enc_stat(out, fstatat(AT_FDCWD, p, &st, AT_SYMLINK_NOFOLLOW), &st);
+}
+
+static void r_fstatat_dirfd(const char *p, char *out)
+{
+    char base[256];
+    int dfd = parent_fd(p, base, sizeof(base));
+    if (dfd < 0) {
+        snprintf(out, CELL_MAX, "skip");
+        return;
+    }
+    struct stat st;
+    int rc = fstatat(dfd, base, &st, 0);
+    enc_stat(out, rc, &st);
+    close(dfd);
+}
+
+/* The subset of Linux's struct statx this row reads. Declared here rather than
+ * taken from the guest libc's headers, which do not all carry it; the syscall
+ * itself is what the row exists to exercise, and it is present on every kernel
+ * elfuse targets. Only the leading fields up to st_mode are named -- the rest
+ * is reserved space the kernel fills and this row does not read -- and the
+ * whole struct is 256 bytes, which the kernel requires.
+ */
+struct linux_statx {
+    uint32_t stx_mask;
+    uint32_t stx_blksize;
+    uint64_t stx_attributes;
+    uint32_t stx_nlink;
+    uint32_t stx_uid;
+    uint32_t stx_gid;
+    uint16_t stx_mode;
+    uint16_t stx_pad1;
+    uint64_t stx_ino;
+    uint8_t stx_rest[256 - 40];
+};
+
+#ifndef SYS_statx
+#define SYS_statx 291
+#endif
+#ifndef STATX_BASIC_STATS
+#define STATX_BASIC_STATS 0x000007ffU
+#endif
+
+static void r_statx(const char *p, char *out)
+{
+    /* The real syscall, not fstatat. statx has its own handler in elfuse -- its
+     * own AT_* validation and its own result writer -- so a row that reached it
+     * through fstatat proved nothing about it: a regression isolated to statx
+     * would have left this row green while claiming to cover it.
+     */
+    struct linux_statx stx;
+    memset(&stx, 0, sizeof(stx));
+    int rc = (int) syscall(SYS_statx, AT_FDCWD, p, AT_NO_AUTOMOUNT,
+                           STATX_BASIC_STATS, &stx);
+    if (rc < 0)
+        snprintf(out, CELL_MAX, "E%d", errno);
+    else
+        snprintf(out, CELL_MAX, "ok:%c", type_char((mode_t) stx.stx_mode));
+}
+
+static void r_access(const char *p, char *out)
+{
+    enc_rc(out, access(p, F_OK));
+}
+
+static void r_faccessat_nofollow(const char *p, char *out)
+{
+    enc_rc(out, faccessat(AT_FDCWD, p, F_OK, AT_SYMLINK_NOFOLLOW));
+}
+
+static void r_readlink(const char *p, char *out)
+{
+    char buf[512];
+    ssize_t n = readlink(p, buf, sizeof(buf));
+    enc_rc(out, n < 0 ? -1 : 0);
+}
+
+static void r_readlinkat(const char *p, char *out)
+{
+    char base[256], buf[512];
+    int dfd = parent_fd(p, base, sizeof(base));
+    if (dfd < 0) {
+        snprintf(out, CELL_MAX, "skip");
+        return;
+    }
+    ssize_t n = readlinkat(dfd, base, buf, sizeof(buf));
+    enc_rc(out, n < 0 ? -1 : 0);
+    close(dfd);
+}
+
+static void r_getdents(const char *p, char *out)
+{
+    DIR *d = opendir(p);
+    if (!d) {
+        enc_rc(out, -1);
+        return;
+    }
+    while (readdir(d))
+        ;
+    closedir(d);
+    snprintf(out, CELL_MAX, "ok");
+}
+
+static void r_statfs(const char *p, char *out)
+{
+    struct statfs sf;
+    enc_fs(out, statfs(p, &sf), &sf);
+}
+
+static void r_fstatfs(const char *p, char *out)
+{
+    /* O_PATH so a symlink column reports its own filesystem rather than its
+     * target's, and so a device node is not opened for I/O.
+     */
+    int fd = open(p, O_RDONLY | O_PATH | O_NOFOLLOW);
+    if (fd < 0) {
+        enc_rc(out, -1);
+        return;
+    }
+    struct statfs sf;
+    enc_fs(out, fstatfs(fd, &sf), &sf);
+    close(fd);
+}
+
+static void r_fstat_type(const char *p, char *out)
+{
+    /* The identity an opened descriptor reports has to be the identity the path
+     * side gave the same name: libusb fstats the node it just opened and
+     * refuses anything that is not a character device.
+     */
+    int fd = open(p, O_RDONLY | O_PATH | O_NOFOLLOW);
+    if (fd < 0) {
+        enc_rc(out, -1);
+        return;
+    }
+    struct stat st;
+    enc_stat(out, fstat(fd, &st), &st);
+    close(fd);
+}
+
+static void r_chdir(const char *p, char *out)
+{
+    int rc = chdir(p);
+    enc_rc(out, rc);
+    if (rc == 0 && chdir("/") != 0)
+        snprintf(out, CELL_MAX, "stuck");
+}
+
+static void r_fchdir(const char *p, char *out)
+{
+    int fd = open(p, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd < 0) {
+        enc_rc(out, -1);
+        return;
+    }
+    int rc = fchdir(fd);
+    enc_rc(out, rc);
+    close(fd);
+    if (rc == 0 && chdir("/") != 0)
+        snprintf(out, CELL_MAX, "stuck");
+}
+
+static void r_epoll_ctl(const char *p, char *out)
+{
+    int ep = epoll_create1(0);
+    if (ep < 0) {
+        enc_rc(out, -1);
+        return;
+    }
+    int fd = open(p, O_RDONLY);
+    if (fd < 0) {
+        enc_rc(out, -1);
+        close(ep);
+        return;
+    }
+    struct epoll_event ev = {.events = EPOLLIN, .data.fd = fd};
+    enc_rc(out, epoll_ctl(ep, EPOLL_CTL_ADD, fd, &ev));
+    close(fd);
+    close(ep);
+}
+
+/* The union rows do not encode "how many entries"; they encode whether each
+ * name that must survive the merge is listed. Counts differ between the
+ * recording host and the guest fixture, presence does not.
+ */
+static void r_union(const char *p, char *out)
+{
+    snprintf(out, CELL_MAX, "n/a");
+}
+
+static const struct {
+    const char *name;
+    row_fn fn;
+} rows[] = {
+    {"open", r_open},
+    {"open_nofollow", r_open_nofollow},
+    {"openat_dirfd", r_openat},
+    {"stat", r_stat},
+    {"lstat", r_lstat},
+    {"fstatat_nofollow", r_fstatat_nofollow},
+    {"fstatat_dirfd", r_fstatat_dirfd},
+    {"statx", r_statx},
+    {"access", r_access},
+    {"faccessat_nofollow", r_faccessat_nofollow},
+    {"readlink", r_readlink},
+    {"readlinkat_dirfd", r_readlinkat},
+    {"getdents64", r_getdents},
+    {"statfs", r_statfs},
+    {"fstatfs", r_fstatfs},
+    {"fstat_type", r_fstat_type},
+    {"chdir", r_chdir},
+    {"fchdir", r_fchdir},
+    {"epoll_ctl", r_epoll_ctl},
+    {"union_listing", r_union},
+};
+#define NROWS ((int) (sizeof(rows) / sizeof(rows[0])))
+
+/* The measured Linux answers. Rows in the order above, columns in col_name
+ * order. "-" means the recording host could not present this class (noted per
+ * cell below) and the guest is not held to a value it was never measured
+ * against.
+ */
+static const char *expect[NROWS][COL_COUNT] = {
+#include "usb-sysfs-matrix-vectors.h"
+};
+
+static bool listed(const char *dir, const char *name)
+{
+    DIR *d = opendir(dir);
+    if (!d)
+        return false;
+    bool found = false;
+    struct dirent *e;
+    while ((e = readdir(d))) {
+        if (!strcmp(e->d_name, name)) {
+            found = true;
+            break;
+        }
+    }
+    closedir(d);
+    return found;
+}
+
+static void record(void)
+{
+    for (int r = 0; r < NROWS; r++) {
+        printf("    /* %-18s */ {", rows[r].name);
+        for (int c = 0; c < COL_COUNT; c++) {
+            char cell[CELL_MAX];
+            errno = 0;
+            if (!strcmp(rows[r].name, "union_listing")) {
+                if (!col_union_names[c][0])
+                    snprintf(cell, sizeof(cell), "n/a");
+                else {
+                    bool all = true;
+                    for (int i = 0; col_union_names[c][i]; i++)
+                        all = all && listed(col_path(c), col_union_names[c][i]);
+                    snprintf(cell, sizeof(cell), all ? "all" : "missing");
+                }
+            } else {
+                rows[r].fn(col_path(c), cell);
+            }
+            printf("\"%s\"%s", cell, c + 1 < COL_COUNT ? ", " : "");
+        }
+        printf("},\n");
+    }
+}
+
+int main(void)
+{
+    discover_subsys();
+    discover_long();
+
+    if (getenv("MATRIX_RECORD")) {
+        record();
+        return 0;
+    }
+
+    for (int r = 0; r < NROWS; r++) {
+        for (int c = 0; c < COL_COUNT; c++) {
+            const char *want = expect[r][c];
+            if (!want || !strcmp(want, "-"))
+                continue;
+
+            /* A leading '?' marks a cell whose Linux value was measured but is
+             * knowingly not met here; the header names each one and why. It is
+             * reported rather than asserted, so a divergence stays visible in
+             * the lane's output instead of being deleted from the matrix.
+             */
+            bool xfail = want[0] == '?';
+            if (xfail)
+                want++;
+
+            char cell[CELL_MAX], msg[256];
+            errno = 0;
+            if (!strcmp(rows[r].name, "union_listing")) {
+                if (!col_union_names[c][0])
+                    snprintf(cell, sizeof(cell), "n/a");
+                else {
+                    /* Collect the missing names; do not assert on them. The
+                     * cell comparison below is the one assertion for this cell,
+                     * and asserting here as well reported a single broken
+                     * listing as two failures -- once per absent name and once
+                     * for "want all got missing" -- which overstates what the
+                     * lane found. The names are printed so the one failure
+                     * still says which they were.
+                     */
+                    char missing[192];
+                    size_t mlen = 0;
+                    missing[0] = '\0';
+                    for (int i = 0; col_union_names[c][i]; i++) {
+                        if (listed(col_path(c), col_union_names[c][i]))
+                            continue;
+                        const char *sep = mlen ? "," : "";
+                        int n = snprintf(missing + mlen, sizeof(missing) - mlen,
+                                         "%s%s", sep, col_union_names[c][i]);
+                        if (n < 0 || (size_t) n >= sizeof(missing) - mlen) {
+                            mlen = strlen(missing);
+                            break;
+                        }
+                        mlen += (size_t) n;
+                    }
+                    if (missing[0])
+                        printf("  union_listing [%s] %s: not listed: %s\n",
+                               col_name[c], col_path(c), missing);
+                    snprintf(cell, sizeof(cell),
+                             missing[0] ? "missing" : "all");
+                }
+            } else {
+                rows[r].fn(col_path(c), cell);
+            }
+
+            if (xfail) {
+                if (strcmp(cell, want))
+                    printf("XFAIL: %s [%s] %s: Linux %s, elfuse %s\n",
+                           rows[r].name, col_name[c], col_path(c), want, cell);
+                continue;
+            }
+            snprintf(msg, sizeof(msg), "%s [%s] %s: want %s got %s",
+                     rows[r].name, col_name[c], col_path(c), want, cell);
+            EXPECT_TRUE(!strcmp(cell, want), msg);
+        }
+    }
+
+    /* The same invariant on the one directory that is reached *through* a
+     * synthetic symlink: /sys/bus, named as <dev>/subsystem/.. . Every name it
+     * lists has to be openable by the spelling that listed it. No measurement
+     * is needed -- it holds on every filesystem -- and it is the disagreement
+     * itself rather than a consequence of it: the listing here offered `pci`
+     * from the backing while every lookup of <dev>/subsystem/../pci answered
+     * ENOENT, because enumeration asked whose the resolved name was and the
+     * lookups asked whose the lexically folded one was.
+     */
+    {
+        char parent[512];
+        snprintf(parent, sizeof(parent), "%s/..", subsys_path);
+        TEST("every name listed through the subsystem link opens");
+        DIR *d = opendir(parent);
+        if (!d) {
+            FAIL("the directory behind the subsystem link would not list");
+        } else {
+            struct dirent *e;
+            char denied[256];
+            denied[0] = '\0';
+            while ((e = readdir(d))) {
+                if (!strcmp(e->d_name, ".") || !strcmp(e->d_name, ".."))
+                    continue;
+                char full[1024];
+                snprintf(full, sizeof(full), "%s/%s", parent, e->d_name);
+                struct stat st;
+                if (stat(full, &st) == 0)
+                    continue;
+                snprintf(denied, sizeof(denied), "%s (errno %d)", e->d_name,
+                         errno);
+                break;
+            }
+            closedir(d);
+            if (denied[0]) {
+                fprintf(stderr, "  %s listed %s but the lookup denied it\n",
+                        parent, denied);
+                FAIL("a listed name could not be looked up");
+            } else {
+                PASS();
+            }
+        }
+    }
+
+    /* One invariant rather than a recorded cell, because it holds on every
+     * filesystem and needs no measurement: the descriptor open() returns names
+     * the object stat() described, so their (st_dev, st_ino) and file type
+     * agree. It is not implied by the fstat_type row above, which opens with
+     * O_PATH -- the read-only open is the one libusb makes, and it was the one
+     * that used to hand back elfuse's staging file: S_IFREG with a zero rdev
+     * where stat reported the character device 189:minor.
+     *
+     * The recording host cannot open its device-less usb node, so the pair is
+     * simply skipped wherever either call fails; every column that opens is
+     * checked on both sides.
+     */
+    for (int c = 0; c < COL_COUNT; c++) {
+        struct stat by_name, by_fd;
+        if (stat(col_path(c), &by_name) != 0)
+            continue;
+        int fd = open(col_path(c), O_RDONLY);
+        if (fd < 0)
+            continue;
+        if (fstat(fd, &by_fd) != 0) {
+            close(fd);
+            continue;
+        }
+        close(fd);
+
+        char msg[256];
+        snprintf(msg, sizeof(msg),
+                 "fd identity [%s] %s: stat says %c dev/ino %llu/%llu, fstat "
+                 "says %c %llu/%llu",
+                 col_name[c], col_path(c), type_char(by_name.st_mode),
+                 (unsigned long long) by_name.st_dev,
+                 (unsigned long long) by_name.st_ino, type_char(by_fd.st_mode),
+                 (unsigned long long) by_fd.st_dev,
+                 (unsigned long long) by_fd.st_ino);
+        EXPECT_TRUE(type_char(by_name.st_mode) == type_char(by_fd.st_mode) &&
+                        by_name.st_dev == by_fd.st_dev &&
+                        by_name.st_ino == by_fd.st_ino,
+                    msg);
+    }
+
+    printf("\n%d passed, %d failed\n", passes, fails);
+    return fails ? 1 : 0;
+}

--- a/tests/test-usb-sysfs-matrix.c
+++ b/tests/test-usb-sysfs-matrix.c
@@ -54,9 +54,15 @@
 #include <unistd.h>
 
 #ifdef MATRIX_STANDALONE
-/* Recording build: runs natively on Linux with no elfuse harness. */
+/* Recording build: runs natively on Linux with no elfuse harness. The four
+ * harness macros the assertions below use are spelled out here rather than
+ * included, because test-harness.h is built for the guest side.
+ */
 #include <sys/syscall.h>
 static int passes, fails;
+#define TEST(name) printf("  %-30s ", name)
+#define PASS() (printf("OK\n"), passes++)
+#define FAIL(msg) (printf("FAIL: %s\n", msg), fails++)
 #define EXPECT_TRUE(cond, msg)                    \
     do {                                          \
         if (cond)                                 \
@@ -85,13 +91,19 @@ enum {
     COL_LONG,       /* a /sys spelling longer than the 63-byte fd stamp */
     COL_SYS_ROOT,   /* /sys itself: synthetic and backed at once */
     COL_DEV_BUS,    /* /dev/bus itself: synthetic and backed at once */
+    COL_SHADOW,     /* a backing name inside a subtree this layer owns */
     COL_SUBSYS_OUT, /* a walk through the subsystem link and back out of usb */
+    COL_FOLD_OUT, /* a '..' out of /dev/bus/usb onto a name the backing owns */
+    COL_FOLD_IN,  /* a '..' out of a foreign bus and back into /dev/bus/usb */
+    COL_SYS_FOLD_IN, /* a '..' out of a backing /sys name and back into ours */
     COL_COUNT,
 };
 
 static const char *col_name[COL_COUNT] = {
-    "synth-dir", "back-sys", "back-dev", "subsys",   "escape",  "escape-syn",
-    "usb-node",  "absent",   "long-sys", "sys-root", "dev-bus", "subsys-out",
+    "synth-dir",  "back-sys",     "back-dev",    "subsys",
+    "escape",     "escape-syn",   "usb-node",    "absent",
+    "long-sys",   "sys-root",     "dev-bus",     "shadow",
+    "subsys-out", "dev-fold-out", "dev-fold-in", "sys-fold-in",
 };
 
 /* COL_SUBSYS is the one spelling that cannot be shared: the recording host's
@@ -149,12 +161,60 @@ static const char *col_path(int c)
         return long_path;
     case COL_SYS_ROOT:
         return "/sys";
+    case COL_SHADOW:
+        return "/dev/bus/usb/099/001";
     case COL_SUBSYS_OUT:
         return subsys_out_path;
+    case COL_FOLD_OUT:
+        return "/dev/bus/usb/../other/f";
+    case COL_FOLD_IN:
+        return "/dev/bus/other/../usb/001/001";
+    case COL_SYS_FOLD_IN:
+        return "/sys/class/../bus/usb/devices";
     default:
         return "/dev/bus";
     }
 }
+
+/* COL_SHADOW is the mirror of COL_BACK_DEV: a name the *backing* carries inside
+ * /dev/bus/usb, one of the two subtrees this layer owns, on a bus number no
+ * device has. Ownership runs both ways -- the layer falls through for the
+ * backing's names outside its subtrees, and the backing must not surface inside
+ * them -- so the sysroot fixture plants this file and every entry point still
+ * has to report what Linux reports for a name that is simply not there.
+ *
+ * It is the column that holds the "claimed and then failed" arm. Only
+ * PROC_NOT_INTERCEPTED means "ask the backing"; taking a claimed name's failure
+ * as one too let access(2), and then statfs(2), answer from the backing here
+ * while open and stat reported ENOENT for the same path.
+ */
+
+/* COL_FOLD_OUT and COL_FOLD_IN are the two spellings that cross the /dev/bus
+ * ownership boundary through a '..'. They are the same two names COL_BACK_DEV
+ * and COL_NODE already carry, written so that the component deciding ownership
+ * is not the one the object ends up under: /dev/bus/usb/../other/f is
+ * COL_BACK_DEV's file reached through the subtree this layer owns, and
+ * /dev/bus/other/../usb/001/001 is COL_NODE's node reached through a bus it
+ * does not.
+ *
+ * They exist because the /sys half of the classifier folds the name before
+ * deciding whose it is and the /dev/bus half used to decide on the guest's
+ * spelling, so both spellings went wrong and in opposite directions: the first
+ * was claimed and answered ENOENT for a file the sysroot really has, the second
+ * was disowned and missed the synthetic node. One column each way, so a fold
+ * applied to only one direction cannot pass.
+ */
+
+/* COL_SYS_FOLD_IN is the /sys mirror of COL_FOLD_IN, and the one direction that
+ * stays unmet. /sys/class/../bus/usb/devices folds to a name this layer owns
+ * and serves, and ownership is decided on that folded name -- but the resolve
+ * behind it joins the unfolded suffix onto the scratch tree, which carries no
+ * `class`, so the lookup fails and the layer answers its own authoritative
+ * ENOENT for a directory it does serve. Recorded as XFAIL rather than repaired:
+ * it is not this series\' doing, and the vectors header carries the measurement
+ * against the merge base and the reason a fold cannot fix this half the way it
+ * fixed the /dev one.
+ */
 
 /* Names that must be listed by the union directories, one comma-free name per
  * entry, NULL-terminated. Empty for the columns where enumeration is not the

--- a/tests/usb-sysfs-matrix-vectors.h
+++ b/tests/usb-sysfs-matrix-vectors.h
@@ -38,52 +38,86 @@
  *   subsys-out  <dev>/subsystem/../pci, discovered
  *               a walk through the subsystem link and back out of the one
  *               subtree this layer owns
+ *   dev-fold-out /dev/bus/usb/../other/f
+ *               back-dev's file, spelled through the subtree this layer owns
+ *   dev-fold-in /dev/bus/other/../usb/001/001
+ *               usb-node's node, spelled through a bus this layer does not
+ *               model
+ *   sys-fold-in /sys/class/../bus/usb/devices
+ *               synth-dir's directory, spelled through a /sys name only the
+ *               backing has
  *
  * Two markers appear in the table.
  *
  * "-" is a cell the recording host cannot present, so no Linux value exists to
- * hold the guest to. All four are usb-node: a mknod'd node with no usb device
- * behind it cannot be opened there (the container's device cgroup answers
- * EPERM, and an unbound minor would answer ENODEV anyway), so open,
- * open_nofollow, openat and epoll_ctl on it were never measured. Every other
- * usb-node cell is measured -- they come from the node's directory entry rather
- * than from opening it.
+ * hold the guest to. All eight are the usb node, four under each of its two
+ * spellings: a mknod'd node with no usb device behind it cannot be opened there
+ * (the container's device cgroup answers EPERM, and an unbound minor would
+ * answer ENODEV anyway), so open, open_nofollow, openat and epoll_ctl on it
+ * were never measured. Every other usb-node and dev-fold-in cell is measured --
+ * they come from the node's directory entry rather than from opening it.
  *
  * "?" is a cell whose Linux value was measured and that elfuse knowingly does
- * not meet; the lane prints it as XFAIL instead of failing. Every one is in the
- * escape-syn column, and they are all the same fact: a '..' chain that walks
- * *through* the synthetic subtree and back out cannot be resolved here. The
- * lexical fold recognizes that the name leaves /sys and hands it to the host
- * walk, but the host walk has to traverse /sys/bus/usb, which exists only
- * inside this layer -- the lane's sysroot /sys carries no `bus/usb`. The name
- * therefore answers ENOENT where Linux resolves it. This predates the synthetic
- * USB tree in kind and reproduces identically on the pre-merge build (377c134)
- * with a sysroot whose /sys has no `bus`; fixing it means having the folded
- * spelling re-enter path translation, which is a path-layer change rather than
- * an ownership one. The neighbouring `escape` column, whose chain transits only
- * backing directories, is asserted normally.
+ * not meet; the lane prints it as XFAIL instead of failing. They fall in two
+ * columns, escape-syn and sys-fold-in, and both are one fact seen from opposite
+ * ends: a folded /sys spelling that crosses this layer's boundary cannot
+ * re-enter path translation, whichever way it crosses.
+ *
+ * escape-syn is a '..' chain that walks *through* the synthetic subtree and
+ * back out cannot be resolved here. The lexical fold recognizes that the name
+ * leaves /sys and hands it to the host walk, but the host walk has to traverse
+ * /sys/bus/usb, which exists only inside this layer -- the lane's sysroot /sys
+ * carries no `bus/usb`. The name therefore answers ENOENT where Linux resolves
+ * it. This predates the synthetic USB tree in kind and reproduces identically
+ * on the pre-merge build (377c134) with a sysroot whose /sys has no `bus`;
+ * fixing it means having the folded spelling re-enter path translation, which
+ * is a path-layer change rather than an ownership one. The neighbouring
+ * `escape` column, whose chain transits only backing directories, is asserted
+ * normally.
+ *
+ * sys-fold-in is the same fact walked the other way, and it is the /sys mirror
+ * of dev-fold-in. /sys/class/../bus/usb/devices folds to a name this layer owns
+ * and does serve, so ownership is decided correctly -- but the resolve that
+ * follows joins the *unfolded* suffix onto the scratch tree, which has no
+ * `class`, so the lookup fails and the layer reports its own authoritative
+ * ENOENT. Eighteen entry points answer E2 where Linux resolves the name. statfs
+ * is the one cell that matches, and it matches because its test is the lexical
+ * /sys prefix rather than a lookup. The listing side says the same thing from
+ * the other end: /sys lists `bus` and /sys/class/.. does not.
+ *
+ * It is recorded rather than repaired because it is not this series' doing.
+ * Measured against the merge base this branch sits on (f70ee7a) with the lane's
+ * own sysroot, the answers are identical on both builds: stat of
+ * /sys/class/../bus/usb/devices is ENOENT, and /sys/class/.. lists `class
+ * kernel` without `bus`. The /dev half could be repaired by folding before
+ * classify because every component of /dev/bus this layer serves is a plain
+ * directory it materialized itself; the /sys half cannot, because
+ * usb_sys_resolve_suffix has to see the '..' in their original positions to
+ * order them against the `subsystem` symlinks. Making these cells green means
+ * having the folded spelling re-enter path translation, the same path-layer
+ * change escape-syn needs.
  */
 
 /* clang-format off */
-/*                          synth-dir  back-sys  back-dev  subsys   escape   escape-syn  usb-node  absent  long-sys  sys-root  dev-bus  subsys-out */
-/* open               */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "-",      "E2",   "ok",     "ok",     "ok",    "ok"},
-/* open_nofollow      */ {"ok",      "ok",     "ok",     "E40",   "ok",    "?ok",      "-",      "E2",   "ok",     "ok",     "ok",    "ok"},
-/* openat_dirfd       */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "-",      "E2",   "ok",     "skip",   "ok",    "ok"},
-/* stat               */ {"ok:d",    "ok:d",   "ok:f",   "ok:d",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
-/* lstat              */ {"ok:d",    "ok:d",   "ok:f",   "ok:l",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
-/* fstatat_nofollow   */ {"ok:d",    "ok:d",   "ok:f",   "ok:l",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
-/* fstatat_dirfd      */ {"ok:d",    "ok:d",   "ok:f",   "ok:d",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "skip",   "ok:d",  "ok:d"},
-/* statx              */ {"ok:d",    "ok:d",   "ok:f",   "ok:d",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
-/* access             */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "ok",     "E2",   "ok",     "ok",     "ok",    "ok"},
-/* faccessat_nofollow */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "ok",     "E2",   "ok",     "ok",     "ok",    "ok"},
-/* readlink           */ {"E22",     "E22",    "E22",    "ok",    "E22",   "?E22",     "E22",    "E2",   "E22",    "E22",    "E22",   "E22"},
-/* readlinkat_dirfd   */ {"E22",     "E22",    "E22",    "ok",    "E22",   "?E22",     "E22",    "E2",   "E22",    "skip",   "E22",   "E22"},
-/* getdents64         */ {"ok",      "ok",     "E20",    "ok",    "E20",   "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "ok"},
-/* statfs             */ {"sysfs",   "sysfs",  "other",  "sysfs", "other", "?other",   "other",  "E2",   "sysfs",  "sysfs",  "other", "sysfs"},
-/* fstatfs            */ {"sysfs",   "sysfs",  "other",  "sysfs", "other", "?other",   "other",  "E2",   "sysfs",  "sysfs",  "other", "sysfs"},
-/* fstat_type         */ {"ok:d",    "ok:d",   "ok:f",   "ok:l",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
-/* chdir              */ {"ok",      "ok",     "E20",    "ok",    "E20",   "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "ok"},
-/* fchdir             */ {"ok",      "ok",     "E20",    "ok",    "E20",   "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "ok"},
-/* epoll_ctl          */ {"E1",      "E1",     "E1",     "E1",    "E1",    "?E1",      "-",      "E2",   "ok",     "E1",     "E1",    "E1"},
-/* union_listing      */ {"n/a",     "n/a",    "n/a",    "n/a",   "n/a",   "n/a",      "n/a",    "n/a",  "n/a",    "all",    "all",   "n/a"},
+/*                       synth-dir  back-sys  back-dev  subsys  escape  escape-syn  usb-node  absent  long-sys  sys-root  dev-bus  shadow  subsys-out  dev-fold-out  dev-fold-in  sys-fold-in */
+/* open               */ {"ok",      "ok",     "ok",     "ok",   "ok",   "?ok",      "-",      "E2",   "ok",     "ok",     "ok",    "E2",   "ok",       "ok",         "-",         "?ok"},
+/* open_nofollow      */ {"ok",      "ok",     "ok",     "E40",  "ok",   "?ok",      "-",      "E2",   "ok",     "ok",     "ok",    "E2",   "ok",       "ok",         "-",         "?ok"},
+/* openat_dirfd       */ {"ok",      "ok",     "ok",     "ok",   "ok",   "?ok",      "-",      "E2",   "ok",     "skip",   "ok",    "skip", "ok",       "ok",         "-",         "?ok"},
+/* stat               */ {"ok:d",    "ok:d",   "ok:f",   "ok:d", "ok:f", "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "E2",   "ok:d",     "ok:f",       "ok:c",      "?ok:d"},
+/* lstat              */ {"ok:d",    "ok:d",   "ok:f",   "ok:l", "ok:f", "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "E2",   "ok:d",     "ok:f",       "ok:c",      "?ok:d"},
+/* fstatat_nofollow   */ {"ok:d",    "ok:d",   "ok:f",   "ok:l", "ok:f", "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "E2",   "ok:d",     "ok:f",       "ok:c",      "?ok:d"},
+/* fstatat_dirfd      */ {"ok:d",    "ok:d",   "ok:f",   "ok:d", "ok:f", "?ok:f",    "ok:c",   "E2",   "ok:f",   "skip",   "ok:d",  "skip", "ok:d",     "ok:f",       "ok:c",      "?ok:d"},
+/* statx              */ {"ok:d",    "ok:d",   "ok:f",   "ok:d", "ok:f", "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "E2",   "ok:d",     "ok:f",       "ok:c",      "?ok:d"},
+/* access             */ {"ok",      "ok",     "ok",     "ok",   "ok",   "?ok",      "ok",     "E2",   "ok",     "ok",     "ok",    "E2",   "ok",       "ok",         "ok",        "?ok"},
+/* faccessat_nofollow */ {"ok",      "ok",     "ok",     "ok",   "ok",   "?ok",      "ok",     "E2",   "ok",     "ok",     "ok",    "E2",   "ok",       "ok",         "ok",        "?ok"},
+/* readlink           */ {"E22",     "E22",    "E22",    "ok",   "E22",  "?E22",     "E22",    "E2",   "E22",    "E22",    "E22",   "E2",   "E22",      "E22",        "E22",       "?E22"},
+/* readlinkat_dirfd   */ {"E22",     "E22",    "E22",    "ok",   "E22",  "?E22",     "E22",    "E2",   "E22",    "skip",   "E22",   "skip", "E22",      "E22",        "E22",       "?E22"},
+/* getdents64         */ {"ok",      "ok",     "E20",    "ok",   "E20",  "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "E2",   "ok",       "E20",        "E20",       "?ok"},
+/* statfs             */ {"sysfs",   "sysfs",  "other",  "sysfs","other","?other",   "other",  "E2",   "sysfs",  "sysfs",  "other", "E2",   "sysfs",    "other",      "other",     "sysfs"},
+/* fstatfs            */ {"sysfs",   "sysfs",  "other",  "sysfs","other","?other",   "other",  "E2",   "sysfs",  "sysfs",  "other", "E2",   "sysfs",    "other",      "other",     "?sysfs"},
+/* fstat_type         */ {"ok:d",    "ok:d",   "ok:f",   "ok:l", "ok:f", "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "E2",   "ok:d",     "ok:f",       "ok:c",      "?ok:d"},
+/* chdir              */ {"ok",      "ok",     "E20",    "ok",   "E20",  "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "E2",   "ok",       "E20",        "E20",       "?ok"},
+/* fchdir             */ {"ok",      "ok",     "E20",    "ok",   "E20",  "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "E2",   "ok",       "E20",        "E20",       "?ok"},
+/* epoll_ctl          */ {"E1",      "E1",     "E1",     "E1",   "E1",   "?E1",      "-",      "E2",   "ok",     "E1",     "E1",    "E2",   "E1",       "E1",         "-",         "?E1"},
+/* union_listing      */ {"n/a",     "n/a",    "n/a",    "n/a",  "n/a",  "n/a",      "n/a",    "n/a",  "n/a",    "all",    "all",   "n/a",  "n/a",      "n/a",        "n/a",       "n/a"},
     /* clang-format on */

--- a/tests/usb-sysfs-matrix-vectors.h
+++ b/tests/usb-sysfs-matrix-vectors.h
@@ -1,0 +1,89 @@
+/*
+ * Measured Linux answers for tests/test-usb-sysfs-matrix.c
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Recorded on Linux, not reasoned about: docker gcc:14 (aarch64, kernel 6.x)
+ * over a real sysfs, with /dev/bus/other/f created and /dev/bus/usb/001/001
+ * mknod'd as char 189:0. See the header comment in the test for the exact
+ * command; MATRIX_RECORD=1 prints this block.
+ *
+ * Columns, in order, with the path each names:
+ *
+ *   synth-dir   /sys/bus/usb/devices
+ *               a directory the layer synthesizes
+ *   back-sys    /sys/class
+ *               a /sys name only the backing has
+ *   back-dev    /dev/bus/other/f
+ *               a /dev/bus name only the backing has
+ *   subsys      <dev>/subsystem, discovered
+ *               a subsystem symlink
+ *   escape      /sys/class/../../etc/hostname
+ *               a '..' chain out of the tree
+ *   escape-syn  /sys/bus/usb/../../../etc/hostname
+ *               the same, through the synthetic subtree
+ *   usb-node    /dev/bus/usb/001/001
+ *               a usbfs device node
+ *   absent      /sys/no-such-name-here
+ *               absent on both sides
+ *   long-sys    a >63-byte spelling of an attribute, discovered
+ *               longer than the virtual-path stamp a descriptor carries
+ *   sys-root    /sys
+ *               synthetic and backed at once
+ *   dev-bus     /dev/bus
+ *               synthetic and backed at once
+ *   shadow      /dev/bus/usb/099/001
+ *               a backing name planted inside a subtree this layer owns
+ *   subsys-out  <dev>/subsystem/../pci, discovered
+ *               a walk through the subsystem link and back out of the one
+ *               subtree this layer owns
+ *
+ * Two markers appear in the table.
+ *
+ * "-" is a cell the recording host cannot present, so no Linux value exists to
+ * hold the guest to. All four are usb-node: a mknod'd node with no usb device
+ * behind it cannot be opened there (the container's device cgroup answers
+ * EPERM, and an unbound minor would answer ENODEV anyway), so open,
+ * open_nofollow, openat and epoll_ctl on it were never measured. Every other
+ * usb-node cell is measured -- they come from the node's directory entry rather
+ * than from opening it.
+ *
+ * "?" is a cell whose Linux value was measured and that elfuse knowingly does
+ * not meet; the lane prints it as XFAIL instead of failing. Every one is in the
+ * escape-syn column, and they are all the same fact: a '..' chain that walks
+ * *through* the synthetic subtree and back out cannot be resolved here. The
+ * lexical fold recognizes that the name leaves /sys and hands it to the host
+ * walk, but the host walk has to traverse /sys/bus/usb, which exists only
+ * inside this layer -- the lane's sysroot /sys carries no `bus/usb`. The name
+ * therefore answers ENOENT where Linux resolves it. This predates the synthetic
+ * USB tree in kind and reproduces identically on the pre-merge build (377c134)
+ * with a sysroot whose /sys has no `bus`; fixing it means having the folded
+ * spelling re-enter path translation, which is a path-layer change rather than
+ * an ownership one. The neighbouring `escape` column, whose chain transits only
+ * backing directories, is asserted normally.
+ */
+
+/* clang-format off */
+/*                          synth-dir  back-sys  back-dev  subsys   escape   escape-syn  usb-node  absent  long-sys  sys-root  dev-bus  subsys-out */
+/* open               */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "-",      "E2",   "ok",     "ok",     "ok",    "ok"},
+/* open_nofollow      */ {"ok",      "ok",     "ok",     "E40",   "ok",    "?ok",      "-",      "E2",   "ok",     "ok",     "ok",    "ok"},
+/* openat_dirfd       */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "-",      "E2",   "ok",     "skip",   "ok",    "ok"},
+/* stat               */ {"ok:d",    "ok:d",   "ok:f",   "ok:d",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
+/* lstat              */ {"ok:d",    "ok:d",   "ok:f",   "ok:l",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
+/* fstatat_nofollow   */ {"ok:d",    "ok:d",   "ok:f",   "ok:l",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
+/* fstatat_dirfd      */ {"ok:d",    "ok:d",   "ok:f",   "ok:d",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "skip",   "ok:d",  "ok:d"},
+/* statx              */ {"ok:d",    "ok:d",   "ok:f",   "ok:d",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
+/* access             */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "ok",     "E2",   "ok",     "ok",     "ok",    "ok"},
+/* faccessat_nofollow */ {"ok",      "ok",     "ok",     "ok",    "ok",    "?ok",      "ok",     "E2",   "ok",     "ok",     "ok",    "ok"},
+/* readlink           */ {"E22",     "E22",    "E22",    "ok",    "E22",   "?E22",     "E22",    "E2",   "E22",    "E22",    "E22",   "E22"},
+/* readlinkat_dirfd   */ {"E22",     "E22",    "E22",    "ok",    "E22",   "?E22",     "E22",    "E2",   "E22",    "skip",   "E22",   "E22"},
+/* getdents64         */ {"ok",      "ok",     "E20",    "ok",    "E20",   "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "ok"},
+/* statfs             */ {"sysfs",   "sysfs",  "other",  "sysfs", "other", "?other",   "other",  "E2",   "sysfs",  "sysfs",  "other", "sysfs"},
+/* fstatfs            */ {"sysfs",   "sysfs",  "other",  "sysfs", "other", "?other",   "other",  "E2",   "sysfs",  "sysfs",  "other", "sysfs"},
+/* fstat_type         */ {"ok:d",    "ok:d",   "ok:f",   "ok:l",  "ok:f",  "?ok:f",    "ok:c",   "E2",   "ok:f",   "ok:d",   "ok:d",  "ok:d"},
+/* chdir              */ {"ok",      "ok",     "E20",    "ok",    "E20",   "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "ok"},
+/* fchdir             */ {"ok",      "ok",     "E20",    "ok",    "E20",   "?E20",     "E20",    "E2",   "E20",    "ok",     "ok",    "ok"},
+/* epoll_ctl          */ {"E1",      "E1",     "E1",     "E1",    "E1",    "?E1",      "-",      "E2",   "ok",     "E1",     "E1",    "E1"},
+/* union_listing      */ {"n/a",     "n/a",    "n/a",    "n/a",   "n/a",   "n/a",      "n/a",    "n/a",  "n/a",    "all",    "all",   "n/a"},
+    /* clang-format on */


### PR DESCRIPTION
NOTE: these are regressions #334 introduced. I found them in a post-merge audit of my own diff, not in a report, and every line below is a measurement against a build of `377c134` (main as it stood before #334) and a build of current main, both driven with `--sysroot` over a rootfs whose `/sys` carries `class/net/eth0/address`, `kernel/mm/transparent_hugepage/enabled`, `devices/system/node/online`, and whose `/dev/bus` carries `other/f`. They reproduce with no USB device attached and no fixture, so every sysroot user is affected.

## Summary

#334 taught the USB layer to stand aside for names it does not synthesize, but wired that decision into only the two `follow` resolve-failure paths. Every other entry point kept answering from the synthetic tree alone, so the layer shadowed the sysroot it was supposed to defer to.

| probe | before #334 | current main | this branch | Linux |
|---|---|---|---|---|
| `lstat("/sys/class")` | OK | **ENOENT** | OK | OK |
| `open("/sys/class", O_NOFOLLOW)` | OK | **ENOENT** | OK | OK |
| `readlink("/sys/class")` | EINVAL | **ENOENT** | EINVAL | EINVAL |
| `readdir("/sys")` | class fs kernel devices | **bus** | bus class fs kernel devices | (both) |
| `readdir("/dev/bus")` | other | **usb** | usb other | other |
| `open("/dev/bus/other/f")` | OK | **ENOENT** while `access` said OK | OK | OK |
| `fstatfs` on `/sys/class` | 0x1a | **0x1a** while `statfs` said SYSFS_MAGIC | SYSFS_MAGIC | SYSFS_MAGIC |

## What

The decision of whether a `/sys` or `/dev/bus` name belongs to this layer is made once, on the resolved name, and every entry point routes through it: open, openat, stat, lstat, fstatat, statx, access and faccessat both ways, readlink, readlinkat, getdents64, statfs, fstatfs, fstat, chdir, fchdir, epoll_ctl.

`getdents64` unions the synthetic entries with the backing directory's own rather than replacing them, deduplicated by name with ours winning, and only for the three directories that exist on both sides. Under `/sys/bus/usb` and `/dev/bus/usb` absence stays authoritative.

The union holds the backing's names, not its descriptor. A second host descriptor pinned for the lifetime of a directory handle would break the budget #342 had just established: measured at `ulimit -n 128`, a guest could hold 896 union directory handles open but only 637 once each was read to the end, against 896 either way on main. The drain reads the backing's listing and closes it before returning, so the extra descriptor never spans a return to the guest, and `tests/test-dir-fd-budget-union` measures that difference so it cannot come back.

A listing that cannot be completed is reported rather than truncated. `getdents64` follows Linux's shape here: a call that already wrote entries returns the count and delivers the error on the next call, a call that wrote nothing returns the error. Two silent truncations turned up while pinning this down and are fixed with it: a `readdir` failure mid-drain ended the listing as though it were the end of the directory, and a first entry too large for the guest buffer returned 0, which a guest reads as end of directory where Linux returns EINVAL.

Along the way the same class of defect surfaced in three more places and is fixed here: `chdir` never consulted the intercepts at all, `epoll_ctl` accepted a synthetic `/sys` directory while refusing the sysroot-backed one beside it, and `fstat` on a descriptor opened on a `/dev/bus/usb` node reported a regular file where `stat` on the same name reported the character device, which libusb reads.

## Tests

`tests/test-usb-sysfs-matrix` is 20 entry points against 11 path classes. The expected values are recorded from a real kernel rather than written by hand: `MATRIX_RECORD=1` on Linux emits the table, and the recorder self-checks 206 of 206 there. Against current main the lane reports 44 failures; here it passes 226. Each fix was reverted in isolation to confirm the rows it owns fail without it.

Nineteen cells are recorded XFAIL rather than deleted: a `..` chain that walks through `/sys/bus/usb` and back out resolves on Linux and does not here, because the host walk would have to traverse a directory that exists only inside this layer. That predates #334, reproduces identically before it, and wants a path-layer change of its own.

## Evidence

```
make check BAREMETAL_CROSS=aarch64-elf-   All 98 tests passed, exit 0
test-usb-sysfs-matrix        226 passed, 0 failed   (44 failed on main)
test-dir-fd-budget-union       3 passed, 0 failed   (fails without the drain fix)
test-dir-backing-drain-error   5/5, 8/8, 8/8
test-getdents64-small-buf      4 passed, 0 failed   (3 of 4 fail without it)
test-dir-fd-budget             OK                   (#342's own lane)
test-epoll, test-fcntl-flags   OK
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops synthetic USB views from shadowing sysroot-backed names under `/sys` and `/dev/bus`: names outside `/sys/bus/usb` and `/dev/bus/usb` now fall through to the backing instead of returning `ENOENT`, while missing names in owned subtrees remain authoritative. Lookup, enumeration, metadata, and capability checks now use the same ownership decision.

**Bug Fixes**
- Shared directories merge synthetic and backing entries with synthetic names taking precedence.
- Backing entries are drained and the backing descriptor is closed before returning, preserving the host descriptor budget.
- `dup`, `dup2`, `F_DUPFD`, `F_DUPFD_CLOEXEC`, and `fork` share directory position and union state instead of re-listing backing names.
- Directory read failures and buffers too small for one entry now report errors instead of silently returning end-of-directory.
- `fstat` and `fstatfs` match path-based USB identity, while `chdir`, `fchdir`, and `epoll_ctl` use the same path handling.
- Traversal through synthetic USB directories with `..`, and a fork child whose parent closes the descriptor before backing drain, remain recorded XFAILs.

**Tests**
- Adds a recorded matrix covering supported entry points and path classes, plus targeted coverage for descriptor budgets, aliases, fd reuse, drain failures, primary read failures, and small buffers.

<sup>Written for commit 4d51314178cdaacd6b1fc3d63a964f7e8af9c020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

