### PR TITLE
Refresh README and docs against the current tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ linker resolved against an external sysroot via `--sysroot`.
   case-colliding names on the default case-folding APFS (see
   [docs/filenames.md](docs/filenames.md))
 - Synthetic `/proc` and selected `/dev` emulation for user-space probes
-- Synthetic USB device tree: `/dev/bus/usb` plus `/sys/bus/usb/devices`
-  built from the IOKit registry, enough for libusb-style enumeration
-  (a udev-backed `lsusb` also needs `name_to_handle_at`, which is not
-  implemented yet; and macOS publishes no root hubs, so there are no
-  `usbN` entries and `lsusb -t` lists devices without their bus rows)
+- USB device passthrough: `/dev/bus/usb` and `/sys/bus/usb/devices` are
+  built from the IOKit registry, and opening a device node yields a
+  usbdevfs fd whose synchronous ioctls (interface claim, control and bulk
+  transfers) drive the attached device through IOKit. Asynchronous URB
+  submission is not implemented; a udev-backed `lsusb` also needs
+  `name_to_handle_at`, and macOS publishes no root hubs, so there are no
+  `usbN` entries and `lsusb -t` lists devices without their bus rows
 - Guest-internal FUSE: `/dev/fuse` and `mount("fuse")` work without
   macFUSE / FUSE-T / FSKit
 - Built-in GDB Remote Serial Protocol stub usable from `gdb` or `lldb`

--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ boot-time overhead those tools impose.
   than leave it to convention, which is a real gain, but the checks inside
   those accessors are the same ones to get right.
 - The defects that surface here are arithmetic and design errors, not
-  memory-safety errors. An overflow-saturated `load_max` in `src/core/elf.c`
-  wraps once the PIE load base is added in `src/syscall/exec.c`, pushing a
-  rejection past the `execve` point of no return. Rust's `+` wraps in release
-  builds too; catching it takes an explicit checked add either way.
+  memory-safety errors. An ELF whose `p_vaddr + p_memsz` overflows has to be
+  rejected where `src/core/elf.c` parses it: saturating `load_max` to
+  `UINT64_MAX` instead relocates the wrap into every consumer that adds a
+  load base, where the `elf_end > guest_size` check it was meant to trip
+  passes. Rust's `+` wraps in release builds too; catching it takes an
+  explicit checked add either way.
 - What guards the memory-safety side is language-independent and already
   gates CI: `cppcheck`, `clang-tidy`, `scan-build`, Infer, and a runtime
   matrix under ASAN, UBSAN, and TSAN. That catches such defects after the

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ linker resolved against an external sysroot via `--sysroot`.
 
 ## Features
 
-- Single native macOS binary (~560 KiB signed), no daemon and no disk
+- Single native macOS binary (under 1 MiB signed), no daemon and no disk
   image
 - Millisecond-scale VM startup; per-syscall overhead is microseconds
 - Native Apple Silicon execution through Hypervisor.framework
@@ -204,9 +204,8 @@ do.
   `posix_spawn`-ing a fresh `elfuse` host process and transferring
   state (see [docs/internals.md](docs/internals.md)).
 - Up to 64 concurrent guest threads per VM (`MAX_THREADS = 64`).
