### PR TITLE
Take a ptrace stop where the registers are real

### DIFF
--- a/.claude/skills/elfuse-guest-abi/SKILL.md
+++ b/.claude/skills/elfuse-guest-abi/SKILL.md
@@ -34,13 +34,14 @@ Only `bad_exception` vectors may clobber X5, because they halt.
 | #0 | Normal exit | x0 = exit code |
 | #2 | Bad exception | x0=ESR, x1=FAR, x2=ELR, x3=SPSR, x5=vector |
 | #4 | Set sysreg | x0 = reg ID, x1 = value |
-| #5 | Syscall forward | X0-X5=args, X8=nr; on return X8=TLBI kind |
+| #5 | Syscall forward | X0-X5=args, X8=nr; on return X8=TLBI kind, X7=ptrace-stop request |
 | #6 | Embedder extension | X8=call nr, X0-X7=args |
 | #7 | MRS trap | host reads reg from ESR ISS, returns in x0 |
 | #9 | W^X toggle | x0=FAR, x1=type (0=exec->RX, 1=write->RW) |
 | #10 | BRK from EL0 | SIGTRAP / ptrace-stop |
 | #11 | EL0 fault | SIGSEGV / SIGILL |
 | #12 | System instruction trap | cache maintenance logging |
+| #13 | Ptrace stop | taken after the shim restores the HVC #5 saved frame |
 
 The register contract per HVC, including which return values each one accepts,
 is the header comment in `src/core/shim.S`. That comment is the specification;
@@ -69,6 +70,23 @@ the block size the shim assumes.
 X11=1 is the icache-flush hint: set when a page transitions to executable, and
 the shim then issues an IC invalidate alongside whichever TLBI it picked. The
 shim restores X11 from the saved frame before ERET, so EL0 never observes it.
+
+X7 is the ptrace-stop request on the same return, and it obeys a rule the TLBI
+codes do not. The shim reads it only after restoring the saved frame, so the
+tracer snapshots the guest's architectural registers rather than shim scratch;
+non-zero means take HVC #13 before the ERET. That makes X7 unusable on the one
+tail that never restores the frame, X8 = 2, where the live registers already
+are the final EL0 state and a host write to X7 would land in EL0 as guest
+state. The host takes that stop inline in the epilogue instead and leaves X7
+alone, and an `execve` re-entry, which has no tail at all, leaves the stop owed
+for the new image.
+
+Two consequences for anyone editing the dispatch in `shim.S`. Every exit from
+it has to reach the X7 test, so branch to `svc_hvc_restore_eret`, never to
+`svc_restore_eret`: a tail that skips the test drops a stop the host has
+already consumed, and the tracer waits forever in `wait4`. And do not put a
+numeric label on `svc_restore_eret`, because a `1f` anywhere in the tail would
+then reach it and skip the test. Both of these have been live bugs.
 
 The host accumulates the smallest sufficient request in `cpu_tlbi_req`
 (`src/core/guest.h`), which is `_Thread_local` per vCPU. Never promote it to a
@@ -108,7 +126,9 @@ your path goes through the dispatch epilogue at all:
   than returning from a syscall, because there is no shim frame to drop.
 - Bypass the epilogue by returning `SYSCALL_EXEC_HAPPENED`. The epilogue
   returns early, before it writes X0 or X8. `sys_execve` works this way, and
