### PR TITLE
Add a security skill for the guest boundary

### DIFF
--- a/.claude/skills/elfuse-security/SKILL.md
+++ b/.claude/skills/elfuse-security/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: elfuse-security
+description: The guest as an attacker - where the trust boundary runs, the rules a handler on it obeys, what the gates already catch, and what is out of scope. Use when a change parses a guest-chosen length, translates a guest address, resolves a guest path, allocates on the guest's behalf, or blocks holding shared state, and when auditing a diff or writing a finding up.
+---
+
+# Security at the guest boundary
+
+The guest binary is untrusted, and it is not a remote attacker. It picks every
+register, every length, and the order the calls arrive in, at machine speed,
+with a debugger attached and as many retries as it likes. A window that needs
+a race to hit is a window it hits.
+
+That is the whole threat model, and it decides what counts as a finding here:
+the guest reading or writing host state it was never handed, escaping the
+sysroot, corrupting host memory through a length the host trusted, exhausting
+a host resource the guest does not own, or reaching a host privilege the
+launching user did not intend to lend it. What the guest does to itself,
+including wedging its own vCPU and exhausting its own address space, is a
+correctness bug at most. Filing that as a security finding spends the
+reviewer's attention in the wrong place.
+
+This skill is the boundary. `elfuse-syscall` is how to add a handler on it,
+`elfuse-guest-abi` is what the guest observes on return, and `elfuse-verify` is
+which lanes prove it.
+
+## Where the boundary runs
+
+Five surfaces, ordered by what one bad value reaches:
+
+- Syscall arguments. X0-X5 and X8 arrive from EL0 with no host filter in
+  front, so every wrapper reached from `src/syscall/dispatch.tbl` is on the
+  boundary.
+- Guest addresses. Every guest pointer becomes a host pointer through one
+  translator, and the permission half is the security half.
+- Formats the host parses for the guest: the ELF the loader reads, netlink
+  messages, FUSE frames, control messages, sigframes, sockaddrs, iovecs,
+  dirents. Each carries lengths, offsets, or counts the guest supplies, but
+  what the guest owns differs per format, so answer that per format rather
+  than assuming it. The ELF is read by offset, a sockaddr length arrives as a
+  separate syscall argument, and a sigframe is built by the host and then left
+  where the guest can rewrite it before `rt_sigreturn` reads it back.
+- Paths. Every name the guest supplies, absolute ones included.
+- Shared pages. The guest and the host see the same memory, so a structure
+  validated in guest memory and then passed on by address was not validated.
+
+## The rules
+
+`elfuse-syscall` carries the mechanism for most of these and names the symbols.
+What this file adds is what breaking each one costs, because the cost lands
+somewhere other than the line that caused it, and a rule with no consequence
+attached gets traded away.
+
+### Sizes
+
+Never validate with arithmetic that can wrap: `off + len > size` wraps and
+passes, `len > size || off > size - len` cannot. Read a wire length into an
+unsigned type at the first assignment and reject the bad case in the same
+statement, since a negative `int` passes an upper-bound test and then converts
+to a vast `size_t` at the call. Give the clamp one spelling; the comment at the
+top of `src/proved/slice.h` names the drifted copies that motivated it.
+
+Cost: an out-of-bounds write that reproduces only at boundary values, which is
+the region hand-written tests skip. New arithmetic on a guest-chosen length
+belongs in `src/proved/` behind a contract, not inline.
+
+A contract there proves the arithmetic and not its callers: they sit outside
+`-wp-fct`, and for `proved/gva.h` they cannot be brought in at all, since
+Frama-C does not parse `src/core/guest.c`. `elfuse-verify` carries that limit,
+and it leaves the call site a review question rather than a proved one.
+
+### Indexes
+
+When a guest-chosen number selects a slot rather than a length: a descriptor,
+a signal number, a bucket, a table entry.
+
+`RANGE_CHECK` in `src/utils.h` is the one spelling, and its form is the point.
+The unsigned subtraction makes a negative index wrap past the size and fail,
+so the lower bound cannot be the one somebody forgets to write. Where the
+bound cannot be tested at the site, state it instead: `elf_record_load` in
+`src/core/elf.c` carries an ACSL `requires` for the lower bound on its slot
+counter, because the function only raises that counter and can see the ceiling
+but not the start.
+
+Cost: the tables a guest number selects are host arrays, so this is the one
+guest-supplied value that reaches host memory without passing through a length
+or a translator. A slot past the end is a host write, and no bound on the
+guest's own address space stands in the way.
+
+### Guest addresses
+
+`elfuse-syscall` owns guest-memory access. Two things it does not decide: a
+host pointer already handed out is not rechecked when a mapping or a
+permission changes, so translate again rather than hold one across; and one
+physical page can carry two mappings, so the permission checked on one is not
+the permission in force. `guest_kbuf_user_va_overlap` in `src/core/guest.h`
+names the range that aliases under Rosetta.
+
+Cost: a translation that checks presence but not entitlement turns any
+read-into-buffer syscall into a disclosure primitive for whatever EL1
+published in that space. Missing the alias costs the other direction: a TTBR0
+mapping left executable over pages TTBR1 maps RW defeats HVF's per-mapping
+W^X.
+
+### The infra reserve
+
+`elfuse-guest-abi` owns the mapping rules. What it leaves to review is that a
+range which maps or repermissions memory is never presented as a pointer, so
+no translator sees it: it is checked with `guest_range_hits_infra` or
+`guest_addr_in_infra` or it is not checked at all.
+
+Cost: the reserve holds the page-table pool, the shim code, and shim_data, so a
+new mapping-shaped syscall that skips the check hands the guest its own page
+tables. That is host memory corruption and host privilege at once, and no
+translator refusal stands in the way, because nothing was translated.
+
+### Paths
+
+`elfuse-syscall` owns `path_translate_at`. The trap it leaves is that an
+absolute at-family argument looks like it needs no directory context, and so
+looks like it needs no resolver.
+
+Cost: a full escape from the containment the rest of the program is built on,
+not a degradation of it.
+
+### Caps
+
+Every allocation the guest sizes gets a ceiling, and so does every aggregate.
+`src/syscall/fuse.c` caps sessions, mounts, open files, pending requests and
+node refs; `src/syscall/netlink.c` caps request size, buffer size and open
+netlink sockets; `src/runtime/futex.c` caps a waitv batch and bounds the
+robust-list walk. Bound every traversal of a structure the guest wrote, since
+a list it supplies can be circular and an unbounded walk hangs a thread
+holding a lock.
+
+Say in the comment which kind of cap it is. One that mirrors Linux is an ABI
+cap, and moving it breaks compatibility; one invented here is a safety bound,
+free to be raised, and sits far above any legitimate caller. The robust-list
+bound in `src/runtime/futex.c` states its kind; `LINUX_SCM_MAX_FD` in
+`src/syscall/net-msg.c` is the other kind and does not move.
+
+Cost: uncapped is not a slow leak, it is one guest call in a loop.
+
+### Lifetime across a wait
+
+Pin the object with a count, then drop the lock. Holding the lock across a
+wait deadlocks, and dropping it without a count lets a concurrent teardown free
+the condition variable the waiter is parked on. The owning descriptor holds a
+reference of its own so teardown and in-flight work share one accounting, and
+destruction happens on the last put rather than at the close. In
+`src/syscall/fuse.c`, the comments at `fuse_session_get_locked` and its
+matching put carry the session half, down to why nothing is emitted to a dead
+daemon, and `fuse_file_get_locked` with the comment on `fuse_file_t.refcount`
+carries the pin-then-drop half.
+
+Cost: a use-after-free on a synchronization primitive, reached by closing a
+descriptor while another thread reads it, presenting as a rare hang rather
+than a crash at the guilty line.
+
+### Shared pages and locks
+
+A guest value read twice is two values. Copy the structure in once, validate
+the copy, then use only the copy; validating in place and passing the original
+address on is the double fetch, and shared memory makes it reachable without
+timing luck. A new file-scope lock goes into the ordering block at the top of
+`src/syscall/internal.h` in the same change. State the memory order at every
+shared access.
+
+Cost: a double fetch is not a race the guest has to win. It re-runs the syscall
+until the two reads differ, so the window is as wide as it needs to be.
+
+### The return path
+
+`elfuse-guest-abi` owns the restart and HVC return-tail rules, and
+`scripts/check-svc-tails.py` gates the tails. The half neither settles is which
+waits owe `syscall_restart_forbid`: a wait that has sent a request or spent
+part of a relative deadline cannot be re-run from its original arguments.
+
+Cost: silent at the site. A wrongly restarted call repeats a side effect the
+guest already observed, and the re-run looks identical to the first.
+
+### Error paths
+
+Fail closed. When an unwind runs, nothing may be left more permitted, more
+mapped, or more executable than before it. Free once, on one path. Report only
+what the Linux ABI specifies, since host paths, host addresses and macOS errno
+detail leaking outward are how a guest learns the layout before using it.
+
+Cost: an unwind that leaves a mapping writable, a descriptor open, or a
+privilege raised converts a failed call into the primitive the guest wanted,
+and the error return makes it look handled.
+
+## What the gates already catch
+
+Do not re-derive what these already prove, and check which target runs the one
+being relied on, because they do not all run together. Read the module
+docstring before relying on a one-line summary here or working around any of
+them; several state a limit that decides whether a review still owes the
+question.
+
+Under `make check`:
+
+- `scripts/check-lock-order.py` fails a file-scope mutex or rwlock missing from
+  the ordering record, and a named lock that no longer exists. It checks
+  membership, not placement.
+- `scripts/check-eintr-contract.py` fails a new interruptible wait whose
+  restart behavior is unstated.
+- `scripts/check-atomics.py` fails a C11 atomic operation written without the
+  `_explicit` form, and bans the compiler builtins, so the order is written at
+  the site. Its docstring names what it deliberately leaves out: plain-operator
+  access to an `_Atomic` object, which needs per-translation-unit declarations
+  and which the tree already carries a large set of. That half is a review
+  question, so it is the one memory-order case to spend budget on rather than
+  skip.
+- `scripts/check-svc-tails.py` holds every return tail to the X7 ptrace test,
+  bar the one exception its docstring names and allowlists.
+- `scripts/check-syscall-coverage.py` is a best-effort audit of `dispatch.tbl`
+  against the tests corpus, satisfied by a textual mention and carrying an
+  allowlist for the indirect cases. A green result is weaker than it looks.
+
+Under `make verify`, once per proof target:
+
+- `scripts/check-acsl-coverage.py` fails a contracted function left outside the
+  proof set, which Frama-C would otherwise assume rather than prove.
+- `scripts/check-char-signedness.py` catches plain `char` in proved code with
+  the compiler rather than a regex, because its signedness differs between the
+  target that compiles the proved sources and the one that compiles the guest
+  tests.
+
+Under `make verify-mutants`, which nothing else runs:
+
+- `scripts/check-mutants.py` asserts each target rejects a known-broken source,
+  which is the only evidence its clauses are load-bearing.
+
+## Out of scope
+
+Recorded once so it is not rediscovered as a finding on every review:
+
+- Web and enterprise categories from the OWASP checklist. There is no server,
+  no session, and no browser.
+- Guest-versus-guest isolation. One process runs one guest program and its
+  children; the guest is not a tenant to be separated from another tenant.
+- Denial of service by the guest against itself. The guest owns its process,
+  so wedging its own vCPU or filling its own address space is its business.
+  Exhausting a host resource is not the same thing and stays in scope, which
+  is what the caps rule above is for.
+- Host hardening the operating system owns. An optional Seatbelt profile may
+  backstop the path resolver, but it is not a second policy: containment stays
+  defined and enforced by `path_translate_at`.
+
+## Reviewing
+
+Four habits that make a review worthless, each of which feels like diligence:
+
+- Flagging without a fix. Naming what to validate, against what, and where is
+  the finding; without it, the issue is not yet understood well enough to
+  report.
+- Claiming absence without tracing. Say which paths were walked and which were
+  not. A stated gap is useful, an unstated one is a false clean.
+- Reporting occurrences instead of the root cause. Findings sharing a cause
+  are one finding with every sink listed.
+- Flagging style as security. Naming and layout do not change the attack
+  surface, and `elfuse-conventions` owns them anyway.
+
+Writing one up: `references/finding-report.md`. Sweeping the whole tree
+rather than a diff, and what each detector gets wrong here:
+`references/sweeping-the-tree.md`.
+
+## Commissioning a review
+
+The habits above are the reviewer's. These are the requester's, and they
+decide whether the reviewer's are reachable at all.
+
+- Name a target and invite the null result. A request to make something
+  secure presumes a defect, and a reviewer with a turn to justify will
+  produce one. Asking for a verdict on a named diff, clean included, is what
+  makes a clean answer worth anything.
+- Require a file and a line for every claim, checked against the source
+  rather than recalled, and read through something that returns the file
+  verbatim. A shell here may be wrapped by a filter that elides content, and
+  a claim built on elided output reads exactly like one that is true.
+- State the threat model, or ask for it before the review rather than after.
+  Without it a reviewer reports what the guest does to itself, and the
+  out-of-scope list above gets rediscovered a category at a time.
+- Ask what each gate deliberately does not check, not only whether it
+  passed. That question is what turns the gate list above into review scope,
+  and every docstring there states its own limit.
+- Use two independent reviewers, both held to the citation rule, and keep
+  what survives both. Without that rule a second opinion is a second guess,
+  and a confident one costs more to disprove than it did to write.
+
+The shape:
+
+```
+Review <target> for security.
+Threat model: <state it, or ask for it first>.
+Verify every claim against the source and cite file:line.
+Say which paths were walked and which were not.
+Each finding: root cause, every sink, the concrete fix.
+Report clean if clean.
+```
+
+## Authoritative sources
+
+- `src/syscall/internal.h` for lock order, `src/syscall/proc.h` for the
+  restart contract, and the module docstring of each script above. All win
+  over this file.
+- CWE-699 for weakness names, preferring the Variant and Base abstractions.
+  The process halves of NIST SP 800-218 and the OWASP checklist are written
+  against web software; only their trust-boundary and input-validation
+  sections carry over.

