### PR TITLE
Answer AT_EMPTY_PATH before the path resolver

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -28,6 +28,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-sysroot-procfs-exec test-sysroot-fd-magiclink \
         test-timeout-disable test-launch-flags \
         test-fuse-alpine \
+        test-fstatat-empty-path \
         test-sysroot-nofollow test-sysroot-chdir test-sysroot-symlink-escape \
         test-sysroot-dotdot test-sysroot-openat2-walk \
         test-sysroot-inotify-names test-sysroot-exec-names \
@@ -249,6 +250,7 @@ $(call run-host-unit,test-elf-headers-host,ELF header validation unit test)
 $(call run-lane,test-usb-sysfs,synthetic USB tree contract)
 $(call run-lane,test-usb-sysfs-sysroot,synthetic USB /sys sharing a populated sysroot)
 $(call run-lane,test-usb-sysfs-overflow,per-bus devnum cap under 127-device overflow)
+$(call run-lane,test-fstatat-empty-path,AT_EMPTY_PATH stat by fd under a sysroot)
 $(call run-lane,test-sysroot-name-unique,one on-disk name per guest name)
 $(call run-lane,test-sysroot-name-relative,relative and dirfd-relative names)
 $(call run-lane,test-sysroot-name-i18n,non-ASCII guest filenames)
@@ -343,6 +345,17 @@ test-sysroot-rename: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-rename
 		printf "$(RED)FAIL$(RESET) rename escaped sysroot to host /tmp\n"; \
 		exit 1; \
 	fi
+
+## AT_EMPTY_PATH names the descriptor rather than a name under it, so it has to
+## be answered before anything resolves against dirfd. Only a sysroot run puts
+## a resolver in front of it, which is why this lane exists next to the matrix
+## registration: without --sysroot the empty path never reaches the code that
+## used to fail it, and the test passes without proving anything.
+test-fstatat-empty-path: $(ELFUSE_BIN) $(BUILD_DIR)/test-fstatat-empty-path
+	@tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	mkdir -p "$$tmpdir/tmp"; \
+	$(ELFUSE_BIN) --sysroot "$$tmpdir" $(BUILD_DIR)/test-fstatat-empty-path
 
 test-sysroot-nofollow: $(ELFUSE_BIN) $(BUILD_DIR)/test-sysroot-nofollow
 	@tmpdir=$$(mktemp -d); \

--- a/src/syscall/fs-stat.c
+++ b/src/syscall/fs-stat.c
@@ -162,6 +162,90 @@ static void translate_statfs(const struct statfs *mac, linux_statfs_t *lin)
     lin->f_frsize = mac->f_bsize;
 }
 
