### PR TITLE
Drain the deferred stack unmap before the tid

### DIFF
--- a/src/runtime/forkipc.c
+++ b/src/runtime/forkipc.c
@@ -1106,10 +1106,11 @@ startup_ok:
      * how pthread_join works in musl: the joining thread does FUTEX_WAIT on
      * this address until it becomes 0.
      *
-     * Drain any deferred munmap of this thread's stack before waking the
-     * joiner: the parent may reuse the freed VA as soon as it returns from
-     * pthread_join, and reuse must not race with the deferred unmap.
+     * Drain deferred stack munmaps before the store, not merely before the
+     * wake: a joiner polling the tid never reaches FUTEX_WAIT, so ordering the
+     * drain against the wake alone lets it reuse the VA while still mapped.
      */
+    mem_cleanup_deferred_stack_unmaps(g, t);
     bool wake_ctid = false;
     if (t->clear_child_tid != 0) {
         uint32_t zero = 0;
@@ -1124,7 +1125,6 @@ startup_ok:
                 (unsigned long long) t->clear_child_tid);
         }
     }
-    mem_cleanup_deferred_stack_unmaps(g, t);
     if (wake_ctid)
         futex_wake_one(g, t->clear_child_tid);
 
@@ -1392,10 +1392,10 @@ static void *vm_clone_thread_run(void *arg)
     int wait_status = 0;
     int exit_code = vcpu_run_loop(vcpu, vexit, g, verbose, 0, &wait_status);
 
-    /* CLONE_CHILD_CLEARTID cleanup. Same ordering as thread_entry: drain
-     * deferred stack munmaps before waking the joiner so the parent does not
-     * reuse the VA before it is released.
+    /* CLONE_CHILD_CLEARTID cleanup. Same ordering as thread_entry: drain before
+     * the store, so a joiner that never blocks cannot reuse the VA early.
      */
+    mem_cleanup_deferred_stack_unmaps(g, t);
     bool wake_ctid = false;
     if (t->clear_child_tid != 0) {
         uint32_t zero = 0;
@@ -1410,7 +1410,6 @@ static void *vm_clone_thread_run(void *arg)
                 (unsigned long long) t->clear_child_tid);
         }
     }
-    mem_cleanup_deferred_stack_unmaps(g, t);
     if (wake_ctid)
         futex_wake_one(g, t->clear_child_tid);
 


### PR DESCRIPTION
Fixes #357.

## Problem

The CLONE_CHILD_CLEARTID exit path stored 0 into the tid address and only
then drained the exiting thread's deferred stack munmaps:

```c
guest_write_small(g, t->clear_child_tid, &zero, sizeof(zero));  /* tid becomes 0 */
mem_cleanup_deferred_stack_unmaps(g, t);                        /* region removed */
if (wake_ctid)
    futex_wake_one(g, t->clear_child_tid);
```

Placing the drain before `futex_wake_one()` orders it only against a joiner
that actually blocks. A joiner polling the tid in an ordinary futex loop
observes the store and exits the loop without ever reaching `FUTEX_WAIT`, so
it can issue the reuse mapping while the stack region is still tracked. The
mapping then fails with `EEXIST` from the `MAP_FIXED_NOREPLACE` overlap check
in `sys_mmap`.

`test-clone3` test 13 (`test_deferred_stack_munmap`) hits exactly this, which
is how it surfaced:

```
FAIL: stack reuse mmap returned 0xffffffffffffffff (expected 0x200000000)
```

Every step is correctly locked, so this is an ordering bug rather than a data
race, which is consistent with TSAN staying green while ASAN failed.

## Fix

Move the drain ahead of the tid store so VA reusability and tid visibility
share one happens-before edge. `vm_clone_thread_run()` carried the same
ordering and is changed with it.

## Verification

macOS 26.5.2 / Apple Silicon, ASAN build
(`-O1 -g -fsanitize=address -fno-omit-frame-pointer`,
`ASAN_OPTIONS=abort_on_error=1:detect_leaks=0`), running `build/test-clone3`
under `build/elfuse`:

| Build | Failures |
|---|---|
| `main` (f70ee7a) as-is | 1 / 100 |
| `main` + `usleep(2000)` before the drain | 27 / 30 |
| this change | 0 / 200 |
| this change + the same `usleep(2000)` | 0 / 30 |

The delay was a diagnostic only and is not part of this change: widening the
window makes the bug near-deterministic, and the same widened window is
harmless once the drain precedes the store.

`make check-sanitizer` completes with exit status 0 and no `[ FAIL ]` lines.

Note that `clang-format` 22 and `commentflow` were not available locally, so
those checks were left to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `CLONE_CHILD_CLEARTID` exit path so deferred stack munmaps drain before the tid store, preventing a joiner from reusing the stack VA while it is still mapped (previously surfaced as an `EEXIST` failure in `test-clone3`).

- Drains deferred stack munmaps ahead of the tid store in `thread_create_and_run` and `vm_clone_thread_run`; previously the drain was ordered against the futex wake, so a joiner polling the tid could observe 0 and reuse the VA early.
- Verified with 200 clean ASAN runs; a diagnostic delay that made the bug near-deterministic dropped failures from 27/30 to 0/30.

<sup>Written for commit bb36cc4f8350d57783ff57b16e33c012bd749b75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