--- a/.claude/skills/elfuse-security/references/finding-report.md
+++ b/.claude/skills/elfuse-security/references/finding-report.md
@@ -1,0 +1,66 @@
+# Writing a finding up
+
+A finding is a claim that a specific guest action reaches a specific bad
+outcome. It is worth writing only when the path can be stated end to end.
+The schema below exists to stop a report degrading into a list of places the
+reviewer felt uneasy about.
+
+Three rules decide what becomes a finding at all:
+
+- One root cause is one finding, with every sink listed. Two callers of the
+  same unchecked helper are one entry. Splitting by call site inflates the
+  count and hides that a single fix closes them all.
+- A finding carries its fix. When the fix cannot be stated, the issue is not
+  understood well enough to report, and the honest output is a question.
+- Order by what one bad value reaches, not by how interesting the bug is.
+
+## Per finding
+
+- ID in the form WK-#, and a name giving the weakness in the entry point, in
+  that order.
+- Entry point: the syscall or format the guest drives, and which of its fields
+  the guest chooses.
+- Attack path: numbered steps from that entry point to the impact, tracing the
+  chosen value from source to sink. One action per step, causally linked, no
+  branching, with `path/to/file:line` and the exact value used at each step.
+- Impact, named from the list the skill body opens with: host state read or
+  written that the guest was never handed, sysroot escape, host memory
+  corruption, host-resource exhaustion, or host privilege reached. When none
+  of them fits, this is a robustness bug and saying so is the useful answer.
+- Existing controls, and how far each one gets. This is where a report earns
+  trust, because it is what the author of the code checks first.
+- Residual severity after those controls. A path an existing control already
+  closes is worth recording once and closing.
+- The fix, at the layer that closes every listed sink.
+- CWE id, Variant or Base. The Class-level ids name a category, not a bug.
+- Confidence in the evidence, stated separately from impact. A high-impact
+  guess and a low-impact certainty read differently and must not be merged.
+- Locations: every sink as `path/to/file:line` or a line range.
+
+CVSS vectors are optional and usually not worth the keystrokes here. When one
+is given the score has to match the vector, since a mismatch discredits the
+report faster than omitting both.
+
+## Evidence
+
+Verbatim excerpts, the smallest that carry the path, original comments
+stripped and excess indentation removed. Mark the file at the top of each
+block and elide non-relevant code. Annotate the flow inline, one sentence
+each: the source where the guest value enters, each propagator that carries
+it, each sanitizer it passes with what that check does not cover, and the sink
+where it does the damage.
+
+The sanitizer line is the one that gets skipped and the one that matters.
+Naming the guard and stating precisely what it fails to cover is what
+separates a finding from a reviewer who did not read the guard.
+
+## Reproducer
+
+One guest program or unit test that fails on the current source and passes
+after the fix, at the cheapest level that exercises the boundary. Least
+damaging form that still demonstrates the path: prove the read leaves its
+bounds, do not demonstrate what could be done with it. `elfuse-verify` says
+which lane it belongs in.
+
+A finding without a reproducer is a hypothesis. That is a legitimate thing to
+report, labeled as one.