-  the normal X0 writeback is exactly what it needs to avoid.
+  the normal X0 writeback is exactly what it needs to avoid. It must also skip
+  the X7 write for the same reason it skips X0, which is what
+  `syscall_return_epilogue` calls an exec re-entry.
 - `signal_rt_sigreturn` does both, because it has restored the entire register
   set and neither the frame restore nor the X0 writeback may happen.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,13 +64,15 @@ Software requirements:
 * [shellcheck](https://www.shellcheck.net/), at warning severity.
 * [shfmt](https://github.com/mvdan/sh) and [black](https://github.com/psf/black), for shell and
   Python.
-  Neither version is pinned; `make indent` uses whatever is on `PATH` and skips the step when the
-  tool is absent.
+  Both are opt-in: neither version is pinned and no gate reads their output, so running them
+  unconditionally rewrites files nothing asked to change. Set `FORMAT_SHELL=1` or `FORMAT_PY=1`
+  to include them, and `make indent` still skips the step when the tool is absent.
 
 To maintain a uniform style across languages, run:
 * `make indent` to rewrite in place: `commentflow` over the C, shell, and assembly sources first,
-  then clang-format over the C sources, `shfmt -ln=bash -i 4 -ci -bn -fn -sr` over the shell
-  scripts, `black` over the Python scripts.
+  then clang-format over the C sources. Adding `FORMAT_SHELL=1` runs
+  `shfmt -ln=bash -i 4 -ci -bn -fn -sr` over the shell scripts and `FORMAT_PY=1` runs `black` over
+  the Python scripts.
   The order is not arbitrary. clang-format breaks a comment line that runs past the limit but never
   refills a short-wrapped one, so commentflow
   runs first and clang-format normalizes whatever indentation the reflow produced; the pair

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ seven commit-message rules the log is written to.
 Two things settle most review comments before they are written:
 
 ```sh
-make indent        # apply every formatter, comment reflow included
+make indent        # clang-format and comment reflow (FORMAT_SHELL/FORMAT_PY add the rest)
 make check-format  # verify without rewriting
 ```
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -354,6 +354,7 @@ aligned address from the `Rt` register); HVF traps DC ZVA via `HCR_EL2.TDZ=1`.
 | #10 | BRK from EL0 | SIGTRAP delivery / ptrace-stop; GPRs in frame |
 | #11 | EL0 fault | SIGSEGV/SIGILL delivery; GPRs in frame |
 | #12 | EL0 system-instruction trap | cache maintenance logging (DC CVAU, IC IVAU, …) and `MSR TPIDR_EL0` emulation |
+| #13 | Ptrace interrupt | the shim restores the saved SVC frame before this stop, so ptrace snapshots architectural registers |
 
 ### Critical Vector-Entry Rule
 
@@ -790,7 +791,12 @@ In `src/syscall/proc.c`:
 - `PTRACE_SEIZE` -- attach without stopping; sets `ptraced = 1`.
 - `PTRACE_CONT` -- resume the stopped tracee, optionally injecting a signal.
 - `PTRACE_INTERRUPT` -- force the tracee into ptrace-stop via
-  `hv_vcpus_exit()`.
+  `hv_vcpus_exit()`. A stop taken on a syscall return whose tail restores the
+  saved SVC frame goes through HVC #13, so ptrace snapshots the architectural
+  GPR set rather than shim scratch. The tails that rebuild EL0 state instead
+  (`X8 = 2`) already hold that set live, so the host stops on them directly;
+  an `execve` re-entry leaves the stop owed for the new image's first
+  syscall.
 - `PTRACE_GETREGSET` / `PTRACE_SETREGSET` (`NT_PRSTATUS`) -- read or write
   the tracee's register snapshot. Writes are applied on resume.
 

--- a/frama-c-stubs/Hypervisor/Hypervisor.h
+++ b/frama-c-stubs/Hypervisor/Hypervisor.h
@@ -36,7 +36,7 @@
 typedef int hv_return_t;
 
 #define HV_SUCCESS 0
-#define HV_BAD_ARGUMENT 0xfae94001
+#define HV_BAD_ARGUMENT 0xfae94003
 
 typedef uint64_t hv_vcpu_t;
 typedef uint32_t hv_reg_t;
@@ -104,7 +104,15 @@ typedef uint32_t hv_memory_flags_t;
 
 typedef uint32_t hv_exit_reason_t;
 
-#define HV_EXIT_REASON_CANCELED 1
+/* hv_vcpu_types.h enumerates these in order from zero. CANCELED read 1 until it
+ * was measured against the SDK, which put every analysis of the run loop's
+ * dispatch on the wrong branch. check-stub-constants.py compiles each of these
+ * against the SDK header, so the values are held rather than trusted.
+ */
+#define HV_EXIT_REASON_CANCELED 0
+#define HV_EXIT_REASON_EXCEPTION 1
+#define HV_EXIT_REASON_VTIMER_ACTIVATED 2
+#define HV_EXIT_REASON_UNKNOWN 3
 
 typedef struct {
     uint64_t syndrome;

--- a/frama-c-stubs/libproc.h
+++ b/frama-c-stubs/libproc.h
@@ -1,0 +1,167 @@
+/*
+ * libproc.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * syscall/proc.c is the one caller. It uses proc_pidpath to answer three
+ * questions about a host pid: what elfuse's own binary is (recorded once at
+ * startup and served to /proc/self/exe), whether a host pid the process table
+ * names is still the process it was, and whether a candidate parent is another
+ * elfuse. It enumerates live pids once besides, to reap the process table
+ * against what the host still has, and runtime/procemu.c lists one process's
+ * open fds to answer /proc/<pid>/fd.
+ *
+ * Declarations only. Both calls are kernel lookups the analyzer's memory model
+ * cannot see into, so a body would be fiction; leaving them unspecified makes
+ * WP treat the buffer as written with unknown contents, which is what the
+ * callers already assume.
+ *
+ * Same placement rule as the other Darwin stubs: outside src/, reachable only
+ * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+
+/* sys/syslimits.h. procemu.c uses this for host-side fd path buffers. */
+#define MAXPATHLEN 1024
+
+/* sys/proc_info.h spells this (4*MAXPATHLEN), and MAXPATHLEN is 1024. */
+#define PROC_PIDPATHINFO_MAXSIZE 4096
+
+/* sys/proc_info.h. The only selector proc_listpids is called with here. */
+#define PROC_ALL_PIDS 1
+
+/* sys/proc_info.h. runtime/procemu.c walks a process's open fds with these. */
+#define PROC_PIDLISTFDS 1
+#define PROC_PIDLISTFD_SIZE (sizeof(struct proc_fdinfo))
+
+/* sys/proc_info.h selector and result for socket fd details. */
+#define PROC_PIDFDSOCKETINFO 3
+
+/* sys/proc_info.h fd types; procemu.c only distinguishes sockets. */
+#define PROX_FDTYPE_SOCKET 2
+
+struct proc_fdinfo {
+    int32_t proc_fd;
+    uint32_t proc_fdtype;
+};
+
+struct proc_fileinfo {
+    uint32_t fi_openflags;
+    uint32_t fi_status;
+    int64_t fi_offset;
+    int32_t fi_type;
+    uint32_t fi_guardflags;
+};
+
+struct in4in6_addr {
+    uint32_t i46a_pad32[3];
+    struct in_addr i46a_addr4;
+};
+
+struct in_sockinfo {
+    int insi_fport;
+    int insi_lport;
+    uint64_t insi_gencnt;
+    uint32_t insi_flags;
+    uint32_t insi_flow;
+    uint8_t insi_vflag;
+    uint8_t insi_ip_ttl;
+    uint32_t rfu_1;
+    union {
+        struct in4in6_addr ina_46;
+        struct in6_addr ina_6;
+    } insi_faddr, insi_laddr;
+    struct {
+        uint8_t in4_tos;
+    } insi_v4;
+    struct {
+        uint8_t in6_hlim;
+        int in6_cksum;
+        uint16_t in6_ifindex;
+        short in6_hops;
+    } insi_v6;
+};
+
+struct tcp_sockinfo {
+    struct in_sockinfo tcpsi_ini;
+    int tcpsi_state;
+    int tcpsi_timer[4];
+    int tcpsi_mss;
+    uint32_t tcpsi_flags;
+    uint32_t rfu_1;
+    uint64_t tcpsi_tp;
+};
+
+struct un_sockinfo {
+    uint64_t unsi_conn_so;
+    uint64_t unsi_conn_pcb;
+    union {
+        struct sockaddr_un ua_sun;
+        char ua_dummy[255];
+    } unsi_addr;
+    union {
+        struct sockaddr_un ua_sun;
+        char ua_dummy[255];
+    } unsi_caddr;
+};
+
+struct sockbuf_info {
+    uint32_t sbi_cc;
+    uint32_t sbi_hiwat;
+    uint32_t sbi_mbcnt;
+    uint32_t sbi_mbmax;
+    uint32_t sbi_lowat;
+    short sbi_flags;
+    short sbi_timeo;
+};
+
+struct socket_info {
+    char soi_stat[136];
+    uint64_t soi_so;
+    uint64_t soi_pcb;
+    int soi_type;
+    int soi_protocol;
+    int soi_family;
+    short soi_options;
+    short soi_linger;
+    short soi_state;
+    short soi_qlen;
+    short soi_incqlen;
+    short soi_qlimit;
+    short soi_timeo;
+    uint16_t soi_error;
+    uint32_t soi_oobmark;
+    struct sockbuf_info soi_rcv;
+    struct sockbuf_info soi_snd;
+    int soi_kind;
+    uint32_t rfu_1;
+    union {
+        struct in_sockinfo pri_in;
+        struct tcp_sockinfo pri_tcp;
+        struct un_sockinfo pri_un;
+    } soi_proto;
+};
+
+struct socket_fdinfo {
+    struct proc_fileinfo pfi;
+    struct socket_info psi;
+};
+
+int proc_pidpath(int pid, void *buffer, uint32_t buffersize);
+int proc_pidinfo(int pid,
+                 int flavor,
+                 uint64_t arg,
+                 void *buffer,
+                 int buffersize);
+int proc_pidfdinfo(int pid, int fd, int flavor, void *buffer, int buffersize);
+int proc_listpids(uint32_t type,
+                  uint32_t typeinfo,
+                  void *buffer,
+                  int buffersize);

--- a/frama-c-stubs/mach/mach.h
+++ b/frama-c-stubs/mach/mach.h
@@ -1,0 +1,96 @@
+/*
+ * mach/mach.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The last header keeping syscall/sys.c and runtime/procemu.c out of the
+ * parsing set. Both ask the same question in the same way: host_statistics64
+ * with HOST_VM_INFO64, for the page counts behind sysinfo's freeram and
+ * /proc/meminfo. sys.c reads free_count and purgeable_count, procemu.c reads
+ * free_count and inactive_count. host_page_size scales them.
+ *
+ * Declarations only, like the other Darwin stubs. What these calls do is
+ * kernel-side and invisible to the memory model, so a body would be fiction.
+ *
+ * struct vm_statistics64 is reproduced in full rather than trimmed to the four
+ * fields the tree reads, because HOST_VM_INFO64_COUNT is derived from its size
+ * and both callers pass that count to host_statistics64. A short struct would
+ * silently pass a different count than the real build does, which is the same
+ * class of quiet wrongness that had HV_EXIT_REASON_CANCELED at 1 for a value
+ * the SDK enumerates as 0.
+ *
+ * Same placement rule as the other Darwin stubs: outside src/, reachable only
+ * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+typedef int kern_return_t;
+typedef unsigned int natural_t;
+typedef int integer_t;
+typedef unsigned int mach_port_t;
+typedef unsigned int mach_msg_type_number_t;
+typedef unsigned long vm_size_t;
+typedef integer_t *host_info64_t;
+
+#define KERN_SUCCESS 0
+#define MACH_PORT_NULL 0
+#define HOST_VM_INFO64 4
+
+/* mach/vm_statistics.h, reproduced verbatim; see the note above on why in full.
+ */
+struct vm_statistics64 {
+    natural_t free_count;
+    natural_t active_count;
+    natural_t inactive_count;
+    natural_t wire_count;
+    uint64_t zero_fill_count;
+    uint64_t reactivations;
+    uint64_t pageins;
+    uint64_t pageouts;
+    uint64_t faults;
+    uint64_t cow_faults;
+    uint64_t lookups;
+    uint64_t hits;
+    uint64_t purges;
+    natural_t purgeable_count;
+    natural_t speculative_count;
+    uint64_t decompressions;
+    uint64_t compressions;
+    uint64_t swapins;
+    uint64_t swapouts;
+    natural_t compressor_page_count;
+    natural_t throttled_count;
+    natural_t external_page_count;
+    natural_t internal_page_count;
+    uint64_t total_uncompressed_pages_in_compressor;
+    uint64_t swapped_count;
+    uint64_t total_tag_storage_pages;
+    uint64_t nontag_pageable_tag_storage_pages;
+    uint64_t nontag_wired_tag_storage_pages;
+    uint64_t free_tag_storage_pages;
+    uint64_t tag_storing_tag_storage_pages;
+    uint64_t total_tagged_pages;
+    uint64_t resident_tagged_pages;
+    uint64_t compressed_tagged_pages;
+    uint64_t tagged_compressions;
+    uint64_t tagged_decompressions;
+    uint64_t compressed_tag_storage_bytes;
+};
+
+typedef struct vm_statistics64 vm_statistics64_data_t;
+typedef struct vm_statistics64 *vm_statistics64_t;
+
+#define HOST_VM_INFO64_COUNT                                    \
+    ((mach_msg_type_number_t) (sizeof(vm_statistics64_data_t) / \
+                               sizeof(integer_t)))
+
+mach_port_t mach_host_self(void);
+kern_return_t host_page_size(mach_port_t host, vm_size_t *out_page_size);
+kern_return_t host_statistics64(mach_port_t host_priv,
+                                int flavor,
+                                integer_t *host_info64_out,
+                                mach_msg_type_number_t *host_info64_outCnt);

--- a/frama-c-stubs/macos-libc.h
+++ b/frama-c-stubs/macos-libc.h
@@ -142,3 +142,18 @@ struct fpunchhole {
 #ifndef st_ctimespec
 #define st_ctimespec st_ctim
 #endif
+
+/* unistd.h confstr selector. syscall/proc.c asks for the per-user temp dir when
+ * it composes the process-table path; Frama-C's libc models confstr but not the
+ * Darwin selectors it takes.
+ */
+#define _CS_DARWIN_USER_TEMP_DIR 65537
+
+/* sys/qos.h. syscall/proc.c raises the vCPU threads to the interactive class so
+ * the scheduler does not park them behind background work. The SDK spells these
+ * as enumerators of qos_class_t, which check-stub-constants.py compares by
+ * compiling against the header.
+ */
+typedef unsigned int qos_class_t;
+#define QOS_CLASS_USER_INTERACTIVE 0x21
+int pthread_set_qos_class_self_np(qos_class_t qos_class, int relative_priority);

--- a/frama-c-stubs/sys/resource.h
+++ b/frama-c-stubs/sys/resource.h
@@ -1,0 +1,88 @@
+/*
+ * sys/resource.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The one stub here that replaces a modeled header outright rather than taking
+ * it through #include_next and renaming a name. Frama-C's libc models struct
+ * rusage with the two fields POSIX requires, ru_utime and ru_stime. Darwin
+ * declares sixteen, and syscall/proc.c does not merely read the extra ones:
+ * write_rusage_to_guest asserts sizeof(struct rusage) equals the guest's
+ * linux_rusage_t and memcpy's one onto the other, so a two-field model fails
+ * the static assertion before any analysis starts. A rename cannot add twelve
+ * fields, and defining the struct alongside the modeled one is a redefinition,
+ * so this file supplies the whole header.
+ *
+ * That makes it the stub most likely to go stale: anything the tree starts
+ * using from sys/resource.h has to be added here or the file stops parsing. The
+ * set below is what src/ uses today (getrusage, getrlimit, setrlimit,
+ * getpriority, setpriority, and the constants beside them), and nothing else.
+ *
+ * Values and layout come from the macOS SDK; scripts/check-stub-constants.py
+ * holds the constants to it. The field order matters as much as the names,
+ * because the assertion above is about size and the memcpy is about layout.
+ *
+ * Same placement rule as the other Darwin stubs: outside src/, reachable only
+ * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/time.h>
+#include <sys/types.h> /* id_t, for the priority calls below */
+
+typedef uint64_t rlim_t;
+
+/* Darwin's __DARWIN_C_FULL spelling. The first two are what POSIX requires and
+ * what Frama-C models; the fourteen longs after them are what this stub exists
+ * for.
+ */
+struct rusage {
+    struct timeval ru_utime;
+    struct timeval ru_stime;
+    long ru_maxrss;
+    long ru_ixrss;
+    long ru_idrss;
+    long ru_isrss;
+    long ru_minflt;
+    long ru_majflt;
+    long ru_nswap;
+    long ru_inblock;
+    long ru_oublock;
+    long ru_msgsnd;
+    long ru_msgrcv;
+    long ru_nsignals;
+    long ru_nvcsw;
+    long ru_nivcsw;
+};
+
+struct rlimit {
+    rlim_t rlim_cur;
+    rlim_t rlim_max;
+};
+
+#define RUSAGE_SELF 0
+#define RUSAGE_CHILDREN (-1)
+
+#define RLIM_INFINITY (((uint64_t) 1 << 63) - 1)
+
+#define RLIMIT_CPU 0
+#define RLIMIT_FSIZE 1
+#define RLIMIT_DATA 2
+#define RLIMIT_STACK 3
+#define RLIMIT_CORE 4
+#define RLIMIT_AS 5
+#define RLIMIT_RSS RLIMIT_AS
+#define RLIMIT_MEMLOCK 6
+#define RLIMIT_NPROC 7
+#define RLIMIT_NOFILE 8
+
+#define PRIO_PROCESS 0
+
+int getrusage(int who, struct rusage *r_usage);
+int getrlimit(int resource, struct rlimit *rlp);
+int setrlimit(int resource, const struct rlimit *rlp);
+int getpriority(int which, id_t who);
+int setpriority(int which, id_t who, int prio);

--- a/frama-c-stubs/sys/sysctl.h
+++ b/frama-c-stubs/sys/sysctl.h
@@ -1,0 +1,55 @@
+/*
+ * sys/sysctl.h, for the analyzer only
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Frama-C's libc does not model this header, which stopped syscall/sys.c and
+ * runtime/procemu.c before either reached the analyzer. It was recorded as one
+ * of the gaps no stub could honestly supply, alongside sys/event.h and
+ * sys/mount.h, but sysctl is not like those: the tree asks it two questions and
+ * both are answerable by declaration.
+ *
+ * runtime/procemu.c reads KERN_BOOTTIME to date /proc/stat's btime and
+ * /proc/uptime, and syscall/sys.c reads HW_MEMSIZE for the totalram sysinfo
+ * reports. Two calls, four constants.
+ *
+ * Declarations only, and deliberately so. What sysctl does is a kernel lookup
+ * the memory model cannot see into, so a body would be fiction; unspecified
+ * leaves WP treating the output buffer as written with unknown contents, which
+ * is what both callers already assume and check the return value for.
+ *
+ * The SDK spells the buffer parameters with __sized_by, a bounds attribute
+ * Frama-C's parser does not take. Dropping it loses nothing here: it documents
+ * a relationship between two arguments that no proof in this tree reasons
+ * about, and the callers pass a sizeof of a local either way.
+ *
+ * Same placement rule as the other Darwin stubs: outside src/, reachable only
+ * through FRAMAC_STUB_DIR in mk/verify.mk, never on a compile's include path.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <sys/types.h>
+
+/* Top-level sysctl namespaces. */
+#define CTL_KERN 1
+#define CTL_HW 6
+
+/* KERN_BOOTTIME yields a struct timeval, HW_MEMSIZE a uint64_t. */
+#define KERN_BOOTTIME 21
+#define HW_MEMSIZE 24
+
+int sysctl(int *name,
+           unsigned int namelen,
+           void *oldp,
+           size_t *oldlenp,
+           void *newp,
+           size_t newlen);
+
+int sysctlbyname(const char *name,
+                 void *oldp,
+                 size_t *oldlenp,
+                 void *newp,
+                 size_t newlen);

--- a/mk/format.mk
+++ b/mk/format.mk
@@ -55,15 +55,31 @@ check-format: check-syscall-dispatch
 	fi
 
 ## Indent all C, shell, and Python files in-place
+#
+# shfmt and black are opt-in, unlike clang-format and commentflow. Those two are
+# pinned (LINT_PKGS in .github/workflows/lint.yml, and commentflow by checksum)
+# and check-format verifies what they write, so running them is idempotent
+# against the tree. shfmt and black are neither pinned nor checked: CI installs
+# shellcheck, which lints shell but does not format it, and nothing looks at
+# Python formatting at all. Their output tracks whichever version the developer
+# happens to have, so running them unconditionally rewrites files no gate asked
+# to change. Measured on shfmt 3.14.0 and black 26.5.1 against cfc696e: one
+# shell script and one Python script, both of which check-format accepts either
+# way, landing as unrelated churn in whatever diff was open.
+#
+# Set FORMAT_SHELL=1 / FORMAT_PY=1 to run them anyway. The other way out is to
+# pin both in the workflow and add shfmt -l / black --check to check-format,
+# which makes the pair inverse; that is a CI change and it has to land with the
+# reformat it implies.
 indent: gen-syscall-dispatch
 	$(Q)COMMENTFLOW=$(COMMENTFLOW) bash .ci/check-commentflow.sh --write
 	@echo "  FMT     src/ tests/"
 	$(Q)$(CLANG_FORMAT) -i $(C_FORMAT_FILES)
-	@if command -v shfmt >/dev/null 2>&1; then \
+	@if [ -n "$(FORMAT_SHELL)" ] && command -v shfmt >/dev/null 2>&1; then \
 		printf "  SHFMT   %d scripts\n" $(words $(SHELL_SCRIPTS)); \
 		shfmt -w -ln=bash -i 4 -ci -bn -fn -sr $(SHELL_SCRIPTS); \
 	fi
-	@if command -v black >/dev/null 2>&1 && [ -n "$(PYTHON_FORMAT_FILES)" ]; then \
+	@if [ -n "$(FORMAT_PY)" ] && command -v black >/dev/null 2>&1 && [ -n "$(PYTHON_FORMAT_FILES)" ]; then \
 		printf "  BLACK   %d files\n" $(words $(PYTHON_FORMAT_FILES)); \
 		black --quiet $(PYTHON_FORMAT_FILES); \
 	fi

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -7,7 +7,7 @@
 # src/elfuse-limits.h.
 ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-nofile)
 
-.PHONY: test-hello test-all check check-syscall-coverage check-eintr-contract check-lock-order check-atomics check-ascii check-skill-refs test-gdbstub test-coreutils test-busybox test-shim-futex-stats test-vcpu-watchdog \
+.PHONY: test-hello test-all check check-syscall-coverage check-eintr-contract check-lock-order check-atomics check-ascii check-svc-tails check-skill-refs test-gdbstub test-coreutils test-busybox test-shim-futex-stats test-vcpu-watchdog \
         test-static-bins \
         test-dynamic test-dynamic-coreutils test-glibc-dynamic \
         test-glibc-coreutils test-perf \
@@ -91,6 +91,11 @@ check-ascii:
 	@echo "  ASCII   src/"
 	@python3 scripts/check-ascii.py --self-test
 	@python3 scripts/check-ascii.py
+
+## Fail when an HVC #5 return tail can reach EL0 without the X7 ptrace test
+check-svc-tails:
+	@python3 scripts/check-svc-tails.py --self-test
+	@python3 scripts/check-svc-tails.py
 
 ## Verify every path, target, and section the skills name still resolves
 check-skill-refs:
@@ -264,7 +269,7 @@ check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) $(CHECK_HOST_UNIT_BINS)
 	$(CHECK_SHARED_LANES)
 
 ## Run the unit test suite plus busybox applet validation
-check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-eintr-contract check-lock-order check-atomics check-ascii check-skill-refs test-config \
+check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-eintr-contract check-lock-order check-atomics check-ascii check-svc-tails check-skill-refs test-config \
 		$(CHECK_HOST_UNIT_BINS)
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
 	$(CHECK_SHARED_LANES)

--- a/scripts/check-stub-constants.py
+++ b/scripts/check-stub-constants.py
@@ -20,9 +20,11 @@ Usage:
 """
 
 import argparse
+import os
 import pathlib
 import re
 import subprocess
+import tempfile
 import sys
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -31,25 +33,40 @@ STUB_DIR = ROOT / "frama-c-stubs"
 # Only object-like defines with an integer value. A macro with parameters or a
 # non-numeric body is not a constant this can compare, and is reported as
 # unchecked rather than silently passed.
+# Any object-like define, not just the ones whose body is a bare literal. A
+# body this cannot turn into an integer is not skipped: it goes to the compile
+# probe below, because a constant the gate cannot read is exactly the one that
+# drifts unnoticed. RLIM_INFINITY, RLIMIT_RSS and RUSAGE_CHILDREN were
+# invisible here while the file's own comment claimed the SDK held them.
+# Same line only: "\s" spans newlines, so a bodyless include guard would
+# otherwise swallow the line after it and read as a constant. A body ending in
+# a backslash is a multi-line macro, which is a derived value rather than a
+# mirrored constant.
 DEFINE = re.compile(
-    r"^#define\s+([A-Z_][A-Z_0-9]*)\s+(0[xX][0-9a-fA-F]+|\d+)\s*$", re.M
+    r"^[ \t]*#[ \t]*define[ \t]+([A-Z_][A-Z_0-9]*)[ \t]+([^\n\\]+?)[ \t]*$",
+    re.M,
 )
+
+LITERAL = re.compile(r"^\(?\s*(-?)\s*(0[xX][0-9a-fA-F]+|\d+)\s*\)?$")
 
 
 def c_int(token):
-    """Value of a C integer literal, octal included.
+    """Value of a C integer literal, octal and a wrapping minus included.
 
     int(token, 0) is not this function: Python rejects a leading zero, and
     Darwin writes whole families that way. TIOCM_DTR is 0002 in sys/ioccom.h,
     so a gate using int(_, 0) does not report a mismatch on it, it raises
     ValueError and takes the build down with a traceback.
     """
-    text = token.lower()
+    m = LITERAL.match(token.strip())
+    if not m:
+        raise ValueError(token)
+    sign, text = (-1 if m.group(1) else 1), m.group(2).lower()
     if text.startswith("0x"):
-        return int(text, 16)
+        return sign * int(text, 16)
     if len(text) > 1 and text.startswith("0"):
-        return int(text, 8)
-    return int(text, 10)
+        return sign * int(text, 8)
+    return sign * int(text, 10)
 
 
 def sdk_path():
@@ -115,6 +132,165 @@ def sdk_values(include_dir, names):
     return found
 
 
+def sdk_enum_values(sdk, search_dirs, names, want_of, origin):
+    """Value-check names the SDK declares as enumerators.
+
+    sdk_values only sees object-like defines, so every Hypervisor constant used
+    to reach the report as "mentioned, value not comparable" and no gate looked
+    at what it equalled. HV_EXIT_REASON_CANCELED sat at 1 that way while the SDK
+    enumerated it as 0, which put every analysis of the run loop's dispatch on
+    the wrong branch.
+
+    The compiler is the only thing that knows an enumerator's value, so ask it:
+    include the SDK header that declares the name and let a _Static_assert
+    compare. Nothing is run, only compiled, and a failure names the constant.
+
+    Returns (disagree, unchecked): the names whose value differs, each with
+    the stub's spelling of it, and the names no SDK header would compile so
+    the question went unanswered.
+    """
+    fw_root = sdk / "System" / "Library" / "Frameworks"
+
+    def include_for(header):
+        """Framework headers must be reached the framework way.
+
+        Including Hypervisor's hv_error.h by absolute path compiles but leaves
+        the enumerators undeclared, because the umbrella header is what pulls
+        in the platform guards they sit behind. The stub tree's own layout says
+        which framework a name belongs to: frama-c-stubs/Hypervisor mirrors
+        Hypervisor.framework.
+        """
+        parts = pathlib.Path(header).parts
+        if "Frameworks" in parts:
+            fw = parts[parts.index("Frameworks") + 1].removesuffix(".framework")
+            return f"<{fw}/{fw}.h>"
+        return f'"{header}"'
+
+    def probe(header, name):
+        """Ask the compiler what @name equals. Returns (decided, disagrees).
+
+        Compares 32-bit bit patterns rather than values. The SDK enumerates
+        HV_BAD_ARGUMENT as a signed int holding 0xFAE94003, so a stub spelling
+        it as the unsigned 0xfae94003 is the same constant and must not read as
+        a disagreement; a genuine difference like 0 against 1 still does.
+
+        A compile that fails for any other reason is not evidence, so only the
+        assertion's own diagnostic counts. Matching on the name would match the
+        source line the compiler echoes back, which contains it either way.
+        """
+        want32 = want_of[name] & 0xFFFFFFFF
+        body = [
+            f"#include {include_for(header)}",
+            f"_Static_assert((unsigned long long) (unsigned int) ({name})"
+            f" == {want32}ULL, \"{name}\");",
+        ]
+        with tempfile.NamedTemporaryFile("w", suffix=".c", delete=False) as f:
+            f.write("\n".join(body) + "\n")
+            path = f.name
+        try:
+            run = subprocess.run(
+                ["cc", "-fsyntax-only", "-isysroot", str(sdk), "-F",
+                 str(fw_root), path],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if run.returncode == 0:
+                return True, False
+            if "static assertion failed" in run.stderr:
+                return True, True
+            return False, False
+        finally:
+            os.unlink(path)
+
+    # One name at a time, trying each header that mentions it until one gives a
+    # definitive answer. Picking the first grep hit and trusting it landed on
+    # block.h, which mentions a name in passing and cannot be compiled alone.
+    bad, unchecked = [], []
+    for name in names:
+        candidates = subprocess.run(
+            ["grep", "-rlE", "--include=*.h", rf"\b{name}\b",
+             *[str(d) for d in search_dirs]],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).stdout.split()
+        for header in candidates:
+            decided, disagrees = probe(header, name)
+            if decided:
+                if disagrees:
+                    bad.append((name, want_of[name]))
+                break
+        else:
+            # No header gave an answer. Reporting that as checked is how an
+            # unverified enumerator would pass, which is the hole this whole
+            # probe exists to close.
+            unchecked.append(name)
+    return bad, unchecked
+
+
+def sdk_expr_values(sdk, search_dirs, exprs):
+    """Check defines whose body is an expression rather than a literal.
+
+    The SDK grep can only compare literals, so these used to fall out of the
+    gate entirely: not reported as unchecked, simply absent. The compiler
+    settles them. Including the SDK header and asserting its spelling of the
+    name against the stub's body also checks a body that names another
+    constant, since both sides then read the SDK.
+
+    Returns (disagree, unchecked).
+    """
+    fw_root = sdk / "System" / "Library" / "Frameworks"
+    bad, unchecked = [], []
+    for name, raw in exprs:
+        candidates = subprocess.run(
+            ["grep", "-rlE", "--include=*.h", rf"\b{name}\b",
+             *[str(d) for d in search_dirs]],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).stdout.split()
+        decided = False
+        for header in candidates:
+            parts = pathlib.Path(header).parts
+            if "Frameworks" in parts:
+                fw = parts[parts.index("Frameworks") + 1].removesuffix(
+                    ".framework"
+                )
+                inc = f"<{fw}/{fw}.h>"
+            else:
+                inc = f'"{header}"'
+            body = [
+                "#include <stdint.h>",
+                f"#include {inc}",
+                f'_Static_assert((long long) ({name}) == (long long) ({raw}),'
+                f' "{name}");',
+            ]
+            with tempfile.NamedTemporaryFile("w", suffix=".c", delete=False) as f:
+                f.write("\n".join(body) + "\n")
+                path = f.name
+            try:
+                run = subprocess.run(
+                    ["cc", "-fsyntax-only", "-isysroot", str(sdk), "-F",
+                     str(fw_root), path],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+            finally:
+                os.unlink(path)
+            if run.returncode == 0:
+                decided = True
+                break
+            if "static assertion failed" in run.stderr:
+                bad.append((name, raw))
+                decided = True
+                break
+        if not decided:
+            unchecked.append((name, raw))
+    return bad, unchecked
+
+
 def stub_files(explicit):
     """Every header under frama-c-stubs, not just macos-libc.h.
 
@@ -163,17 +339,37 @@ def main():
             frameworks.append(headers.resolve())
 
     defines = []
+    exprs = []
     origin = {}
     for stub in stubs:
         for name, raw in DEFINE.findall(stub.read_text()):
-            defines.append((name, raw))
             origin[name] = stub.relative_to(ROOT)
+            try:
+                c_int(raw)
+            except ValueError:
+                # Not a literal, so the SDK grep cannot compare it. The
+                # compiler can: assert the SDK's name against this body.
+                exprs.append((name, raw))
+                continue
+            defines.append((name, raw))
     if not defines:
         print(f"  no integer defines found under {STUB_DIR}; the regex moved")
         return 1
 
     names = [name for name, _ in defines]
     found = sdk_values(include_dir, names)
+
+    if exprs:
+        bad_expr, unchecked_expr = sdk_expr_values(
+            sdk, [include_dir, *frameworks], exprs
+        )
+        if bad_expr or unchecked_expr:
+            print("  stub constants the SDK does not agree with:")
+            for name, raw in bad_expr:
+                print(f"    {origin[name]}: {name} is not {raw} in the SDK")
+            for name, raw in unchecked_expr:
+                print(f"    {origin[name]}: {name} could not be compiled")
+            return 1
 
     # Only for the names the value scan came up empty on. Asking it about all of
     # them means grepping a 3,400-file tree for bare words, and one of those
@@ -195,6 +391,25 @@ def main():
             # other; either way there is nothing here that matches the stub.
             wrong.append((name, want, sorted(got)))
 
+    # The enumerator half. Everything above compares object-like defines; these
+    # need the compiler, so they are checked separately and folded into the same
+    # report.
+    if enum_only:
+        want_of = {name: c_int(raw) for name, raw in defines}
+        disagree, unchecked = sdk_enum_values(
+            sdk, [include_dir, *frameworks], enum_only, want_of, origin
+        )
+        for name, want in disagree:
+            wrong.append((name, want, ["differs; the SDK enumerates it"]))
+            enum_only.remove(name)
+        if unchecked:
+            print("  no SDK header would compile for these, so their values")
+            print("  went unchecked:")
+            for name in sorted(unchecked):
+                print(f"    {origin[name]}: {name}")
+            print("  An unverified enumerator must not read as a verified one.")
+            return 1
+
     if wrong:
         print("  stub constants disagree with the macOS SDK:")
         for name, want, got in wrong:
@@ -215,7 +430,7 @@ def main():
     note = ""
     if enum_only:
         note = (
-            f"; {len(enum_only)} named by the SDK as enumerators, value not comparable"
+            f"; {len(enum_only)} named by the SDK as enumerators, value checked by compiling against it"
         )
     print(
         f"  STUBCONST {checked} stub constant(s) in {len(stubs)} "

--- a/scripts/check-svc-tails.py
+++ b/scripts/check-svc-tails.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Hold every HVC #5 return tail to the X7 ptrace test.
+
+The host encodes a ptrace-stop request in X7 on the HVC #5 return and the shim
+reads it in svc_hvc_restore_eret. A tail that reaches EL0 without passing
+through that label drops a stop the host has already consumed, and the tracer
+waits out its wait4 forever. Nothing in the compiler or the assembler notices,
+because every spelling assembles.
+
+Two live bugs had this exact shape, which is why this is a gate and not a
+comment:
+
+  exec_drop_frame never tested X7. That one is now deliberate (the host leaves
+  X7 alone on the X8 == 2 tail, whose live registers are already the final EL0
+  state) and is the single allowed exception below.
+
+  tlbi_selective's defensive zero-count exit was "cbz x10, 1f", and 1f resolved
+  to a numeric label sitting inside svc_restore_eret, past the test. A numeric
+  local label is invisible to review in a way a named one is not, which is the
+  second thing this checks.
+
+The gate reads the dispatch region only: from the HVC #5 itself to the start of
+svc_restore_eret. Every tail the host can select lives there. Numeric labels
+inside that region are fine, and the selective-TLBI loop uses one; what is not
+fine is a reference that resolves past the end of it.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SHIM = ROOT / "src" / "core" / "shim.S"
+
+REGION_START = re.compile(r"^\s*hvc\s+#5\b")
+REGION_END = re.compile(r"^svc_restore_eret:")
+
+LABEL = re.compile(r"^([A-Za-z_.][A-Za-z_0-9.]*):")
+NUM_LABEL = re.compile(r"^(\d+):")
+BRANCH = re.compile(r"^\s*(?:b|bl|b\.[a-z]+|cbz|cbnz|tbz|tbnz)\s+(.*)$")
+
+# Transfers this script cannot follow: a register branch, and "ret", which
+# leaves through X30 rather than through the tail. The shim has none today;
+# one added here needs a different argument than "the branch targets look
+# right".
+INDIRECT = re.compile(r"^\s*(?:br|blr|ret)\b")
+
+# Control leaves a tail only through one of these. Anything else as the last
+# instruction before svc_restore_eret means the tail falls through into it,
+# which reaches EL0 having skipped the X7 test just as surely as a branch would.
+#
+# "ret" is deliberately absent. It leaves through X30, which in this dispatch
+# is a guest register restored from the saved frame, so it is neither a tail
+# this gate can follow nor one that reaches the test.
+TERMINAL = re.compile(r"^\s*(?:b|br|eret)\b(?!\.)")
+
+# The gate label earns its name only while it still tests X7.
+X7_TEST = re.compile(r"^\s*(?:cbz|cbnz)\s+x7\b")
+
+GATE = "svc_hvc_restore_eret"
+FORBIDDEN = "svc_restore_eret"
+
+# The one tail allowed to skip the test, and why. Keep the reason with the name:
+# an exception added later without one is the bug this gate exists to stop.
+ALLOWED_SKIP = {
+    "exec_drop_frame": "X8 == 2; the host takes that stop inline, never writes X7",
+}
+
+
+def branch_target(operands):
+    """The label of a branch is its last comma-separated operand."""
+    tail = operands.split(",")[-1].strip()
+    return tail.split()[0] if tail else ""
+
+
+def check(lines, path, counted=None):
+    """Return a list of problem strings. Empty means the tails are sound.
+
+    @counted, when a list, receives the number of tails reaching the test, so
+    the caller does not walk the file again just to report it.
+    """
+    start = end = None
+    for i, line in enumerate(lines):
+        if start is None and REGION_START.match(line):
+            start = i
+        elif start is not None and REGION_END.match(line):
+            end = i
+            break
+    if start is None:
+        return [f"{path}: no 'hvc #5' found; the dispatch moved or was renamed"]
+    if end is None:
+        return [f"{path}: no '{FORBIDDEN}:' after the HVC #5; the tail moved"]
+
+    named = {m.group(1): i for i, l in enumerate(lines) if (m := LABEL.match(l))}
+    numeric = [
+        (int(m.group(1)), i) for i, l in enumerate(lines) if (m := NUM_LABEL.match(l))
+    ]
+
+    problems = []
+
+    # The whole gate rests on this label testing X7. Renaming or emptying it
+    # would leave every tail branching somewhere that no longer checks.
+    gate_at = named.get(GATE)
+    if gate_at is None:
+        problems.append(f"{path}: no '{GATE}:' label; the X7 tail is gone")
+    elif not any(
+        X7_TEST.match(lines[k])
+        for k in range(gate_at + 1, min(gate_at + 6, len(lines)))
+    ):
+        problems.append(
+            f"{path}:{gate_at + 1}: '{GATE}' no longer tests X7, so every tail "
+            f"branching to it reaches EL0 unchecked"
+        )
+
+    # Fallthrough. The tail physically above svc_restore_eret reaches it with no
+    # branch at all if its last instruction is not a transfer, and a branch walk
+    # alone says nothing about that. Deleting one 'b svc_hvc_restore_eret' is the
+    # whole of the mistake.
+    last = None
+    for i in range(start, end):
+        body = LABEL.sub("", NUM_LABEL.sub("", lines[i])).strip()
+        if not body or body.startswith(("/*", "*", "//", ".")):
+            continue
+        last, last_body = i, body
+    if last is None:
+        problems.append(f"{path}: the HVC #5 dispatch has no instructions")
+    elif not TERMINAL.match(" " + last_body) and not INDIRECT.match(
+        " " + last_body
+    ):
+        problems.append(
+            f"{path}:{last + 1}: the last instruction of the HVC #5 dispatch is "
+            f"'{last_body}', so control falls through into "
+            f"{FORBIDDEN} without the X7 test. End the tail with an explicit "
+            f"'b {GATE}'."
+        )
+
+    for i in range(start, end):
+        if INDIRECT.match(lines[i]):
+            problems.append(
+                f"{path}:{i + 1}: register branch in the HVC #5 dispatch; this "
+                f"gate cannot follow it, so the X7 test cannot be shown to be "
+                f"reached."
+            )
+
+    # A numeric label on svc_restore_eret is what let a stray "1f" land past the
+    # test. Numeric labels inside the dispatch are fine; the branch walk below
+    # proves each reference resolves in the region rather than assuming it.
+    for value, at in numeric:
+        if at == end + 1:
+            problems.append(
+                f"{path}:{at + 1}: numeric label '{value}:' on {FORBIDDEN}. A "
+                f"'{value}f' anywhere in the tail above resolves here and skips "
+                f"the X7 test, which is how one live bug got in. Leave this "
+                f"label named."
+            )
+
+    for i in range(start, end):
+        m = BRANCH.match(lines[i])
+        if not m:
+            continue
+        target = branch_target(m.group(1))
+        if not target:
+            continue
+        where = f"{path}:{i + 1}"
+
+        if target == FORBIDDEN:
+            problems.append(
+                f"{where}: branches to {FORBIDDEN}, skipping the X7 ptrace "
+                f"test. Branch to {GATE} instead; it tests X7 and falls through "
+                f"to {FORBIDDEN}."
+            )
+            continue
+
+        if target == GATE:
+            continue
+
+        if target in ALLOWED_SKIP:
+            # Only the X8 == 2 edge is exempt, not the label. An unconditional
+            # branch here, or one not guarded by that compare, reaches a tail
+            # that never restores the frame from a path where the host did
+            # write X7.
+            guarded = lines[i].strip().startswith("b.eq") and any(
+                re.match(r"\s*cmp\s+x8,\s*#2\b", lines[j])
+                for j in range(max(start, i - 4), i)
+            )
+            if not guarded:
+                problems.append(
+                    f"{where}: reaches '{target}' other than through the "
+                    f"'cmp x8, #2' / 'b.eq' edge. That tail never restores the "
+                    f"frame, so a path where the host wrote X7 must not get "
+                    f"there."
+                )
+            continue
+
+        if num := re.fullmatch(r"(\d+)([fb])", target):
+            value, direction = int(num.group(1)), num.group(2)
+            candidates = [at for v, at in numeric if v == value]
+            if direction == "f":
+                dest = min((at for at in candidates if at > i), default=None)
+            else:
+                dest = max((at for at in candidates if at < i), default=None)
+            if dest is None:
+                problems.append(f"{where}: '{target}' resolves to nothing")
+            elif not start <= dest < end:
+                problems.append(
+                    f"{where}: '{target}' resolves to line {dest + 1}, outside "
+                    f"the HVC #5 dispatch, so it leaves EL1 without the X7 "
+                    f"test. Branch to {GATE} or to a named label in the tail."
+                )
+            continue
+
+        at = named.get(target)
+        if at is None:
+            problems.append(f"{where}: unknown branch target '{target}'")
+        elif not start <= at < end:
+            problems.append(
+                f"{where}: branches out of the HVC #5 dispatch to '{target}', "
+                f"which does not test X7. Every tail must reach {GATE}; add "
+                f"'{target}' to ALLOWED_SKIP in this script, with the reason, "
+                f"if it is genuinely exempt."
+            )
+
+    if counted is not None:
+        counted.append(
+            sum(
+                1
+                for i in range(start, end)
+                if (m := BRANCH.match(lines[i]))
+                and branch_target(m.group(1)) == GATE
+            )
+        )
+
+    return problems
+
+
+def _shim(tail):
+    """Wrap a dispatch tail in the minimum surrounding shape."""
+    return (
+        ["handle_svc_0:", "    hvc #5", "    cbz x8, svc_hvc_restore_eret"]
+        + tail
+        + [
+            "svc_restore_eret:",
+            "    RESTORE_GPRS_KEEP_X0",
+            "    eret",
+            "svc_hvc_restore_eret:",
+            "    cbz x7, svc_restore_eret",
+            "    b svc_restore_eret",
+            "exec_drop_frame:",
+            "    eret",
+        ]
+    )
+
+
+CASES = [
+    ("clean dispatch", _shim(["tlbi_full:", "    b svc_hvc_restore_eret"]), 0),
+    (
+        "tail branching straight to the restore",
+        _shim(["tlbi_full:", "    b svc_restore_eret"]),
+        1,
+    ),
+    (
+        "numeric forward reference escaping the region",
+        [
+            "handle_svc_0:",
+            "    hvc #5",
+            "    cbz x10, 1f",
+            "    b svc_hvc_restore_eret",
+            "svc_restore_eret:",
+            "1:",
+            "    eret",
+            "svc_hvc_restore_eret:",
+            "    cbz x7, svc_restore_eret",
+            "    eret",
+        ],
+        2,
+    ),
+    (
+        "in-region loop label is not a finding",
+        _shim(
+            [
+                "tlbi_selective:",
+                "    cbz x10, svc_hvc_restore_eret",
+                "3:  tlbi vae1is, x11",
+                "    b.ne 3b",
+                "    b svc_hvc_restore_eret",
+            ]
+        ),
+        0,
+    ),
+    (
+        "documented exception is allowed",
+        _shim(
+            [
+                "tlbi_full:",
+                "    cmp x8, #2",
+                "    b.eq exec_drop_frame",
+                "    b svc_hvc_restore_eret",
+            ]
+        ),
+        0,
+    ),
+    (
+        "tail falling through into the restore",
+        [
+            "handle_svc_0:",
+            "    hvc #5",
+            "    cbz x8, svc_hvc_restore_eret",
+            "tlbi_full:",
+            "    isb",
+            "svc_restore_eret:",
+            "    eret",
+            "svc_hvc_restore_eret:",
+            "    cbz x7, svc_restore_eret",
+            "    eret",
+        ],
+        1,
+    ),
+    (
+        "register branch cannot be cleared",
+        _shim(["tlbi_full:", "    br x16"]),
+        1,
+    ),
+    (
+        "branch out to an unrelated handler",
+        _shim(["tlbi_full:", "    b handle_brk"]) + ["handle_brk:", "    eret"],
+        1,
+    ),
+    ("no dispatch at all", ["_start:", "    ret"], 1),
+    (
+        "tail leaving through ret",
+        _shim(["tlbi_full:", "    b svc_hvc_restore_eret", "other:", "    ret"]),
+        1,
+    ),
+    (
+        "unconditional branch to the exempt tail",
+        _shim(["tlbi_full:", "    b exec_drop_frame"]),
+        1,
+    ),
+    (
+        "the X8 == 2 edge is still allowed",
+        _shim(
+            [
+                "tlbi_full:",
+                "    cmp x8, #2",
+                "    b.eq exec_drop_frame",
+                "    b svc_hvc_restore_eret",
+            ]
+        ),
+        0,
+    ),
+    (
+        "gate label emptied of its X7 test",
+        [
+            "handle_svc_0:",
+            "    hvc #5",
+            "    cbz x8, svc_hvc_restore_eret",
+            "    b svc_hvc_restore_eret",
+            "svc_restore_eret:",
+            "    eret",
+            "svc_hvc_restore_eret:",
+            "    b svc_restore_eret",
+        ],
+        1,
+    ),
+]
+
+
+def self_test():
+    print("  SVCTAIL self-test", flush=True)
+    failures = 0
+    for name, lines, expected in CASES:
+        got = len(check(lines, "<case>"))
+        if got != expected:
+            print(f"  FAIL {name}: expected {expected} problem(s), got {got}")
+            failures += 1
+    if failures:
+        print(f"  self-test: {failures} of {len(CASES)} cases failed")
+        return 1
+    print(f"  self-test: {len(CASES)} cases, all pass")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--self-test", action="store_true", help="run the checker's own cases"
+    )
+    if parser.parse_args().self_test:
+        return self_test()
+
+    counted = []
+    problems = check(SHIM.read_text().splitlines(), str(SHIM), counted)
+    print(f"  SVCTAIL {SHIM.relative_to(ROOT)}", flush=True)
+    if problems:
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            f"\n  {len(problems)} HVC #5 tail(s) can reach EL0 without the X7 "
+            f"ptrace test.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"  {counted[0]} HVC #5 tail(s) reach the X7 test, "
+        f"{len(ALLOWED_SKIP)} documented exception"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-wp-result.py
+++ b/scripts/check-wp-result.py
@@ -31,9 +31,14 @@ RESET = "\033[0m"
 # prefix that varies per proof and says nothing about which function is open,
 # so strip it and report the bare name.
 OPEN_GOAL = re.compile(
-    r"^\[wp\] \[(?:Timeout|Stepout|Unknown|Failed)\] "
+    r"^\[wp\] \[(Timeout|Stepout|Unknown|Failed)\] "
     r"(?:typed_caveat_|typed_|bytes_)?([A-Za-z0-9_]+)"
 )
+
+# Timeout and Stepout are the prover giving up on the clock or the step budget,
+# not a counterexample. They say nothing about whether the goal holds, so they
+# get their own advice below rather than the read-the-suffix key.
+RESOURCE_VERDICTS = {"Timeout", "Stepout"}
 
 PROVED_GOALS = re.compile(r"^\[wp\] Proved goals: *([0-9]+) / ([0-9]+)$")
 
@@ -55,6 +60,21 @@ MIN_GOALS_HINT = """\
            raise VERIFY_*_MIN_GOALS when adding proved functions\
 """
 
+RESOURCE_HINT = """\
+           %d of the open obligations above are prover resource limits
+           (%s), which say nothing about whether the goal holds. A loaded
+           host is the usual cause; measure before concluding anything."""
+
+# WP memoizes a verdict per goal, and a Timeout is memoized like any other, so
+# one run on a loaded host leaves the target red on every later run including
+# on an idle one. Nothing in the output says the verdict is a replay unless the
+# prover line is read, which is why this names the way out.
+CACHED_HINT = """\
+           At least one came from the WP cache in .frama-c/ rather than from a
+           prover run this time. The cache stores a timeout as if it were a
+           result, so the verdict outlives the load that caused it. Re-run the
+           target with FRAMAC_WP_CACHE=rebuild before reading anything into it."""
+
 SUFFIX_KEY = """\
            Each open obligation named above is either a real defect or an
            ACSL contract too weak to justify the code. Read the suffix:
@@ -72,12 +92,21 @@ def unproven(reason):
     return 1
 
 
+def open_goals(lines):
+    """Return [(verdict, goal, cached)] for every obligation WP left open."""
+    found = []
+    for line in lines:
+        if match := OPEN_GOAL.match(line):
+            found.append((match.group(1), match.group(2), "(Cached)" in line))
+    return found
+
+
 def report(log_path, lines, status, min_goals, src, unproved):
     """Verdict for one proof. Returns the process exit status."""
-    for line in lines:
-        match = OPEN_GOAL.match(line)
-        if match:
-            print("          open: %s" % match.group(1))
+    opened = open_goals(lines)
+    for verdict, goal, cached in opened:
+        suffix = " [%s%s]" % (verdict, ", cached" if cached else "")
+        print("          open: %s%s" % (goal, suffix))
 
     if status != 0:
         rc = unproven("frama-c exited %s; its own summary is not trusted" % status)
@@ -112,7 +141,18 @@ def report(log_path, lines, status, min_goals, src, unproved):
             "%d of %d proof obligations discharged, %d left open"
             % (proved, total, total - proved)
         )
-        print(SUFFIX_KEY)
+        resource = [g for g in opened if g[0] in RESOURCE_VERDICTS]
+        if resource:
+            kinds = ", ".join(sorted({g[0] for g in resource}))
+            print(RESOURCE_HINT % (len(resource), kinds))
+            if any(g[2] for g in resource):
+                print(CACHED_HINT)
+        # Compared against the count WP reported, not against the lines that
+        # parsed. An open obligation this could not classify still needs the
+        # key, and measuring against @opened would let one parsed timeout
+        # suppress the guidance for a second goal nobody read.
+        if len(resource) < total - proved:
+            print(SUFFIX_KEY)
         print("           Full prover output: %s" % log_path)
         return rc
 

--- a/src/core/shim-globals.h
+++ b/src/core/shim-globals.h
@@ -310,8 +310,7 @@ int shim_globals_install_per_vcpu(hv_vcpu_t vcpu,
 void shim_globals_raise_attention(guest_t *g);
 
 /* Raise or drop the ptrace lane. Separate from the signal lane's
- * raise/recompute pair because nothing recomputes this one: the thread that
- * takes the stop is what drops it.
+ * raise/recompute pair because the thread consuming the stop drops it.
  */
 void shim_globals_ptrace_attention(guest_t *g, bool owed);
 void shim_globals_recompute_attention(guest_t *g);

--- a/src/core/shim.S
+++ b/src/core/shim.S
@@ -30,6 +30,7 @@
  *                          tail preserves X0/X1/X2/X30 so signal_deliver's
  *                          register writes survive.
  *   #12  System instr trap cache maintenance logging (DC CVAU, IC IVAU, ...)
+ *   #13  Ptrace interrupt  GPRs restored from HVC #5's saved SVC frame
  *
  * X8 on return from #5, the post-syscall request:
  *   0  no flush
@@ -41,6 +42,16 @@
  *   4  single-shot TLBI RVAE1IS (FEAT_TLBIRANGE), operand pre-encoded in X9 as
  *      baddr | NUM<<39 | SCALE<<44 | TTL<<37 | ASID<<48 (SCALE, TTL and ASID
  *      are all 0 today)
+ *
+ * X7 on return from #5 is the ptrace-stop request, read on every tail that
+ * restores the saved frame, which is all of them but X8 == 2: non-zero means
+ * take HVC #13 after the restore, so the tracer sees the architectural GPR set
+ * rather than shim scratch. The host leaves X7 alone on the X8 == 2 tail, which
+ * never restores the frame and would carry the flag into EL0 as guest state; it
+ * takes that stop itself, where the live registers are already final. A tail
+ * that skips the X7 test drops a stop the host has already consumed, so new
+ * exits from the dispatch below go through svc_hvc_restore_eret, never straight
+ * to svc_restore_eret.
  *
  * X11 is the I-cache hint, read for X8 in {1, 3, 4}: 1 issues IC IALLU after
  * the TLBI because the change made new content executable, 0 skips it. X8 == 2
@@ -1708,7 +1719,7 @@ handle_svc_0:
     /* Dispatch on X8. Encoded so the common case (X8 == 0, no flush) hits the
      * cbz fast path; the other branches sort by frequency thereafter.
      */
-    cbz x8, 1f
+    cbz x8, svc_hvc_restore_eret
     cmp x8, #1
     b.eq tlbi_full
     cmp x8, #3
@@ -1736,7 +1747,7 @@ tlbi_full:
     dsb ish
 .Ltlbi_full_skip_ic:
     isb
-    b svc_restore_eret
+    b svc_hvc_restore_eret
 
 tlbi_selective:
     /* Selective TLBI VAE1IS loop.
@@ -1755,7 +1766,7 @@ tlbi_selective:
      * x11 arrives as the I-cache hint and x9 feeds the per-page operand, so
      * save the hint into x13 before clobbering.
      */
-    cbz x10, 1f
+    cbz x10, svc_hvc_restore_eret
     mov x13, x11              /* x13 = saved I-cache hint */
     /* TLBI VAE1IS operand: VA[55:12] held in bits [43:0]. ubfx pins the 44-bit
      * width so future LPA2 / TTL / tagged-address support cannot leak VA bits
@@ -1773,7 +1784,7 @@ tlbi_selective:
     dsb ish
 .Ltlbi_sel_skip_ic:
     isb
-    b svc_restore_eret
+    b svc_hvc_restore_eret
 
 tlbi_range_large:
     /* Single-shot TLBI RVAE1IS (FEAT_TLBIRANGE, ARMv8.4+). The host has encoded
@@ -1790,24 +1801,46 @@ tlbi_range_large:
     dsb ish
 .Ltlbi_rvae_skip_ic:
     isb
-    b svc_restore_eret
+    b svc_hvc_restore_eret
 
 svc_restore_eret:
-1:
     /* Restore all guest registers except X0, which now holds the syscall return
      * value. Linux preserves X1-X30, including X8.
      *
-     * Named alias for the cross-function jump from the identity fast path in
-     * svc_handler. A bare 'b 1f' from up there would resolve to the next
-     * forward '1:', which sits inside handle_inst_abort, and silently re-route
-     * the identity result into a W^X toggle. Caught the hard way during the
-     * prior P2 attempt; keep the named symbol to make the intent explicit.
+     * Named target for every jump that lands here, and deliberately without a
+     * numeric label. A bare 'b 1f' from the identity fast path in svc_handler
+     * would resolve to the next forward '1:', which sits inside
+     * handle_inst_abort, and silently re-route the identity result into a W^X
+     * toggle. Caught the hard way during the prior P2 attempt; a numeric label
+     * on this line invites the same accident from the other direction, since a
+     * '1f' anywhere in the SVC tail would reach it and skip the X7 test.
      */
     RESTORE_GPRS_KEEP_X0
 
     /* Return to EL0. X0 now holds the syscall return value, X1-X30 retain their
      * original EL0 values.
      */
+    eret
+
+svc_hvc_restore_eret:
+    cbz x7, svc_restore_eret
+
+    /* Restore the saved SVC frame before stopping, so ptrace snapshots and
+     * restores the architectural GPR set rather than shim scratch.
+     */
+    RESTORE_GPRS_KEEP_X0
+    hvc #13
+
+    /* The frame is gone, so there is no scratch register left to decode an X8
+     * request with. Flush unconditionally: a ptrace-stop has already cost a
+     * tracer round trip, and this is what covers anything the host touched
+     * while the tracee was stopped.
+     */
+    tlbi vmalle1is
+    dsb ish
+    ic iallu
+    dsb ish
+    isb
     eret
 
 exec_drop_frame:

--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -535,6 +535,24 @@ void thread_for_each(void (*fn)(thread_entry_t *t, void *ctx), void *ctx)
     pthread_mutex_unlock(&thread_lock);
 }
 
+bool thread_ptrace_interrupt_pending_locked(void)
+{
+    THREAD_FOR_EACH_ACTIVE (t) {
+        /* A vm-clone that has exited keeps its slot until a wait reaps it, and
+         * carries whatever it was owed to the grave: nothing will consume it.
+         * Counting one holds ATTN_BIT_PTRACE up for the life of the process and
+         * sends every fast path down the slow lane for a stop that can never be
+         * taken. execve reaches here past its own guard, which counts only
+         * clones that have not exited.
+         */
+        if (t->is_vm_clone && t->vm_exited)
+            continue;
+        if (t->ptrace_interrupt_pending)
+            return true;
+    }
+    return false;
+}
+
 /* exec_mode is de_thread's contract rather than teardown's: the process
  * continues afterwards, so a straggler must not be detached (the handle stays
  * claimable for the real teardown) and a vm-clone slot must not be waited on at
@@ -1168,7 +1186,17 @@ static int64_t thread_elapsed_ms(const struct timespec *since)
 
 int thread_exec_de_thread(void)
 {
-    if (!current_thread || thread_count_joinable_siblings() == 0)
+    if (!current_thread)
+        return 0;
+
+    /* execve tears down an in-process tracer with the old thread group. */
+    pthread_mutex_lock(&thread_lock);
+    current_thread->ptraced = false;
+    current_thread->tracer_tid = 0;
+    current_thread->ptrace_interrupt_pending = false;
+    pthread_mutex_unlock(&thread_lock);
+
+    if (thread_count_joinable_siblings() == 0)
         return 0;
 
     /* Let an open quiesce window close before reaping anything.

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -566,6 +566,10 @@ int64_t thread_ptrace_wait(int64_t tracer_tid,
                            int options);
 
 /* Get the thread table mutex (needed for ptrace wait blocking). */
+/*@
+  ensures \valid(\result);
+  assigns \nothing;
+ */
 pthread_mutex_t *thread_get_lock(void);
 
 /* Snapshot every active guest stack range overlapping [start, end), then record

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -178,9 +178,11 @@ typedef struct thread_entry {
                                        * shim, where the live registers are shim
                                        * scratch and a stop would show the tracer
                                        * those instead of the guest's. Consumed
-                                       * where the state is readable: the HVC #5
-                                       * epilogue, or the canceled-exit handler
-                                       * once it has established EL0. A vCPU
+                                       * in the HVC #5 epilogue, which then
+                                       * either stops in place or routes the
+                                       * stop through HVC #13, or by the
+                                       * canceled-exit handler once it has
+                                       * established EL0. A vCPU
                                        * still in bring-up (!vcpu_valid) cannot
                                        * be kicked at all and self-kicks at
                                        * publish. Under thread_lock.
@@ -364,6 +366,11 @@ uint64_t thread_alloc_sp_el1(const guest_t *g, thread_entry_t *t);
  * thread table lock during iteration.
  */
 void thread_for_each(void (*fn)(thread_entry_t *t, void *ctx), void *ctx);
+
+/* True when a tracee that can still consume one owes a PTRACE_INTERRUPT stop.
+ * An exited vm-clone is not one of those. Caller holds thread_lock.
+ */
+bool thread_ptrace_interrupt_pending_locked(void);
 
 /* Count active VM-clone threads (is_vm_clone && !vm_exited). Used to detect
  * when the last VM-clone child exits.

--- a/src/syscall/exec.c
+++ b/src/syscall/exec.c
@@ -137,6 +137,25 @@ static void exec_republish_shim_globals_or_die(hv_vcpu_t vcpu,
     shim_globals_rebuild_urandom_bitmap();
     shim_globals_refill_urandom_ring(g);
     shim_globals_recompute_attention(g);
+
+    /* The ptrace lane is not part of the recompute above, which owns only the
+     * signal lane, so shim_globals_init's memset is otherwise the last word on
+     * it. Restate it from the live thread table instead of inheriting a zero.
+     *
+     * No test covers this and none can today, which is worth saying plainly
+     * rather than leaving as an apparent gap: after a successful execve no
+     * tracer is left to observe the lane. thread_exec_de_thread has removed
+     * every CLONE_THREAD sibling, and an execve with a live CLONE_VM child is
+     * refused with ENOSYS well before this point, so the scan can only answer
+     * false and the memset already wrote that. What this buys is that the
+     * post-exec value is stated where the other lanes are stated, instead of
+     * being a consequence of a memset elsewhere continuing to be correct. It
+     * starts carrying weight the moment a tracer can outlive an exec.
+     */
+    pthread_mutex_t *tlock = thread_get_lock();
+    pthread_mutex_lock(tlock);
+    shim_globals_ptrace_attention(g, thread_ptrace_interrupt_pending_locked());
+    pthread_mutex_unlock(tlock);
 }
 
 /* Release the buffers and temporary host-side files that sys_execve allocates

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -1920,9 +1920,11 @@ int64_t sys_ptrace(guest_t *g,
          * fast path, and stopping there snapshots shim scratch as the guest's
          * registers (thread_ptrace_stop reads the live set) and discards
          * whatever the tracer writes back, since the shim restores its own
-         * frame over it. The two places that can read the guest's state
-         * honestly consume the flag instead: the HVC #5 epilogue, and the
-         * canceled-exit handler once it has established the vCPU is at EL0.
+         * frame over it. The HVC #5 epilogue consumes the flag and then either
+         * stops right there, on the tails whose live registers are already the
+         * final EL0 set, or asks the shim through X7 to restore the frame and
+         * come back at HVC #13. The canceled-exit handler consumes it once it
+         * has established the vCPU is at EL0.
          *
          * Attention goes up before the kick, the same order
          * shim_globals_raise_attention uses and for the same reason: a fast
@@ -3867,28 +3869,13 @@ static bool vcpu_handle_el0_fault(guest_t *g,
     return sig_ret >= 0;
 }
 
-static void ptrace_attention_owed(thread_entry_t *t, void *opaque)
-{
-    if (t->ptrace_interrupt_pending)
-        *(bool *) opaque = true;
-}
-
-/* Take the ptrace-stop this thread is owed, if any, and inject whatever signal
- * the tracer resumed it with.
- *
- * Both callers reach here only where the guest's registers are the live set:
- * the HVC #5 epilogue, which runs with the syscall frame still architectural,
- * and the canceled-exit handler after it has established EL0. That is the whole
- * point of routing PTRACE_INTERRUPT through a flag rather than acting on the
- * kick where it lands, which can be anywhere inside the shim.
- *
- * Returns false when the tracer resumed with a signal whose delivery failed,
- * which is the caller's cue to stop running.
+/* Consume this thread's owed stop. The pending scan and attention clear share
+ * thread_lock with PTRACE_INTERRUPT so a racing request cannot lose its hint.
  */
-static bool ptrace_take_owed_stop(guest_t *g, hv_vcpu_t vcpu, int *exit_code)
+static bool ptrace_consume_owed_stop(guest_t *g)
 {
     if (!current_thread)
-        return true;
+        return false;
 
     pthread_mutex_t *tlock = thread_get_lock();
     pthread_mutex_lock(tlock);
@@ -3896,28 +3883,39 @@ static bool ptrace_take_owed_stop(guest_t *g, hv_vcpu_t vcpu, int *exit_code)
                 current_thread->ptraced && !current_thread->ptrace_stopped;
     if (owed)
         current_thread->ptrace_interrupt_pending = false;
+    if (owed && !thread_ptrace_interrupt_pending_locked())
+        shim_globals_ptrace_attention(g, false);
     pthread_mutex_unlock(tlock);
 
-    if (!owed)
-        return true;
+    return owed;
+}
 
-    /* Dropped before the stop, not after: thread_ptrace_stop blocks until the
-     * tracer resumes, and holding the hint up for that whole time would make
-     * every other thread's fast paths bail for as long as a human is looking at
-     * a register dump. Keep it raised while another thread still owes a stop.
-     */
-    bool attention_owed = false;
-    thread_for_each(ptrace_attention_owed, &attention_owed);
-    if (!attention_owed)
-        shim_globals_ptrace_attention(g, false);
+/* Set where the syscall epilogue asks the shim for the HVC #13 detour, cleared
+ * where that detour arrives. Per-vCPU like cpu_tlbi_req and for the same
+ * reason: the thread that arms it is the thread that takes the stop.
+ *
+ * The window between the two is the X7 test, the frame restore, and the HVC,
+ * with nothing else reachable in between. A canceled exit can land there, and
+ * the flag has to survive that, which is why it is not cleared per exit; the
+ * canceled handler sees EL1 in CPSR and resumes into the same window. No other
+ * HVC is reachable from the SVC tail, and EL0 cannot issue one at all, so an
+ * unarmed HVC #13 means the shim and this file disagree.
+ */
+static _Thread_local bool cpu_ptrace_stop_armed;
 
+/* Take a consumed ptrace-stop and inject the tracer's resume signal. Every
+ * caller has already consumed the stop, which establishes current_thread.
+ */
+static bool ptrace_take_stop(guest_t *g, hv_vcpu_t vcpu, int *exit_code)
+{
     int cont_sig = thread_ptrace_stop(current_thread, SIGTRAP);
-    if (cont_sig > 0) {
+    if (cont_sig > 0)
         signal_queue(cont_sig);
-        if (signal_deliver(vcpu, g, exit_code) < 0)
-            return false;
-    }
-    return true;
+
+    /* One delivery covers both the injected resume signal and anything that
+     * arrived while the tracee was stopped, so neither caller repeats it.
+     */
+    return !signal_pending() || signal_deliver(vcpu, g, exit_code) >= 0;
 }
 
 /* What a run-loop exit handler tells the loop to do next. VCPU_RESUME means the
@@ -3943,6 +3941,84 @@ typedef enum {
  * signal delivery both skip themselves once something has failed) and a caller
  * flag would not be visible to them.
  */
+
+/* Finish an HVC #5 return: take or defer any owed ptrace-stop, deliver pending
+ * signals, and place the shim's X7 detour request.
+ *
+ * Returns whether the guest keeps running.
+ */
+static bool syscall_return_epilogue(guest_t *g,
+                                    hv_vcpu_t vcpu,
+                                    int ret,
+                                    bool running,
+                                    int *exit_code)
+{
+    /* Whether the shim's tail restores the saved frame is what decides if X7 is
+     * host-only. The vector entry clobbers no GPR below X9, so the live set at
+     * HVC #5 is still the guest's, and only that restore puts a host write to
+     * X7 back. Two tails skip it: X8 == 2, where the host has rebuilt EL0 state
+     * and the live registers are already final, and an execve re-entry, which
+     * goes through the MMU-off _start with no tail at all.
+     *
+     * Only the exec-happened return has to ask the vCPU which of those it is.
+     * Everywhere else tlbi_request_emit_to_vcpu has just written X8 itself and
+     * never writes 2, so the answer is known without the register read.
+     */
+    bool frame_restored = ret != SYSCALL_EXEC_HAPPENED;
+    bool regs_final = false;
+    if (!frame_restored) {
+        uint64_t x8_req = 0;
+        hv_vcpu_get_reg(vcpu, HV_REG_X8, &x8_req);
+        regs_final = x8_req == 2; /* rt_sigreturn, as against execve */
+    }
+
+    /* An execve re-entry leaves the stop owed rather than consuming it: there
+     * is no tail to carry X7, and stopping on the MMU-off bootstrap state would
+     * show the tracer an EL1 PC. Attention stays raised, so the new image's
+     * first syscall takes it.
+     */
+    bool defer_stop = false, stop_taken = false;
+    if (running && (frame_restored || regs_final) &&
+        ptrace_consume_owed_stop(g)) {
+        if (regs_final) {
+            /* Live registers are already the architectural EL0 set, which is
+             * what the detour exists to produce. Stop here instead.
+             */
+            running = ptrace_take_stop(g, vcpu, exit_code);
+            stop_taken = true;
+        } else {
+            defer_stop = true;
+        }
+    }
+
+    /* Deliver pending signals after each syscall. A deferred stop takes its
+     * signal in the HVC #13 handler, once the shim has restored the frame.
+     * signal_deliver is a once-per-epilogue call by its own contract: it walks
+     * past discarded signals to the first the guest can see, and a second call
+     * here would stack a frame on the handler the first one just installed.
+     * ptrace_take_stop has already made that call on the inline path.
+     */
+    if (running && !defer_stop && !stop_taken && signal_pending()) {
+        int sig_ret = signal_deliver(vcpu, g, exit_code);
+        if (sig_ret < 0)
+            running = false; /* Default TERM/CORE disposition */
+        else if (sig_ret > 0)
+            frame_restored = false; /* committed to a handler frame: X8 = 2 */
+    }
+
+    /* X7 asks the shim to restore its SVC frame and enter HVC #13 for this
+     * stop. Written only on the tails that do restore the frame, which put the
+     * guest's own X7 back before the ERET. The flag beside it is what lets the
+     * HVC #13 arm say a stop was actually asked for.
+     */
+    if (frame_restored) {
+        hv_vcpu_set_reg(vcpu, HV_REG_X7, defer_stop);
+        cpu_ptrace_stop_armed = defer_stop;
+    }
+
+    return running;
+}
+
 static vcpu_action_t vcpu_handle_exception_exit(guest_t *g,
                                                 hv_vcpu_t vcpu,
                                                 const hv_vcpu_exit_t *vexit,
@@ -4011,22 +4087,7 @@ static vcpu_action_t vcpu_handle_exception_exit(guest_t *g,
                     (unsigned long long) tblocked, signal_pending());
             }
 
-            /* Take any ptrace-stop owed to this thread. Here rather than where
-             * the PTRACE_INTERRUPT kick landed, because the kick can land at
-             * EL1 in the shim and the guest's registers are only the live set
-             * on this path. Before signal delivery, so a tracer that resumes
-             * with a signal sees it delivered on top of the state it just
-             * inspected.
-             */
-            if (running && !ptrace_take_owed_stop(g, vcpu, exit_code))
-                running = false;
-
-            /* Deliver pending signals after each syscall */
-            if (running && signal_pending()) {
-                int sig_ret = signal_deliver(vcpu, g, exit_code);
-                if (sig_ret < 0)
-                    running = false; /* Default TERM/CORE disposition */
-            }
+            running = syscall_return_epilogue(g, vcpu, ret, running, exit_code);
 
             /* After exec, verify critical registers before resuming vCPU. This
              * closes any gap where signal delivery or other code between
@@ -4109,6 +4170,24 @@ static vcpu_action_t vcpu_handle_exception_exit(guest_t *g,
             vcpu_handle_sysinstr_trap(vcpu, verbose, prefix);
             break;
         }
+
+        case 13:
+            /* Only the epilogue above arms this. Without the check a detour
+             * nobody asked for would park the thread in thread_ptrace_stop
+             * waiting on a tracer that will never CONT it: a silent hang
+             * instead of a report.
+             */
+            if (!cpu_ptrace_stop_armed) {
+                log_fatal("%s: HVC #13 with no ptrace stop armed", prefix);
+                crash_report(vcpu, g, CRASH_UNEXPECTED_HVC,
+                             "HVC #13 without an armed ptrace stop");
+                *exit_code = 128;
+                running = false;
+                break;
+            }
+            cpu_ptrace_stop_armed = false;
+            running = ptrace_take_stop(g, vcpu, exit_code);
+            break;
 
         case 2: {
             running = vcpu_handle_bad_exception(g, vcpu, prefix, exit_code);
@@ -4300,8 +4379,8 @@ static vcpu_action_t vcpu_handle_canceled_exit(guest_t *g,
      * either HVC #5 or an ERET to EL0, the fast paths test attention on entry,
      * futex_wait_fast re-tests it inside its spin, and both the signal and
      * ptrace kicks raise attention before kicking. So the work lands a
-     * microsecond later at HVC #5, where the epilogue does it on the path built
-     * for it.
+     * microsecond later at HVC #5, which restores the frame before HVC #13
+     * takes the stop.
      */
     uint64_t cur_cpsr = 0;
     hv_vcpu_get_reg(vcpu, HV_REG_CPSR, &cur_cpsr);
@@ -4323,7 +4402,7 @@ static vcpu_action_t vcpu_handle_canceled_exit(guest_t *g,
      * brought the vCPU here may not be the one that owes it, and the flag is
      * what says whether anything is owed at all.
      */
-    if (!ptrace_take_owed_stop(g, vcpu, exit_code))
+    if (ptrace_consume_owed_stop(g) && !ptrace_take_stop(g, vcpu, exit_code))
         return VCPU_STOP;
 
     /* rseq preemption abort: mirrors Linux rseq_ip_fixup() on context switch.

--- a/tests/test-busybox.sh
+++ b/tests/test-busybox.sh
@@ -260,7 +260,29 @@ run_check find "hello.txt" "$TMPDIR" "-name" "hello.txt"
 
 # Networking
 printf '\n%s── Networking ──%s\n' "$BLUE" "$RESET"
-run_check nslookup "Address" "example.com"
+
+# nslookup queries live DNS, so a host that has momentarily lost its uplink
+# fails it for reasons that say nothing about busybox or about elfuse's socket
+# path. The wget guard below already draws that line; without the same one here
+# a dropped uplink turns make check red with a misleading verdict, which is what
+# it did on a hotspot that came back a minute later.
+#
+# The probe reaches the nameserver the guest will query, over TCP, rather than
+# asking the system resolver. dscacheutil goes through mDNSResponder, which
+# answers from cache, so on a dropped uplink it still returns the record it
+# holds while the guest's live UDP query gets nothing: the probe would pass and
+# the test would fail, which is the case this guard exists to prevent.
+#
+# Reachability of the resolver rather than a full lookup, so a nameserver that
+# is up but answering SERVFAIL still reaches the check and is reported. A
+# resolver that serves UDP but refuses TCP reads as unreachable and skips, which
+# loses coverage rather than inventing a failure.
+nameserver=$(scutil --dns 2> /dev/null | awk '/nameserver\[0\]/ {print $3; exit}')
+if [ -n "$nameserver" ] && nc -z -w 2 "$nameserver" 53 2> /dev/null; then
+    run_check nslookup "Address" "example.com"
+else
+    run_skip nslookup "no reachable nameserver from this host"
+fi
 
 # wget pulls a real document from example.com. In sandboxed CI / corporate
 # networks where outbound HTTP is filtered, this fails with "No route to host"

--- a/tests/test-ptrace-interrupt.c
+++ b/tests/test-ptrace-interrupt.c
@@ -28,7 +28,10 @@
  * This is an elfuse-internal test. PTRACE_SEIZE of a thread in the caller's own
  * thread group fails with EPERM on Linux, so the reference kernel cannot
  * adjudicate the shape, and what is under test is elfuse's own register
- * snapshot rather than a kernel behavior.
+ * snapshot rather than a kernel behavior. The penultimate stop also changes
+ * x21, which the final snapshot verifies survived PTRACE_CONT. The tracee
+ * signals itself throughout, so a share of the kicks are consumed on the
+ * rt_sigreturn tail, which returns on host-rebuilt state.
  */
 
 #include <stdint.h>
@@ -50,6 +53,8 @@
  * the guest's own code.
  */
 #define CANARY 0x5ec0ffee5ec0ffeeULL
+#define SIGUSR1 10
+#define UPDATED_CANARY 0x1234567812345678ULL
 
 /* Between the highest address this guest maps and the lowest the shim uses, so
  * a PC at or above it can only be shim state.
@@ -87,11 +92,45 @@ static char tracee_stack[64 * 1024] __attribute__((aligned(16)));
 static volatile int tracee_ready;
 static volatile int tracee_stop;
 
-/* Only calls the shim answers without ever reaching the host: getpid off the
+typedef struct {
+    void (*handler)(int);
+    unsigned long flags;
+    void *restorer;
+    unsigned long mask;
+} k_sigaction_t;
+
+static volatile int tracee_nosig;
+static volatile int tracee_sigs;
+static volatile int tracee_quiet;
+
+/* A stop can land inside this handler, and the canary check upstairs cannot
+ * tell which frame it caught. Pin X21 to the value the loop holds so either
+ * frame answers the same.
+ */
+static void tracee_sig_handler(int sig)
+{
+    register uint64_t canary asm("x21") = CANARY;
+    (void) sig;
+    tracee_sigs++;
+    __asm__ volatile("" : : "r"(canary));
+}
+
+/* Mostly calls the shim answers without ever reaching the host: getpid off the
  * identity cache, and a 256-byte urandom read off the entropy ring, which is
  * the longest EL1 run the shim has that cannot block. Nothing here parks, so
  * the thread is always either in EL0 or inside the shim and a kick has
  * somewhere useful to land.
+ *
+ * The self-signal is the exception, and it is deliberate: rt_sigreturn returns
+ * on state the host rebuilt rather than on the shim's saved frame, so it is the
+ * one syscall tail that cannot carry the stop request back through the shim. A
+ * kick consumed there and not taken is a stop the tracer never sees.
+ *
+ * That coverage is statistical, not guaranteed: nothing here can observe which
+ * tail consumed a given kick, only that the run as a whole raised signals. It
+ * holds because the signal cycle dominates the loop, and it was measured to
+ * hold, failing at round 0 or 1 every time the inline stop was removed. Thin
+ * the signal traffic here and the detector weakens with it.
  */
 static int tracee_fn(void)
 {
@@ -100,11 +139,27 @@ static int tracee_fn(void)
     int fd = (int) raw_syscall4(56, -100 /* AT_FDCWD */, (long) "/dev/urandom",
                                 0 /* O_RDONLY */, 0);
 
+    k_sigaction_t act = {tracee_sig_handler, 0, 0, 0};
+    raw_syscall4(134, SIGUSR1, (long) &act, 0, 8); /* rt_sigaction */
+    long pid = raw_getpid();
+    long tid = raw_gettid();
+
     tracee_ready = 1;
     while (!tracee_stop) {
+        /* Reached only outside a handler: the signal this loop raises is
+         * delivered on the tgkill return below, so a handler that started has
+         * already returned by the time control is back here. Publishing the
+         * acknowledgement here, and never raising another signal once nosig is
+         * set, is what lets the tracer know no sigframe is in flight.
+         */
+        if (tracee_nosig)
+            tracee_quiet = 1;
+
         raw_getpid();
         if (fd >= 0)
             raw_syscall3(63, fd, (long) buf, sizeof(buf)); /* read */
+        if (!tracee_nosig)
+            raw_tgkill((int) pid, (int) tid, SIGUSR1);
         raw_getpid();
     }
 
@@ -131,6 +186,28 @@ static long getregs(long tid, user_pt_regs_t *regs)
     return raw_syscall4(117, PTRACE_GETREGSET, tid, NT_PRSTATUS, (long) &iov);
 }
 
+static long setregs(long tid, const user_pt_regs_t *regs)
+{
+    iovec_t iov = {(void *) regs, sizeof(*regs)};
+    return raw_syscall4(117, PTRACE_SETREGSET, tid, NT_PRSTATUS, (long) &iov);
+}
+
+/* Yield while a wait is likely to be short, then sleep. A pure yield spin is a
+ * convoy on the thread table lock the tracee needs to make progress, and a pure
+ * sleep costs a millisecond on waits that almost always resolve at once.
+ */
+static void poll_backoff(int spin)
+{
+    struct {
+        long sec, nsec;
+    } ms = {0, 1000000};
+
+    if (spin < 500)
+        raw_syscall0(124); /* sched_yield */
+    else
+        raw_syscall2(101, (long) &ms, 0); /* nanosleep */
+}
+
 int main(void)
 {
     long stops = 0, el1_pc = 0, bad_canary = 0;
@@ -149,20 +226,45 @@ int main(void)
     }
 
     for (int r = 0; r < ROUNDS; r++) {
+        /* Quiesce the self-signal before the SETREGSET rounds and wait for the
+         * tracee to acknowledge from outside any handler.
+         *
+         * Counting rounds is not enough. A stop can catch the tracee inside a
+         * handler, SETREGSET then writes x21 into the handler's live set, and
+         * the rt_sigreturn that follows restores the sigframe's older x21 over
+         * it. The final round would read the pre-write canary and fail a test
+         * that is not testing signals at all. The acknowledgement is published
+         * at a point no sigframe can be in flight, so the write lands on the
+         * loop's own registers.
+         */
+        if (r == ROUNDS - 4) {
+            tracee_nosig = 1;
+            for (int spin = 0; spin < 1000 && !tracee_quiet; spin++)
+                poll_backoff(spin);
+            if (!tracee_quiet) {
+                printf("FAIL: tracee never quiesced at round %d\n", r);
+                return 1;
+            }
+        }
+
         if (raw_syscall4(117, PTRACE_INTERRUPT, tracee, 0, 0) != 0)
             continue;
 
         /* WNOHANG with a bounded poll rather than a blocking wait4: a stop that
          * never arrives is the regression this file is about, and it should be
          * reported rather than hung on.
+         *
+         * poll_backoff explains the shape. The budget stays under the 10 s
+         * TEST_TIMEOUT in tests/lib/test-runner.sh, so a genuinely lost stop is
+         * reported here rather than by the harness watchdog.
          */
         int status = 0;
         long w = -1;
-        for (int spin = 0; spin < 200000; spin++) {
+        for (int spin = 0; spin < 1500; spin++) {
             w = raw_syscall4(260, tracee, (long) &status, 1 /* WNOHANG */, 0);
             if (w > 0)
                 break;
-            raw_syscall0(124);
+            poll_backoff(spin);
         }
         if (w <= 0) {
             printf("FAIL: no ptrace-stop within the poll at round %d\n", r);
@@ -179,8 +281,17 @@ int main(void)
         stops++;
         if (regs.pc >= EL0_PC_CEILING)
             el1_pc++;
-        if (regs.regs[21] != CANARY)
+        uint64_t expected_canary = (r == ROUNDS - 1) ? UPDATED_CANARY : CANARY;
+        if (regs.regs[21] != expected_canary)
             bad_canary++;
+
+        if (r == ROUNDS - 2) {
+            regs.regs[21] = UPDATED_CANARY;
+            if (setregs(tracee, &regs) != 0) {
+                printf("FAIL: SETREGSET refused at round %d\n", r);
+                return 1;
+            }
+        }
 
         raw_syscall4(117, PTRACE_CONT, tracee, 0, 0);
     }
@@ -201,7 +312,11 @@ int main(void)
                stops);
         return 1;
     }
-
-    printf("OK: ptrace-stop reports EL0 state (%ld stops)\n", stops);
+    if (tracee_sigs == 0) {
+        printf("FAIL: the tracee never took its own signal\n");
+        return 1;
+    }
+    printf("OK: ptrace-stop reports EL0 state (%ld stops, %d signals)\n", stops,
+           tracee_sigs);
     return 0;
 }

--- a/tests/test-signal.c
+++ b/tests/test-signal.c
@@ -13,6 +13,9 @@
  * 3. sigprocmask blocks/unblocks signals correctly
  * 4. SA_RESETHAND resets the handler to SIG_DFL after delivery
  * 5. alarm() interrupts a blocking read with EINTR
+ * 6. X7 survives delivery and rt_sigreturn (aarch64: the host uses X7 on the
+ *    HVC #5 return to ask the shim for a ptrace detour, and the tails that
+ *    rebuild EL0 state never restore it from the saved frame)
  */
 
 #include <errno.h>
@@ -22,6 +25,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <ucontext.h>
 
 static volatile sig_atomic_t handler_called = 0;
 static volatile int handler_signum = 0;
@@ -107,6 +111,45 @@ static int test_callee_saved(void)
 #undef N_CALLEE_SAVED
     return ok;
 }
+
+#if defined(__aarch64__)
+#define X7_CANARY 0x00C0FFEE0000B007ULL
+static volatile unsigned long uc_x7 = 0;
+
+static void x7_handler(int sig, siginfo_t *info, void *ucv)
+{
+    (void) info;
+    ucontext_t *uc = ucv;
+    uc_x7 = uc->uc_mcontext.regs[7];
+    handler_signum = sig;
+    handler_called = 1;
+}
+
+/* Park the canary in X7, then take an SVC that queues a signal to this thread.
+ * Delivery happens on that syscall's return path, so both the handler's
+ * ucontext and the state rt_sigreturn resumes on have to show the canary. A
+ * host-only flag left in X7 shows up as a zero in one or both.
+ */
+static unsigned long x7_across_signal(long pid, long sig)
+{
+    register long x0 __asm__("x0") = pid;
+    register long x1 __asm__("x1") = sig;
+    register unsigned long x7 __asm__("x7") = X7_CANARY;
+    register long x8 __asm__("x8") = 129; /* SYS_kill */
+
+    /* X8 is an in-out operand, not an input. Linux preserves it across SVC and
+     * so does the shim's frame restore, but a signal delivered on this return
+     * takes the drop-frame tail, and the frame rt_sigreturn restores from
+     * snapshotted X8 after the host had already written the TLBI request into
+     * it. Letting the compiler assume 129 survives would be wrong here.
+     */
+    __asm__ volatile("svc #0\n"
+                     : "+r"(x0), "+r"(x7), "+r"(x8)
+                     : "r"(x1)
+                     : "memory", "cc");
+    return x7;
+}
+#endif
 
 int main(void)
 {
@@ -223,6 +266,27 @@ int main(void)
             close(p[1]);
         }
     }
+
+#if defined(__aarch64__)
+    /* Test 6: X7 is not part of the syscall return ABI */
+    printf("test-signal: 6. X7 survives delivery and rt_sigreturn... ");
+    {
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_sigaction = x7_handler;
+        sa.sa_flags = SA_SIGINFO;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGUSR1, &sa, NULL);
+        handler_called = 0;
+        uc_x7 = 0;
+        unsigned long resumed = x7_across_signal(getpid(), SIGUSR1);
+        if (handler_called && uc_x7 == X7_CANARY && resumed == X7_CANARY) {
+            printf("PASS\n");
+        } else {
+            printf("FAIL (uc=0x%lx resumed=0x%lx)\n", uc_x7, resumed);
+            failures++;
+        }
+    }
+#endif
 
     if (failures == 0) {
         printf("test-signal: all tests passed -- PASS\n");


### PR DESCRIPTION
A PTRACE_INTERRUPT that lands while the tracee is at EL1 inside a shim fast
path stops there, which snapshots shim scratch as the guest's registers and
discards whatever the tracer writes back once the shim restores its own frame.
The host now routes the stop through X7 and `HVC #13` so the frame is restored
first, and takes it inline on the two tails that have already rebuilt EL0
state.

Reproduction, before the first commit:

    make check
    tests/test-ptrace-interrupt.c reports a PC above EL0_PC_CEILING

The branch also carries verification and harness work that came out of
validating the above, and can be split off if that reads better as its own
PR: two Hypervisor stub constants disagreed with the SDK
(HV_EXIT_REASON_CANCELED read 1 where the SDK enumerates 0), the gate that
should have caught them could not see enumerator values, four new stubs bring
syscall/proc.c and syscall/sys.c into the parsing set, and nslookup now skips
rather than fails when the host itself cannot resolve.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PTRACE_INTERRUPT stops taken while the tracee sits inside a shim fast path: they used to snapshot shim scratch as the guest's registers and discard the tracer's writes. Stops are now routed through X7 on the HVC #5 return and HVC #13, so the shim restores its saved SVC frame first; the two tails that rebuild EL0 state stop inline, and an execve re-entry leaves the stop owed for the new image.

**Bug fixes**
- An unarmed HVC #13 is now a crash report instead of a thread parked forever.
- A new `check-svc-tails` gate holds every HVC #5 tail to the X7 test, with `exec_drop_frame` as the sole documented exception.

**Verification and harness**
- `check-stub-constants.py` now checks enumerator values by compiling against the SDK, catching `HV_EXIT_REASON_CANCELED` at 1 where the SDK enumerates 0.
- New Frama-C stubs (`sys/resource.h`, `libproc.h`, `sys/sysctl.h`, `mach/mach.h`) bring `syscall/proc.c` and `syscall/sys.c` into the parsing set.
- `check-wp-result.py` reports prover timeouts and cached verdicts distinctly from real open goals.
- `make indent` runs shfmt and black only with `FORMAT_SHELL=1` / `FORMAT_PY=1`.
- `nslookup` skips rather than fails when the host resolver cannot reach DNS.
- `test-ptrace-interrupt` signals itself so kicks land on the rt_sigreturn tail, and verifies `SETREGSET` writes survive `PTRACE_CONT`.
- `test-signal` checks X7 survives signal delivery and `rt_sigreturn`.

<sup>Written for commit c5344e3778ea8d03880bdf984f4c371861818c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