+/* Stat the descriptor an *at-style call names with AT_EMPTY_PATH and an empty
+ * path.
+ *
+ * The empty path names the descriptor rather than anything beneath it, so it
+ * resolves nothing and must be answered before a resolver ever sees it. A
+ * resolver measures a relative name against dirfd, and the empty path is
+ * relative, so it owes ENOTDIR for a dirfd that is not a directory -- correct
+ * for a name, wrong for the descriptor itself, and glibc has spelled fstat(fd)
+ * as fstatat(fd, "", AT_EMPTY_PATH) since 2.33. sys_fchmodat and sys_fchownat
+ * short-circuit ahead of translation for the same reason.
+ *
+ * The order mirrors sys_fstat, since this answers the same question: the FUSE
+ * shim first, because a FUSE descriptor is answered by the emulation layer
+ * rather than by a host file; then the /proc intercept, which an O_PATH
+ * descriptor needs because its host fd cannot be stat'ed for the emulated
+ * object; then the host.
+ *
+ * sys_fstat calls this rather than keeping a body of its own, since glibc's
+ * spelling makes this the form most fstat() calls arrive in and there is no
+ * second policy worth having. The classification and the descriptor come from
+ * one fd_lock window here, so a sibling thread cannot close and reuse the slot
+ * between the two: answering the /proc intercept for one object and then
+ * stat'ing another is what separate reads allow.
+ *
+ * AT_FDCWD is not handled here -- it names the current directory, which always
+ * has a base path to resolve against, so the caller keeps answering it the way
+ * Linux specifies it.
+ *
+ * Returns 0 on success or a negative Linux errno.
+ */
+static int64_t stat_empty_path_fd(int dirfd, struct stat *mac_st)
+{
+    int frc = fuse_fstat_fd(dirfd, mac_st);
+    if (frc == 0)
+        return 0;
+    if (frc != -LINUX_EBADF)
+        return frc;
+
+    fd_entry_t snap;
+    host_fd_ref_t ref = HOST_FD_REF_INIT;
+    if (thread_is_single_active()) {
+        /* No sibling can mutate the slot, so the pin has nothing to defend
+         * against and the snapshot alone is already consistent -- the rule
+         * fd_block_state states for the same reason. A closed slot, or one
+         * carrying no host descriptor, is the EBADF that fd_to_host would have
+         * reported on this path before.
+         */
+        if (!fd_snapshot(dirfd, &snap) || snap.host_fd < 0)
+            return -LINUX_EBADF;
+        ref.fd = snap.host_fd;
+    } else {
+        /* Pin, not dup: the descriptor has to stay valid across the stat, not
+         * become private, and retiring a dup would drop the guest's record
+         * locks on the file (fcntl(2)).
+         */
+        if (fd_host_ref_acquire(dirfd, &snap, &ref.lifetime) < 0)
+            return linux_errno(); /* EBADF or ENOMEM; the helper picks. */
+        ref.fd = snap.host_fd;
+    }
+
+    int64_t rc = 0;
+    if (snap.type == FD_PATH && snap.proc_path[0] != '\0') {
+        /* The descriptor already names one object: an O_PATH open that followed
+         * refers to the target, one made with O_NOFOLLOW to the link itself, so
+         * the open's flag is what selects here.
+         */
+        bool follow = !(snap.linux_flags & LINUX_O_NOFOLLOW);
+        int intercepted =
+            proc_intercept_stat_at(snap.proc_path, mac_st, follow);
+        if (intercepted == 0)
+            goto done;
+        if (intercepted == -1) {
+            rc = linux_errno();
+            goto done;
+        }
+    }
+    if (fstat(ref.fd, mac_st) < 0)
+        rc = linux_errno();
+
+done:
+    host_fd_ref_close(&ref);
+    return rc;
+}
+
 /* Resolve the directory + path arguments of a *at-style stat operation and fill
  * *mac_st via the appropriate host call (proc intercept where applicable).
  * Shared by sys_newfstatat and sys_statx; the caller copies the result into the
@@ -191,6 +275,10 @@ static int64_t stat_at_path(guest_t *g,
     if (guest_read_path(g, path_gva, short_path, sizeof(short_path), path,
                         sizeof(path), &pathp) < 0)
         return -LINUX_EFAULT;
+
+    if ((flags & LINUX_AT_EMPTY_PATH) && pathp[0] == '\0' &&
+        dirfd != LINUX_AT_FDCWD)
+        return stat_empty_path_fd(dirfd, mac_st);
 
     if (pathp[0] == '/' && fuse_path_matches_mount(pathp)) {
         int frc = fuse_stat_path(pathp, mac_st, flags);
@@ -224,46 +312,15 @@ static int64_t stat_at_path(guest_t *g,
     host_fd_ref_t dir_ref = HOST_FD_REF_INIT;
     if ((flags & LINUX_AT_EMPTY_PATH) && pathp[0] == '\0') {
         /* Linux: AT_EMPTY_PATH with dirfd == AT_FDCWD operates on the current
-         * working directory.
+         * working directory. Every other descriptor was answered by
+         * stat_empty_path_fd above, before anything tried to resolve the empty
+         * path against it.
          */
