### PR TITLE
Return from wait as soon as the child exits

### DIFF
--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -2263,6 +2263,25 @@ static int64_t proc_wait_autoreap_children(int pid, int options)
     }
 }
 
+/* Has the local table already recorded this child's exit? The lifecycle
+ * registry carries the guest exit before the child's host process finishes
+ * tearing down, so this can be true while waitpid(2) on the host pid still
+ * reports the process as running.
+ */
+static bool proc_guest_child_exited_locked(int64_t guest_pid)
+{
+    proc_entry_t *entry = proc_find_guest_entry(guest_pid);
+    return entry && entry->exited;
+}
+
+static bool proc_guest_child_exited(int64_t guest_pid)
+{
+    pthread_mutex_lock(&pid_lock);
+    bool exited = proc_guest_child_exited_locked(guest_pid);
+    pthread_mutex_unlock(&pid_lock);
+    return exited;
+}
+
 /* sys_wait4. */
 
 /* Reap host children whose terminal status the guest already consumed from the
@@ -2563,9 +2582,41 @@ int64_t sys_wait4(guest_t *g,
                         return -LINUX_EINTR;
                     struct timespec ts;
                     timespec_deadline_in_ms(&ts, 100);
+
+                    /* Import before the sleep as well as after it. The poll
+                     * above runs unlocked, so a broadcast landing between it
+                     * and the lock below finds nobody parked and evaporates:
+                     * pid_cond keeps no count. The doorbell sets entry->exited
+                     * under pid_lock before it broadcasts, so re-reading the
+                     * table inside the same critical section the sleep releases
+                     * is what closes that window. The import itself stays
+                     * outside the lock, like the poll: it touches the registry
+                     * file, and pid_lock holds only bounded table walks.
+                     */
+                    lifecycle_import_children();
                     pthread_mutex_lock(&pid_lock);
+                    if (proc_guest_child_exited_locked(gpid)) {
+                        pthread_mutex_unlock(&pid_lock);
+                        return sys_wait4(g, pid, status_gva, options,
+                                         rusage_gva);
+                    }
                     pthread_cond_timedwait(&pid_cond, &pid_lock, &ts);
                     pthread_mutex_unlock(&pid_lock);
+
+                    /* The doorbell reports the guest exit about a millisecond
+                     * before the child's host process becomes reapable, so the
+                     * poll above still says "running" when the wakeup arrives.
+                     * The registry carries the exit by then, so importing it
+                     * copies the status across and flags the host reap for
+                     * proc_deferred_reap_poll(), after which the table lookup
+                     * at the top of sys_wait4 answers without waiting for the
+                     * host process at all. Without this the wakeup is wasted
+                     * and the wait costs the full 100 ms timeout.
+                     */
+                    lifecycle_import_children();
+                    if (proc_guest_child_exited(gpid))
+                        return sys_wait4(g, pid, status_gva, options,
+                                         rusage_gva);
                 }
             }
             if (ret > 0) {

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -2953,6 +2953,26 @@ static void *preempt_thread_main(void *arg)
             atomic_store_explicit(&g_external_guest_signal, 1,
                                   memory_order_release);
             drain_external_guest_signal();
+
+            /* The doorbell is also how a fork child reports that it exited.
+             * sys_wait4 and sys_waitid sleep on pid_cond between re-checks, and
+             * nothing on this path signaled it, so a waiting parent only
+             * re-checked when its 100 ms safety-net timeout expired: every
+             * fork/wait pair paid that timeout in full even though the child
+             * was already gone.
+             *
+             * Broadcast under pid_lock, not beside it. A sleeper holds the lock
+             * across its predicate check and only releases it inside
+             * pthread_cond_timedwait, so taking the lock here means the
+             * broadcast cannot land in the window between the two and be lost.
+             * pid_lock is a leaf (see the lock-order block in
+             * syscall/internal.h) and every critical section under it is a
+             * bounded table walk, so this cannot invert an order or park the
+             * sigwait thread on someone else's blocking call.
+             */
+            pthread_mutex_lock(&pid_lock);
+            pthread_cond_broadcast(&pid_cond);
+            pthread_mutex_unlock(&pid_lock);
             wakeup_pipe_signal();
         } else if (sig == SIGALRM) {
             static uint64_t last_progress;

--- a/src/syscall/proc.c
+++ b/src/syscall/proc.c
@@ -2242,10 +2242,27 @@ static int64_t proc_wait_autoreap_children(int pid, int options)
             } else if (ret == 0) {
                 still_active = true;
             } else {
+                /* ret < 0, in practice ECHILD: the host child is gone. It can
+                 * be gone because proc_deferred_reap_poll() took it from the
+                 * watchdog tick, which reaches a single-threaded guest parked
+                 * here and not only one racing a second guest thread. When the
+                 * registry already carried the exit, the entry holds the status
+                 * and the rusage, so finish it the way the ret == host_pid
+                 * branch does: deactivating alone drops the child's time from
+                 * RUSAGE_CHILDREN and leaves the lifecycle row to be imported
+                 * again.
+                 */
                 proc_entry_t *entry =
                     proc_find_host_guest_entry(host_pid, guest_pid);
-                if (entry)
+                if (entry && entry->exited) {
+                    proc_account_entry_locked(entry);
                     entry->active = false;
+                    pthread_mutex_unlock(&pid_lock);
+                    lifecycle_consume(guest_pid);
+                    pthread_mutex_lock(&pid_lock);
+                } else if (entry) {
+                    entry->active = false;
+                }
             }
         }
         pthread_mutex_unlock(&pid_lock);
