### PR TITLE
Close four gaps in the skills

### DIFF
--- a/.claude/skills/elfuse-conventions/SKILL.md
+++ b/.claude/skills/elfuse-conventions/SKILL.md
@@ -337,13 +337,18 @@ Stop nl_put_attr truncating its own extent
 Prove the netlink walk loops
 Count the shared pty declarations correctly
 Give a pty's slave accounting one home
-Say what the proof matrix cache actually costs
+Name the SysV message size ceiling
 ```
 
 Note what is absent: no Conventional Commits prefix (`fix:`, `feat:`, `chore:`),
 no area tag, no ticket number in the subject. The subject is a sentence about
 behavior. A commit that removes something says what stops happening; a commit
 that adds a proof says what is now proved.
+
+A subject does not open with "Say". It names the act of writing rather than
+what changed, so every prose commit takes the same verb and the log stops
+telling them apart. Name the rule that now holds or the mechanism now stated
+instead. The ones already in the log stay; rewriting them is not a task.
 
 The body is where the reasoning goes: what the old code claimed, why that
 was wrong, what breaks if you do it the obvious other way. Substantial is

--- a/.claude/skills/elfuse-conventions/SKILL.md
+++ b/.claude/skills/elfuse-conventions/SKILL.md
@@ -133,8 +133,7 @@ selects already formats to itself, and every file commentflow selects already
 reflows to itself. That was not free. The tree's comments were wrapped by hand
 before the tool existed, and the one-time reflow rewrote 142 of the 353 C and
 header files, both assembly files, and 36 of the 41 shell scripts. It landed as
-its own commit because a mechanical change with no behavior in it cannot be
-reviewed alongside one that has some.
+its own commit, under the rule the commit section states.
 
 The gate is what keeps it a no-op. If `make indent` ever hands you a diff in a
 file you did not touch, something reintroduced hand-wrapping, or your
@@ -368,6 +367,11 @@ arrows, and third person throughout. A commit body is the surface those
 classes were written for.
 
 Merge commits keep git's generated subject and are exempt.
+
+A change with no behavior in it lands as its own commit, whether it is a
+mechanical sweep or a reshape a feature is waiting on; the reshape lands before
+the feature. Combined, neither half is reviewable. The one-time `commentflow`
+reflow is the precedent.
 
 ## Pull requests
 

--- a/.claude/skills/elfuse-refactor/SKILL.md
+++ b/.claude/skills/elfuse-refactor/SKILL.md
@@ -27,10 +27,17 @@ that both moves code and changes behavior cannot be reviewed as either.
 
 ## Decide whether the finding is real
 
-Measure it first. `references/measuring.md` carries the scans for function
-size, duplication, and nesting, and the traps in reading each. Report a number
-with the command that produced it and a judgment as a judgment; never quote a
-count from a document, this one included.
+Name the friction before treating it, and let that name bound the diff: which
+call site is hard to read, which contract is hard to find, which edit had to be
+repeated across files. A cleanup with no named friction has no stop condition,
+and the reviewer inherits the job of deciding where it should have ended. A
+second finding met on the way out is reported in its own diff, not absorbed
+into this one.
+
+Measure it. `references/measuring.md` carries the scans for function size,
+duplication, and nesting, and the traps in reading each. Report a number with
+the command that produced it and a judgment as a judgment; never quote a count
+from a document, this one included.
 
 Prefer deletion, an existing local helper, or a direct rewrite over a new
 abstraction. A parameter every caller gives the same value, a hook with one

--- a/.claude/skills/elfuse-refactor/SKILL.md
+++ b/.claude/skills/elfuse-refactor/SKILL.md
@@ -102,22 +102,10 @@ the selected baseline before a multi-step cleanup. Keep inherited failures
 separate from the change. Stop when the baseline is red in the area being
 changed.
 
-A failure blamed on the environment earns one reproduction attempt under the
-condition blamed for it before it is written off. "Transient" and "the host was
-busy" are the two that hide real defects here, because a test harness racing
-its own pipeline and a probe that measures the wrong thing both fail only under
-load or only on some networks. Reproduce it, or say it went unexplained; do not
-report it as understood.
-
-The throughput guardrail is the one lane where load genuinely decides the
-result, and it distinguishes UNMEASURED from FAIL for that reason. Reaching it
-at the end of `make check` means measuring on a machine `make check` has just
-loaded, so an UNMEASURED verdict there says nothing about the change. Re-run
-that lane alone on an idle host and report what it says.
-
 Make one behavior-preserving step at a time, then run its mapped lanes. A pure
-cleanup uses the same validation as the feature area, not a weaker set. Changes
-under `src/proved/` require `make verify` and `make verify-mutants`.
+cleanup uses the same validation as the feature area, not a weaker set, and
+`elfuse-verify` owns reading the verdicts. Changes under `src/proved/` require
+`make verify` and `make verify-mutants`.
 
 `make lint` is advisory except for `readability-function-size`, which
 `.clang-tidy` names in `WarningsAsErrors`, so a function crossing the ceiling

--- a/.claude/skills/elfuse-syscall/SKILL.md
+++ b/.claude/skills/elfuse-syscall/SKILL.md
@@ -43,6 +43,13 @@ rules for handling one it chose badly are `elfuse-security`.
 3. Implement it in two pieces. The `sc_` wrapper and the `sys_` function are
    not the same thing and do not live in the same file.
 
+   Write step 4's test before the `sys_` body, and have it pass a
+   distinguishable non-zero value in every slot the wrapper consumes. A test
+   written afterward is shaped by the implementation, so it accepts x3-x5
+   reading as zero and the `<extra>` mistake from step 1 survives its own
+   test. Run it without elfuse's `-v`, or a verbose run turns the one test
+   that would catch this green.
+
    3a. The wrapper goes in `src/syscall/syscall.c`, as one line built by the
    `SC_FORWARD` / `SC_LOCKED` / `SC_STUB` macros. It exists to unpack x0-x5
    into typed arguments. `SC_LOCKED` is the variant that holds `mmap_lock`

--- a/.claude/skills/elfuse-syscall/SKILL.md
+++ b/.claude/skills/elfuse-syscall/SKILL.md
@@ -23,10 +23,10 @@ rules for handling one it chose badly are `elfuse-security`.
    ```
 
    `<extra>` becomes `needs_extra_regs` in `syscall_table`