--- a/.claude/skills/elfuse-security/references/sweeping-the-tree.md
+++ b/.claude/skills/elfuse-security/references/sweeping-the-tree.md
@@ -1,0 +1,52 @@
+# Sweeping the whole tree
+
+Reviewing a diff and sweeping `src/` are different jobs. A diff has an author
+and a reason; a sweep has neither, so it needs a fixed set of detectors and an
+honest account of what each one cannot see. What follows is the set, and the
+false positives each one produces here, which are worth knowing in advance
+because every one of them costs a file read to dismiss.
+
+State the scope in the result. A sweep that names the files it walked is
+evidence; one that reports a verdict over `src/` without saying what it read
+is a claim about every line in it that nobody made.
+
+## The detectors
+
+Run them over `src` with `--include='*.c'`, excluding `src/proved/`, whose
+arithmetic is under contract already.
+
+- Unsafe C string primitives: `strcpy`, `strcat`, `sprintf`, `gets`,
+  `vsprintf`. Any hit is a finding; there is no accepted use in this tree.
+- `alloca`, and array declarations whose size is a variable. A guest number
+  must never size a stack object.
+- `malloc`, `calloc` and `realloc` whose size argument is not a `sizeof`
+  expression. Each hit is traced to the cap that bounds it, or it is a
+  finding. This one is slow and is the highest-yield of the set.
+- Additions inside a bounds test: `if (a + b > c)`. The wrap is the bug.
+- Array subscripts named like syscall arguments: fd, signum, idx, slot, tid,
+  clockid, nr.
+- The same guest address read twice inside one function, which is the double
+  fetch when the second read is the one used.
+- A fallback that substitutes a constant for entropy.
+
+## What each one gets wrong here
+
+- The addition detector is mostly noise. Most hits combine values already
+  bounded by `NAME_MAX` or by the destination size, and only the ones adding
+  a length the other side chose can wrap. Read the provenance of both
+  operands before writing anything down.
+- The subscript detector answers a question about shape when the question is
+  provenance. Most hits index a loop counter the code owns. It earns its
+  place because the few that do take a guest number reach a host array.
+- A grep for a discarded `guest_read` or `guest_write` return matches the
+  continuation lines of multi-line conditions, and misses the case where the
+  check is an accumulator on the previous line. Both directions are wrong, so
+  confirm every hit against the file.
+
+## What no sweep sees
+
+The same three things grep never sees: indirection, where the dangerous call
+sits behind a helper; absence, where the missing check has no text to match;
+and logic, where each step is safe and the sequence is not. Those need the
+rules in the skill body applied by reading, and they are why a clean sweep is
+reported as a clean sweep rather than as a clean tree.