@@ -2301,24 +2318,37 @@ static void proc_deferred_reap_poll(void)
             proc_table[i].host_reap_pending = false;
             continue;
         }
+
+        /* Claim the entry by clearing the flag before dropping the lock, and
+         * put it back below if the child was not reapable after all. The
+         * watchdog tick made this a second concurrent caller even for a guest
+         * with one thread, and two callers that both saw the flag would both
+         * call wait4 on this host_pid. The host OS can hand that pid to a
+         * freshly spawned fork child the instant the first call reaps it, so
+         * the second would reap that one and discard its status. The paired
+         * lookup below guards which entry the flag is written back to, not the
+         * reap itself.
+         */
+        proc_table[i].host_reap_pending = false;
         pthread_mutex_unlock(&pid_lock);
         int st;
         pid_t r = wait4(host_pid, &st, WNOHANG, NULL);
         pthread_mutex_lock(&pid_lock);
 
-        /* Only clear the flag once the zombie is gone (r > 0) or the child is
-         * no longer ours to reap (r < 0, typically ECHILD). The guest_pid check
-         * guards against host_pid reuse: the host OS can hand this exact pid to
-         * a brand new process the instant wait4 above reaps it, and a second
-         * guest fork admitted on another thread during this unlocked window
-         * could land that new child in slot i under the same host_pid. Clearing
-         * host_reap_pending for it instead of (or in addition to) the original
-         * entry would strand a real pending zombie.
+        /* Restore the claim when the child was still running (r == 0), so a
+         * later sweep tries again; a reaped zombie (r > 0) or one that is no
+         * longer ours (r < 0, typically ECHILD) stays cleared. The guest_pid
+         * check guards against host_pid reuse: the host OS can hand this exact
+         * pid to a brand new process the instant wait4 above reaps it, and a
+         * second guest fork admitted on another thread during this unlocked
+         * window could land that new child in slot i under the same host_pid.
+         * Writing the flag back onto it would ask a later sweep to reap a live
+         * child.
          */
-        if (r != 0 && i < proc_table_capacity &&
+        if (r == 0 && i < proc_table_capacity &&
             proc_table[i].host_pid == host_pid &&
             proc_table[i].guest_pid == guest_pid)
-            proc_table[i].host_reap_pending = false;
+            proc_table[i].host_reap_pending = true;
     }
     pthread_mutex_unlock(&pid_lock);
 }
@@ -2625,6 +2655,22 @@ int64_t sys_wait4(guest_t *g,
             } else if (ret == 0) {
                 return 0; /* WNOHANG */
             }