-- Around 213 syscalls implemented; anything outside
-  `src/syscall/dispatch.tbl` returns `-ENOSYS` rather than silently
-  succeeding.
+- The implemented syscall set is `src/syscall/dispatch.tbl`; anything
+  outside it returns `-ENOSYS` rather than silently succeeding.
 - `FUTEX_LOCK_PI` and friends behave as plain mutex acquire / release;
   true priority-inheritance scheduling is not modeled.
 - `sched_setaffinity` is honored as a no-op (returns the all-CPUs

--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ boot-time overhead those tools impose.
   gates CI: `cppcheck`, `clang-tidy`, `scan-build`, Infer, and a runtime
   matrix under ASAN, UBSAN, and TSAN. That catches such defects after the
   fact rather than excluding them by construction, which is the honest cost
-  of the choice.
+  of the choice. Frama-C proves each selected function body free of arithmetic
+  runtime errors, assuming its stated preconditions: the WP targets in
+  `mk/verify.mk` (`make verify`) discharge the bounds math in `src/proved/` and
+  the ELF loader's arithmetic helpers under `-wp-rte`, and
+  `make verify-mutants` asserts each proof rejects a known-broken source.
 - The host surface is nearly all C ABI: Hypervisor.framework, Mach, pthreads,
   macOS syscalls, `SCM_RIGHTS`, and hosting Apple Rosetta. The EL1 shim is
   aarch64 assembly under any host language.
@@ -173,14 +177,17 @@ make elfuse        # build and codesign build/elfuse
 make check         # quick unit suite + BusyBox applet smoke
 make test-gdbstub  # debugger integration
 make test-matrix   # cross-check elfuse against QEMU on the same corpus
+make verify        # Frama-C WP proofs
 make lint          # clang-tidy
 ```
 
 `make check` is the recommended pre-commit gate. `make test-matrix` is the
 recommended gate for changes touching procfs, dynamic linking, networking,
 or process semantics. `make test-rosetta-all` covers the x86_64 acceptance
-suites in isolation. See [docs/testing.md](docs/testing.md) for the full
-target list, fixture flow, and validation-by-change-type guidance.
+suites in isolation. `make verify` and `make verify-mutants` gate changes to
+`src/proved/`, to the ACSL contracts, or to any function a proof target
+names. See [docs/testing.md](docs/testing.md) for the full target list,
+fixture flow, and validation-by-change-type guidance.
 
 The first `make` in a fresh clone installs Git hooks that run the same checks
 CI does, at commit and push time instead of after: staged formatting, comment

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1774,22 +1774,53 @@ It is a property of how the loader is structured.
 
 ### Verification Actually In Place
 
-No formal-methods gate exists today. What gates CI is language-independent
-tooling: `clang-format`, a banned-API and unsafe-preprocessor scan,
-`cppcheck`, and the dispatch-table consistency check on Linux; `scan-build`
-as an advisory job; `clang-tidy` advisory except for
-`readability-function-size`, which is named in `WarningsAsErrors` and fails
-the job when a function crosses its ceiling; an Infer run that fails on any
-finding;
-and a runtime matrix under ASAN, UBSAN, and TSAN (see [Testing And
-Confidence](#testing-and-confidence)).
+The language-independent tooling gates CI: `clang-format`, a banned-API and
+unsafe-preprocessor scan, `cppcheck`, and the dispatch-table consistency check
+on Linux; `scan-build` as an advisory job; `clang-tidy` advisory except for
+`readability-function-size`, which is named in `WarningsAsErrors` and fails the
+job when a function crosses its ceiling; an Infer run that fails on any
+finding; and a runtime matrix under ASAN, UBSAN, and TSAN (see [Testing And
+Confidence](#testing-and-confidence)). That catches memory-safety defects after
+the fact rather than excluding them by construction, which is the honest cost
+of the choice.
 
-That catches memory-safety defects after the fact rather than excluding them
-by construction, which is the honest cost of the choice. The improvement
-worth pursuing on this surface is a proof obligation over the ELF parser
-rather than another runtime check, because a guest-triggerable abort inside a
-VMM is a denial of service, and a language that panics on bad input does not
-address that.
+The formal layer proves each selected function body free of arithmetic runtime
+errors, assuming its stated preconditions. `.github/workflows/verify.yml` runs
+the targets a change can move, split between a proof leg and a per-target
+mutation matrix, with a final job that requires both halves; `make verify`
+runs the whole set locally. Each target names a function set and discharges
+its obligations with `-wp-rte`, which adds the implicit runtime-error goals
+(overflow, out-of-bounds, invalid dereference) that the ACSL contracts alone
+leave open.
+`verify-elf` covers the named arithmetic helpers in `src/core/elf.c`, not
+`elf_load_fd`, `elf_map_segments_fd`, or their call-site preconditions; the
+others cover the bounds math of the remaining attacker-facing parsers and
+packers.
+
+Two shapes, and `mk/verify.mk` is the list that says which one a target is.
+Most name functions in a header under `src/proved/`, which is what lets one
+`.c` file's arithmetic be proved while the rest of that file stays unparsable
+to the analyzer. A few name functions in a `.c` file directly, so the loops
+are proved as written rather than as a copy of the math.
+
+Four gates close the ways a proof can say less than it appears to:
+
+- `scripts/check-proof-targets.py` (in `make check`): nothing lands in
+  `src/proved/` without a proof target.
+- `scripts/check-acsl-coverage.py`: a contracted function left out of the
+  proof set is an assumed axiom, so the target fails rather than trusting it.
+- `make verify-mutants`: each target must reject a known-broken source, which
+  is what catches a contract whose clauses do not bite.
+- `make check-contracts`: rebuilds with `-DELFUSE_CONTRACT_ASSERT` so the
+  expressible preconditions of `proved/gva.h` are checked on every call the
+  suite makes, since `src/core/guest.c` does not parse under the analyzer and
+  nothing else checks its call sites.
+
+What the proofs do not cover: the I/O around the proved arithmetic (`pread`,
+`malloc`) stays test-covered, and preconditions at call sites in files the
+analyzer cannot parse are review-only. `frama-c-stubs/` supplies the Darwin
+declarations the analyzer needs, held to the SDK's own values by
+`scripts/check-stub-constants.py`.
 
 ### Host Interface Surface
 
@@ -1818,6 +1849,10 @@ layers for that surface.
 - `make test-matrix` -- cross-checks elfuse (aarch64), QEMU (aarch64),
   and elfuse (x86_64-via-Rosetta) on overlapping corpora, with per-host
   baselines for the Rosetta branch.
+- `make verify` and `make verify-mutants`: the Frama-C WP proof targets, and
+  the assertion that each of them rejects a known-broken source. Run the two
+  together, and not beside a timing lane, because both fan out and the timed
+  lanes fail under the load they create.
 
 The rule for contributors is simple: match the validation depth to the
 subsystem you changed. Procfs, process state, dynamic linking, and

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1752,16 +1752,17 @@ arguments arriving as guest-controlled integers.
 
 ### What Defects Surface In Practice
 
-One worked example, from the loader. `elf_load_fd` saturates `load_max` to
-`UINT64_MAX` when `p_vaddr + p_memsz` overflows (`src/core/elf.c`). For
-`ET_EXEC` the saturation does its job: the fits-in-guest check in
-`src/syscall/exec.c` sees `UINT64_MAX` and rejects the image. For `ET_DYN`
-that check first adds `PIE_LOAD_BASE`, and the sum wraps to `0x3FFFFF`, which
-passes. Nothing lands out of bounds, because `elf_map_segments_fd`
-bounds-checks every segment against `guest_size`. What moves is the
-rejection: it lands at a call site past the `execve` point of no return,
-turning a recoverable `-ENOEXEC` into a fatal exec. Guarding it takes an
-explicit checked add where `load_max` meets the load base.
+One worked example, from the loader. A PT_LOAD whose `p_vaddr + p_memsz`
+overflows is rejected where it is parsed, by the checked `elf_add_no_wrap`
+(`src/core/elf.c`), and `verify-elf` discharges that arithmetic as a proof
+obligation. Saturating `load_max` to `UINT64_MAX` is the alternative that does
+not hold: every consumer adds a load base to it before comparing against
+`guest_size`, so the clamp relocates the wrap into the consumer, where the
+bound check it was meant to trip reads `elf_end > guest_size` and passes.
+Where the image lands is a separate question, checked per segment by
+`elf_place_segment` under `elf_check_placement`, which `sys_execve` calls
+before its point of no return so an unplaceable image is a recoverable
+`-ENOEXEC` rather than a fatal exec.
 
 The class of defect is the point. That is integer arithmetic, not memory
 safety. Rust's `+` wraps silently in release builds too, so the same checked

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,11 +91,34 @@ What they do:
 - `make check`: fast elfuse-internal gate. Runs, in order:
   - `scripts/check-syscall-coverage.py` so any new `dispatch.tbl`
     entry without a direct or aliased test reference fails the build
+  - `scripts/check-eintr-contract.py` so a new interruptible wait fails
+    the build until it states whether it may be restarted (`forbids`,
+    `restartable`, or `not-a-wait`), with the `forbids` claims checked
+    against the source
   - `scripts/check-lock-order.py` so a new file-scope `pthread_mutex_t`
     or `pthread_rwlock_t` that the lock-ordering block at the top of
     `src/syscall/internal.h` does not name fails the build. Membership
     only: whether the lock belongs in the ordered list or the leaf list
     stays a judgement for review
+  - `scripts/check-atomics.py` so a C11 atomic call written without its
+    `_explicit` form, or a `__atomic_*` / `__sync_*` builtin, fails the
+    build. Plain-operator access to an `_Atomic` object needs the
+    declarations resolved and stays a review question
+  - `scripts/check-ascii.py` so a source file carrying non-ASCII outside
+    the comment-diagram set fails the build
+  - `scripts/check-svc-tails.py` so an HVC #5 return tail cannot reach EL0
+    without the X7 ptrace test
+  - `scripts/check-skill-refs.py` so a path, make target, or docs section
+    a skill names that no longer resolves fails the build
+  - `scripts/check-proof-targets.py` so a header added under `src/proved/`
+    with no proof target fails here rather than on the branch later. It
+    asks make for the target list, which is the point: a `VERIFY_<T>_SRC`
+    block written below the `:=` that builds `VERIFY_TARGETS` parses fine
+    and generates no rule
+  - the two harness self-tests, `test-config` (that `tests/test-config.sh`
+    keeps its CLI mode separate from its sourced mode) and `test-runner`
+    (the shared shell runner's output matching and exit-status checks), so
+    the harness is known good before any lane leans on it
   - the unit suite from `tests/manifest.txt` -- deliberately narrow: the
     elfuse-internal implementation tests with no real Linux counterpart (the
     EL1 shim fast-path suite, `test-mremap-infra`, `test-mremap-fork-tracking`,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -81,6 +81,7 @@ make check
 make test-rosetta-all
 make test-gdbstub
 make test-matrix
+make verify
 make lint
 make clean
 ```
@@ -204,6 +205,21 @@ What they do:
   assembled from the rebuilt binaries. It also runs as a lane of `make check`.
 - `make test-matrix`: cross-check `elfuse` (aarch64), QEMU (aarch64),
   and `elfuse` (x86_64-via-Rosetta) on overlapping corpora
+- `make verify`: every Frama-C WP proof target, one `frama-c` process each
+  and parallel by default (`VERIFY_JOBS=1` for serial). Each target names a
+  function set and discharges its obligations under `-wp-rte`; `mk/verify.mk`
+  is the target list and records the data model and memory model each one
+  assumes. Needs `opam install frama-c` plus `why3 config detect`; without
+  the latter WP aborts with "Prover not found" instead of reporting unproved
+  goals. `make verify-<name>` runs one target
+- `make verify-mutants`: assert every proof target rejects a known-broken
+  source, so a contract whose clauses do not bite fails. `MUTANT_TARGET=<name>`
+  narrows it to one target, `MUTANT_SINCE=<ref>` to what a branch touched, and
+  `MUTANT_JOBS=N` overrides the one-per-core default
+- `make check-contracts`: rebuild with `-DELFUSE_CONTRACT_ASSERT` so the
+  expressible `proved/gva.h` preconditions are checked on every call the suite
+  makes. Separate from `make check` because those checks sit on the
+  `guest_read` / `guest_write` hot path
 - `make lint`: static analysis through `clang-tidy`
 
 ## Quick Iteration

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -308,6 +308,21 @@ That has a few direct implications:
   [internals.md](internals.md), section "USB Device Passthrough", for the
   per-ioctl gaps.
 
+## Diagnostic Environment Variables
+
+Off by default, and useful when a guest misbehaves rather than in normal use:
+
+- `ELFUSE_STARTUP_TRACE`: `steps` prints per-step VM bring-up timings,
+  `syscalls` prints a per-syscall histogram of startup traffic (frozen at the
+  first `execve`, so steady-state calls do not swamp it), `all` does both.
+  Comma-separated tokens are accepted, and `1` is a legacy alias for `steps`.
+- `ELFUSE_SHIM_STATS=1`: dump the EL1 shim counter table to stderr at exit, so
+  a syscall that should be served inside the shim but takes the HVC #5 exit is
+  attributed without a rebuild.
+- `ELFUSE_DISABLE_TLBI_RANGE=1`: refuse `FEAT_TLBIRANGE` and fall back to
+  per-page and broadcast invalidation, which separates a stale-TLB bug from
+  the range-encoding path.
+
 ## OCI Images
 
 `build/elfuse-oci` is separate from the C runtime. It pulls images into a local

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -299,6 +299,14 @@ That has a few direct implications:
   work entirely inside the VM. Programs that link against `libfuse`
   (sshfs, ntfs-3g, AppImage runtimes) run without macFUSE, FUSE-T, or
   FSKit on the host.
+- USB devices attached to the Mac are reachable: `/dev/bus/usb` and
+  `/sys/bus/usb/devices` are built from the IOKit registry, and opening a
+  device node gives a usbdevfs fd whose synchronous ioctls (interface claim,
+  control and bulk transfers) drive the device through IOKit. Asynchronous
+  URB submission is not implemented, and macOS arbitrates per interface: a
+  claim fails while a host driver holds that interface open. See
+  [internals.md](internals.md), section "USB Device Passthrough", for the
+  per-ioctl gaps.
 
 ## OCI Images
 


### PR DESCRIPTION
Six documentation commits, no code. Each fixes a claim the tree no longer
supports, or documents a surface that reached the tree without reaching the
docs.

- `docs/internals.md` stated that no formal-methods gate exists, and named a
  proof obligation over the ELF parser as the improvement worth pursuing. Both
  predate `mk/verify.mk` and `.github/workflows/verify.yml`, and `verify-elf`
  is that obligation.
- The loader worked example described a saturated `load_max` reaching a
  fits-in-guest check in `src/syscall/exec.c`. `elf_add_no_wrap` rejects the
  wrap where `elf.c` parses the segment, and `elf_check_placement` reports
  `ENOEXEC` before the point of no return.
- README described the USB surface as enough for libusb-style enumeration,
  which predates the synchronous usbdevfs ioctls in `src/syscall/usbdev.c`.
- `docs/testing.md` named two of the eight scripts `make check` depends on,
  and no entry for `make verify` or `make verify-mutants`.
- `ELFUSE_STARTUP_TRACE`, `ELFUSE_SHIM_STATS` and `ELFUSE_DISABLE_TLBI_RANGE`
  appeared in no document.
- The binary size and syscall count in README had both drifted. They are gone
  rather than refreshed: the size becomes a bound the build keeps, and the
  syscall limitation points at `src/syscall/dispatch.tbl`.

Checked at every commit, so the series bisects on the gates that apply to
markdown:

```sh
python3 scripts/check-ascii.py
python3 scripts/check-skill-refs.py
git rev-list origin/main..HEAD | bash scripts/check-commit-log.sh
```

No `.c` or `.h` file is touched, so `make check` was not run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes README and docs to match the current tree: fixes claims the code no longer supports and documents surfaces that reached the tree without docs. No `.c` or `.h` changes.

**Details**
- Corrects the ELF overflow example: `elf_add_no_wrap` rejects the wrap at parse time, and `elf_check_placement` reports `ENOEXEC` before the `execve` point of no return.
- Replaces the USB enumeration claim with the actual usbdevfs ioctl passthrough, noting missing async URB support and macOS per-interface arbitration.
- Documents `ELFUSE_STARTUP_TRACE`, `ELFUSE_SHIM_STATS`, and `ELFUSE_DISABLE_TLBI_RANGE` in a new "Diagnostic Environment Variables" section.
- Adds `make verify` and `make verify-mutants` to README and `docs/testing.md`, including the four gates that keep proofs honest.
- Names all eight scripts `make check` depends on in `docs/testing.md`.
- Drops the drifting binary-size and syscall-count numbers from README, pointing at a build-kept bound and `src/syscall/dispatch.tbl`.
- Each commit passes `scripts/check-ascii.py` and `scripts/check-skill-refs.py`.

<sup>Written for commit 935294abfff3740be99279c96f11d3f226b01822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