--- a/.claude/skills/elfuse-syscall/SKILL.md
+++ b/.claude/skills/elfuse-syscall/SKILL.md
@@ -11,7 +11,8 @@ from an entry there.
 This skill covers the host side of the boundary: taking guest arguments,
 translating them, and calling macOS. Anything that changes what the guest sees
 when it comes back is `elfuse-guest-abi`, even when the file lives under
-`src/syscall/`.
+`src/syscall/`. The guest chooses every argument a wrapper receives, so the
+rules for handling one it chose badly are `elfuse-security`.
 
 ## The steps
 

--- a/.claude/skills/elfuse-syscall/SKILL.md
+++ b/.claude/skills/elfuse-syscall/SKILL.md
@@ -147,8 +147,9 @@ eventfd, timerfd, signalfd). A class check that reads the raw fd number is wrong
 a `dup`.
 
 The lock order is the comment at the top of `internal.h`. Acquire in the order
-it lists, and add a new lock to that comment before using it in a second
-module. Three constraints in it are not derivable from the ordering:
+it lists, and add a new lock to that comment as soon as it exists, whether or
+not a second module uses it. Three constraints in it are not derivable from
+the ordering:
 
 - The per-epoll-instance lock is taken under `fd_lock` by the close hook, but
   taken alone by `epoll_ctl` and `epoll_pwait`. This is the one a summary

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/random.h>
 
 #include "proved/stack.h"
 #include "core/stack.h"