+
+            /* ECHILD here does not have to mean the guest has no such child.
+             * proc_deferred_reap_poll() collects host zombies whose status the
+             * guest already has, and it runs from the watchdog tick as well as
+             * from this entry, so it can take this host_pid between the poll
+             * above and this line. The status is copied into the table before
+             * the reap is flagged, so ask the table before reporting the host
+             * errno; the re-entry answers from the lookup at the top.
+             */
+            int wait_errno = errno;
+            if (wait_errno == ECHILD) {
+                lifecycle_import_children();
+                if (proc_guest_child_exited(gpid))
+                    return sys_wait4(g, pid, status_gva, options, rusage_gva);
+            }
+            errno = wait_errno;
             return linux_errno();
         }
     }
@@ -3026,6 +3072,15 @@ static void *preempt_thread_main(void *arg)
             pthread_mutex_unlock(&pid_lock);
             wakeup_pipe_signal();
         } else if (sig == SIGALRM) {
+            /* sys_wait4's entry is the only other caller, so a guest that takes
+             * its last child's status and never waits again strands that
+             * child's host process as a zombie for the rest of the run. The
+             * tick already exists and already runs on this thread, so sweeping
+             * from it bounds the strand to a period or two without adding a
+             * thread, a wakeup, or a cost on the wait path.
+             */
+            proc_deferred_reap_poll();
+
             static uint64_t last_progress;
             uint64_t now =
                 atomic_load_explicit(&g_vcpu_progress, memory_order_relaxed);

--- a/tests/test-fork-wait-latency.c
+++ b/tests/test-fork-wait-latency.c
@@ -1,0 +1,182 @@
+/*
+ * fork/wait round-trip latency
+ *
+ * Copyright 2026 elfuse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A child's exit reaches its parent through the cross-process doorbell, and the
+ * parent's wait4 sleeps on a condition variable with a 100 ms timeout behind
+ * it. When the doorbell does not reach that sleeper, the wait still returns the
+ * right answer, just a timeout late -- so the defect is invisible to a test
+ * that only checks the status. Measure the delay instead: the gap between the
+ * child's last instant and the parent's return from wait.
+ *
+ * Both spellings are exercised because they take different paths inside elfuse.
+ * wait(2) settles from the lifecycle registry, waitpid(2) on one pid polls the
+ * child's host process, and the host process outlives the guest exit by about a
+ * millisecond -- so a wakeup that satisfies the first can still leave the
+ * second waiting out the whole timeout.
+ */
+
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "test-harness.h"
+
+int passes = 0, fails = 0;
+
+/* Ten times the fastest gap seen with the notification path connected, and a
+ * quarter of the 100 ms timeout that is the failure being ruled out. A machine
+ * would have to be some fifty times slower than the reference to cross it from
+ * below, and no machine speed moves the timeout above it.
+ */
+#define MAX_GAP_MS 20.0
+#define ITERS 8
+
+static double ms_between(const struct timespec *a, const struct timespec *b)
+{
+    return (double) (b->tv_sec - a->tv_sec) * 1000.0 +
+           (double) (b->tv_nsec - a->tv_nsec) / 1e6;
+}
+
+/* Wait for one child, retrying the interrupted call rather than reporting the
+ * gap it did not measure.
+ *
+ * Returns 0 once that child is reaped with a clean exit, -1 on anything else: a
+ * wait that fails leaves the child unreaped and still records a fast gap, so an
+ * unchecked error reads as a pass here and the leftover child is then visible
+ * to the wait(-1) in the other case.
+ */
+static int wait_for(pid_t child, int specific_pid)
+{
+    for (;;) {
+        int status = 0;
+        pid_t got = specific_pid ? waitpid(child, &status, 0) : wait(&status);
+        if (got < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        if (got != child)
+            return -1;
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+            return -1;
+        return 0;
+    }
+}
+
+static void sort_gaps(double *v, int n)
+{
+    for (int i = 1; i < n; i++) {
+        double key = v[i];
+        int j = i - 1;
+        while (j >= 0 && v[j] > key) {
+            v[j + 1] = v[j];
+            j--;
+        }
+        v[j + 1] = key;
+    }
+}
+
+/* Median gap from the child's final timestamp to the parent's return from wait,
+ * or -1 if a child could not be run to completion.
+ *
+ * The child is held at a pipe read until the parent is about to wait, so the
+ * exit cannot land before the parent reaches the syscall. Without that, a
+ * parent that arrives late finds the exit already in the table and returns from
+ * the lookup at the top of sys_wait4 without ever reaching the condition
+ * variable -- a fast iteration on a tree where the wakeup is still missing.
+ *
+ * The median rather than the minimum for the same reason: one such iteration
+ * would carry a minimum, while an unlucky scheduling delay in one trial cannot
+ * move a median that half the trials have to cross.
+ */
+static double median_gap(int specific_pid)
+{
+    double gaps[ITERS];
+
+    for (int i = 0; i < ITERS; i++) {
+        int go[2], report[2];
+        if (pipe(go) != 0)
+            return -1;
+        if (pipe(report) != 0) {
+            close(go[0]);
+            close(go[1]);
+            return -1;
+        }
+
+        pid_t pid = fork();
+        if (pid < 0) {
+            close(go[0]);
+            close(go[1]);
+            close(report[0]);
+            close(report[1]);
+            return -1;
+        }
+        if (pid == 0) {
+            char go_byte;
+            struct timespec c;
+            close(go[1]);
+            close(report[0]);
+            /* Park here until the parent is on its way into wait. */
+            if (read(go[0], &go_byte, 1) != 1)
+                _exit(1);
+            clock_gettime(CLOCK_MONOTONIC, &c);
+            if (write(report[1], &c, sizeof(c)) != (ssize_t) sizeof(c))
+                _exit(1);
+            _exit(0);
+        }
+
+        close(go[0]);
+        close(report[1]);
+
+        int failed = (write(go[1], "g", 1) != 1);
+        close(go[1]);
+        if (!failed)
+            failed = (wait_for(pid, specific_pid) != 0);
+
+        struct timespec parent;
+        clock_gettime(CLOCK_MONOTONIC, &parent);
+
+        struct timespec child;
+        ssize_t got = read(report[0], &child, sizeof(child));
+        close(report[0]);
+        if (failed || got != (ssize_t) sizeof(child))
+            return -1;
+
+        gaps[i] = ms_between(&child, &parent);
+    }
+
+    sort_gaps(gaps, ITERS);
+    return (gaps[ITERS / 2 - 1] + gaps[ITERS / 2]) / 2.0;
+}
+
+static void check(const char *name, int specific_pid)
+{
+    double gap = median_gap(specific_pid);
+    TEST(name);
+    if (gap < 0) {
+        FAIL("could not run a child to completion");
+        return;
+    }
+    if (gap < MAX_GAP_MS) {
+        PASS();
+        return;
+    }
+    char msg[96];
+    snprintf(msg, sizeof(msg),
+             "waited %.1fms after the child exited (max %.0f)", gap,
+             MAX_GAP_MS);
+    FAIL(msg);
+}
+
+int main(void)
+{
+    check("wait() returns as soon as the child exits", 0);
+    check("waitpid(pid) returns as soon as the child exits", 1);
+
+    SUMMARY("test-fork-wait-latency");
+    return fails ? 1 : 0;
+}

--- a/tests/test-matrix.sh
+++ b/tests/test-matrix.sh
@@ -706,6 +706,8 @@ run_unit_tests()
     test_check "$runner" "test-clone-childtid" "PASS" "$bindir/test-clone-childtid"
     test_check "$runner" "test-exec" "exec-works" "$bindir/test-exec" "$bindir/echo-test" exec-works
     test_check "$runner" "test-fork-exec" "PASS" "$bindir/test-fork-exec" "$bindir/echo-test"
+    test_check "$runner" "test-fork-wait-latency" "PASS" \
+        "$bindir/test-fork-wait-latency"
     test_rc "$runner" "test-process-lifecycle" 0 \
         "$bindir/test-process-lifecycle"
     test_check "$runner" "test-cloexec" "PASS" "$bindir/test-cloexec"


### PR DESCRIPTION
A guest that forks and waits pays about 100 ms per child even though the child is already gone. The exit reaches the parent, but nothing wakes the thread waiting for it, so every wait runs out its safety-net timeout.

`proc_process_exit()` appends the exit to the lifecycle registry and rings the cross-process doorbell, SIGUSR2. The parent's sigwait thread takes the signal, drains the record and pokes the vCPU's signal pipe, but nothing on that path touches `pid_cond`, which is where `sys_wait4` and `sys_waitid` sleep between re-checks. The comment at the first of those waits says the condvar handles normal exits and the timeout only catches edge cases. The condvar was never signaled: the only caller of `proc_mark_child_exited()` is the `CLONE_VFORK` branch of `sys_clone`, so an ordinary `SIGCHLD` fork never reached it.

Broadcasting there fixes `wait(2)` and leaves `waitpid(2)` on a single pid exactly as slow, because the two re-check different things. The `pid == -1` loop imports the registry after waking, and the registry already carries the exit. The single-pid loop polls the child's host process with `WNOHANG`, and that process outlives the guest exit by about 0.7 ms while it tears down its VM, so the poll still reports it running when the wakeup arrives and nothing rings a second time. The second commit imports the registry there too, then re-enters through the table lookup at the top of `sys_wait4`.

That loop polls with no lock held and takes `pid_lock` only to sleep, so a broadcast landing between the two finds nobody parked and evaporates. `wait4` cannot be the predicate that closes the window, because it answers about the host process and still reports "running" at the moment of the broadcast; the doorbell sets `entry->exited` under `pid_lock` before it broadcasts, so the loop reads that instead, inside the same critical section the sleep releases.

The third commit sweeps unreaped host children from the watchdog tick. `proc_deferred_reap_poll()` collects the host process of a child whose status the guest already took from the registry, and `sys_wait4`'s entry was its only caller, so a guest that takes its last child's status and never waits again left that child a zombie for the rest of the run. The SIGALRM branch of the sigwait thread already runs on its own, which bounds the strand to a period or two without a new thread or any cost on the wait path. Two paths then have to hold up under a second concurrent sweeper: the poll claims an entry under `pid_lock` before its unlocked `wait4`, so two callers cannot reap the same host pid and have the second take a freshly spawned child that inherited it, and `proc_wait_autoreap_children()` now accounts and consumes an entry the registry already marked exited instead of only deactivating it.

Reproduction, against the Alpine rootfs under `externals/test-fixtures`:

```
build/elfuse --sysroot $RF $RF/bin/busybox sh -c \
    'i=0; while [ $i -lt 20 ]; do (:) ; i=$((i+1)); done'
```

Delay from the child's own last timestamp to the parent's return from wait, median of 8 rounds, measured by `tests/test-fork-wait-latency.c`:

| | before | after | Linux 6.12 |
|---|---:|---:|---:|
| `wait(2)` | 98.7 ms | 0.20 ms | 0.02 ms |
| `waitpid(2)` on one pid | 99.5 ms | 0.20 ms | 0.02 ms |

Shell workloads, wall clock, median of three runs, same tree built with and without the change:

| | before | after |
|---|---:|---:|
| fork only x20 | 2300 ms | 160 ms |
| fork and exec x100 | 11390 ms | 1420 ms |
| md5sum over 34 files | 2620 ms | 390 ms |
| find piped to wc | 120 ms | 40 ms |
| command substitution x30 | 440 ms | 450 ms |

The last row is a control. `$(...)` learns the child is done by reading the pipe to EOF, so `wait4` finds a zombie and never reaches the condvar. It does not move, and it already sat at the ratio the other rows reach after the change.

The test measures the delay rather than the status, because a missed wakeup returns the right answer late and a status check cannot see it. The child is held at a pipe read until the parent is on its way into wait, so the exit cannot land before the parent reaches the syscall and answer from the table lookup at the top of `sys_wait4` without ever reaching the condvar. It asserts on the median for the same reason: one such iteration would carry a minimum. It is registered in `test-matrix.sh`, so the same assertion is checked against Linux 6.12.

`make check`, `make check-format` and `make lint` are clean. `make check-tsan` and `make check-asan` are clean. Rebased on 73d8246.
