### PR TITLE
Decide the commit-message rules in the C locale

### DIFF
--- a/scripts/git-commit-msg.sh
+++ b/scripts/git-commit-msg.sh
@@ -15,6 +15,10 @@
 
 set -uo pipefail
 
+# Every rule below is defined over printable ASCII, and a glob range or a
+# bracket expression follows LC_COLLATE instead. Decide them all in C.
+export LC_ALL=C
+
 message_file=$1
 
 # "-" reads standard input. The hook itself is always handed a real path, but

--- a/scripts/test-git-hooks.sh
+++ b/scripts/test-git-hooks.sh
@@ -103,6 +103,33 @@ expect_fail 'body line 73' 'Add a syscall
 expect_fail 'single word' 'Fix' 'more than one word'
 expect_fail '51 characters' 'Reject a syscall that outlives its own page tables!' 'exceeds 50'
 expect_fail 'lowercase start' 'add a syscall' 'capital letter'
+
+# Rule 3 decides the case of the first letter with a glob range, and a range
+# follows LC_COLLATE rather than ASCII. Only a locale that interleaves the cases
+# puts a capital inside [a-z], and a UTF-8 charmap alone does not say that: a
+# C.UTF-8 keeps the C collation and takes the same branch the C locale does. Ask
+# each candidate whether "A" falls in the range, put the accepted subject to the
+# ones that say yes, and say so when no candidate does.
+locale_legs=0
+for locale_name in $(locale -a 2>/dev/null | grep -i 'utf-*8$'); do
+    (
+        export LC_ALL="$locale_name"
+        # The constant subject is the point: ask where this locale sorts "A".
+        # shellcheck disable=SC2194
+        case A in [a-z]) exit 0 ;; esac
+        exit 1
+    ) || continue
+    checks=$((checks + 1))
+    locale_legs=$((locale_legs + 1))
+    if ! locale_out=$(printf 'Add a syscall' | LC_ALL="$locale_name" "$hook" - 2>&1); then
+        printf 'FAIL (rejected under %s): %s\n' "$locale_name" "$locale_out" >&2
+        failures=$((failures + 1))
+    fi
+    [ "$locale_legs" -lt 8 ] || break
+done
+if [ "$locale_legs" -eq 0 ]; then
+    echo 'note: no UTF-8 locale here collates a capital into [a-z]' >&2
+fi
 expect_fail 'trailing period' 'Add a syscall.' 'end with a period'
 expect_fail 'past tense' 'Added a syscall' 'imperative mood'
 expect_fail 'gerund' 'Adding a syscall' 'imperative mood'


### PR DESCRIPTION
## The bug

`scripts/git-commit-msg.sh` decides rule 3 with a glob range:

```sh
case "$subject" in
    [a-z]*) error "subject must start with a capital letter" ;;
esac
```

A bracket range follows `LC_COLLATE`, not ASCII. A UTF-8 locale collates
`aAbBcC...`, so every capital falls inside `[a-z]` and a correct subject is
rejected for want of a capital.

Measured on bash 3.2.57 with `Add a syscall`:

| locale | verdict |
| --- | --- |
| `C`, `C.UTF-8` | accepted |
| `en_US.UTF-8`, `de_DE.UTF-8`, `zh_TW.UTF-8` | `subject must start with a capital letter` |

`scripts/check-commit-log.sh` feeds the pre-push hook and the CI gate through
the same script over every commit in the range, so a contributor whose locale
is one of those cannot push at all, and the rejection names commits that are
already on `main`:

```
Invalid commit: 1ee0dea Match the lock-order rule to what the gate checks
Commit message: subject must start with a capital letter
```

CI does not see this because the runner's locale is `C`.

## The fix

`LC_ALL=C` is exported for the script rather than applied to the one range.
Every rule in the file is defined over printable ASCII, and the message check
at the top rejects anything else before a range is consulted, so no rule here
wants the caller's collation. The existing `LC_ALL=C grep` on the ASCII check
stays, since it documents its own reason.

## The test

`scripts/test-git-hooks.sh` puts the accepted subject to each UTF-8 locale the
system carries, up to eight, and prints a note when it carries none, so a
runner with only `C` does not read as covered. Eight of eight legs fail before
the change; after it all 52 checks pass under both `C` and `zh_TW.UTF-8`.

## Verification

`make check-format` (which runs the 57-script shell lane and the comment
reflow) and `make check-ascii` are clean. `scripts/check-commit-log.sh` now
accepts an unmodified `main..` range without an `LC_ALL` prefix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes commit-message validation so valid subjects are accepted regardless of the caller's locale. Previously, UTF-8 locales like `en_US.UTF-8` and `zh_TW.UTF-8` rejected subjects starting with a capital letter, which blocked `git push` for contributors using them.

- The script now evaluates all its rules in the C locale; since every rule is defined over printable ASCII, no rule is affected by the caller's collation.
- The test suite now checks the accepted subject under each UTF-8 locale the system carries, up to eight, and prints a note when none are installed.
- CI did not catch the bug because the runner's locale is `C`.

<sup>Written for commit e95b1a8a1b5b5b1a0d79accfffccca64a20f7b23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/elfuse/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