-   (`src/syscall/syscall.c`). The dispatcher always fetches X0-X2 and fetches
-   X3/X4/X5 only when it is set, so the criterion is whether the wrapper
-   expression consumes x3, x4, or x5 - not the syscall's documented argument
-   count. Several three-argument entries carry 1.
+   (`src/syscall/syscall.c`). The dispatcher always fetches X0-X2 and, on a
+   quiet run, fetches X3/X4/X5 only when it is set, so the criterion is
+   whether the wrapper expression consumes x3, x4, or x5 - not the syscall's
+   documented argument count. Several three-argument entries carry 1.
 
    The dispatcher zero-initializes x3-x5, so a wrapper that reads them with
    `<extra>` left at 0 sees a deterministic 0, not a stale register: a syscall
@@ -47,8 +47,10 @@ rules for handling one it chose badly are `elfuse-security`.
    distinguishable non-zero value in every slot the wrapper consumes. A test
    written afterward is shaped by the implementation, so it accepts x3-x5
    reading as zero and the `<extra>` mistake from step 1 survives its own
-   test. Run it without elfuse's `-v`, or a verbose run turns the one test
-   that would catch this green.
+   test. Run that test without elfuse's `-v`: the fetch is gated on
+   `verbose || ... || needs_extra_regs` (`src/syscall/syscall.c`), so a
+   verbose run hands the wrapper the real X3-X5 and passes on the very entry
+   the test exists to catch.
 
    3a. The wrapper goes in `src/syscall/syscall.c`, as one line built by the
    `SC_FORWARD` / `SC_LOCKED` / `SC_STUB` macros. It exists to unpack x0-x5

--- a/.claude/skills/elfuse-verify/SKILL.md
+++ b/.claude/skills/elfuse-verify/SKILL.md
@@ -20,7 +20,7 @@ of `make check`.
 The defaults below are what that table falls back to, not a substitute for it.
 
 ```
-make check                       # unit tests, busybox, syscall coverage gate
+make check                       # unit tests, busybox, coverage gate, guardrail
 bash tests/test-matrix.sh all    # the three modes
 ```
 
@@ -217,8 +217,8 @@ make infer-uninit          # uninitialized reads
 ## What done means
 
 Green is a claim about named commands, so report it as one: which lanes ran,
-what each said, and which ones did not run. Three failure modes to avoid, all
-of which have shipped before:
+what each said, and which ones did not run. The failure modes to avoid, all of
+which have shipped before:
 
 - A lane that could not run is named along with the risk that leaves. It is
   never rounded up into the passing set.
@@ -227,6 +227,21 @@ of which have shipped before:
   measured and is not.
 - A proof is done when `make verify` and `make verify-mutants` say so from the
   Makefile. MCP goals discharging is progress, not a verdict.
+- A failure blamed on the environment earns one reproduction attempt under the
+  condition blamed for it before it is written off. "Transient" and "the host
+  was busy" are the two that hide real defects here, because a test harness
+  racing its own pipeline and a probe that measures the wrong thing both fail
+  only under load or only on some networks. Reproduce it, or say it went
+  unexplained; do not report it as understood. Raising the reproduction rate on
+  a failure that will not repeat on demand is `elfuse-debug`, under "When it
+  only fails sometimes".
+
+The throughput guardrail is the exception to that bullet: it is the one lane
+where load genuinely decides the result. It runs near the end of `make check`,
+so it measures on a machine `make check` has just loaded, and an UNMEASURED
+verdict there says nothing about the change. Re-run `make test-bench-guardrail`
+alone on an idle host and report what it says. UNMEASURED exits non-zero
+exactly as a threshold violation does.
 
 Establish the baseline before a multi-command session rather than after: this
 tree is not green everywhere, and without the before-picture there is no way
@@ -241,3 +256,5 @@ so prefer them when the two disagree:
   area to command mapping.
 - `mk/verify.mk` - the per-target `_SRC` / `_MODEL` / `_FCTS` variables and
   the comment above each explaining its model choice.
+- `tests/test-bench-guardrail.sh` - the comment above the unmeasured check,
+  for why UNMEASURED and FAIL both exit non-zero.


### PR DESCRIPTION
Gaps found reading the skills against the tree: a cleanup with no stop
condition, lane verdict rules filed where a syscall author never
reaches them, no rule for when a structural change lands on its own,
and a test ordering that let a missing needs_extra_regs survive its
own test. One rule per commit.

Also bans a commit subject opening with "Say", which names the act of
writing rather than what changed. The calibration block was printing
one as an exemplar.

No source changes.

Validated with:

    make check-skill-refs
    git rev-list origin/main..HEAD | bash scripts/check-commit-log.sh
