### PR TITLE
Name deferral as a register class

### DIFF
--- a/.claude/skills/elfuse-conventions/SKILL.md
+++ b/.claude/skills/elfuse-conventions/SKILL.md
@@ -380,6 +380,14 @@ addressed threads with "Resolve conversation"; a reply carries the
 correction, the measurement, or nothing. A concise what and why belongs in
 the commit body, not the thread.
 
+A reply that hands the choice back to the reviewer is the same artifact in
+a politer form. "If you would rather the source read uniformly one way or
+the other, say so and I will move the remaining three" asks for an
+instruction where a technical answer belongs ("Let's concentrate on real
+discussions!", PR#350). A tradeoff already measured is settled in the
+reply, with the measurement as the reason. Ask the reviewer a question only
+where the code leaves one open.
+
 The body is intent plus reproduction and commands: for a bug, a minimal
 reproduction with host macOS and SDK version, hardware, and `make check`
 status (PR#21, PR#41); for a performance claim, A/B benchmarks on a named

--- a/.claude/skills/elfuse-conventions/references/prose-register.md
+++ b/.claude/skills/elfuse-conventions/references/prose-register.md
@@ -36,6 +36,11 @@ State the fact and stop:
 - Effort and flattery: "carefully reviewed", "comprehensive", "thoroughly
   tested", "Great catch", "You're absolutely right". Effort is not a
   finding; name what ran and what it reported.
+- Deferral and self-report: an offer to redo the work another way ("say so
+  and I will", "happy to split this"), an apology for a correction, or an
+  announcement of candor before a caveat that stands on its own ("worth
+  flagging rather than hiding"). State the decision and the reason that
+  settles it; a reviewer who disagrees says so without being invited.
 - Formatting as emphasis in docs and PR text: bolded bullet-header runs
   where a paragraph belongs, decorative rules, emoji.
 - Machine artifacts, defects on sight: zero-width and bidi characters,


### PR DESCRIPTION
`references/prose-register.md` names the classes that mark machine-written
prose, and binds PR bodies and review replies alongside source comments and
`docs/`. One class was missing: text about the writer rather than about the
work.

#350 carried an instance. A reply closed a decision that had already been
measured by offering to reverse it on request, and the answer was "Let's
concentrate on real discussions!". The same shape reaches review text as an
apology for a correction, and as an announcement of candor in front of a
caveat that stands on its own.

Two commits, one per surface, following the split the register states in its
own opening: the register defines a class, and a `SKILL.md` section names
that class's instance on one surface.

* The register gains the class, next to "Effort and flattery", which is the
  neighbouring case of writing about the writer.
* The Pull requests section gains the reply form, quoting the rejected
  sentence and citing #350 the way the rules around it cite PR#21, PR#41 and
  PR#209.

Why it costs a reviewer something: an offer to redo the work another way asks
them to choose between two shapes the writer has already measured, when the
decision and the reason that settles it were what they needed. A reviewer who
disagrees says so without being invited.

## Verification

`scripts/check-skill-refs.py` resolves every path, target, section and
cross-reference across the 12 files under `.claude/`, and
`scripts/check-commit-log.sh` accepts both commits. Documentation only: no
build or test target reads these files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names deferral and self-report as a prose-register class so guidance can flag text about the writer instead of the work. Pull request replies should state a measured decision and its reason rather than hand the choice back to the reviewer.

- Covers offers to redo work, apologies for corrections, and candor announcements before independent caveats.
- Names the reply form in the Pull requests section and adds PR#350 as a concrete example.
- Documentation-only; no runtime behavior changes.

<sup>Written for commit 1804ceb317c4320ed9811cd3757cb149414aab4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