@@ -206,9 +205,14 @@ uint64_t build_linux_stack(guest_t *g,
     if (!stack_take(&str_ptr, stack_floor, 16))
         return 0;
     uint64_t random_ptr = str_ptr;
+
+    /* glibc and musl derive the stack canary and the pointer guard from these
+     * 16 bytes, so they must never be predictable. arc4random_buf returns void
+     * and cannot fail, which leaves no error path to substitute a constant on.
+     * sys.c serves getrandom(2) from it for the same reason.
+     */
     uint8_t random_bytes[16];
-    if (getentropy(random_bytes, 16) != 0)
-        memset(random_bytes, 0x42, 16); /* Fallback: deterministic fill */
+    arc4random_buf(random_bytes, sizeof(random_bytes));
     int str_err = 0;
     str_err |=
         guest_write_small(g, random_ptr, random_bytes, sizeof(random_bytes));

--- a/src/runtime/procemu.c
+++ b/src/runtime/procemu.c
@@ -2969,8 +2969,19 @@ int proc_intercept_open(const guest_t *g,
          *   priority(18) nice(19) num_threads(20) itrealvalue(21)
          *   starttime(22) vsize(23) rss(24) rsslim(25) ... (52 fields total)
          */
+        /* tty_nr(7) and tpgid(8) follow the controlling-terminal state rather
+         * than the constants that stood here. elfuse models no specific tty
+         * device, so tty_nr reports the UNIX98 pts major with minor 0 when a
+         * terminal is held: readers such as ps only test it against zero to
+         * decide whether to print a tty at all. tpgid is the foreground process
+         * group, or -1 with no terminal, which is what Linux emits.
+         */
+        int has_ctty = proc_get_ctty();
+        int tty_nr = has_ctty ? (136 << 8) : 0;
+        long long tpgid = has_ctty ? (long long) proc_get_fg_pgrp() : -1;
+
         return proc_emit_fmt(
-            "%lld (%.15s) R %lld %lld %lld 0 -1 0 "        /* 1-9 */
+            "%lld (%.15s) R %lld %lld %lld %d %lld 0 "     /* 1-9 */
             "0 0 0 0 %ld %ld 0 0 "                         /* 10-17 */
             "20 0 %d 0 0 %llu %llu "                       /* 18-24 */
             "18446744073709551615 0 0 %llu 0 0 0 "         /* 25-31 */
@@ -2979,7 +2990,7 @@ int proc_intercept_open(const guest_t *g,
             (long long) proc_get_ppid(),
             (long long) proc_get_pid(), /* pgrp = pid */
             (long long) proc_get_pid(), /* session = pid */
-            utime_ticks, stime_ticks, thread_active_count(),
+            tty_nr, tpgid, utime_ticks, stime_ticks, thread_active_count(),
             (unsigned long long) vsize, (unsigned long long) rss_pages,
             (unsigned long long) start_stack);
     }

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -2644,11 +2644,19 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         proc_set_ctty(0);
         return 0;
     case LINUX_TIOCGSID: {
-        /* Get session ID of the controlling terminal. Linux answers ENOTTY when
-         * the caller has none, rather than reporting the session id of a
-         * terminal it does not hold.
+        /* Get session ID of the controlling terminal. Linux answers ENOTTY on
+         * two counts, and both are checked here: the fd must be a terminal at
+         * all, which tcgetattr decides the same way every termios case below
+         * does, and the caller must hold a controlling terminal rather than be
+         * told the session id of one it detached from.
+         *
+         * Linux also rejects an fd that is a terminal but not this caller's
+         * controlling one. elfuse records only whether a controlling terminal
+         * is held, not which device it is, so that third case still answers.
+         * Narrowing it needs proc_set_ctty to record the terminal's identity.
          */
-        if (!proc_get_ctty()) {
+        struct termios sid_t;
+        if (tcgetattr(host_fd, &sid_t) < 0 || !proc_get_ctty()) {
             host_fd_ref_close(&host_ref);
             return -LINUX_ENOTTY;
         }

--- a/src/syscall/io.c
+++ b/src/syscall/io.c
@@ -2644,7 +2644,14 @@ int64_t sys_ioctl(guest_t *g, int fd, uint64_t request, uint64_t arg)
         proc_set_ctty(0);
         return 0;
     case LINUX_TIOCGSID: {
-        /* Get session ID of the controlling terminal. */
+        /* Get session ID of the controlling terminal. Linux answers ENOTTY when
+         * the caller has none, rather than reporting the session id of a
+         * terminal it does not hold.
+         */
+        if (!proc_get_ctty()) {
+            host_fd_ref_close(&host_ref);
+            return -LINUX_ENOTTY;
+        }
         int32_t val = (int32_t) proc_get_sid();
         host_fd_ref_close(&host_ref);
         if (guest_write_small(g, arg, &val, sizeof(val)) < 0)

--- a/src/syscall/net.c
+++ b/src/syscall/net.c
@@ -1587,6 +1587,17 @@ static inline uint32_t ip_copyval_clamp(int level,
     return actual_len;
 }
 
+/* How many bytes a getsockopt reply may write into the caller's buffer.
+ *
+ * Not the MIN macro in utils.h: it is a statement expression, which this tree
+ * compiles with -Werror against.
+ */
+static inline uint32_t sockopt_write_len(uint32_t actual_len,
+                                         uint32_t guest_optlen)
+{
+    return actual_len < guest_optlen ? actual_len : guest_optlen;
+}
+
 int64_t sys_getsockopt(guest_t *g,
                        int fd,
                        int level,
@@ -1617,9 +1628,8 @@ int64_t sys_getsockopt(guest_t *g,
             .uid = proc_get_uid(),
             .gid = proc_get_gid(),
         };
-        uint32_t out_len = sizeof(cred);
-        if (guest_optlen < out_len)
-            out_len = guest_optlen;
+        uint32_t out_len =
+            sockopt_write_len((uint32_t) sizeof(cred), guest_optlen);
         if (out_len > 0 && guest_write_small(g, optval_gva, &cred, out_len) < 0)
             return -LINUX_EFAULT;
         uint32_t actual_len = sizeof(cred);
@@ -1656,9 +1666,7 @@ int64_t sys_getsockopt(guest_t *g,
         if (net_socket_cached_int_get(fd, level, optname, &value)) {
             uint32_t actual_len =
                 ip_copyval_clamp(level, guest_optlen, value, sizeof(int));
-            uint32_t write_len = actual_len;
-            if (write_len > guest_optlen)
-                write_len = guest_optlen;
+            uint32_t write_len = sockopt_write_len(actual_len, guest_optlen);
             if (write_len > 0 &&
                 guest_write_small(g, optval_gva, &value, write_len) < 0)
                 return -LINUX_EFAULT;
@@ -1721,9 +1729,7 @@ getsockopt_translated:
 
         actual_len = used_cache ? sizeof(int) : (uint32_t) mac_optlen;
         actual_len = ip_copyval_clamp(level, guest_optlen, value, actual_len);
-        write_len = actual_len;
-        if (write_len > guest_optlen)
-            write_len = guest_optlen;
+        write_len = sockopt_write_len(actual_len, guest_optlen);
         if (write_len > 0 &&
             guest_write_small(g, optval_gva, &value, write_len) < 0) {
             host_fd_ref_close(&host_ref);
@@ -1771,14 +1777,12 @@ getsockopt_translated:
         }
     }
 
-    /* Write option value, truncating to guest buffer size if needed. Write back
-     * actual length (not truncated) per Linux semantics: Linux getsockopt
-     * returns the real option size so the caller can detect truncation and
-     * retry with a larger buffer.
+    /* Write at most the caller's buffer, but report the option's real size:
+     * Linux getsockopt does that so a caller can detect truncation and retry
+     * with a larger buffer. Every write above clamps the same way.
      */
-    uint32_t actual_len = (uint32_t) mac_optlen, write_len = actual_len;
-    if (write_len > guest_optlen)
-        write_len = guest_optlen;
+    uint32_t actual_len = (uint32_t) mac_optlen;
+    uint32_t write_len = sockopt_write_len(actual_len, guest_optlen);
     if (guest_write_small(g, optval_gva, optval, write_len) < 0) {
         host_fd_ref_close(&host_ref);
         return -LINUX_EFAULT;

--- a/src/syscall/proc-identity.c
+++ b/src/syscall/proc-identity.c
@@ -338,6 +338,11 @@ int64_t proc_get_fg_pgrp(void)
     return guest_fg_pgrp;
 }
 
+int proc_get_ctty(void)
+{
+    return guest_has_ctty;
+}
+
 void proc_set_session(int64_t sid, int64_t pgid)
 {
     guest_sid = sid;

--- a/src/syscall/proc.h
+++ b/src/syscall/proc.h
@@ -222,6 +222,12 @@ int64_t proc_sys_getsid(int64_t pid);
 void proc_set_fg_pgrp(int64_t pgrp);
 void proc_set_ctty(int has_ctty);
 
+/* Nonzero while the guest holds a controlling terminal. Consumed by TIOCGSID,
+ * which Linux answers with ENOTTY when there is none, and by the tty_nr and
+ * tpgid fields of /proc/self/stat.
+ */
+int proc_get_ctty(void);
+
 /* Emulated UID/GID accessors. */
 uint32_t proc_get_uid(void);
 uint32_t proc_get_euid(void);


### PR DESCRIPTION
## Add a security skill for the guest boundary

The tree has skills for adding a syscall, the guest ABI, verification,
debugging, refactoring and conventions, but none saying what makes the guest
hostile or what counts as a security finding against it. Reviews kept
rediscovering the same out-of-scope categories, and generic checklists got
applied to a boundary they were not written for: there is no server, no
session and no browser here.

The skill states the threat model as a decision procedure. Five impacts
count: host state the guest was never handed, sysroot escape, host memory
corruption through a trusted length, host resource exhaustion, and host
privilege the launching user did not lend. What the guest does to itself is a
correctness bug at most, which is what stops a wedged vCPU being filed as a
vulnerability.

Each rule names what breaking it costs rather than restating mechanism a
sibling skill already owns. The gate inventory is split by the target that
runs it, because "make check", "make verify" and "make verify-mutants" do not
run the same set, and telling a reviewer to skip ground a gate covers is
unsafe when that gate did not run. Two limits are stated where they change
what review still owes: a contract proves the arithmetic and not its callers,
and check-atomics.py leaves plain-operator access to an _Atomic object to
review.

Two reference files carry what only one branch of the work reaches: the
finding schema, and the detectors a whole-tree sweep runs together with what
each one gets wrong in this tree.

## Match the lock-order rule to what the gate checks

The syscall skill said to add a new lock to the ordering block before using it
in a second module. check-lock-order.py fails any file-scope mutex or rwlock
the block does not name, whether one module uses it or ten.

## Give the getsockopt truncation one spelling

Four sites in sys_getsockopt clamped the reply to the caller buffer in three
different forms, one with the comparison inverted. ip_copyval_clamp had
already taken the IP-specific half out, so the extraction was half finished.

## Seed AT_RANDOM from a call that cannot fail

build_linux_stack drew the 16 AT_RANDOM bytes from getentropy and, on failure,
filled them with a constant, so every process in that run would have shared
one publicly known canary. arc4random_buf returns void, so the fallback branch
goes with it. Not a boundary finding: it weakens the guest against its own
memory-safety bugs and hands it nothing of the host.