-        if (dirfd == LINUX_AT_FDCWD) {
-            dir_ref.fd = AT_FDCWD;
-            int mac_flags = translate_at_flags(flags);
-            if (fstatat(AT_FDCWD, ".", mac_st, mac_flags) < 0) {
-                rc = linux_errno();
-                goto done;
-            }
-        } else {
-            /* Pin, not dup: fstatat needs the descriptor to stay valid, not to
-             * be private, and retiring a dup would drop the guest's record
-             * locks on the file (fcntl(2)).
-             */
-            fd_entry_t snap;
-            if (fd_host_ref_acquire(dirfd, &snap, &dir_ref.lifetime) < 0) {
-                /* EBADF or ENOMEM; the helper distinguishes them. */
-                rc = linux_errno();
-                goto done;
-            }
-            dir_ref.fd = snap.host_fd;
-            if (snap.type == FD_PATH && snap.proc_path[0] != '\0') {
-                /* The descriptor already names one object: an O_PATH open that
-                 * followed refers to the target, one made with O_NOFOLLOW to
-                 * the link itself, so the open's flag is what selects here.
-                 */
-                bool follow = !(snap.linux_flags & LINUX_O_NOFOLLOW);
-                int intercepted =
-                    proc_intercept_stat_at(snap.proc_path, mac_st, follow);
-                if (intercepted == 0)
-                    goto done;
-                if (intercepted == -1) {
-                    rc = linux_errno();
-                    goto done;
-                }
-            }
-            if (fstat(dir_ref.fd, mac_st) < 0) {
-                rc = linux_errno();
-                goto done;
-            }
+        dir_ref.fd = AT_FDCWD;
+        int mac_flags = translate_at_flags(flags);
+        if (fstatat(AT_FDCWD, ".", mac_st, mac_flags) < 0) {
+            rc = linux_errno();
+            goto done;
         }
     } else {
         int64_t ref_err = host_dirfd_ref_open(dirfd, &dir_ref);
@@ -305,52 +362,20 @@ int64_t sys_fstat(guest_t *g, int fd, uint64_t stat_gva)
      * from it.
      */
     struct stat mac_st = {0};
-    int frc = fuse_fstat_fd(fd, &mac_st);
-    if (frc == 0) {
-        if (write_linux_stat(g, stat_gva, &mac_st) < 0)
-            return -LINUX_EFAULT;
-        return 0;
-    }
-    if (frc != -LINUX_EBADF)
-        return frc;
 
-    fd_entry_t snap;
-    if (fd_snapshot(fd, &snap) && snap.type == FD_PATH &&
-        snap.proc_path[0] != '\0') {
-        /* As in stat_at_path's AT_EMPTY_PATH branch: the open already chose
-         * between the link and its target, so replay that choice here.
-         */
-        bool follow = !(snap.linux_flags & LINUX_O_NOFOLLOW);
-        int intercepted =
-            proc_intercept_stat_at(snap.proc_path, &mac_st, follow);
-        if (intercepted == 0) {
-            if (write_linux_stat(g, stat_gva, &mac_st) < 0)
-                return -LINUX_EFAULT;
-            return 0;
-        }
-        if (intercepted == -1)
-            return linux_errno();
+    /* fstat(fd) and fstatat(fd, "", AT_EMPTY_PATH) are the same question --
+     * glibc has spelled the first as the second since 2.33 -- so they are
+     * answered by one body rather than two that can drift.
+     */
+    int64_t rc = stat_empty_path_fd(fd, &mac_st);
+    if (rc < 0) {
+        log_debug("fstat(%d): failed rc=%lld", fd, (long long) rc);
+        return rc;
     }
 
-    host_fd_ref_t host_ref;
-    int64_t ref_err = host_fd_ref_open(fd, &host_ref);
-    if (ref_err < 0) {
-        log_debug("fstat(%d): invalid guest fd", fd);
-        return ref_err;
-    }
-    if (fstat(host_ref.fd, &mac_st) < 0) {
-        log_debug("fstat(%d->%d): host fstat failed errno=%d", fd, host_ref.fd,
-                  errno);
-        host_fd_ref_close(&host_ref);
-        return linux_errno();
-    }
-
-    if (write_linux_stat(g, stat_gva, &mac_st) < 0) {
-        host_fd_ref_close(&host_ref);
+    if (write_linux_stat(g, stat_gva, &mac_st) < 0)
         return -LINUX_EFAULT;
-    }
 
-    host_fd_ref_close(&host_ref);
     return 0;
 }
 

--- a/tests/test-fstatat-empty-path.c
+++ b/tests/test-fstatat-empty-path.c
@@ -1,0 +1,295 @@
+/*
+ * fstatat/statx AT_EMPTY_PATH tests
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * fstatat(fd, "", &st, AT_EMPTY_PATH) stats fd itself rather than a name
+ * beneath it, so it has to work for descriptors that name no path at all: a
+ * pipe, a socket, an eventfd. glibc has spelled fstat(fd) exactly that way
+ * since 2.33, which is what makes this ordinary rather than exotic -- a program
+ * that never mentions AT_EMPTY_PATH still arrives here through plain fstat().
+ *
+ * The interesting failure is a resolver reached before the empty path is
+ * recognized: the empty path is relative, so measuring it against dirfd owes
+ * ENOTDIR for a dirfd that is not a directory, which is right for a name and
+ * wrong for the descriptor itself. Every case below therefore asserts the
+ * fstatat answer against the plain fstat answer for the same descriptor, since
+ * the two are the same question and a divergence is the bug.
+ *
+ * statx(2) shares the same resolution path and is checked on the same
+ * descriptors. AT_FDCWD is checked too: it names the current directory, which
+ * always has a path, so it is the case that keeps working when the rest breaks.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+#include "test-harness.h"
+
+#ifndef O_PATH
+#define O_PATH 010000000
+#endif
+#ifndef AT_EMPTY_PATH
+#define AT_EMPTY_PATH 0x1000
+#endif
+#ifndef SYS_statx
+#define SYS_statx 291
+#endif
+
+/* STATX_BASIC_STATS. Spelled out because the mask is what the guest sends and
+ * the header's name for it is not present on every libc this cross-builds
+ * against.
+ */
+#define STATX_MASK_BASIC 0x7ff
+
+int passes = 0, fails = 0;
+
+static char tmp_file[] = "/tmp/elfuse-fstatat-empty-XXXXXX";
+
+/* Both spellings of the same question must return the same answer. st_dev and
+ * st_ino identify the object, st_mode carries the type the caller switches on,
+ * and nothing else is stable enough across descriptor kinds to compare.
+ */
+static void expect_agrees_with_fstat(const char *what, int fd, mode_t want_fmt)
+{
+    TEST(what);
+
+    struct stat direct;
+    memset(&direct, 0, sizeof(direct));
+    if (fstat(fd, &direct) != 0) {
+        FAIL("fstat failed, nothing to compare against");
+        return;
+    }
+
+    struct stat viaat;
+    memset(&viaat, 0, sizeof(viaat));
+    errno = 0;
+    if (fstatat(fd, "", &viaat, AT_EMPTY_PATH) != 0) {
+        FAIL("fstatat with AT_EMPTY_PATH failed");
+        return;
+    }
+
+    if (want_fmt && (viaat.st_mode & S_IFMT) != want_fmt) {
+        FAIL("wrong file type");
+        return;
+    }
+    EXPECT_TRUE(viaat.st_mode == direct.st_mode &&
+                    viaat.st_dev == direct.st_dev &&
+                    viaat.st_ino == direct.st_ino,
+                "fstatat disagreed with fstat on the same descriptor");
+}
+
+/* statx shares the resolution path, so it breaks and recovers with fstatat.
+ *
+ * Identity is compared, not just the type: an answer that carries the right
+ * type from the wrong object is exactly what a resolver reached too early
+ * produces, and a type-only check would pass it. statx is also where dev is
+ * split into major and minor, so the two halves are checked against the dev
+ * fstat reports for the same descriptor.
+ */
+static void expect_statx_agrees(const char *what, int fd)
+{
+    TEST(what);
+
+    struct stat direct;
+    memset(&direct, 0, sizeof(direct));
+    if (fstat(fd, &direct) != 0) {
+        FAIL("fstat failed, nothing to compare against");
+        return;
+    }
+
+    struct statx sx;
+    memset(&sx, 0, sizeof(sx));
+    errno = 0;
+    long rc = syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_MASK_BASIC, &sx);
+    if (rc != 0) {
+        FAIL("statx with AT_EMPTY_PATH failed");
+        return;
+    }
+    EXPECT_TRUE((sx.stx_mode & S_IFMT) == (direct.st_mode & S_IFMT) &&
+                    sx.stx_ino == direct.st_ino &&
+                    sx.stx_dev_major == major(direct.st_dev) &&
+                    sx.stx_dev_minor == minor(direct.st_dev),
+                "statx disagreed with fstat on the same descriptor");
+}
+
+/* A pipe, a socket and an eventfd have no host path behind them, which is what
+ * separates them from every other descriptor here.
+ */
+static void test_pathless_descriptors(void)
+{
+    int p[2];
+    if (pipe(p) == 0) {
+        expect_agrees_with_fstat("pipe read end", p[0], S_IFIFO);
+        expect_agrees_with_fstat("pipe write end", p[1], S_IFIFO);
+        expect_statx_agrees("statx on a pipe", p[0]);
+        close(p[0]);
+        close(p[1]);
+    } else {
+        TEST("pipe read end");
+        FAIL("pipe");
+    }
+
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0) {
+        expect_agrees_with_fstat("socketpair fd", sv[0], S_IFSOCK);
+        expect_statx_agrees("statx on a socket", sv[0]);
+        close(sv[0]);
+        close(sv[1]);
+    } else {
+        TEST("socketpair fd");
+        FAIL("socketpair");
+    }
+
+    /* No expected type: an eventfd is an anonymous inode and its st_mode is not
+     * something a program should be reading a promise out of. That it answers
+     * at all, and answers the same as fstat, is the whole claim.
+     */
+    int efd = eventfd(0, 0);
+    if (efd >= 0) {
+        expect_agrees_with_fstat("eventfd", efd, 0);
+        expect_statx_agrees("statx on an eventfd", efd);
+        close(efd);
+    } else {
+        TEST("eventfd");
+        FAIL("eventfd");
+    }
+}
+
+/* Descriptors that do name a path. These worked before and have to keep
+ * working: the fix moves them onto a different branch.
+ */
+static void test_descriptors_with_a_path(void)
+{
+    int fd = open(tmp_file, O_RDONLY);
+    if (fd >= 0) {
+        expect_agrees_with_fstat("regular file fd", fd, S_IFREG);
+        expect_statx_agrees("statx on a regular file", fd);
+        close(fd);
+    } else {
+        TEST("regular file fd");
+        FAIL("open");
+    }
+
+    /* O_PATH is the case plain fstat() cannot serve on Linux for every
+     * operation, so AT_EMPTY_PATH is the only spelling some callers have.
+     */
+    int pfd = open(tmp_file, O_PATH);
+    if (pfd >= 0) {
+        expect_agrees_with_fstat("O_PATH fd", pfd, S_IFREG);
+        expect_statx_agrees("statx on an O_PATH fd", pfd);
+        close(pfd);
+    } else {
+        TEST("O_PATH fd");
+        FAIL("open O_PATH");
+    }
+
+    int dfd = open("/", O_RDONLY | O_DIRECTORY);
+    if (dfd >= 0) {
+        expect_agrees_with_fstat("directory fd", dfd, S_IFDIR);
+        close(dfd);
+    } else {
+        TEST("directory fd");
+        FAIL("open directory");
+    }
+}
+
+static void test_at_fdcwd_names_the_cwd(void)
+{
+    TEST("AT_FDCWD with an empty path stats the cwd");
+
+    struct stat dot;
+    memset(&dot, 0, sizeof(dot));
+    if (stat(".", &dot) != 0) {
+        FAIL("stat(\".\") failed, nothing to compare against");
+        return;
+    }
+
+    struct stat viaat;
+    memset(&viaat, 0, sizeof(viaat));
+    errno = 0;
+    if (fstatat(AT_FDCWD, "", &viaat, AT_EMPTY_PATH) != 0) {
+        FAIL("fstatat(AT_FDCWD, \"\", AT_EMPTY_PATH) failed");
+        return;
+    }
+    EXPECT_TRUE(viaat.st_dev == dot.st_dev && viaat.st_ino == dot.st_ino,
+                "AT_FDCWD did not resolve to the current directory");
+}
+
+/* A closed descriptor still owes EBADF, not the ENOTDIR that a resolver would
+ * produce for it. The two are easy to confuse from the outside, which is why
+ * this is asserted rather than assumed.
+ */
+static void test_closed_fd_is_ebadf(void)
+{
+    TEST("a closed fd reports EBADF");
+
+    int p[2];
+    if (pipe(p) != 0) {
+        FAIL("pipe");
+        return;
+    }
+    close(p[0]);
+    close(p[1]);
+
+    struct stat st;
+    errno = 0;
+    int rc = fstatat(p[0], "", &st, AT_EMPTY_PATH);
+    EXPECT_TRUE(rc == -1 && errno == EBADF, "expected EBADF for a closed fd");
+}
+
+/* The flag is what turns the empty name into "this descriptor", so without it
+ * the call must not answer for the descriptor. Only that it fails is asserted:
+ * which errno an empty path earns without the flag is a separate question from
+ * this one, and elfuse does not answer it the way Linux does today.
+ */
+static void test_the_flag_is_what_selects_the_fd(void)
+{
+    TEST("an empty path without the flag does not stat the fd");
+
+    int p[2];
+    if (pipe(p) != 0) {
+        FAIL("pipe");
+        return;
+    }
+
+    struct stat st;
+    errno = 0;
+    int rc = fstatat(p[0], "", &st, 0);
+    close(p[0]);
+    close(p[1]);
+    EXPECT_TRUE(rc == -1, "an empty path without the flag stat'ed the fd");
+}
+
+int main(void)
+{
+    printf("test-fstatat-empty-path: AT_EMPTY_PATH stat-by-fd semantics\n");
+
+    int seed = mkstemp(tmp_file);
+    if (seed < 0) {
+        perror("setup: mkstemp");
+        return 1;
+    }
+    close(seed);
+
+    test_pathless_descriptors();
+    test_descriptors_with_a_path();
+    test_at_fdcwd_names_the_cwd();
+    test_closed_fd_is_ebadf();
+    test_the_flag_is_what_selects_the_fd();
+
+    unlink(tmp_file);
+
+    SUMMARY("test-fstatat-empty-path");
+    return fails == 0 ? 0 : 1;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -973,6 +973,9 @@ run_unit_tests()
     printf "\nfchmodat2 AT_EMPTY_PATH\n"
     test_rc "$runner" "test-fchmodat-empty-path" 0 "$bindir/test-fchmodat-empty-path"
 
+    printf "\nfstatat/statx AT_EMPTY_PATH\n"
+    test_rc "$runner" "test-fstatat-empty-path" 0 "$bindir/test-fstatat-empty-path"
+
     printf "\nX11 raw protocol\n"
     test_check "$runner" "test-x11" "0 failed" "$bindir/test-x11"
 


### PR DESCRIPTION
Closes #322.

**Credit where it is due:** the diagnosis, the root cause and the shape of this
fix are @doanbaotrung's, from the report in #322, including the observation
that `sys_fchmodat`/`sys_fchownat` already get this right and `stat_at_path` is
the odd one out. The patch in that issue is written against `b1aac9a` and
predates #324's move from dup to pin, so it no longer applies; this is the same
fix rebuilt on `fd_host_ref_acquire`, plus the regression test the report
proposed and the verification it says it could not run (no cross toolchain).
@doanbaotrung reported this and may have a patch in flight; this one is
redundant if so.

## The bug

glibc has spelled `fstat(fd)` as `fstatat(fd, "", AT_EMPTY_PATH)` since 2.33, so
an ordinary `fstat()` of a pipe reaches `stat_at_path` with an empty path. The
empty path is relative, and `stat_at_path` resolved it before it looked at the
flag: `path_translate_at` measures a relative name against `dirfd`, and a
descriptor that is not a directory owes ENOTDIR for a name. Correct for a name,
wrong for the empty path, which names the descriptor and resolves nothing.

`sys_statx` shares `stat_at_path`, so it failed identically.

## Reproduction

It needs no distro rootfs and no glibc of a particular vintage: an empty
directory passed to `--sysroot` is enough, because the gate is only that a
sysroot is active. A guest program that opens a pipe, a socketpair and an
eventfd and calls `fstatat(fd, "", &st, AT_EMPTY_PATH)` on each:

```
### before, --sysroot <empty dir> ###
  pipe-read    fstatat(fd,"",AT_EMPTY_PATH) rc=-1 errno=20(Not a directory)
  pipe-read    fstat(fd)                    rc=0  mode=10000
  socketpair   fstatat(fd,"",AT_EMPTY_PATH) rc=-1 errno=20(Not a directory)
  eventfd      fstatat(fd,"",AT_EMPTY_PATH) rc=-1 errno=20(Not a directory)
  dirfd        fstatat(fd,"",AT_EMPTY_PATH) rc=0  mode=40000
```

Without `--sysroot` every line already returned 0, which matches the report.

## The fix

The empty path is answered from the descriptor before anything tries to resolve
it. The new `stat_empty_path_fd` is the branch that already existed for this
case, moved in front of the resolver rather than left behind it, so the FUSE
shim, the `/proc` intercept for O_PATH and the plain `fstat` keep their order,
the order `sys_fstat` uses, since it answers the same question. AT_FDCWD stays
where it was: the cwd always has a base path, so it was never affected, and the
branch that served it is now the only thing left there.

## Test

`tests/test-fstatat-empty-path.c`, in the shape of `test-fchmodat-empty-path.c`
as the report suggested. Every case asserts the `fstatat` answer against what
plain `fstat()` returns for the same descriptor, since the two are the same
question and the divergence is the bug: pipe read end, pipe write end,
socketpair, eventfd, plus a regular fd, an O_PATH fd and a directory fd for the
paths this change moves; `statx` over the same set; AT_FDCWD; and EBADF for a
closed fd.

| | pass | fail |
|---|---|---|
| unfixed, `--sysroot` | 8 | **7**, every one ENOTDIR |
| fixed, `--sysroot` | 15 | 0 |
| fixed, no sysroot | 15 | 0 |

Registered in two places, deliberately: `tests/test-matrix.sh` so a real kernel
adjudicates the semantics, and a `make check` lane in `mk/tests.mk` that runs it
under `--sysroot`, since without one the empty path never reaches the code that
used to fail it and the test would pass without proving anything.

## What I ran

`make test-fstatat-empty-path`, `bash tests/driver.sh -e build/elfuse -d build`
(97 passed, 1 failed, `test-hello`, missing binary: this machine has no
`aarch64-none-elf-as`, and it fails the same way on an unmodified tree),
`test-pty`, `test-file-ops`, `test-proc`, `test-fd-family`, `test-chown-overlay`,
and the `test-sysroot-nofollow`, `test-sysroot-path-matrix`,
`test-sysroot-case-exact`, `test-sysroot-dotdot` and `test-usb-sysfs-sysroot`
lanes, all green. `make check-format`, `make check-ascii`,
`make check-skill-refs` and `.ci/check-matrix-lists.sh` pass. Full `make check`
stops at `build/test-hello` for the toolchain reason above, so everything past
that is on CI.

## Two things left deliberately undone

- **`EXPECTED_BASELINES` not raised.** This adds one registered test to both
  aarch64 lanes, but I cannot run the matrix here (no fixtures), and the comment
  above that table is explicit that a floor too low costs nothing while an
  unobserved one asserts a run that did not happen.
- **An adjacent deviation, not fixed here.** Under `--sysroot`,
  `fstatat(pipe_fd, "", &st, 0)` (no AT_EMPTY_PATH) returns ENOTDIR, where
  Linux returns ENOENT: `getname_flags()` rejects an empty name before
  `path_init()` ever reaches the `d_can_lookup()` check, and that check is
  gated on `*s` being non-empty anyway. Same resolver, different question, and
  the closed-fd case next to it (EBADF here, ENOENT on Linux by the same
  reasoning) would need deciding with it. I could not test either against a real
  kernel from this machine, so the test asserts only that the call fails without
  the flag rather than asserting an errno I have not measured. Filed separately
  as #354, with the measurements and the kernel reading behind them.


