### PR TITLE
Avoid SIGPIPE in output pattern checks

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -22,7 +22,7 @@ ELFUSE_HOST_NOFILE_MIN ?= $(shell bash "$(CURDIR)/tests/test-config.sh" --host-n
         test-sysroot-create-paths test-fork-ipc-protocol-host \
         test-vcpu-run-hooks-host test-identity-override-host \
         test-dynamic-array-host test-string-builder-host test-gdbstub-host \
-        test-config \
+        test-config test-runner \
         test-mremap-tail-emfile \
         test-proctitle-host test-proctitle-low-stack \
         test-sysroot-procfs-exec test-sysroot-fd-magiclink \
@@ -65,6 +65,10 @@ test-hello: $(ELFUSE_BIN) $(TEST_HELLO_DEP)
 ## Verify test-config.sh keeps its CLI mode separate from sourced mode
 test-config:
 	@bash tests/test-config-cli.sh
+
+## Verify output matching and exit status checks in the shared shell runner
+test-runner:
+	@bash tests/test-runner.sh
 
 ## Run the libc-based file-backed region removal EMFILE regression probe
 test-mremap-tail-emfile: $(ELFUSE_BIN) $(BUILD_DIR)/test-mremap-tail-emfile
@@ -283,7 +287,7 @@ check-sanitizer: $(ELFUSE_BIN) $(TEST_DEPS) $(CHECK_HOST_UNIT_BINS)
 	$(CHECK_SHARED_LANES)
 
 ## Run the unit test suite plus busybox applet validation
-check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-eintr-contract check-lock-order check-atomics check-ascii check-svc-tails check-skill-refs test-config \
+check: $(ELFUSE_BIN) $(TEST_DEPS) check-syscall-coverage check-eintr-contract check-lock-order check-atomics check-ascii check-svc-tails check-skill-refs test-config test-runner \
 		$(CHECK_HOST_UNIT_BINS)
 	@bash tests/driver.sh -e $(ELFUSE_BIN) -d $(TEST_DIR) -v
 	$(CHECK_SHARED_LANES)

--- a/tests/lib/test-runner.sh
+++ b/tests/lib/test-runner.sh
@@ -264,7 +264,7 @@ run_check()
         test_report fail "$tool" " (exit rc=$rc)"
         test_excerpt "$output"
         fail=$((fail + 1))
-    elif printf "%s\n" "$output" | grep -qE "$pattern"; then
+    elif grep -qE "$pattern" <<< "$output"; then
         test_report ok "$tool"
         pass=$((pass + 1))
     else
@@ -324,7 +324,7 @@ run_pipe()
         test_report fail "$tool" " (exit rc=$rc)"
         test_excerpt "$output"
         fail=$((fail + 1))
-    elif printf "%s\n" "$output" | grep -qE "$pattern"; then
+    elif grep -qE "$pattern" <<< "$output"; then
         test_report ok "$tool"
         pass=$((pass + 1))
     else

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -562,7 +562,7 @@ test_check()
         test_report fail "$label" " (exit $rc)"
         test_excerpt "$output"
         fail=$((fail + 1))
-    elif echo "$output" | grep -qE "$pattern"; then
+    elif grep -qE "$pattern" <<< "$output"; then
         test_report ok "$label"
         pass=$((pass + 1))
     else
@@ -630,7 +630,7 @@ test_pipe()
         test_report fail "$label" " (exit $rc)"
         test_excerpt "$output"
         fail=$((fail + 1))
-    elif echo "$output" | grep -qE "$pattern"; then
+    elif grep -qE "$pattern" <<< "$output"; then
         test_report ok "$label"
         pass=$((pass + 1))
     else

--- a/tests/test-runner.sh
+++ b/tests/test-runner.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 if [ "${1:-}" = "--emit" ]; then
     awk 'BEGIN {
         print "match-begin"
+        # Keep output larger than pipe capacity to expose early-match SIGPIPE.
         for (i = 0; i < 30000; i++)
             print "abcdefghijklmnopqrstuvwxyz"
         print "match-end"
@@ -31,6 +32,7 @@ expect_result()
     local runner="$1" label="$2" pattern="$3" rc="$4" want="$5"
     local output
     checks=$((checks + 1))
+    # Each subshell inherits zero pass and fail counts and discards updates.
     if output=$(
         if [ "$runner" = run_pipe ]; then
             run_pipe test-runner.sh "$pattern" input --emit "$rc"

--- a/tests/test-runner.sh
+++ b/tests/test-runner.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 elfuse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "${1:-}" = "--emit" ]; then
+    awk 'BEGIN {
+        print "match-begin"
+        for (i = 0; i < 30000; i++)
+            print "abcdefghijklmnopqrstuvwxyz"
+        print "match-end"
+    }'
+    exit "$2"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export TEST_SAMPLE_TIMEOUTS=0
+TEST_RUNNER=("$BASH")
+BIN="$SCRIPT_DIR"
+
+# shellcheck source=tests/lib/test-runner.sh
+. "$SCRIPT_DIR/lib/test-runner.sh"
+
+checks=0
+failures=0
+
+expect_result()
+{
+    local runner="$1" label="$2" pattern="$3" rc="$4" want="$5"
+    local output
+    checks=$((checks + 1))
+    if output=$(
+        if [ "$runner" = run_pipe ]; then
+            run_pipe test-runner.sh "$pattern" input --emit "$rc"
+        else
+            run_check test-runner.sh "$pattern" --emit "$rc"
+        fi
+        [ "$pass" -eq "$want" ] && [ "$fail" -eq "$((1 - want))" ]
+    ); then
+        printf 'PASS: %s %s\n' "$runner" "$label"
+    else
+        printf 'FAIL: %s %s\n%s\n' "$runner" "$label" "$output" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+for runner in run_check run_pipe; do
+    expect_result "$runner" early-match '^match-begin$' 0 1
+    expect_result "$runner" late-match '^match-end$' 0 1
+    expect_result "$runner" missing-pattern '^absent$' 0 0
+    expect_result "$runner" failed-command '^match-begin$' 7 0
+done
+
+printf 'test-runner: %s checks, %s failures\n' "$checks" "$failures"
+[ "$failures" -eq 0 ]

--- a/tests/test-static-bins.sh
+++ b/tests/test-static-bins.sh
@@ -90,7 +90,7 @@ srun_check()
     if [ "$rc" -eq 124 ]; then
         test_report fail "$label" " (timeout)"
         fail=$((fail + 1))
-    elif echo "$output" | grep -qE "$pattern"; then
+    elif grep -qE "$pattern" <<< "$output"; then
         test_report ok "$label"
         pass=$((pass + 1))
     else
@@ -124,7 +124,7 @@ srun_pipe()
     if [ "$rc" -eq 124 ]; then
         test_report fail "$label" " (timeout)"
         fail=$((fail + 1))
-    elif echo "$output" | grep -qE "$pattern"; then
+    elif grep -qE "$pattern" <<< "$output"; then
         test_report ok "$label"
         pass=$((pass + 1))
     else
@@ -158,7 +158,7 @@ srun_script()
     if [ "$rc" -eq 124 ]; then
         test_report fail "$label" " (timeout)"
         fail=$((fail + 1))
-    elif echo "$output" | grep -qE "$pattern"; then
+    elif grep -qE "$pattern" <<< "$output"; then
         test_report ok "$label"
         pass=$((pass + 1))
     else
@@ -355,7 +355,7 @@ if [ -n "$DIFF_BIN" ]; then
     if [ "$rc" -eq 124 ]; then
         test_report fail "$label" " (timeout)"
         fail=$((fail + 1))
-    elif [ "$rc" = "1" ] && echo "$output" | grep -qE "^[<>]"; then
+    elif [ "$rc" = "1" ] && grep -qE "^[<>]" <<< "$output"; then
         test_report ok "$label"
         pass=$((pass + 1))
     else


### PR DESCRIPTION
A successful command with a match near the start of a large output can fail
run_check or run_pipe: grep exits early, printf receives SIGPIPE, and pipefail
reports a failed pattern check. Feed captured output through a here-string.

The regression emits a matching first line followed by 30,000 lines. Both
early-match cases fail before the fix; all eight cases pass afterward. Late
matches, missing patterns and nonzero command exits are also covered.

Validated on Apple M3 Pro, macOS 27.0 (26A5425a), SDK 26.5:

- make test-runner: 8 checks pass under Bash 3.2 and Bash 5.2.
- BusyBox integration using the changed runner: 80 pass, 0 fail, 4 skip.
- make check-format: passes, including 57 shell scripts.
- Baseline make check stopped at an UNMEASURED throughput guardrail; its
  separate rerun after parallel builds stopped passes. The baseline
  AArch64 matrix reports 279 pass, 0 fail, 10 skip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky failures in `run_check`, `run_pipe`, and the matrix and static-bins pattern checks when a successful command matched early in large output: `grep` exited before the pipe finished writing, SIGPIPE surfaced under `pipefail`, and the check was reported as failed. All captured-output pattern checks now read from a here-string instead of piping through `echo`/`printf`.

- Replaces piped `grep -qE` checks with `grep -qE "$pattern" <<< "$output"` in `tests/lib/test-runner.sh`, `tests/test-matrix.sh`, and `tests/test-static-bins.sh`, preserving `diff`'s expected exit status of 1.
- Adds `tests/test-runner.sh` covering early matches, late matches, missing patterns, and nonzero command exits, and wires it into `make check` via `mk/tests.mk`; the generated output exceeds pipe capacity so the early-exit path is actually exercised.

<sup>Written for commit 6a8518633e8fa52424469d03ecbdeb8b3ca59208. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

